### PR TITLE
[INLONG-4769][CI] Fix error trigger condition in the docker workflow

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -21,12 +21,18 @@ on:
   push:
     paths:
       - '.github/workflows/ci_docker.yml'
-      - '**/Dockerfile'
-      - 'inlong-agent/agent-docker/**'
-      - 'inlong-audit/audit-docker/**'
-      - 'inlong-dataproxy/dataproxy-docker/**'
-      - 'inlong-manager/manager-docker/**'
-      - 'inlong-tubemq/tubemq-docker/**'
+      - '**/pom.xml'
+      - 'inlong-agent/**'
+      - 'inlong-audit/**'
+      - 'inlong-common/**'
+      - 'inlong-dashboard/**'
+      - 'inlong-dataproxy/**'
+      - 'inlong-distribution/**'
+      - 'inlong-manager/**'
+      - 'inlong-sdk/**'
+      - 'inlong-sort/**'
+      - 'inlong-sort-standalone/**'
+      - 'inlong-tubemq/**'
       - '!**.md'
 
   pull_request:
@@ -73,6 +79,13 @@ jobs:
         env:
           CI: false
 
+      # Check if only the workflow file is changed.
+      - name: Check workflow diff
+        id: check-workflow-diff
+        uses: apache/pulsar-test-infra/diff-only@master
+        with:
+          args: .github/workflows/ci_docker.yml
+
       # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
       - name: Match branch
         id: match-branch
@@ -85,8 +98,12 @@ jobs:
               echo "::set-output name=match::true"
           fi
 
+      # If only this workflow file is changed, there is no need to publish Docker images.
       - name: Push Docker images to Docker Hub
-        if: ${{ success() && steps.match-branch.outputs.match == 'true' }}
+        if: |
+          success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish.sh
         env:


### PR DESCRIPTION
Fixes #4769

### Motivation

Now, if only the source codes are changed, the docker workflow won't be triggerd.
If the source codes are changed, the docker workflow should be triggered when pushing them, and not in a pull request.

### Modifications

In a pull request. the docker workflow is only triggered when the build files are changed.
In a pushed commit, changes to the source codes or build files will both trigger the docker workflow.
So, if you just changed the source codes, the docker workflow will not be triggered in you pull request, but it will be triggered when your pull request is merged.

```yaml
on:
  push:
    paths:
      - '.github/workflows/ci_docker.yml'
      - '**/pom.xml'
      - 'inlong-agent/**'
      - 'inlong-audit/**'
      - 'inlong-common/**'
      - 'inlong-dashboard/**'
      - 'inlong-dataproxy/**'
      - 'inlong-distribution/**'
      - 'inlong-manager/**'
      - 'inlong-sdk/**'
      - 'inlong-sort/**'
      - 'inlong-sort-standalone/**'
      - 'inlong-tubemq/**'
      - '!**.md'

  pull_request:
    paths:
      - '.github/workflows/ci_docker.yml'
      - '**/Dockerfile'
      - 'inlong-agent/agent-docker/**'
      - 'inlong-audit/audit-docker/**'
      - 'inlong-dataproxy/dataproxy-docker/**'
      - 'inlong-manager/manager-docker/**'
      - 'inlong-tubemq/tubemq-docker/**'
      - '!**.md'
```
