### PR TITLE
[INLONG-4758][Doc] Remove leading $ sign in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,12 @@ Requirements:
 
 Compile and install:
 ```
-$ mvn clean install -DskipTests
+mvn clean install -DskipTests
 ```
 (Optional) Compile using docker image:
 ```
-$ docker pull maven:3.6-openjdk-8
-$ docker run -v `pwd`:/inlong  -w /inlong maven:3.6-openjdk-8 mvn clean install -DskipTests
+docker pull maven:3.6-openjdk-8
+docker run -v `pwd`:/inlong  -w /inlong maven:3.6-openjdk-8 mvn clean install -DskipTests
 ```
 after compile successfully, you could find distribution file at `inlong-distribution/target`.
 


### PR DESCRIPTION

- Fixes #4758

### Motivation

In convenience of coping and pasting for users, command line codes in READEME should remove leading $ sign. take [kafka](https://github.com/apache/kafka) for example, there is no leading $ sign before the codes in kafka READEME.md

### Modifications

Removed  leading $ sign in README.md


### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
