### PR TITLE
[INLONG-4653][Revert] Add concurrency support on GitHub Actions

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -52,10 +52,6 @@ on:
       - 'inlong-tubemq/**'
       - '!**.md'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build:
     name: Build

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -40,10 +40,6 @@ env:
   CT_CONFIG_PATH: '.github/ct.yml'
   KIND_CONFIG_PATH: '.github/kind.yml'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   chart-test:
     name: Lint and test charts

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -19,10 +19,6 @@ name: InLong Check License Header
 
 on: [ push, pull_request ]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   check-license:
     name: Check license header

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -40,10 +40,6 @@ on:
       - 'inlong-tubemq/tubemq-docker/**'
       - '!**.md'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   docker:
     name: Docker build and push
@@ -77,13 +73,6 @@ jobs:
         env:
           CI: false
 
-      # Check if only the workflow file is changed.
-      - name: Check workflow diff
-        id: check-workflow-diff
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: .github/workflows/ci_docker.yml
-
       # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
       - name: Match branch
         id: match-branch
@@ -97,10 +86,7 @@ jobs:
           fi
 
       - name: Push Docker images to Docker Hub
-        if: |
-          success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-branch.outputs.match == 'true'
+        if: ${{ success() && steps.match-branch.outputs.match == 'true' }}
         working-directory: docker
         run: bash +x publish.sh
         env:

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -52,10 +52,6 @@ on:
       - 'inlong-tubemq/**'
       - '!**.md'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   unit-test:
     name: Unit Test


### PR DESCRIPTION
Reverts apache/inlong#4654

because it will affect docker image build and cancel the running workflow.