### PR TITLE
[INLONG-4843][Manager] Add RPC URL for TubeMQ cluster 

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterDTO.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterDTO.java
@@ -13,36 +13,49 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package org.apache.inlong.manager.common.pojo.cluster.tube;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-import org.apache.inlong.manager.common.enums.ClusterType;
-import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
-import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+
+import javax.validation.constraints.NotNull;
 
 /**
- * Inlong cluster request for Tube
+ * Tube cluster info
  */
 @Data
-@ToString(callSuper = true)
-@EqualsAndHashCode(callSuper = true)
-@JsonTypeDefine(value = ClusterType.TUBE)
-@ApiModel("Inlong cluster request for Tube")
-public class TubeClusterRequest extends ClusterRequest {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Tube cluster info")
+public class TubeClusterDTO {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(); // thread safe
 
     @ApiModelProperty(value = "Master URL http://120.0.0.1:8080")
     private String masterUrl;
 
-    // no field
-
-    public TubeClusterRequest() {
-        this.setType(ClusterType.TUBE);
+    /**
+     * Get the dto instance from the JSON string.
+     */
+    public static TubeClusterDTO getFromJson(@NotNull String extParams) {
+        try {
+            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return OBJECT_MAPPER.readValue(extParams, TubeClusterDTO.class);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.GROUP_INFO_INCORRECT.getMessage());
+        }
     }
 
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterDTO.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterDTO.java
@@ -43,8 +43,8 @@ public class TubeClusterDTO {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(); // thread safe
 
-    @ApiModelProperty(value = "Master URL http://120.0.0.1:8080")
-    private String masterUrl;
+    @ApiModelProperty(value = "Master Web URL http://120.0.0.1:8080")
+    private String masterWebUrl;
 
     /**
      * Get the dto instance from the JSON string.

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
@@ -37,8 +37,8 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @ApiModel("Inlong cluster info for Tube")
 public class TubeClusterInfo extends ClusterInfo {
 
-    @ApiModelProperty(value = "Master URL http://120.0.0.1:8080")
-    private String masterUrl;
+    @ApiModelProperty(value = "Master Web URL http://120.0.0.1:8080")
+    private String masterWebUrl;
 
     public TubeClusterInfo() {
         this.setType(ClusterType.TUBE);

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterInfo.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.common.pojo.cluster.tube;
 
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -36,7 +37,8 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @ApiModel("Inlong cluster info for Tube")
 public class TubeClusterInfo extends ClusterInfo {
 
-    // no fields
+    @ApiModelProperty(value = "Master URL http://120.0.0.1:8080")
+    private String masterUrl;
 
     public TubeClusterInfo() {
         this.setType(ClusterType.TUBE);

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/tube/TubeClusterRequest.java
@@ -36,8 +36,8 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @ApiModel("Inlong cluster request for Tube")
 public class TubeClusterRequest extends ClusterRequest {
 
-    @ApiModelProperty(value = "Master URL http://120.0.0.1:8080")
-    private String masterUrl;
+    @ApiModelProperty(value = "Master Web URL http://120.0.0.1:8080")
+    private String masterWebUrl;
 
     // no field
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -355,8 +355,8 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         Preconditions.checkNotNull(approveInfo, "inlong approve request cannot be empty");
         String groupId = approveInfo.getInlongGroupId();
         Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
-        String mqType = approveInfo.getMqType();
-        Preconditions.checkNotNull(mqType, "MQ type cannot be empty");
+        // String mqType = approveInfo.getMqType();
+        Preconditions.checkNotNull("TUBE", "MQ type cannot be empty");
 
         // update status to [GROUP_APPROVE_PASSED]
         this.updateStatus(groupId, GroupStatus.APPROVE_PASSED.getCode(), operator);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -355,8 +355,8 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         Preconditions.checkNotNull(approveInfo, "inlong approve request cannot be empty");
         String groupId = approveInfo.getInlongGroupId();
         Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
-        // String mqType = approveInfo.getMqType();
-        Preconditions.checkNotNull("TUBE", "MQ type cannot be empty");
+        String mqType = approveInfo.getMqType();
+        Preconditions.checkNotNull(mqType, "MQ type cannot be empty");
 
         // update status to [GROUP_APPROVE_PASSED]
         this.updateStatus(groupId, GroupStatus.APPROVE_PASSED.getCode(), operator);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/mq/util/TubeMQOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/mq/util/TubeMQOperator.java
@@ -69,7 +69,7 @@ public class TubeMQOperator {
      * Create topic for the given tube cluster.
      */
     public void createTopic(@Nonnull TubeClusterInfo tubeCluster, String topicName, String operator) {
-        String masterUrl = tubeCluster.getMasterUrl();
+        String masterUrl = tubeCluster.getMasterWebUrl();
         LOGGER.info("begin to create tube topic {} in master {}", topicName, masterUrl);
         if (StringUtils.isEmpty(masterUrl) || StringUtils.isEmpty(topicName)) {
             throw new BusinessException("tube master url or tube topic cannot be null");
@@ -88,7 +88,7 @@ public class TubeMQOperator {
      * Create consumer group for the given tube topic and cluster.
      */
     public void createConsumerGroup(TubeClusterInfo tubeCluster, String topic, String consumerGroup, String operator) {
-        String masterUrl = tubeCluster.getMasterUrl();
+        String masterUrl = tubeCluster.getMasterWebUrl();
         LOGGER.info("begin to create consumer group {} for topic {} in master {}", consumerGroup, topic, masterUrl);
         if (StringUtils.isEmpty(masterUrl) || StringUtils.isEmpty(consumerGroup) || StringUtils.isEmpty(topic)) {
             throw new BusinessException("tube master url, consumer group, or tube topic cannot be null");

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/mq/util/TubeMQOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/mq/util/TubeMQOperator.java
@@ -69,7 +69,7 @@ public class TubeMQOperator {
      * Create topic for the given tube cluster.
      */
     public void createTopic(@Nonnull TubeClusterInfo tubeCluster, String topicName, String operator) {
-        String masterUrl = tubeCluster.getUrl();
+        String masterUrl = tubeCluster.getMasterUrl();
         LOGGER.info("begin to create tube topic {} in master {}", topicName, masterUrl);
         if (StringUtils.isEmpty(masterUrl) || StringUtils.isEmpty(topicName)) {
             throw new BusinessException("tube master url or tube topic cannot be null");
@@ -88,7 +88,7 @@ public class TubeMQOperator {
      * Create consumer group for the given tube topic and cluster.
      */
     public void createConsumerGroup(TubeClusterInfo tubeCluster, String topic, String consumerGroup, String operator) {
-        String masterUrl = tubeCluster.getUrl();
+        String masterUrl = tubeCluster.getMasterUrl();
         LOGGER.info("begin to create consumer group {} for topic {} in master {}", consumerGroup, topic, masterUrl);
         if (StringUtils.isEmpty(masterUrl) || StringUtils.isEmpty(consumerGroup) || StringUtils.isEmpty(topic)) {
             throw new BusinessException("tube master url, consumer group, or tube topic cannot be null");


### PR DESCRIPTION
Add Manager configuration parameters to Tube.

- Fixes #4843 

### Motivation
Task configuration succeeded.

<img width="1652" alt="image" src="https://user-images.githubusercontent.com/17596132/177004029-c914a6ee-5f84-4501-bba9-589ea7fddf6f.png">


### Modifications

Add RPC Url

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
