### PR TITLE
[INLONG-4735][Sort] Add precision support for DecimalFormatInfo, TimeFormatInfo

### DIFF
--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DecimalFormatSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DecimalFormatSqlParseTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.inlong.sort.formats.common.DecimalFormatInfo;
+import org.apache.inlong.sort.formats.common.LongFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.enums.KafkaScanStartupMode;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.KafkaExtractNode;
+import org.apache.inlong.sort.protocol.node.format.CanalJsonFormat;
+import org.apache.inlong.sort.protocol.node.load.KafkaLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Test for {@link DecimalFormatInfo} and {@link FlinkSqlParser}
+ */
+public class DecimalFormatSqlParseTest extends AbstractTestBase {
+
+    private KafkaExtractNode buildKafkaExtractNode() {
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("salary", new DecimalFormatInfo(13, 9)));
+        return new KafkaExtractNode("1", "kafka_input", fields, null,
+                null, "kafka_input", "localhost:9092",
+                new CanalJsonFormat(), KafkaScanStartupMode.EARLIEST_OFFSET,
+                null, "groupId_1");
+    }
+
+    private KafkaLoadNode buildKafkaLoadNode() {
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("salary", new DecimalFormatInfo(13, 9)));
+        List<FieldRelation> relations = Arrays
+                .asList(new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                                new FieldInfo("id", new LongFormatInfo())),
+                        new FieldRelation(new FieldInfo("salary", new DecimalFormatInfo(13, 9)),
+                                new FieldInfo("salary", new DecimalFormatInfo(13, 9)))
+                );
+        return new KafkaLoadNode("2", "kafka_output", fields, relations, null,
+                null, "kafka_output", "localhost:9092",
+                new CanalJsonFormat(), null,
+                null, null);
+    }
+
+    public NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    /**
+     * Test precision, scale for {@link DecimalFormatInfo}
+     *
+     * @throws Exception The exception may throws when executing
+     */
+    @Test
+    public void testDecimalFormatSqlParse() throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode = buildKafkaExtractNode();
+        Node outputNode = buildKafkaLoadNode();
+        StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, outputNode),
+                Collections.singletonList(
+                        buildNodeRelation(Collections.singletonList(inputNode), Collections.singletonList(outputNode))
+                ));
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+
+}

--- a/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
+++ b/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
@@ -108,9 +108,9 @@ public class TableFormatUtils {
      * Returns the {@link DeserializationSchema} described by the given
      * properties.
      *
-     * @param properties The properties describing the deserializer.
+     * @param properties  The properties describing the deserializer.
      * @param classLoader The class loader for the deserializer.
-     * @param <T> The type of the data.
+     * @param <T>         The type of the data.
      * @return The {@link DeserializationSchema} described by the properties.
      */
     public static <T> DeserializationSchema<T> getDeserializationSchema(
@@ -131,9 +131,9 @@ public class TableFormatUtils {
      * Returns the {@link SerializationSchema} described by the given
      * properties.
      *
-     * @param properties The properties describing the serializer.
+     * @param properties  The properties describing the serializer.
      * @param classLoader The class loader for the serializer.
-     * @param <T> The type of the data.
+     * @param <T>         The type of the data.
      * @return The {@link SerializationSchema} described by the properties.
      */
     public static <T> SerializationSchema<T> getSerializationSchema(
@@ -154,10 +154,10 @@ public class TableFormatUtils {
      * Returns the {@link DeserializationSchema} described by the given
      * properties.
      *
-     * @param properties The properties describing the deserializer.
-     * @param fields The fields to project.
+     * @param properties  The properties describing the deserializer.
+     * @param fields      The fields to project.
      * @param classLoader The class loader for the deserializer.
-     * @param <T> The type of the data.
+     * @param <T>         The type of the data.
      * @return The {@link DeserializationSchema} described by the properties.
      */
     public static <T> DeserializationSchema<Row> getProjectedDeserializationSchema(
@@ -180,8 +180,8 @@ public class TableFormatUtils {
      * Returns the {@link SerializationSchema} described by the given
      * properties.
      *
-     * @param properties The properties describing the serializer.
-     * @param fields The fields to project.
+     * @param properties  The properties describing the serializer.
+     * @param fields      The fields to project.
      * @param classLoader The class loader for the serializer.
      * @return The {@link SerializationSchema} described by the properties.
      */
@@ -205,7 +205,7 @@ public class TableFormatUtils {
      * Returns the {@link TableFormatSerializer} described by the given
      * properties.
      *
-     * @param properties The properties describing the serializer.
+     * @param properties  The properties describing the serializer.
      * @param classLoader The class loader for the serializer.
      * @return The {@link TableFormatSerializer} described by the properties.
      */
@@ -228,7 +228,7 @@ public class TableFormatUtils {
      * Returns the {@link TableFormatDeserializer} described by the
      * given properties.
      *
-     * @param properties The properties describing the deserializer.
+     * @param properties  The properties describing the deserializer.
      * @param classLoader The class loader for the deserializer.
      * @return The {@link TableFormatDeserializer} described by the properties.
      */
@@ -344,9 +344,10 @@ public class TableFormatUtils {
         } else if (formatInfo instanceof DoubleFormatInfo) {
             return new DoubleType();
         } else if (formatInfo instanceof DecimalFormatInfo) {
-            return new DecimalType();
+            DecimalFormatInfo decimalFormatInfo = (DecimalFormatInfo) formatInfo;
+            return new DecimalType(decimalFormatInfo.getPrecision(), decimalFormatInfo.getScale());
         } else if (formatInfo instanceof TimeFormatInfo) {
-            return new TimeType();
+            return new TimeType(((TimeFormatInfo) formatInfo).getPrecision());
         } else if (formatInfo instanceof DateFormatInfo) {
             return new DateType();
         } else if (formatInfo instanceof TimestampFormatInfo) {

--- a/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
+++ b/inlong-sort/sort-formats/format-base/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
@@ -108,9 +108,9 @@ public class TableFormatUtils {
      * Returns the {@link DeserializationSchema} described by the given
      * properties.
      *
-     * @param properties  The properties describing the deserializer.
+     * @param properties The properties describing the deserializer.
      * @param classLoader The class loader for the deserializer.
-     * @param <T>         The type of the data.
+     * @param <T> The type of the data.
      * @return The {@link DeserializationSchema} described by the properties.
      */
     public static <T> DeserializationSchema<T> getDeserializationSchema(
@@ -131,9 +131,9 @@ public class TableFormatUtils {
      * Returns the {@link SerializationSchema} described by the given
      * properties.
      *
-     * @param properties  The properties describing the serializer.
+     * @param properties The properties describing the serializer.
      * @param classLoader The class loader for the serializer.
-     * @param <T>         The type of the data.
+     * @param <T> The type of the data.
      * @return The {@link SerializationSchema} described by the properties.
      */
     public static <T> SerializationSchema<T> getSerializationSchema(
@@ -154,10 +154,10 @@ public class TableFormatUtils {
      * Returns the {@link DeserializationSchema} described by the given
      * properties.
      *
-     * @param properties  The properties describing the deserializer.
-     * @param fields      The fields to project.
+     * @param properties The properties describing the deserializer.
+     * @param fields The fields to project.
      * @param classLoader The class loader for the deserializer.
-     * @param <T>         The type of the data.
+     * @param <T> The type of the data.
      * @return The {@link DeserializationSchema} described by the properties.
      */
     public static <T> DeserializationSchema<Row> getProjectedDeserializationSchema(
@@ -180,8 +180,8 @@ public class TableFormatUtils {
      * Returns the {@link SerializationSchema} described by the given
      * properties.
      *
-     * @param properties  The properties describing the serializer.
-     * @param fields      The fields to project.
+     * @param properties The properties describing the serializer.
+     * @param fields The fields to project.
      * @param classLoader The class loader for the serializer.
      * @return The {@link SerializationSchema} described by the properties.
      */
@@ -205,7 +205,7 @@ public class TableFormatUtils {
      * Returns the {@link TableFormatSerializer} described by the given
      * properties.
      *
-     * @param properties  The properties describing the serializer.
+     * @param properties The properties describing the serializer.
      * @param classLoader The class loader for the serializer.
      * @return The {@link TableFormatSerializer} described by the properties.
      */
@@ -228,7 +228,7 @@ public class TableFormatUtils {
      * Returns the {@link TableFormatDeserializer} described by the
      * given properties.
      *
-     * @param properties  The properties describing the deserializer.
+     * @param properties The properties describing the deserializer.
      * @param classLoader The class loader for the deserializer.
      * @return The {@link TableFormatDeserializer} described by the properties.
      */

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/DecimalFormatInfo.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/DecimalFormatInfo.java
@@ -18,6 +18,9 @@
 
 package org.apache.inlong.sort.formats.common;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 
 /**
@@ -25,9 +28,32 @@ import java.math.BigDecimal;
  */
 public class DecimalFormatInfo implements BasicFormatInfo<BigDecimal> {
 
-    private static final long serialVersionUID = 1L;
-
     public static final DecimalFormatInfo INSTANCE = new DecimalFormatInfo();
+
+    public static final int DEFAULT_PRECISION = 10;
+
+    public static final int DEFAULT_SCALE = 0;
+
+    private static final long serialVersionUID = 1L;
+    @JsonProperty("precision")
+    private int precision;
+
+    @JsonProperty("scale")
+    private int scale;
+
+    public DecimalFormatInfo() {
+        this(DEFAULT_PRECISION, DEFAULT_SCALE);
+    }
+
+    public DecimalFormatInfo(@JsonProperty("scale") int scale) {
+        this(DEFAULT_PRECISION, scale);
+    }
+
+    @JsonCreator
+    public DecimalFormatInfo(@JsonProperty("precision") int precision, @JsonProperty("scale") int scale) {
+        this.precision = precision;
+        this.scale = scale;
+    }
 
     @Override
     public DecimalTypeInfo getTypeInfo() {
@@ -61,5 +87,21 @@ public class DecimalFormatInfo implements BasicFormatInfo<BigDecimal> {
     @Override
     public String toString() {
         return "DecimalFormatInfo";
+    }
+
+    public int getPrecision() {
+        return precision;
+    }
+
+    public void setPrecision(int precision) {
+        this.precision = precision;
+    }
+
+    public int getScale() {
+        return scale;
+    }
+
+    public void setScale(int scale) {
+        this.scale = scale;
     }
 }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/TimeFormatInfo.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/TimeFormatInfo.java
@@ -18,17 +18,18 @@
 
 package org.apache.inlong.sort.formats.common;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.sql.Time;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import static org.apache.inlong.sort.formats.common.Constants.DATE_AND_TIME_STANDARD_ISO_8601;
 import static org.apache.inlong.sort.formats.common.Constants.DATE_AND_TIME_STANDARD_SQL;
@@ -41,21 +42,23 @@ public class TimeFormatInfo implements BasicFormatInfo<Time> {
     private static final long serialVersionUID = 1L;
 
     private static final String FIELD_FORMAT = "format";
-
+    // to support avro format, precision must be less than 3
+    private static final int DEFAULT_PRECISION_FOR_TIMESTAMP = 2;
     @JsonProperty(FIELD_FORMAT)
     @Nonnull
     private final String format;
-
     @JsonIgnore
     @Nullable
     private final SimpleDateFormat simpleDateFormat;
+    @JsonProperty("precision")
+    private int precision;
 
     @JsonCreator
     public TimeFormatInfo(
-            @JsonProperty(FIELD_FORMAT) @Nonnull String format
-    ) {
+            @JsonProperty(FIELD_FORMAT) @Nonnull String format,
+            @JsonProperty("precision") int precision) {
         this.format = format;
-
+        this.precision = precision;
         if (!format.equals("MICROS")
                 && !format.equals("MILLIS")
                 && !format.equals("SECONDS")
@@ -67,8 +70,12 @@ public class TimeFormatInfo implements BasicFormatInfo<Time> {
         }
     }
 
+    public TimeFormatInfo(@JsonProperty(FIELD_FORMAT) @Nonnull String format) {
+        this(format, DEFAULT_PRECISION_FOR_TIMESTAMP);
+    }
+
     public TimeFormatInfo() {
-        this("HH:mm:ss");
+        this("HH:mm:ss", DEFAULT_PRECISION_FOR_TIMESTAMP);
     }
 
     @Nonnull
@@ -158,5 +165,13 @@ public class TimeFormatInfo implements BasicFormatInfo<Time> {
     @Override
     public String toString() {
         return "TimeFormatInfo{" + "format='" + format + '\'' + '}';
+    }
+
+    public int getPrecision() {
+        return precision;
+    }
+
+    public void setPrecision(int precision) {
+        this.precision = precision;
     }
 }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/TypeInfo.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/common/TypeInfo.java
@@ -18,9 +18,10 @@
 
 package org.apache.inlong.sort.formats.common;
 
-import java.io.Serializable;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.Serializable;
 
 /**
  * The type information for data types.


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-4735][Sort] Add precision support for DecimalFormatInfo, TimeFormatInfo

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #4735 

### Motivation

Add precision support for DecimalFormatInfo, TimeFormatInfo

### Modifications

The precision configuration of DecimalFormatInfo, TimeFormatInfo will be supported.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
