### PR TITLE
[INLONG-4732][Sort] Fix Iceberg commit Hive catalog table not found

### DIFF
--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -47,6 +47,7 @@
         <rat.basedir>${basedir}</rat.basedir>
         <hbase.version>2.2.3</hbase.version>
         <dlc.hive.version>2.3.7</dlc.hive.version>
+        <iceberg.hive.version>2.3.7</iceberg.hive.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/inlong-sort/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-connectors/iceberg/pom.xml
@@ -40,6 +40,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
+            <version>${iceberg.hive.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

[INLONG-4732][Sort] Iceberg commit hive catalog table failed because table not found

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #4732 

### Motivation

fix iceberg hive Compatibility issues

