### PR TITLE
[INLONG-4814][Sort][Manager] Declare the primary key for sink table when the query contains update/delete

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -281,7 +281,11 @@ public class LoadNodeUtils {
                 ckSink.getTableName(),
                 ckSink.getJdbcUrl() + "/" + ckSink.getDbName(),
                 ckSink.getUsername(),
-                ckSink.getPassword()
+                ckSink.getPassword(),
+                ckSink.getEngine(),
+                ckSink.getPartitionBy(),
+                ckSink.getOrderBy(),
+                ckSink.getPrimaryKey()
         );
     }
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -282,9 +282,6 @@ public class LoadNodeUtils {
                 ckSink.getJdbcUrl() + "/" + ckSink.getDbName(),
                 ckSink.getUsername(),
                 ckSink.getPassword(),
-                ckSink.getEngine(),
-                ckSink.getPartitionBy(),
-                ckSink.getOrderBy(),
                 ckSink.getPrimaryKey()
         );
     }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
@@ -37,6 +37,11 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * clickHouse update operations is heavy, it will takes precedence over all others operation to execute, so it has a
+ * poor performance. It is more suitable for batch scenes but not streaming scenes where operations are performed
+ * frequently.
+ */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("clickHouseLoad")
 @Data

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
@@ -61,6 +61,18 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
     @Nonnull
     private String password;
 
+    @JsonProperty("engine")
+    private String engine;
+
+    @JsonProperty("partitionBy")
+    private String partitionBy;
+
+    @JsonProperty("orderBy")
+    private String orderBy;
+
+    @JsonProperty("primaryKey")
+    private String primaryKey;
+
     @JsonCreator
     public ClickHouseLoadNode(@JsonProperty("id") String id,
             @JsonProperty("name") String name,
@@ -73,12 +85,21 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
             @Nonnull @JsonProperty("tableName") String tableName,
             @Nonnull @JsonProperty("url") String url,
             @Nonnull @JsonProperty("userName") String userName,
-            @Nonnull @JsonProperty("passWord") String password) {
+            @Nonnull @JsonProperty("passWord") String password,
+            @JsonProperty("engine") String engine,
+            @JsonProperty("partitionBy") String partitionBy,
+            @JsonProperty("orderBy") String orderBy,
+            @JsonProperty("primaryKey") String primaryKey
+    ) {
         super(id, name, fields, fieldRelations, filters, filterStrategy, sinkParallelism, properties);
         this.tableName = Preconditions.checkNotNull(tableName, "table name is null");
         this.url = Preconditions.checkNotNull(url, "url is null");
         this.userName = Preconditions.checkNotNull(userName, "userName is null");
         this.password = Preconditions.checkNotNull(password, "password is null");
+        this.engine = engine;
+        this.partitionBy = partitionBy;
+        this.orderBy = orderBy;
+        this.primaryKey = primaryKey;
     }
 
     @Override
@@ -100,7 +121,7 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
 
     @Override
     public String getPrimaryKey() {
-        return super.getPrimaryKey();
+        return primaryKey;
     }
 
     @Override

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNode.java
@@ -66,15 +66,6 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
     @Nonnull
     private String password;
 
-    @JsonProperty("engine")
-    private String engine;
-
-    @JsonProperty("partitionBy")
-    private String partitionBy;
-
-    @JsonProperty("orderBy")
-    private String orderBy;
-
     @JsonProperty("primaryKey")
     private String primaryKey;
 
@@ -91,9 +82,6 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
             @Nonnull @JsonProperty("url") String url,
             @Nonnull @JsonProperty("userName") String userName,
             @Nonnull @JsonProperty("passWord") String password,
-            @JsonProperty("engine") String engine,
-            @JsonProperty("partitionBy") String partitionBy,
-            @JsonProperty("orderBy") String orderBy,
             @JsonProperty("primaryKey") String primaryKey
     ) {
         super(id, name, fields, fieldRelations, filters, filterStrategy, sinkParallelism, properties);
@@ -101,9 +89,6 @@ public class ClickHouseLoadNode extends LoadNode implements Serializable {
         this.url = Preconditions.checkNotNull(url, "url is null");
         this.userName = Preconditions.checkNotNull(userName, "userName is null");
         this.password = Preconditions.checkNotNull(password, "password is null");
-        this.engine = engine;
-        this.partitionBy = partitionBy;
-        this.orderBy = orderBy;
         this.primaryKey = primaryKey;
     }
 

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNodeTest.java
@@ -45,9 +45,6 @@ public class ClickHouseLoadNodeTest extends SerializeBaseTest<Node> {
                 "jdbc:clickhouse://localhost:8023/default",
                 "root",
                 "root",
-                "Log",
-                "",
-                "",
                 ""
         );
     }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ClickHouseLoadNodeTest.java
@@ -44,6 +44,11 @@ public class ClickHouseLoadNodeTest extends SerializeBaseTest<Node> {
                 "ck_demo",
                 "jdbc:clickhouse://localhost:8023/default",
                 "root",
-                "root");
+                "root",
+                "Log",
+                "",
+                "",
+                ""
+        );
     }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
@@ -27,6 +27,9 @@ import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
 
 /**
  * JDBC dialect for ClickHouse SQL.
@@ -120,4 +123,37 @@ public class ClickHouseDialect extends AbstractJdbcDialect {
                 LogicalTypeRoot.UNRESOLVED);
     }
 
+    /**
+     * Get update one row statement by condition fields
+     */
+    @Override
+    public String getUpdateStatement(
+            String tableName, String[] fieldNames, String[] conditionFields) {
+        String setClause =
+                Arrays.stream(fieldNames)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(", "));
+        String conditionClause =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        return "ALTER TABLE "
+                + quoteIdentifier(tableName)
+                + " UPDATE "
+                + setClause
+                + " WHERE "
+                + conditionClause;
+    }
+
+    /**
+     * Get delete one row statement by condition fields
+     */
+    @Override
+    public String getDeleteStatement(String tableName, String[] conditionFields) {
+        String conditionClause =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        return "ALTER TABLE " + quoteIdentifier(tableName) + " DELETE WHERE " + conditionClause;
+    }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDialects.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDialects.java
@@ -20,7 +20,6 @@ package org.apache.inlong.sort.jdbc.table;
 
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
 import org.apache.flink.connector.jdbc.dialect.MySQLDialect;
-import org.apache.inlong.sort.jdbc.dialect.ClickHouseDialect;
 import org.apache.inlong.sort.jdbc.dialect.OracleDialect;
 import org.apache.inlong.sort.jdbc.dialect.SqlServerDialect;
 import org.apache.inlong.sort.jdbc.dialect.TDSQLPostgresDialect;
@@ -45,7 +44,6 @@ public final class JdbcDialects {
         DIALECTS.add(new TDSQLPostgresDialect());
         DIALECTS.add(new SqlServerDialect());
         DIALECTS.add(new OracleDialect());
-        DIALECTS.add(new ClickHouseDialect());
     }
 
     /**

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDialects.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDialects.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.jdbc.table;
 
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
 import org.apache.flink.connector.jdbc.dialect.MySQLDialect;
+import org.apache.inlong.sort.jdbc.dialect.ClickHouseDialect;
 import org.apache.inlong.sort.jdbc.dialect.OracleDialect;
 import org.apache.inlong.sort.jdbc.dialect.SqlServerDialect;
 import org.apache.inlong.sort.jdbc.dialect.TDSQLPostgresDialect;
@@ -44,6 +45,7 @@ public final class JdbcDialects {
         DIALECTS.add(new TDSQLPostgresDialect());
         DIALECTS.add(new SqlServerDialect());
         DIALECTS.add(new OracleDialect());
+        DIALECTS.add(new ClickHouseDialect());
     }
 
     /**

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ClickHouseSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ClickHouseSqlParserTest.java
@@ -80,9 +80,6 @@ public class ClickHouseSqlParserTest {
                 "jdbc:clickhouse://localhost:8123/demo",
                 "default",
                 "",
-                "Log",
-                "",
-                "",
                 "");
 
     }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ClickHouseSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ClickHouseSqlParserTest.java
@@ -21,11 +21,11 @@ package org.apache.inlong.sort.parser;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
-import org.apache.inlong.sort.parser.result.ParseResult;
 import org.apache.inlong.sort.formats.common.LongFormatInfo;
 import org.apache.inlong.sort.formats.common.StringFormatInfo;
 import org.apache.inlong.sort.jdbc.dialect.ClickHouseDialect;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.GroupInfo;
 import org.apache.inlong.sort.protocol.StreamInfo;
@@ -79,6 +79,10 @@ public class ClickHouseSqlParserTest {
                 "ck_demo",
                 "jdbc:clickhouse://localhost:8123/demo",
                 "default",
+                "",
+                "Log",
+                "",
+                "",
                 "");
 
     }

--- a/inlong-sort/sort-end-to-end-tests/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>clickhouse</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <scope>test</scope>
@@ -113,7 +118,11 @@
             <artifactId>flink-table-planner-blink_${flink.scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>ru.yandex.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-sort/sort-end-to-end-tests/src/test/java/org/apache/inlong/sort/tests/ClickHouseCase.java
+++ b/inlong-sort/sort-end-to-end-tests/src/test/java/org/apache/inlong/sort/tests/ClickHouseCase.java
@@ -1,0 +1,161 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.inlong.sort.tests;
+
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.JdbcProxy;
+import org.apache.inlong.sort.tests.utils.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ClickHouseContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * End-to-end tests
+ * Test flink sql mysql cdc to clickHouse
+ */
+public class ClickHouseCase extends FlinkContainerTestEnv {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseCase.class);
+
+    private static final Path jdbcJar = TestUtils.getResource("sort-connector-jdbc.jar");
+    private static final Path mysqlJar = TestUtils.getResource("sort-connector-mysql-cdc.jar");
+    private static final Path mysqlJdbcJar = TestUtils.getResource("mysql-driver.jar");
+    // Can't use getResource("xxx").getPath(), windows will don't know that path
+    private static final String sqlFile;
+
+    static {
+        try {
+            sqlFile = Paths.get(ClickHouseCase.class.getResource("/flinkSql/clickhouse_test.sql").toURI()).toString();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @ClassRule
+    public static final ClickHouseContainer CLICK_HOUSE_CONTAINER = (ClickHouseContainer) new ClickHouseContainer(
+            "yandex/clickhouse-server:20.1.8.41")
+            .withNetwork(NETWORK)
+            .withNetworkAliases("clickhouse")
+            .withLogConsumer(new Slf4jLogConsumer(LOG));
+
+    @Before
+    public void setup() {
+        initializeMysqlTable();
+        initializeClickHouseTable();
+    }
+
+    @After
+    public void teardown() {
+        if (CLICK_HOUSE_CONTAINER != null) {
+            CLICK_HOUSE_CONTAINER.stop();
+        }
+    }
+
+    private void initializeClickHouseTable() {
+        try {
+            Class.forName(CLICK_HOUSE_CONTAINER.getDriverClassName());
+            Connection conn = DriverManager
+                    .getConnection(CLICK_HOUSE_CONTAINER.getJdbcUrl(), CLICK_HOUSE_CONTAINER.getUsername(),
+                            CLICK_HOUSE_CONTAINER.getPassword());
+            Statement stat = conn.createStatement();
+            stat.execute("create table test_output1 (\n"
+                    + "       id Int32,\n"
+                    + "       name Nullable(String),\n"
+                    + "       description Nullable(String)\n"
+                    + ")\n"
+                    + "engine=MergeTree ORDER BY id;");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void initializeMysqlTable() {
+        try (Connection conn =
+                DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+                Statement stat = conn.createStatement()) {
+            stat.execute(
+                    "CREATE TABLE test_input1 (\n"
+                            + "  id INTEGER primary key,\n"
+                            + "  name VARCHAR(255) NOT NULL DEFAULT 'flink',\n"
+                            + "  description VARCHAR(512)\n"
+                            + ");");
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    /**
+     * Test flink sql mysql cdc to clickHouse
+     *
+     * @throws Exception The exception may throws when execute the case
+     */
+    @Test
+    public void testClickHouseUpdateAndDelete() throws Exception {
+        submitSQLJob(sqlFile, jdbcJar, mysqlJar, mysqlJdbcJar);
+        waitUntilJobRunning(Duration.ofSeconds(30));
+
+        // generate input
+        try (Connection conn =
+                DriverManager.getConnection(MYSQL.getJdbcUrl(), MYSQL.getUsername(), MYSQL.getPassword());
+                Statement stat = conn.createStatement()) {
+            stat.execute(
+                    "INSERT INTO test_input1 "
+                            + "VALUES (1,'jacket','water resistent white wind breaker');");
+            stat.execute(
+                    "INSERT INTO test_input1 VALUES (2,'scooter','Big 2-wheel scooter ');");
+            stat.execute(
+                    "update test_input1 set name = 'tom' where id = 2;");
+            stat.execute(
+                    "delete from test_input1 where id = 1;");
+        } catch (SQLException e) {
+            LOG.error("Update table for CDC failed.", e);
+            throw e;
+        }
+
+        JdbcProxy proxy =
+                new JdbcProxy(CLICK_HOUSE_CONTAINER.getJdbcUrl(), CLICK_HOUSE_CONTAINER.getUsername(),
+                        CLICK_HOUSE_CONTAINER.getPassword(),
+                        CLICK_HOUSE_CONTAINER.getDriverClassName());
+        List<String> expectResult =
+                Arrays.asList("2,tom,Big 2-wheel scooter ");
+        proxy.checkResultWithTimeout(
+                expectResult,
+                "test_output1",
+                3,
+                60000L);
+    }
+
+}

--- a/inlong-sort/sort-end-to-end-tests/src/test/java/org/apache/inlong/sort/tests/ClickHouseCase.java
+++ b/inlong-sort/sort-end-to-end-tests/src/test/java/org/apache/inlong/sort/tests/ClickHouseCase.java
@@ -96,6 +96,8 @@ public class ClickHouseCase extends FlinkContainerTestEnv {
                     + "       description Nullable(String)\n"
                     + ")\n"
                     + "engine=MergeTree ORDER BY id;");
+            stat.close();
+            conn.close();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/inlong-sort/sort-end-to-end-tests/src/test/resources/flinkSql/clickhouse_test.sql
+++ b/inlong-sort/sort-end-to-end-tests/src/test/resources/flinkSql/clickhouse_test.sql
@@ -1,0 +1,33 @@
+CREATE TABLE test_input1 (
+    `id` INT primary key,
+    name STRING,
+    description STRING
+) WITH (
+    'connector' = 'mysql-cdc-inlong',
+    'hostname' = 'mysql',
+    'port' = '3306',
+    'username' = 'inlong',
+    'password' = 'inlong',
+    'database-name' = 'test',
+    'table-name' = 'test_input1',
+    'scan.incremental.snapshot.chunk.size' = '4',
+    'scan.incremental.snapshot.enabled' = 'false'
+);
+
+CREATE TABLE test_output1 (
+    `id` INT primary key,
+    name STRING,
+    description STRING
+) WITH (
+    'connector' = 'jdbc-inlong',
+    'url' = 'jdbc:clickhouse://clickhouse:8123/default',
+    'table-name' = 'test_output1',
+    'username' = 'default',
+    'password' = ''
+);
+
+INSERT INTO test_output1 select * from test_input1;
+
+
+
+

--- a/inlong-sort/sort-end-to-end-tests/src/test/resources/flinkSql/clickhouse_test.sql
+++ b/inlong-sort/sort-end-to-end-tests/src/test/resources/flinkSql/clickhouse_test.sql
@@ -23,11 +23,11 @@ CREATE TABLE test_output1 (
     'url' = 'jdbc:clickhouse://clickhouse:8123/default',
     'table-name' = 'test_output1',
     'username' = 'default',
-    'password' = ''
+    'password' = '',
+    'dialect-impl' = 'org.apache.inlong.sort.jdbc.dialect.ClickHouseDialect'
 );
 
 INSERT INTO test_output1 select * from test_input1;
-
 
 
 


### PR DESCRIPTION
Handling exceptions: please declare primary key for sink table when query contains update/delete record.

- Fixes #4814 

Briefly describe ideas

1. The problem is that with flink JDBC SQL you have to specify the primary key.
![wecom-temp-5cf30d79023ca92a09bfb0eaee00ac84](https://user-images.githubusercontent.com/20356765/177348452-d69faf2a-cc61-4d8e-bbde-655f3309b610.png)

2. When the Sort module sees the processing of primaryKey, it should be a problem with the parameters in the node. Gotta go check it out
![wecom-temp-ae9621b69bbce4feb44abe2b79454ee2](https://user-images.githubusercontent.com/20356765/177348105-93502218-fd38-4f0d-8f90-f75caa7929a8.png)

3. Debug test locates that the primaryKey in the file read by sort is indeed empty
<img width="1581" alt="image" src="https://user-images.githubusercontent.com/20356765/177348864-00113314-63bb-4c8c-a540-10cc42af4d9a.png">

4.  To query the source of assignment of GroupInfo.StreamInfo.nodes, there are only CreateSortConfigListenerV2 and CreateStreamSortConfigListener classes, and they are both created by the createNodesForStream() method.
![image](https://user-images.githubusercontent.com/20356765/177351283-b31ecc2e-507e-4fd3-8461-9fb69db6b4bf.png)

5. Test after bug fixes
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/20356765/177351479-b449221e-0169-401a-8996-51f29a07cc99.png">


