### PR TITLE
[INLONG-1694][TubeMQ][Bug] Build docker mirror error for TubeMQ C++

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-cpp/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-cpp/Dockerfile
@@ -18,7 +18,7 @@
 #
 FROM rikorose/gcc-cmake:gcc-4
 RUN apt-get remove openssl -y
-RUN wget https://www.openssl.org/source/openssl-1.1.0f.tar.gz \
+RUN wget https://www.openssl.org/source/openssl-1.1.0f.tar.gz --no-check-certificate \
     && tar -xzvf openssl-1.1.0f.tar.gz \
     && rm openssl-1.1.0f.tar.gz && cd openssl-1.1.0f \
     && ./config && make && make install


### PR DESCRIPTION
### Title Name: [INLONG-1694][TubeMQ][Bug] Build docker mirror error for TubeMQ C++

where *XYZ* should be replaced by the actual issue number.

Fixes #1694 

### Motivation

When build docker mirror for TubeMQ, use `--no-check-certificate` to skip the certificate check.

### Modifications

Change the Dockerfile for TubeMQ

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation
