### PR TITLE
[INLONG-1607] Add master version option in bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,8 +70,8 @@ body:
       multiple: false
       options:
         - '0.9.0'
-        - '0.10.0 RC0'
         - '0.10.0 RC1'
+        - 'master'
     validations:
       required: true
 


### PR DESCRIPTION
fix: #1607

### Motivation

Add master version option in the `bug-report.yml`.

### Modifications

- `.github/ISSUE_TEMPLATE/bug-report.yml`
