### PR TITLE
[INLONG-4730][Sort] Fix meta field format is null when parse json to sql

### DIFF
--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -483,7 +483,7 @@ public class FlinkSqlParser implements Parser {
                         && outputField != null
                         && outputField.getFormatInfo() != null
                         && outputField.getFormatInfo().getTypeInfo().equals(formatInfo.getTypeInfo());
-                if (sameType) {
+                if (sameType || field.getFormatInfo() == null) {
                     sb.append("\n    ").append(inputField.format()).append(" AS ").append(field.format()).append(",");
                 } else {
                     String targetType = TableFormatUtils.deriveLogicalType(field.getFormatInfo()).asSummaryString();

--- a/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
+++ b/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
@@ -316,7 +316,8 @@ public class TableFormatUtils {
         } else if (logicalType instanceof NullType) {
             return NullFormatInfo.INSTANCE;
         } else {
-            throw new UnsupportedOperationException();
+            throw new IllegalArgumentException(String.format("not found logicalType %s",
+                    logicalType == null ? "null" : logicalType.toString()));
         }
     }
 
@@ -375,7 +376,8 @@ public class TableFormatUtils {
         } else if (formatInfo instanceof NullFormatInfo) {
             return new NullType();
         } else {
-            throw new UnsupportedOperationException();
+            throw new IllegalArgumentException(String.format("not found formatInfo %s",
+                    formatInfo == null ? "null" : formatInfo.toString()));
         }
     }
 


### PR DESCRIPTION
### Prepare a Pull Request

- Title Example: [INLONG-4730][Sort] Fix meta field format is null when parse json to sql

- Fixes #4730 

### Motivation

Fix meta field format is null when parse json to sql

### Modifications

modify UT  `DataTypeConvertSqlParseTest`
add exception detail for TableFormatUtils
modify `parseFieldRelations` of FlinkSqlParser

### Verifying this change

