### PR TITLE
[INLONG-4721][TubeMQ] Remove the "incubat*" tag in the tubemq-go-sdk code

### DIFF
--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/README.md
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/README.md
@@ -35,13 +35,13 @@ depend on the [TubeMQ C++ library](https://github.com/apache/inlong/tree/master/
 
 Import the `client` and`config` library:
 ```go
-import "github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
-import "github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+import "github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
+import "github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
 ```
 
 Import the `log` library for log if needed:
 ```go
-import "github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+import "github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
 ```
 
 Create a Consumer by parsing address:

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer.go
@@ -20,7 +20,7 @@
 package client
 
 import (
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
 )
 
 // ConsumerResult of a consumption.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
@@ -31,18 +31,18 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/selector"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/selector"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/heartbeat.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/heartbeat.go
@@ -24,11 +24,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 type heartbeatMetadata struct {

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec/tubemq_codec.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec/tubemq_codec.go
@@ -31,7 +31,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec/tubemq_codec_test.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec/tubemq_codec_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
 )
 
 func TestBasicEncodingDecoding(t *testing.T) {

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -27,8 +27,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 const (
@@ -45,7 +45,7 @@ const (
 )
 
 // Config defines multiple configuration options.
-// Refer to: https://github.com/apache/incubator-inlong/blob/3249de37acf054a9c43677131cfbb09fc6d366d1/tubemq-client/src/main/java/org/apache/tubemq/client/config/ConsumerConfig.java
+// Refer to: https://github.com/apache/inlong/blob/3249de37acf054a9c43677131cfbb09fc6d366d1/tubemq-client/src/main/java/org/apache/tubemq/client/config/ConsumerConfig.java
 type Config struct {
 	// Net is the namespace for network-level properties used by broker and Master.
 	Net struct {
@@ -282,7 +282,7 @@ func (c *Config) validateTopicFilters() error {
 	for topic, filters := range c.Consumer.TopicFilters {
 		if len(topic) > MaxTopicLen {
 			return errs.New(errs.RetInvalidConfig,
-				fmt.Sprintf("Check parameter topicFilters error: topic's length " +
+				fmt.Sprintf("Check parameter topicFilters error: topic's length "+
 					"over max length %d", MaxTopicLen))
 		}
 		if valid, err := util.IsValidString(topic); !valid {
@@ -295,7 +295,7 @@ func (c *Config) validateTopicFilters() error {
 			}
 			if len(filter) > MaxFilterLen {
 				return errs.New(errs.RetInvalidConfig,
-					fmt.Sprintf("Check parameter topicFilters error: topic %s's filter's " +
+					fmt.Sprintf("Check parameter topicFilters error: topic %s's filter's "+
 						"length over max length %d", topic, MaxFilterLen))
 			}
 			if valid, err := util.IsValidFilterItem(filter); !valid {
@@ -304,7 +304,7 @@ func (c *Config) validateTopicFilters() error {
 		}
 		if len(filters) > MaxFilterLen {
 			return errs.New(errs.RetInvalidConfig,
-				fmt.Sprintf("Check parameter topicFilters error: topic %s's filter item " +
+				fmt.Sprintf("Check parameter topicFilters error: topic %s's filter item "+
 					"over max item count %d", topic, MaxFilterLen))
 		}
 	}

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/example/consumer.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/example/consumer.go
@@ -20,9 +20,9 @@ package main
 import (
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
 )
 
 func main() {

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/example/multi_routine_consumer.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/example/multi_routine_consumer.go
@@ -22,10 +22,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg"
 )
 
 var lastPrintTime int64

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl/handler.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl/handler.go
@@ -29,8 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 // RuleHandler represents the flow control handler.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl/item.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl/item.go
@@ -18,7 +18,7 @@
 package flowctrl
 
 import (
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/go.mod
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/go.mod
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go
+module github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go
 
 go 1.14
 

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/node.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/node.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
 )
 
 // Node represents the metadata of a node.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/partition.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/partition.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 // Partition represents the metadata of a partition.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/subscribe_info.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata/subscribe_info.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
 )
 
 // SubscribeInfo represents the metadata of the subscribe info.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing/multiplexing.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing/multiplexing.go
@@ -31,7 +31,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
 )
 
 var (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing/multlplexing_test.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing/multlplexing_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
 )
 
 var (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote/remote.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote/remote.go
@@ -25,10 +25,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/flowctrl"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 // RmtDataCache represents the data returned from TubeMQ.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/broker.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/broker.go
@@ -22,13 +22,13 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/client.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/client.go
@@ -21,15 +21,15 @@ package rpc
 import (
 	"context"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/master.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/master.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/metadata"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/remote"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/selector/selector.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/selector/selector.go
@@ -21,7 +21,7 @@ package selector
 import (
 	"fmt"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
 )
 
 // Selector is abstraction of route selector which can return an available address

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info.go
@@ -23,8 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
 )
 
 // InValidOffset represents the offset which is invalid.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info_test.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/sub/info_test.go
@@ -20,7 +20,7 @@ package sub
 import (
 	"testing"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg/bin_msg.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg/bin_msg.go
@@ -20,7 +20,7 @@ package tdmsg
 import (
 	"encoding/binary"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg/td_msg.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/tdmsg/td_msg.go
@@ -24,10 +24,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util"
 	"github.com/golang/snappy"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/errs"
 )
 
 const (

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport/client.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/transport/client.go
@@ -22,8 +22,8 @@ package transport
 import (
 	"context"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/codec"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/multiplexing"
 )
 
 // Options represents the transport options

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util/util.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util/util.go
@@ -26,7 +26,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/apache/incubator-inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
+	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/protocol"
 )
 
 // InvalidValue defines the invalid value of TubeMQ config.

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-python/setup.py
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-python/setup.py
@@ -68,7 +68,7 @@ setup(
     version=__version__,
     author="dockerzhang",
     author_email="dockerzhang@apache.org",
-    url="https://github.com/apache/incubator-tubemq/tree/tubemq-client-python",
+    url="https://github.com/apache/inlong/tree/master/inlong-tubemq/tubemq-client-twins/tubemq-client-python",
     description="TubeMq Python SDK Client project built with pybind11",
     long_description="",
     ext_modules=ext_modules,


### PR DESCRIPTION
- Fixes #4721
