### PR TITLE
[INLONG-4890][Sort] Support TubeMQ connector

### DIFF
--- a/inlong-distribution/src/main/assemblies/sort-connectors.xml
+++ b/inlong-distribution/src/main/assemblies/sort-connectors.xml
@@ -139,6 +139,14 @@
             </includes>
             <fileMode>0644</fileMode>
         </fileSet>
+        <fileSet>
+            <directory>../inlong-sort/sort-connectors/tubemq/target</directory>
+            <outputDirectory>inlong-sort/connectors</outputDirectory>
+            <includes>
+                <include>sort-connector-tubemq-${project.version}.jar</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
         <!-- module's 3td-licenses, notices-->
         <fileSet>
             <directory>../licenses/inlong-sort-connectors</directory>

--- a/inlong-sort/sort-connectors/pom.xml
+++ b/inlong-sort/sort-connectors/pom.xml
@@ -51,6 +51,7 @@
         <module>elasticsearch-base</module>
         <module>elasticsearch-6</module>
         <module>elasticsearch-7</module>
+        <module>tubemq</module>
     </modules>
 
     <dependencies>

--- a/inlong-sort/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-connectors/tubemq/pom.xml
@@ -37,13 +37,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
         </dependency>
     </dependencies>
 
@@ -60,13 +59,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.inlong:tubemq-client</include>
-                                    <include>org.apache.inlong:sort-common</include>
-                                    <include>org.apache.inlong:flink-table-common</include>
-                                </includes>
-                            </artifactSet>
                             <filters>
                                 <filter>
                                     <artifact>org.apache.inlong:sort-connector-*</artifact>

--- a/inlong-sort/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-connectors/tubemq/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>sort-connectors</artifactId>
+        <groupId>org.apache.inlong</groupId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>sort-connector-tubemq</artifactId>
+    <name>Apache InLong - Sort-connector-tubemq</name>
+    <packaging>jar</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>tubemq-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.inlong:tubemq-client</include>
+                                    <include>org.apache.inlong:sort-common</include>
+                                    <include>org.apache.inlong:flink-table-common</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/inlong-sort/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-connectors/tubemq/pom.xml
@@ -69,6 +69,13 @@
                             </artifactSet>
                             <filters>
                                 <filter>
+                                    <artifact>org.apache.inlong:sort-connector-*</artifact>
+                                    <includes>
+                                        <include>org/apache/inlong/**</include>
+                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
+                                    </includes>
+                                </filter>
+                                <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/*.SF</exclude>

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
@@ -1,0 +1,362 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.tubemq;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.inlong.sort.tubemq.table.TubeMQOptions;
+import org.apache.inlong.tubemq.client.config.ConsumerConfig;
+import org.apache.inlong.tubemq.client.consumer.ConsumePosition;
+import org.apache.inlong.tubemq.client.consumer.ConsumerResult;
+import org.apache.inlong.tubemq.client.consumer.PullMessageConsumer;
+import org.apache.inlong.tubemq.client.factory.TubeSingleSessionFactory;
+import org.apache.inlong.tubemq.corebase.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO;
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.TimeUtils.parseDuration;
+
+/**
+ * The Flink TubeMQ Consumer.
+ *
+ * @param <T> The type of records produced by this data source
+ */
+public class FlinkTubeMQConsumer<T>
+        extends RichParallelSourceFunction<T> implements CheckpointedFunction {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FlinkTubeMQConsumer.class);
+
+    private static final String TUBE_OFFSET_STATE = "tube-offset-state";
+
+    private static final String SPLIT_COMMA = ",";
+    private static final String SPLIT_COLON = ":";
+
+    /**
+     * The address of TubeMQ master, format eg: 127.0.0.1:8715,127.0.0.2:8715.
+     */
+    private final String masterAddress;
+
+    /**
+     * The topic name.
+     */
+    private final String topic;
+
+    /**
+     * The tubemq consumers use this tid set to filter records reading from server.
+     */
+    private final TreeSet<String> tidSet;
+
+    /**
+     * The consumer group name.
+     */
+    private final String consumerGroup;
+
+    /**
+     * The deserializer for records.
+     */
+    private final DeserializationSchema<T> deserializationSchema;
+
+    /**
+     * The random key for TubeMQ consumer group when startup.
+     */
+    private final String sessionKey;
+
+    /**
+     * True if consuming message from max offset.
+     */
+    private final boolean consumeFromMax;
+
+    /**
+     * The time to wait if tubemq broker returns message not found.
+     */
+    private final Duration messageNotFoundWaitPeriod;
+
+    /**
+     * The max time to marked source idle.
+     */
+    private final Duration maxIdleTime;
+
+    /**
+     * Flag indicating whether the consumer is still running.
+     **/
+    private volatile boolean running;
+
+    /**
+     * The state for the offsets of queues.
+     */
+    private transient ListState<Tuple2<String, Long>> offsetsState;
+
+    /**
+     * The current offsets of partitions which are stored in {@link #offsetsState}
+     * once a checkpoint is triggered.
+     *
+     * NOTE: The offsets are populated in the main thread and saved in the
+     * checkpoint thread. Its usage must be guarded by the checkpoint lock.</p>
+     */
+    private transient Map<String, Long> currentOffsets;
+
+    /**
+     * The TubeMQ session factory.
+     */
+    private transient TubeSingleSessionFactory messageSessionFactory;
+
+    /**
+     * The TubeMQ pull consumer.
+     */
+    private transient PullMessageConsumer messagePullConsumer;
+
+    /**
+     * Build a TubeMQ source function
+     *
+     * @param masterAddress the master address of TubeMQ
+     * @param topic the topic name
+     * @param tidSet the  topic's filter condition items
+     * @param consumerGroup the consumer group name
+     * @param deserializationSchema the deserialize schema
+     * @param configuration the configure
+     */
+    public FlinkTubeMQConsumer(
+            String masterAddress,
+            String topic,
+            TreeSet<String> tidSet,
+            String consumerGroup,
+            DeserializationSchema<T> deserializationSchema,
+            Configuration configuration,
+            String sessionKey
+    ) {
+        checkNotNull(masterAddress,
+                "The master address must not be null.");
+        checkNotNull(topic,
+                "The topic must not be null.");
+        checkNotNull(tidSet,
+                "The tid set must not be null.");
+        checkNotNull(consumerGroup,
+                "The consumer group must not be null.");
+        checkNotNull(deserializationSchema,
+                "The deserialization schema must not be null.");
+        checkNotNull(configuration,
+                "The configuration must not be null.");
+
+        this.masterAddress = masterAddress;
+        this.topic = topic;
+        this.tidSet = tidSet;
+        this.consumerGroup = consumerGroup;
+        this.deserializationSchema = deserializationSchema;
+        this.sessionKey = sessionKey;
+
+        //those param set default
+        this.consumeFromMax =
+                configuration.getBoolean(TubeMQOptions.BOOTSTRAP_FROM_MAX);
+        this.messageNotFoundWaitPeriod =
+                parseDuration(
+                        configuration.getString(
+                                TubeMQOptions.MESSAGE_NOT_FOUND_WAIT_PERIOD));
+        this.maxIdleTime =
+                parseDuration(
+                        configuration.getString(
+                                TubeMQOptions.SOURCE_MAX_IDLE_TIME));
+    }
+
+    @Override
+    public void initializeState(
+            FunctionInitializationContext context
+    ) throws Exception {
+
+        TypeInformation<Tuple2<String, Long>> typeInformation =
+                new TupleTypeInfo<>(STRING_TYPE_INFO, LONG_TYPE_INFO);
+        ListStateDescriptor<Tuple2<String, Long>> stateDescriptor =
+                new ListStateDescriptor<>(TUBE_OFFSET_STATE, typeInformation);
+
+        OperatorStateStore stateStore = context.getOperatorStateStore();
+        offsetsState = stateStore.getListState(stateDescriptor);
+
+        currentOffsets = new HashMap<>();
+        if (context.isRestored()) {
+            for (Tuple2<String, Long> tubeOffset : offsetsState.get()) {
+                currentOffsets.put(tubeOffset.f0, tubeOffset.f1);
+            }
+
+            LOG.info("Successfully restore the offsets {}.", currentOffsets);
+        } else {
+            LOG.info("No restore offsets.");
+        }
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        ConsumerConfig consumerConfig =
+                new ConsumerConfig(masterAddress, consumerGroup);
+        consumerConfig.setConsumePosition(consumeFromMax
+                ? ConsumePosition.CONSUMER_FROM_MAX_OFFSET_ALWAYS
+                : ConsumePosition.CONSUMER_FROM_FIRST_OFFSET);
+
+        consumerConfig.setMsgNotFoundWaitPeriodMs(messageNotFoundWaitPeriod.toMillis());
+
+        final int numTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+
+        messageSessionFactory = new TubeSingleSessionFactory(consumerConfig);
+
+        messagePullConsumer =
+                messageSessionFactory.createPullConsumer(consumerConfig);
+        messagePullConsumer
+                .subscribe(topic, tidSet);
+        messagePullConsumer
+                .completeSubscribe(sessionKey, numTasks, true, currentOffsets);
+
+        running = true;
+    }
+
+    @Override
+    public void run(SourceContext<T> ctx) throws Exception {
+
+        Instant lastConsumeInstant = Instant.now();
+
+        while (running) {
+
+            ConsumerResult consumeResult = messagePullConsumer.getMessage();
+            if (!consumeResult.isSuccess()) {
+                if (!(consumeResult.getErrCode() == 400
+                        || consumeResult.getErrCode() == 404
+                        || consumeResult.getErrCode() == 405
+                        || consumeResult.getErrCode() == 406
+                        || consumeResult.getErrCode() == 407
+                        || consumeResult.getErrCode() == 408)) {
+                    LOG.info("Could not consume messages from tubemq (errcode: {}, "
+                                    + "errmsg: {}).", consumeResult.getErrCode(),
+                            consumeResult.getErrMsg());
+                }
+
+                Duration idleTime =
+                        Duration.between(lastConsumeInstant, Instant.now());
+                if (idleTime.compareTo(maxIdleTime) > 0) {
+                    ctx.markAsTemporarilyIdle();
+                }
+
+                continue;
+            }
+
+            List<Message> messageList = consumeResult.getMessageList();
+            lastConsumeInstant = Instant.now();
+
+            List<T> records = new ArrayList<>();
+            if (messageList != null) {
+                lastConsumeInstant = Instant.now();
+
+                for (Message message : messageList) {
+                    T record =
+                            deserializationSchema.deserialize(message.getData());
+                    records.add(record);
+                }
+            }
+
+            synchronized (ctx.getCheckpointLock()) {
+
+                for (T record : records) {
+                    ctx.collect(record);
+                }
+
+                currentOffsets.put(
+                        consumeResult.getPartitionKey(),
+                        consumeResult.getCurrOffset()
+                );
+            }
+
+            ConsumerResult confirmResult =
+                    messagePullConsumer
+                            .confirmConsume(consumeResult.getConfirmContext(), true);
+            if (!confirmResult.isSuccess()) {
+                if (!(confirmResult.getErrCode() == 400
+                        || confirmResult.getErrCode() == 404
+                        || confirmResult.getErrCode() == 405
+                        || confirmResult.getErrCode() == 406
+                        || confirmResult.getErrCode() == 407
+                        || confirmResult.getErrCode() == 408)) {
+                    LOG.warn("Could not confirm messages to tubemq (errcode: {}, "
+                                    + "errmsg: {}).", confirmResult.getErrCode(),
+                            confirmResult.getErrMsg());
+                }
+            }
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+
+        offsetsState.clear();
+        for (Map.Entry<String, Long> entry : currentOffsets.entrySet()) {
+            offsetsState.add(new Tuple2<>(entry.getKey(), entry.getValue()));
+        }
+
+        LOG.info("Successfully save the offsets in checkpoint {}: {}.",
+                context.getCheckpointId(), currentOffsets);
+    }
+
+    @Override
+    public void cancel() {
+        running = false;
+    }
+
+    @Override
+    public void close() throws Exception {
+
+        cancel();
+
+        if (messagePullConsumer != null) {
+            try {
+                messagePullConsumer.shutdown();
+            } catch (Throwable t) {
+                LOG.warn("Could not properly shutdown the tubemq pull consumer.", t);
+            }
+        }
+
+        if (messageSessionFactory != null) {
+            try {
+                messageSessionFactory.shutdown();
+            } catch (Throwable t) {
+                LOG.warn("Could not properly shutdown the tubemq session factory.", t);
+            }
+        }
+
+        super.close();
+
+        LOG.info("Closed the tubemq source.");
+    }
+}

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.tubemq.table;
+
+import com.google.common.base.Objects;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.tubemq.corebase.Message;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class DynamicTubeMQDeserializationSchema implements DeserializationSchema<RowData> {
+
+    /**
+     * data buffer message
+     */
+    private final DeserializationSchema<RowData> deserializationSchema;
+
+    /**
+     * {@link MetadataConverter} of how to produce metadata from message.
+     */
+    private final MetadataConverter[] metadataConverters;
+
+    /**
+     * {@link TypeInformation} of the produced {@link RowData} (physical + meta data).
+     */
+    private final TypeInformation<RowData> producedTypeInfo;
+
+    /**
+     * status of error
+     */
+    private final boolean ignoreErrors;
+
+    public DynamicTubeMQDeserializationSchema(
+            DeserializationSchema<RowData> schema,
+            MetadataConverter[] metadataConverters,
+            TypeInformation<RowData> producedTypeInfo,
+            boolean ignoreErrors) {
+        this.deserializationSchema = schema;
+        this.metadataConverters = metadataConverters;
+        this.producedTypeInfo = producedTypeInfo;
+        this.ignoreErrors = ignoreErrors;
+    }
+
+    @Override
+    public RowData deserialize(byte[] bytes) throws IOException {
+        return deserializationSchema.deserialize(bytes);
+    }
+
+    @Override
+    public void deserialize(byte[] message, Collector<RowData> out) throws IOException {
+        deserializationSchema.deserialize(message, out);
+    }
+
+    @Override
+    public boolean isEndOfStream(RowData rowData) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return producedTypeInfo;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DynamicTubeMQDeserializationSchema)) {
+            return false;
+        }
+        DynamicTubeMQDeserializationSchema that = (DynamicTubeMQDeserializationSchema) o;
+        return ignoreErrors == that.ignoreErrors
+                && Objects.equal(Arrays.stream(metadataConverters).collect(Collectors.toList()),
+                Arrays.stream(that.metadataConverters).collect(Collectors.toList()))
+                && Objects.equal(deserializationSchema, that.deserializationSchema)
+                && Objects.equal(producedTypeInfo, that.producedTypeInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(deserializationSchema, metadataConverters, producedTypeInfo, ignoreErrors);
+    }
+    
+    /**
+     * add metadata column
+     */
+    private void emitRow(Message head, GenericRowData physicalRow, Collector<RowData> out) {
+        if (metadataConverters.length == 0) {
+            out.collect(physicalRow);
+            return;
+        }
+        final int physicalArity = physicalRow.getArity();
+        final int metadataArity = metadataConverters.length;
+        final GenericRowData producedRow =
+                new GenericRowData(physicalRow.getRowKind(), physicalArity + metadataArity);
+        for (int physicalPos = 0; physicalPos < physicalArity; physicalPos++) {
+            producedRow.setField(physicalPos, physicalRow.getField(physicalPos));
+        }
+        for (int metadataPos = 0; metadataPos < metadataArity; metadataPos++) {
+            producedRow.setField(
+                    physicalArity + metadataPos, metadataConverters[metadataPos].read(head));
+        }
+        out.collect(producedRow);
+    }
+
+    interface MetadataConverter extends Serializable {
+
+        Object read(Message head);
+    }
+}

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQDynamicTableFactory.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.sort.tubemq.table;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.format.Format;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DeserializationFormatFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.FactoryUtil.TableFactoryHelper;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.BOOTSTRAP_FROM_MAX;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.GROUP_ID;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.KEY_FORMAT;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.MASTER_RPC;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.PROPERTIES_PREFIX;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.SESSION_KEY;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.TID;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.TOPIC;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.TOPIC_PATTERN;
+import static org.apache.inlong.sort.tubemq.table.TubeMQOptions.getTubeMQProperties;
+
+;
+
+/**
+ * A dynamic table factory implementation for TubeMQ.
+ */
+public class TubeMQDynamicTableFactory implements DynamicTableSourceFactory {
+
+    public static final String IDENTIFIER = "tubemq";
+
+    private static DecodingFormat<DeserializationSchema<RowData>> getValueDecodingFormat(
+            TableFactoryHelper helper) {
+        return helper.discoverOptionalDecodingFormat(
+                DeserializationFormatFactory.class, FORMAT)
+                .orElseGet(
+                        () ->
+                                helper.discoverDecodingFormat(
+                                        DeserializationFormatFactory.class, FORMAT));
+    }
+
+    private static void validatePKConstraints(
+            ObjectIdentifier tableName, CatalogTable catalogTable, Format format) {
+        if (catalogTable.getSchema().getPrimaryKey().isPresent()
+                && format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+            Configuration options = Configuration.fromMap(catalogTable.getOptions());
+            String formatName =
+                    options.getOptional(FORMAT).orElse(options.get(FORMAT));
+            throw new ValidationException(
+                    String.format(
+                            "The TubeMQ table '%s' with '%s' format doesn't support defining PRIMARY KEY constraint"
+                                    + " on the table, because it can't guarantee the semantic of primary key.",
+                            tableName.asSummaryString(), formatName));
+        }
+    }
+
+    private static Optional<DecodingFormat<DeserializationSchema<RowData>>> getKeyDecodingFormat(
+            TableFactoryHelper helper) {
+        final Optional<DecodingFormat<DeserializationSchema<RowData>>> keyDecodingFormat =
+                helper.discoverOptionalDecodingFormat(
+                        DeserializationFormatFactory.class, KEY_FORMAT);
+        keyDecodingFormat.ifPresent(
+                format -> {
+                    if (!format.getChangelogMode().containsOnly(RowKind.INSERT)) {
+                        throw new ValidationException(
+                                String.format(
+                                        "A key format should only deal with INSERT-only records. "
+                                                + "But %s has a changelog mode of %s.",
+                                        helper.getOptions().get(KEY_FORMAT),
+                                        format.getChangelogMode()));
+                    }
+                });
+        return keyDecodingFormat;
+    }
+    
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+
+        final ReadableConfig tableOptions = helper.getOptions();
+
+        final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
+                getValueDecodingFormat(helper);
+
+        // validate all options
+        helper.validate();
+
+        helper.validateExcept(PROPERTIES_PREFIX);
+
+        validatePKConstraints(
+                context.getObjectIdentifier(), context.getCatalogTable(), valueDecodingFormat);
+
+        final Configuration properties = getTubeMQProperties(context.getCatalogTable().getOptions());
+
+        final DataType physicalDataType =
+                context.getCatalogTable().getSchema().toPhysicalRowDataType();
+
+        return createTubeMQTableSource(
+                physicalDataType,
+                valueDecodingFormat,
+                TubeMQOptions.getSourceTopics(tableOptions),
+                TubeMQOptions.getMasterRpcAddress(tableOptions),
+                TubeMQOptions.getTiSet(tableOptions),
+                TubeMQOptions.getConsumerGroup(tableOptions),
+                TubeMQOptions.getSessionKey(tableOptions),
+                properties);
+    }
+    
+    protected TubeMQTableSource createTubeMQTableSource(
+            DataType physicalDataType,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            String topic,
+            String url,
+            TreeSet<String> tid,
+            String consumerGroup,
+            String sessionKey,
+            Configuration properties) {
+        return new TubeMQTableSource(
+                physicalDataType,
+                valueDecodingFormat,
+                url,
+                topic,
+                tid,
+                consumerGroup,
+                sessionKey,
+                properties,
+                null,
+                null,
+                false);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(MASTER_RPC);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FORMAT);
+        options.add(TOPIC);
+        options.add(GROUP_ID);
+        options.add(TID);
+        options.add(SESSION_KEY);
+        options.add(BOOTSTRAP_FROM_MAX);
+        options.add(TOPIC_PATTERN);
+        return options;
+    }
+}

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQOptions.java
@@ -1,0 +1,418 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.sort.tubemq.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.description.Description;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.util.Preconditions;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.function.Consumer;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.hasRoot;
+
+/**
+ * Option utils for tubeMQ table source and sink.
+ */
+public class TubeMQOptions {
+
+    // --------------------------------------------------------------------------------------------
+    // Option enumerations
+    // --------------------------------------------------------------------------------------------
+
+    public static final String PROPERTIES_PREFIX = "properties.";
+
+    // Start up offset.
+    //Always start from the max consume position.
+    public static final String CONSUMER_FROM_MAX_OFFSET_ALWAYS = "max";
+    //Start from the latest position for the first time. Otherwise start from last consume position.
+    public static final String CONSUMER_FROM_LATEST_OFFSET = "latest";
+    //Start from 0 for the first time. Otherwise start from last consume position.
+    public static final String CONSUMER_FROM_FIRST_OFFSET = "earliest";
+
+    // --------------------------------------------------------------------------------------------
+    // Format options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> KEY_FORMAT = ConfigOptions
+            .key("key." + FORMAT.key())
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Defines the format identifier for encoding key data. "
+                    + "The identifier is used to discover a suitable format factory.");
+
+    public static final ConfigOption<List<String>> KEY_FIELDS =
+            ConfigOptions.key("key.fields")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            "Defines an explicit list of physical columns from the table schema "
+                                    + "that configure the data type for the key format. By default, this list is "
+                                    + "empty and thus a key is undefined.");
+
+    // --------------------------------------------------------------------------------------------
+    // TubeMQ specific options
+    // --------------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> TOPIC =
+            ConfigOptions.key("topic")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Topic names from which the table is read. Either 'topic' "
+                                    + "or 'topic-pattern' must be set for source.");
+
+    public static final ConfigOption<String> TOPIC_PATTERN =
+            ConfigOptions.key("topic-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional topic pattern from which the table is read for source."
+                                    + " Either 'topic' or 'topic-pattern' must be set.");
+
+    public static final ConfigOption<String> MASTER_RPC =
+            ConfigOptions.key("master.rpc")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Required TubeMQ master connection string");
+
+    public static final ConfigOption<String> GROUP_ID =
+            ConfigOptions.key("group.id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Required consumer group in TubeMQ consumer");
+
+    public static final ConfigOption<String> TUBE_MESSAGE_NOT_FOUND_WAIT_PERIOD =
+            ConfigOptions.key("tubemq.message.not.found.wait.period")
+                    .stringType()
+                    .defaultValue("350ms")
+                    .withDescription("The time of waiting period if "
+                            + "tubeMQ broker return message not found.");
+
+    public static final ConfigOption<Long> TUBE_SUBSCRIBE_RETRY_TIMEOUT =
+            ConfigOptions.key("tubemq.subscribe.retry.timeout")
+                    .longType()
+                    .defaultValue(300000L)
+                    .withDescription("The time of subscribing tubeMQ timeout, in millisecond");
+
+    public static final ConfigOption<Integer> SOURCE_EVENT_QUEUE_CAPACITY =
+            ConfigOptions.key("source.event.queue.capacity")
+                    .intType()
+                    .defaultValue(1024);
+
+    public static final ConfigOption<String> SESSION_KEY =
+            ConfigOptions.key("session.key")
+                    .stringType()
+                    .defaultValue("default_session_key")
+                    .withDescription("The session key for this consumer group at startup.");
+
+    public static final ConfigOption<List<String>> TID =
+            ConfigOptions.key("topic.tid")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription("The tid owned this topic.");
+
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("max.retries")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("The maximum number of retries when an "
+                            + "exception is caught.");
+
+    public static final ConfigOption<Boolean> BOOTSTRAP_FROM_MAX =
+            ConfigOptions.key("bootstrap.from.max")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("True if consuming from the most recent "
+                            + "position when the tubemq source starts.. It only takes "
+                            + "effect when the tubemq source does not recover from "
+                            + "checkpoints.");
+
+    public static final ConfigOption<String> SOURCE_MAX_IDLE_TIME =
+            ConfigOptions.key("source.task.max.idle.time")
+                    .stringType()
+                    .defaultValue("5min")
+                    .withDescription("The max time of the source marked as temporarily idle.");
+
+    public static final ConfigOption<String> MESSAGE_NOT_FOUND_WAIT_PERIOD =
+            ConfigOptions.key("message.not.found.wait.period")
+                    .stringType()
+                    .defaultValue("500ms")
+                    .withDescription("The time of waiting period if tubemq broker return message not found.");
+
+
+    public static final ConfigOption<ValueFieldsStrategy> VALUE_FIELDS_INCLUDE =
+            ConfigOptions.key("value.fields-include")
+                    .enumType(ValueFieldsStrategy.class)
+                    .defaultValue(ValueFieldsStrategy.ALL)
+                    .withDescription(
+                            String.format(
+                                    "Defines a strategy how to deal with key columns in the data type "
+                                            + "of the value format. By default, '%s' physical columns "
+                                            + "of the table schema will be included in the value "
+                                            + "format which means that the key columns "
+                                            + "appear in the data type for both the key and value format.",
+                                    ValueFieldsStrategy.ALL));
+
+    public static final ConfigOption<String> KEY_FIELDS_PREFIX =
+            ConfigOptions.key("key.fields-prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Defines a custom prefix for all fields of the key format to avoid "
+                                                    + "name clashes with fields of the value format. "
+                                                    + "By default, the prefix is empty.")
+                                    .linebreak()
+                                    .text(
+                                            String.format(
+                                                    "If a custom prefix is defined, both the table schema "
+                                                            + "and '%s' will work with prefixed names.",
+                                                    KEY_FIELDS.key()))
+                                    .linebreak()
+                                    .text(
+                                            "When constructing the data type of the key format, "
+                                                    + "the prefix will be removed and the "
+                                                    + "non-prefixed names will be used within the key format.")
+                                    .linebreak()
+                                    .text(
+                                            String.format(
+                                                    "Please note that this option requires that '%s' must be '%s'.",
+                                                    VALUE_FIELDS_INCLUDE.key(),
+                                                    ValueFieldsStrategy.EXCEPT_KEY))
+                                    .build());
+
+    // --------------------------------------------------------------------------------------------
+    // Validation
+    // --------------------------------------------------------------------------------------------
+    private static final Set<String> CONSUMER_STARTUP_MODE_ENUMS = new HashSet<>(Arrays.asList(
+            CONSUMER_FROM_MAX_OFFSET_ALWAYS,
+            CONSUMER_FROM_LATEST_OFFSET,
+            CONSUMER_FROM_FIRST_OFFSET));
+
+    public static void validateTableSourceOptions(ReadableConfig tableOptions) {
+        validateSourceTopic(tableOptions);
+    }
+
+    public static void validateSourceTopic(ReadableConfig tableOptions) {
+        Optional<String> topic = tableOptions.getOptional(TOPIC);
+        Optional<String> pattern = tableOptions.getOptional(TOPIC_PATTERN);
+
+        if (topic.isPresent() && pattern.isPresent()) {
+            throw new ValidationException(
+                    "Option 'topic' and 'topic-pattern' shouldn't be set together.");
+        }
+
+        if (!topic.isPresent() && !pattern.isPresent()) {
+            throw new ValidationException("Either 'topic' or 'topic-pattern' must be set.");
+        }
+    }
+
+    /**
+     * Creates an array of indices that determine which physical fields of the table schema to
+     * include in the value format.
+     *
+     * <p>See  {@link #VALUE_FIELDS_INCLUDE}, and {@link #KEY_FIELDS_PREFIX}
+     * for more information.</p>
+     */
+    public static int[] createValueFormatProjection(
+            ReadableConfig options, DataType physicalDataType) {
+        final LogicalType physicalType = physicalDataType.getLogicalType();
+        Preconditions.checkArgument(
+                hasRoot(physicalType, LogicalTypeRoot.ROW), "Row data type expected.");
+        final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
+        final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
+
+        final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+        final ValueFieldsStrategy strategy = options.get(VALUE_FIELDS_INCLUDE);
+        if (strategy == ValueFieldsStrategy.ALL) {
+            if (keyPrefix.length() > 0) {
+                throw new ValidationException(
+                        String.format(
+                                "A key prefix is not allowed when option '%s' is set to '%s'. "
+                                        + "Set it to '%s' instead to avoid field overlaps.",
+                                VALUE_FIELDS_INCLUDE.key(),
+                                ValueFieldsStrategy.ALL,
+                                ValueFieldsStrategy.EXCEPT_KEY));
+            }
+            return physicalFields.toArray();
+        } else if (strategy == ValueFieldsStrategy.EXCEPT_KEY) {
+            final int[] keyProjection = createKeyFormatProjection(options, physicalDataType);
+            return physicalFields
+                    .filter(pos -> IntStream.of(keyProjection).noneMatch(k -> k == pos))
+                    .toArray();
+        }
+        throw new TableException("Unknown value fields strategy:" + strategy);
+    }
+
+    /**
+     * Creates an array of indices that determine which physical fields of the table schema to
+     * include in the key format and the order that those fields have in the key format.
+     *
+     * <p>See {@link #KEY_FIELDS}for more information.</p>
+     */
+    public static int[] createKeyFormatProjection(
+            ReadableConfig options, DataType physicalDataType) {
+        final LogicalType physicalType = physicalDataType.getLogicalType();
+        Preconditions.checkArgument(
+                hasRoot(physicalType, LogicalTypeRoot.ROW), "Row data type expected.");
+        final Optional<String> optionalKeyFormat = options.getOptional(KEY_FORMAT);
+        final Optional<List<String>> optionalKeyFields = options.getOptional(KEY_FIELDS);
+
+        if (!optionalKeyFormat.isPresent() && optionalKeyFields.isPresent()) {
+            throw new ValidationException(
+                    String.format(
+                            "The option '%s' can only be declared if a key format is defined using '%s'.",
+                            KEY_FIELDS.key(), KEY_FORMAT.key()));
+        } else if (optionalKeyFormat.isPresent()
+                && (!optionalKeyFields.isPresent() || optionalKeyFields.get().size() == 0)) {
+            throw new ValidationException(
+                    String.format(
+                            "A key format '%s' requires the declaration of one or more of key fields using '%s'.",
+                            KEY_FORMAT.key(), KEY_FIELDS.key()));
+        }
+
+        if (!optionalKeyFormat.isPresent()) {
+            return new int[0];
+        }
+
+        final String keyPrefix = options.getOptional(KEY_FIELDS_PREFIX).orElse("");
+
+        final List<String> keyFields = optionalKeyFields.get();
+        final List<String> physicalFields = LogicalTypeChecks.getFieldNames(physicalType);
+        return keyFields.stream()
+                .mapToInt(
+                        keyField -> {
+                            final int pos = physicalFields.indexOf(keyField);
+                            // check that field name exists
+                            if (pos < 0) {
+                                throw new ValidationException(
+                                        String.format(
+                                                "Could not find the field '%s' in the table schema for usage "
+                                                        + "in the key format.A key field must be a regular,"
+                                                        + " physical column.The following columns can "
+                                                        + "be selected in the '%s' option:\n"
+                                                        + "%s",
+                                                keyField, KEY_FIELDS.key(), physicalFields));
+                            }
+                            // check that field name is prefixed correctly
+                            if (!keyField.startsWith(keyPrefix)) {
+                                throw new ValidationException(
+                                        String.format(
+                                                "All fields in '%s' must be prefixed with '%s' when option '%s' "
+                                                        + "is set but field '%s' is not prefixed.",
+                                                KEY_FIELDS.key(),
+                                                keyPrefix,
+                                                KEY_FIELDS_PREFIX.key(),
+                                                keyField));
+                            }
+                            return pos;
+                        })
+                .toArray();
+    }
+
+    public static Configuration getTubeMQProperties(Map<String, String> tableOptions) {
+        final Configuration tubeMQProperties = new Configuration();
+
+        if (hasTubeMQClientProperties(tableOptions)) {
+            tableOptions.keySet().stream()
+                    .filter(key -> key.startsWith(PROPERTIES_PREFIX))
+                    .forEach(
+                            key -> {
+                                final String value = tableOptions.get(key);
+                                final String subKey = key.substring((PROPERTIES_PREFIX).length());
+                                tubeMQProperties.toMap().put(subKey, value);
+                            });
+        }
+        return tubeMQProperties;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Scan specific options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Decides if the table options contains TubeMQ client properties that start with prefix
+     * 'properties'.
+     */
+    private static boolean hasTubeMQClientProperties(Map<String, String> tableOptions) {
+        return tableOptions.keySet().stream().anyMatch(k -> k.startsWith(PROPERTIES_PREFIX));
+    }
+
+    public static String getSourceTopics(ReadableConfig tableOptions) {
+        return tableOptions.getOptional(TOPIC).orElse(null);
+    }
+
+    public static String getMasterRpcAddress(ReadableConfig tableOptions) {
+        return tableOptions.getOptional(MASTER_RPC).orElse(null);
+    }
+
+    public static TreeSet<String> getTiSet(ReadableConfig tableOptions) {
+        TreeSet<String> set = new TreeSet<>();
+        tableOptions.getOptional(TID).ifPresent(new Consumer<List<String>>() {
+            @Override
+            public void accept(List<String> strings) {
+                set.addAll(strings);
+            }
+        });
+        return set;
+    }
+
+    public static String getConsumerGroup(ReadableConfig tableOptions) {
+        return tableOptions.getOptional(GROUP_ID).orElse(null);
+    }
+
+    public static String getSessionKey(ReadableConfig tableOptions) {
+        return tableOptions.getOptional(SESSION_KEY).orElse(SESSION_KEY.defaultValue());
+    }
+
+    /**
+     * Strategies to derive the data type of a value format by considering a key format.
+     */
+    public enum ValueFieldsStrategy {
+
+        ALL,
+
+        EXCEPT_KEY
+
+    }
+
+}

--- a/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQTableSource.java
+++ b/inlong-sort/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/TubeMQTableSource.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.sort.tubemq.table;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.DecodingFormat;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsWatermarkPushDown;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeChecks;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.util.Preconditions;
+import org.apache.inlong.sort.tubemq.FlinkTubeMQConsumer;
+import org.apache.inlong.sort.tubemq.table.DynamicTubeMQDeserializationSchema.MetadataConverter;
+import org.apache.inlong.tubemq.corebase.Message;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+/**
+ * .
+ */
+public class TubeMQTableSource implements ScanTableSource, SupportsReadingMetadata, SupportsWatermarkPushDown {
+
+    private static final String VALUE_METADATA_PREFIX = "value.";
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+    /**
+     * Data type to configure the formats.
+     */
+    private final DataType physicalDataType;
+    /**
+     * Format for decoding values from TubeMQ.
+     */
+    private final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat;
+
+    //-------------------------------------------------------------------
+    /**
+     * The address of TubeMQ master, format eg: 127.0.0.1:8715,127.0.0.2:8715.
+     */
+    private final String masterAddress;
+    /**
+     * The TubeMQ topic name.
+     */
+    private final String topic;
+    /**
+     * The TubeMQ tid filter collection.
+     */
+    private final TreeSet<String> tidSet;
+    /**
+     * The TubeMQ consumer group name.
+     */
+    private final String consumerGroup;
+    /**
+     * The parameters collection for TubeMQ consumer.
+     */
+    private final Configuration configuration;
+    /**
+     * The TubeMQ session key.
+     */
+    private final String sessionKey;
+    /**
+     * Field name of the processing time attribute, null if no processing time
+     * field is defined.
+     */
+    private final Optional<String> proctimeAttribute;
+    /**
+     * status of error
+     */
+    private final boolean ignoreErrors;
+    /**
+     * Data type that describes the final output of the source.
+     */
+    protected DataType producedDataType;
+    /**
+     * Metadata that is appended at the end of a physical source row.
+     */
+    protected List<String> metadataKeys;
+    /**
+     * Watermark strategy that is used to generate per-partition watermark.
+     */
+    @Nullable
+    private WatermarkStrategy<RowData> watermarkStrategy;
+
+    public TubeMQTableSource(DataType physicalDataType,
+            DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
+            String masterAddress, String topic,
+            TreeSet<String> tidSet, String consumerGroup, String sessionKey,
+            Configuration configuration, @Nullable WatermarkStrategy<RowData> watermarkStrategy,
+            Optional<String> proctimeAttribute, Boolean ignoreErrors) {
+        Preconditions.checkNotNull(
+                physicalDataType, "Physical data type must not be null.");
+        Preconditions.checkNotNull(valueDecodingFormat,
+                "The deserialization schema must not be null.");
+        Preconditions.checkNotNull(masterAddress,
+                "The master address must not be null.");
+        Preconditions.checkNotNull(topic,
+                "The topic must not be null.");
+        Preconditions.checkNotNull(tidSet,
+                "The tid set must not be null.");
+        Preconditions.checkNotNull(consumerGroup,
+                "The consumer group must not be null.");
+        Preconditions.checkNotNull(configuration,
+                "The configuration must not be null.");
+
+        this.physicalDataType = physicalDataType;
+        this.producedDataType = physicalDataType;
+        this.metadataKeys = Collections.emptyList();
+        this.valueDecodingFormat = valueDecodingFormat;
+        this.masterAddress = masterAddress;
+        this.topic = topic;
+        this.tidSet = tidSet;
+        this.consumerGroup = consumerGroup;
+        this.sessionKey = sessionKey;
+        this.configuration = configuration;
+        this.watermarkStrategy = watermarkStrategy;
+        this.proctimeAttribute = proctimeAttribute;
+        this.ignoreErrors = ignoreErrors;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return valueDecodingFormat.getChangelogMode();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
+        final LogicalType physicalType = physicalDataType.getLogicalType();
+        final int physicalFieldCount = LogicalTypeChecks.getFieldCount(physicalType);
+        final IntStream physicalFields = IntStream.range(0, physicalFieldCount);
+        final DeserializationSchema<RowData> deserialization =
+                createDeserialization(context, valueDecodingFormat, physicalFields.toArray(), null);
+
+        final TypeInformation<RowData> producedTypeInfo =
+                context.createTypeInformation(physicalDataType);
+
+        final FlinkTubeMQConsumer<RowData> tubeMQConsumer =
+                createTubeMQConsumer(deserialization, producedTypeInfo, ignoreErrors);
+
+        return SourceFunctionProvider.of(tubeMQConsumer, false);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new TubeMQTableSource(
+                physicalDataType, valueDecodingFormat, masterAddress,
+                topic, tidSet, consumerGroup, sessionKey, configuration,
+                watermarkStrategy, proctimeAttribute, ignoreErrors);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "TubeMQ table source";
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new LinkedHashMap<>();
+        valueDecodingFormat
+                .listReadableMetadata()
+                .forEach((key, value) -> metadataMap.put(VALUE_METADATA_PREFIX + key, value));
+
+        // add connector metadata
+        Stream.of(ReadableMetadata.values())
+                .forEachOrdered(m -> metadataMap.putIfAbsent(m.key, m.dataType));
+
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // separate connector and format metadata
+        final List<String> formatMetadataKeys =
+                metadataKeys.stream()
+                        .filter(k -> k.startsWith(VALUE_METADATA_PREFIX))
+                        .collect(Collectors.toList());
+        final List<String> connectorMetadataKeys = new ArrayList<>(metadataKeys);
+        connectorMetadataKeys.removeAll(formatMetadataKeys);
+
+        // push down format metadata
+        final Map<String, DataType> formatMetadata = valueDecodingFormat.listReadableMetadata();
+        if (formatMetadata.size() > 0) {
+            final List<String> requestedFormatMetadataKeys =
+                    formatMetadataKeys.stream()
+                            .map(k -> k.substring(VALUE_METADATA_PREFIX.length()))
+                            .collect(Collectors.toList());
+            valueDecodingFormat.applyReadableMetadata(requestedFormatMetadataKeys);
+        }
+        this.metadataKeys = connectorMetadataKeys;
+        this.producedDataType = producedDataType;
+
+    }
+
+    @Override
+    public void applyWatermark(WatermarkStrategy<RowData> watermarkStrategy) {
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final TubeMQTableSource that = (TubeMQTableSource) o;
+        return Objects.equals(physicalDataType, that.physicalDataType)
+                && Objects.equals(valueDecodingFormat, that.valueDecodingFormat)
+                && Objects.equals(masterAddress, that.masterAddress)
+                && Objects.equals(topic, that.topic)
+                && Objects.equals(String.valueOf(tidSet), String.valueOf(that.tidSet))
+                && Objects.equals(consumerGroup, that.consumerGroup)
+                && Objects.equals(proctimeAttribute, that.proctimeAttribute)
+                && Objects.equals(watermarkStrategy, that.watermarkStrategy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                physicalDataType,
+                valueDecodingFormat,
+                masterAddress,
+                topic,
+                tidSet,
+                consumerGroup,
+                configuration,
+                watermarkStrategy,
+                proctimeAttribute);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    private @Nullable
+    DeserializationSchema<RowData> createDeserialization(
+            DynamicTableSource.Context context,
+            @Nullable DecodingFormat<DeserializationSchema<RowData>> format,
+            int[] projection,
+            @Nullable String prefix) {
+        if (format == null) {
+            return null;
+        }
+        DataType physicalFormatDataType =
+                DataTypeUtils.projectRow(this.physicalDataType, projection);
+        if (prefix != null) {
+            physicalFormatDataType = DataTypeUtils.stripRowPrefix(physicalFormatDataType, prefix);
+        }
+        return format.createRuntimeDecoder(context, physicalFormatDataType);
+    }
+
+    protected FlinkTubeMQConsumer<RowData> createTubeMQConsumer(
+            DeserializationSchema<RowData> deserialization,
+            TypeInformation<RowData> producedTypeInfo,
+            boolean ignoreErrors) {
+        final MetadataConverter[] metadataConverters =
+                metadataKeys.stream()
+                        .map(
+                                k ->
+                                        Stream.of(ReadableMetadata.values())
+                                                .filter(rm -> rm.key.equals(k))
+                                                .findFirst()
+                                                .orElseThrow(IllegalStateException::new))
+                        .map(m -> m.converter)
+                        .toArray(MetadataConverter[]::new);
+        final DeserializationSchema<RowData> tubeMQDeserializer =
+                new DynamicTubeMQDeserializationSchema(deserialization, metadataConverters, producedTypeInfo,
+                        ignoreErrors);
+
+        final FlinkTubeMQConsumer<RowData> tubeMQConsumer =
+                new FlinkTubeMQConsumer(masterAddress, topic, tidSet, consumerGroup, tubeMQDeserializer,
+                        configuration, sessionKey);
+        return tubeMQConsumer;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Metadata handling
+    // --------------------------------------------------------------------------------------------
+
+    enum ReadableMetadata {
+        TOPIC(
+                "topic",
+                DataTypes.STRING().notNull(),
+                new MetadataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(Message msg) {
+                        return StringData.fromString(msg.getTopic());
+                    }
+                });
+
+        final String key;
+
+        final DataType dataType;
+
+        final MetadataConverter converter;
+
+        ReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+            this.key = key;
+            this.dataType = dataType;
+            this.converter = converter;
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/tubemq/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/inlong-sort/sort-connectors/tubemq/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.inlong.sort.tubemq.table.TubeMQDynamicTableFactory

--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -199,6 +199,12 @@
             <artifactId>hadoop-common</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-tubemq</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
feature: Add TubeMQ connector
1.It can be used through the Flink Table API and SQL.
2.This feature currently supports only reads.

TubeMQ introduce：https://inlong.apache.org/docs/next/modules/tubemq/overview

- Fixes #4890 

### Motivation

1.Extend support for MQ types.
2.Use the large-scale data capabilities of TubeMQ.

### Modifications

1.Add TubeMQ consumers .
2.Extend Flink's dynamic table.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
