### PR TITLE
[INLONG-4910][CI] Build arm images only on the release branch

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -51,78 +51,13 @@ jobs:
     name: Docker build and push
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Set up JDK
-        uses: actions/setup-java@v3
-        with:
-          java-version: 8
-          distribution: adopt
-
-      - name: Set up Python
-        uses: actions/setup-python@v3
-        with:
-          python-version: 3.7
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/apache/inlong
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-
-      - name: Build Docker images
-        run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
-        env:
-          CI: false
-
       - name: Match branch
         id: match
-        if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
         run: |
-          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-            echo "::set-output name=match_master::true"
-          elif [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::set-output name=match_release::true"
-          else
-            echo "::set-output name=match_branch::false"
-          fi
+          echo "::set-output name=match_master::true"
 
-      # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'release-1.0.0'.
-      - name: Push x86 Docker images to Docker Hub
-        if: |
-          steps.match.outputs.match_master == 'true'
-          || steps.match.outputs.match_release == 'true'
-        working-directory: docker
-        run: |
-          bash +x publish-by-arch.sh --tag --publish
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'release-1.0.0'.
-      - name: Push aarch64 Docker images to Docker Hub
-        if: ${{ steps.match.outputs.match_release == 'true' }}
-        working-directory: docker
-        run: |
-          bash +x build-docker-images.sh --buildx aarch64
-          bash +x publish-by-arch.sh --tag --arch aarch64 --publish
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      # Push manifest after publishing Docker images.
       - name: Push manifest to Docker Hub
-        if: ${{ steps.match.outputs.match_branch != 'false' }}
-        working-directory: docker
         run: |
-          bash +x publish-by-arch.sh --manifest
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          echo "${{ steps.match.outputs.match_master }}"
+          echo "${{ steps.match.outputs.match_branch }}"
+          echo "${{ steps.match.outputs.match_branch != 'false' }}"

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -102,6 +102,8 @@ jobs:
       - name: Push x86 Docker images to Docker Hub
         if: |
           success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --tag --publish
         env:
@@ -124,6 +126,8 @@ jobs:
       - name: Push aarch64 Docker images to Docker Hub
         if: |
           success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-release-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --tag --buildx aarch64 --publish
         env:
@@ -134,6 +138,8 @@ jobs:
       - name: Push manifest to Docker Hub
         if: |
           success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-release-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --manifest
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -79,69 +79,48 @@ jobs:
         env:
           CI: false
 
-      # Check if only the workflow file is changed.
-      - name: Check workflow diff
-        id: check-workflow-diff
-        uses: apache/pulsar-test-infra/diff-only@master
-        with:
-          args: .github/workflows/ci_docker.yml
-
-      # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
       - name: Match branch
-        id: match-branch
+        id: match
         if: |
           success()
           && github.event_name == 'push'
           && github.repository_owner == 'apache'
         run: |
-          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} || ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::set-output name=match::true"
+          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+            echo "::set-output name=match_master::true"
+          elif [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::set-output name=match_release::true"
+          else
+            echo "::set-output name=match_branch::false"
           fi
 
-      # If only this workflow file is changed, there is no need to publish Docker images.
+      # Publish x86 Docker images when the changes are being pushed to the master branch.
       - name: Push x86 Docker images to Docker Hub
-        if: |
-          success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-branch.outputs.match == 'true'
+        if: ${{ steps.match.outputs.match_master == 'true' }}
         working-directory: docker
-        run: bash +x publish-by-arch.sh --tag --publish
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
-      - name: Match release branch
-        id: match-release-branch
-        if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
         run: |
-          if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "::set-output name=match::true"
-          fi
-
-      # If only this workflow file is changed, there is no need to publish Docker images.
-      - name: Push aarch64 Docker images to Docker Hub
-        if: |
-          success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-release-branch.outputs.match == 'true'
-        working-directory: docker
-        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag --arch aarch64 --publish
+          bash +x publish-by-arch.sh --tag --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      # If only this workflow file is changed, there is no need to publish Docker images.
-      - name: Push manifest to Docker Hub
-        if: |
-          success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-release-branch.outputs.match == 'true'
+      # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'release-1.0.0'.
+      - name: Push aarch64 Docker images to Docker Hub
+        if: ${{ steps.match.outputs.match_release == 'true' }}
         working-directory: docker
-        run: bash +x publish-by-arch.sh --manifest
+        run: |
+          bash +x build-docker-images.sh --buildx aarch64
+          bash +x publish-by-arch.sh --tag --arch aarch64 --publish
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Push manifest after publishing Docker images.
+      - name: Push manifest to Docker Hub
+        if: ${{ steps.match.outputs.match_branch != 'false' }}
+        working-directory: docker
+        run: |
+          bash +x publish-by-arch.sh --manifest
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -127,7 +127,7 @@ jobs:
         if: |
           success()
         working-directory: docker
-        run: bash +x publish-by-arch.sh --tag --buildx aarch64
+        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -94,9 +94,11 @@ jobs:
             echo "::set-output name=match_branch::false"
           fi
 
-      # Publish x86 Docker images when the changes are being pushed to the master branch.
+      # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'release-1.0.0'.
       - name: Push x86 Docker images to Docker Hub
-        if: ${{ steps.match.outputs.match_master == 'true' }}
+        if: |
+          steps.match.outputs.match_master == 'true'
+          || steps.match.outputs.match_release == 'true'
         working-directory: docker
         run: |
           bash +x publish-by-arch.sh --tag --publish

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -51,13 +51,78 @@ jobs:
     name: Docker build and push
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: adopt
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+
+      - name: Cache Maven packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/org/apache/inlong
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Build Docker images
+        run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
+        env:
+          CI: false
+
       - name: Match branch
         id: match
+        if: |
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
         run: |
-          echo "::set-output name=match_master::true"
+          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+            echo "::set-output name=match_master::true"
+          elif [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::set-output name=match_release::true"
+          else
+            echo "::set-output name=match_branch::false"
+          fi
 
-      - name: Push manifest to Docker Hub
+      # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'release-1.0.0'.
+      - name: Push x86 Docker images to Docker Hub
+        if: |
+          steps.match.outputs.match_master == 'true'
+          || steps.match.outputs.match_release == 'true'
+        working-directory: docker
         run: |
-          echo "${{ steps.match.outputs.match_master }}"
-          echo "${{ steps.match.outputs.match_branch }}"
-          echo "${{ steps.match.outputs.match_branch != 'false' }}"
+          bash +x publish-by-arch.sh --tag --publish
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'release-1.0.0'.
+      - name: Push aarch64 Docker images to Docker Hub
+        if: ${{ steps.match.outputs.match_release == 'true' }}
+        working-directory: docker
+        run: |
+          bash +x build-docker-images.sh --buildx aarch64
+          bash +x publish-by-arch.sh --tag --arch aarch64 --publish
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Push manifest after publishing Docker images.
+      - name: Push manifest to Docker Hub
+        if: ${{ steps.match.outputs.match_branch != 'false' }}
+        working-directory: docker
+        run: |
+          bash +x publish-by-arch.sh --manifest
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -126,6 +126,8 @@ jobs:
       - name: Push aarch64 Docker images to Docker Hub
         if: |
           success()
+          && steps.check-workflow-diff.outputs.changed_only == 'no'
+          && steps.match-release-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag --arch aarch64
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -119,7 +119,9 @@ jobs:
 
       # Push manifest after publishing Docker images.
       - name: Push manifest to Docker Hub
-        if: ${{ steps.match.outputs.match_branch != 'false' }}
+        if: |
+          steps.match.outputs.match_branch != ''
+          && steps.match.outputs.match_branch != 'false'
         working-directory: docker
         run: |
           bash +x publish-by-arch.sh --manifest

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -90,8 +90,6 @@ jobs:
             echo "::set-output name=match_master::true"
           elif [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=match_release::true"
-          else
-            echo "::set-output name=match_branch::false"
           fi
 
       # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'release-1.0.0'.
@@ -117,11 +115,9 @@ jobs:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Push manifest after publishing Docker images.
+      # Push manifest after publishing aarch64 Docker images.
       - name: Push manifest to Docker Hub
-        if: |
-          steps.match.outputs.match_branch != ''
-          && steps.match.outputs.match_branch != 'false'
+        if: ${{ steps.match.outputs.match_release == 'true' }}
         working-directory: docker
         run: |
           bash +x publish-by-arch.sh --manifest

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -126,10 +126,8 @@ jobs:
       - name: Push aarch64 Docker images to Docker Hub
         if: |
           success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-release-branch.outputs.match == 'true'
         working-directory: docker
-        run: bash +x publish-by-arch.sh --tag --buildx aarch64 --publish
+        run: bash +x publish-by-arch.sh --tag --buildx aarch64
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -102,20 +102,28 @@ jobs:
       - name: Push x86 Docker images to Docker Hub
         if: |
           success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --tag --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+      # If the changes are being pushed to the master branch or a branch like 'release-1.0.0', this step will output true.
+      - name: Match release branch
+        id: match-release-branch
+        if: |
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
+        run: |
+          if [[ ${{ github.ref_name }} =~ ^release-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "::set-output name=match::true"
+          fi
+
       # If only this workflow file is changed, there is no need to publish Docker images.
       - name: Push aarch64 Docker images to Docker Hub
         if: |
           success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --tag --buildx aarch64 --publish
         env:
@@ -126,8 +134,6 @@ jobs:
       - name: Push manifest to Docker Hub
         if: |
           success()
-          && steps.check-workflow-diff.outputs.changed_only == 'no'
-          && steps.match-branch.outputs.match == 'true'
         working-directory: docker
         run: bash +x publish-by-arch.sh --manifest
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -127,7 +127,7 @@ jobs:
         if: |
           success()
         working-directory: docker
-        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag
+        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag --arch aarch64
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -129,7 +129,7 @@ jobs:
           && steps.check-workflow-diff.outputs.changed_only == 'no'
           && steps.match-release-branch.outputs.match == 'true'
         working-directory: docker
-        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag --arch aarch64
+        run: bash +x build-docker-images.sh --buildx aarch64; bash +x publish-by-arch.sh --tag --arch aarch64 --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -69,7 +69,7 @@ for (( i=1; i<=$#; i++)); do
 done
 
 if [ "$BUILD_ARCH" = "$ARCH_X86" ] && [ "$ENV_ARCH" = "$ARCH_X86" ]; then
-  mvn clean install -DskipTests -Pdocker
+  mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
   exit 0
 fi
 

--- a/docker/publish-by-arch.sh
+++ b/docker/publish-by-arch.sh
@@ -254,7 +254,7 @@ Options:
   -t, --tag             Add tag operation before publish. Add arch after version and add docker registry org.
   -p, --publish         Publish images according to docker registry information.
   -m, --manifest        Push manifest. This option doesn't need arch.
-  -x, --buildx <ARCH>   Use buildx to build docker images for another arch. This option doesn't need -b.
+  -a, --arch <ARCH>     Use buildx to build docker images for another arch.
                         Arch must be provided, as aarch64 or x86.
   -h, --help            Show help information.
 Example:
@@ -273,8 +273,7 @@ for (( i=1; i<="$#"; i++)); do
     NEED_MANIFEST=true
   elif [ "${!i}" = "-p" ] || [ "${!i}" = "--publish" ]; then
     NEED_PUBLISH=true
-  elif [ "${!i}" = "-x" ] || [ "${!i}" = "--buildx" ]; then
-    NEED_BUILD=true
+  elif [ "${!i}" = "-a" ] || [ "${!i}" = "--arch" ]; then
     USE_BUILDX="--buildx"
     j=$((i+1))
     BUILD_ARCH=${!j}

--- a/docker/publish-by-arch.sh
+++ b/docker/publish-by-arch.sh
@@ -40,9 +40,9 @@ buildImage() {
   cd "${SHELL_FOLDER}"
   cd ..
   if [ "$BUILD_ARCH" = "$ARCH_X86" ] && [ "$ENV_ARCH" = "$ARCH_X86" ]; then
-    mvn clean install -DskipTests -Pdocker
+    mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
   else
-    mvn clean install -DskipTests
+    mvn --batch-mode --update-snapshots -e -V clean package -DskipTests
     sh ./docker/build-docker-images.sh ${USE_BUILDX} ${BUILD_ARCH}
   fi
   echo "End building images"


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-4910][CI] Build arm images only on release branch
- Fixes #4910 

### Motivation

Rebuild ci_docker steps to make arm images only build with release branch.

### Modifications

Rebuild ci_docker steps to make arm images only build with release branch.
