### PR TITLE
[INLONG-4827][Kubernets] Add Flink config into the YAML files

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       - USERNAME=root
       - PASSWORD=inlong
       - ZK_URL=tubemq-server:2181
+      - FLINK_HOST=localhost
+      - FLINK_PORT=8081
 
   webisite:
     image: inlong/dashboard

--- a/docker/kubernetes/templates/manager-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-statefulset.yaml
@@ -95,6 +95,10 @@ spec:
                   key: mysql-password
             - name: ZK_URL
               value: "{{ template "inlong.zookeeper.hostname" . }}:{{ .Values.zookeeper.ports.client }}"
+            - name: FLINK_HOST
+              value: {{ .Values.external.flink.hostname | quote }}
+            - name: FLINK_PORT
+              value: {{ .Values.external.flink.port | quote }}
             {{- range $key, $value := .Values.manager.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -645,3 +645,7 @@ external:
     enabled: false
     serviceUrl: "localhost:6650"
     adminUrl: "localhost:8080"
+  flink:
+    enabled: false
+    hostname: "127.0.0.1"
+    port: 8081

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -646,6 +646,6 @@ external:
     serviceUrl: "localhost:6650"
     adminUrl: "localhost:8080"
   flink:
-    enabled: false
+    enabled: true
     hostname: "127.0.0.1"
     port: 8081

--- a/inlong-manager/manager-docker/manager-docker.sh
+++ b/inlong-manager/manager-docker/manager-docker.sh
@@ -26,12 +26,16 @@ if [ -f "${ACTIVE_PROFILE}" ]; then
 fi
 
 conf_file="${file_path}"/conf/application-"${ACTIVE_PROFILE}".properties
+flink_conf_file="${file_path}"/plugins/flink-sort-plugin.properties
 
 # replace the configuration
 sed -i "s/spring.profiles.active=.*$/spring.profiles.active=${ACTIVE_PROFILE}/g" "${file_path}"/conf/application.properties
 sed -i "s/127.0.0.1:3306/${JDBC_URL}/g" "${conf_file}"
 sed -i "s/datasource.druid.username=.*$/datasource.druid.username=${USERNAME}/g" "${conf_file}"
 sed -i "s/datasource.druid.password=.*$/datasource.druid.password=${PASSWORD}/g" "${conf_file}"
+
+sed -i "s/flink.rest.address=.*$/flink.rest.address=${FLINK_HOST}/g" "${flink_conf_file}"
+sed -i "s/flink.rest.port=.*$/flink.rest.port=${FLINK_PORT}/g" "${flink_conf_file}"
 
 # startup the application
 JAVA_OPTS="-Dspring.profiles.active=${ACTIVE_PROFILE}"


### PR DESCRIPTION
### Prepare a Pull Request
[Improve][Kubernets] Add flink configure in k8s yaml

- Fixes #4827 

### Motivation

Add flink configure in k8s yaml.
Get env from yaml to change inlong-manager/plugins/flink-sort-plugin.properties flink hostname and port.


### Modifications

Add flink configure in k8s yaml.
Get env from yaml to change inlong-manager/plugins/flink-sort-plugin.properties flink hostname and port.

