### PR TITLE
[INLONG-4834][Manager] After deleting the data_proxy cluster config, the data_proxy node under it was not deleted

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -342,6 +342,13 @@ public class InlongClusterServiceImpl implements InlongClusterService {
             return false;
         }
 
+        List<InlongClusterNodeEntity> nodeEntities = clusterNodeMapper.selectByParentId(id);
+        if (CollectionUtils.isNotEmpty(nodeEntities)) {
+            String errMsg = String.format("there are undeleted nodes under the cluster [%s], "
+                    + "please delete the node first", entity.getName());
+            throw new BusinessException(errMsg);
+        }
+
         entity.setIsDeleted(entity.getId());
         entity.setModifier(operator);
         clusterMapper.updateById(entity);


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #4834 

### Motivation

*After deleting the data_proxy cluster config, the data_proxy node under it was not deleted*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.
