### PR TITLE
[INLONG-4874][Manager] Cascade modification of associated data when modifying or deleting cluster tag

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
@@ -32,7 +32,7 @@ public interface InlongClusterEntityMapper {
     InlongClusterEntity selectById(Integer id);
 
     /**
-     * Select clusters by tags, name and type, the tag and name can be null.
+     * Select clusters by tags, name and type.
      */
     List<InlongClusterEntity> selectByKey(@Param("clusterTag") String clusterTag, @Param("name") String name,
             @Param("type") String type);

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -43,6 +43,8 @@ public interface InlongGroupEntityMapper {
 
     List<InlongGroupBriefInfo> selectBriefList(InlongGroupPageRequest request);
 
+    List<InlongGroupEntity> selectByClusterTag(@Param(value = "inlongClusterTag") String inlongClusterTag);
+
     int updateByPrimaryKey(InlongGroupEntity record);
 
     int updateByIdentifierSelective(InlongGroupEntity record);

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -65,14 +65,15 @@
         from inlong_cluster
         where id = #{id,jdbcType=INTEGER}
     </select>
-    <select id="selectByKey" parameterType="org.apache.inlong.manager.common.pojo.cluster.ClusterRequest"
-            resultType="org.apache.inlong.manager.dao.entity.InlongClusterEntity">
+    <select id="selectByKey" resultType="org.apache.inlong.manager.dao.entity.InlongClusterEntity">
         select
         <include refid="Base_Column_List"/>
         from inlong_cluster
         <where>
             is_deleted = 0
-            and `type` = #{type, jdbcType=VARCHAR}
+            <if test="type != null and type != ''">
+                and `type` = #{type, jdbcType=VARCHAR}
+            </if>
             <if test="clusterTag != null and clusterTag != ''">
                 and find_in_set(#{clusterTag, jdbcType=VARCHAR}, cluster_tags)
             </if>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -185,6 +185,14 @@
         order by modify_time desc
         limit 100
     </select>
+    <select id="selectByClusterTag" resultType="org.apache.inlong.manager.dao.entity.InlongGroupEntity">
+        select
+        <include refid="Base_Column_List"/>
+        from inlong_group
+        where is_deleted = 0
+        and inlong_cluster_tag = #{inlongClusterTag, jdbcType=VARCHAR}
+        limit 10
+    </select>
 
     <update id="updateByPrimaryKey" parameterType="org.apache.inlong.manager.dao.entity.InlongGroupEntity">
         update inlong_group


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #4874

### Motivation

Cascade modification of associated data when modifying or deleting cluster tag.

### Modifications

Modify or delete the cluster tag, if there are some InlongGroups that use this tag, an exception will be thrown and those InlongGroupIds using this cluster tag will be returned.

If there is no InlongGroup using this tag, modify/delete the tag and modify/delete the tag associated with other clusters.

### Verifying this change

- [x] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)
