### PR TITLE
[INLONG-4178][Manager]  Refactor getSortSource API for Sort Standalone

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.sortstandalone;
+
+import com.google.common.base.Splitter;
+import com.google.gson.Gson;
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Data
+public class SortSourceClusterInfo {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceClusterInfo.class);
+    private static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on("&").trimResults()
+            .withKeyValueSeparator("=");
+    private static final String KEY_IS_CONSUMABLE = "consumer";
+
+    private static final long serialVersionUID = 1L;
+    String name;
+    String type;
+    String clusterTag;
+    String extTag;
+    String extParams;
+    Map<String, String> extTagMap = new ConcurrentHashMap<>();
+    Map<String, String> extParamsMap = new ConcurrentHashMap<>();
+
+    public Map<String, String> getExtParamsMap() {
+        if (extParamsMap.isEmpty() && extParams != null) {
+            try {
+                Gson gson = new Gson();
+                extParamsMap = gson.fromJson(extParams, Map.class);
+            } catch (Throwable t) {
+                LOGGER.error(t.getMessage(), t);
+            }
+        }
+        return extParamsMap;
+    }
+
+    public Map<String, String> getExtTagMap() {
+        if (extTagMap.isEmpty() && StringUtils.isNotBlank(extTag)) {
+            try {
+                extTagMap = MAP_SPLITTER.split(extTag);
+            } catch (Throwable t) {
+                LOGGER.error(t.getMessage(), t);
+            }
+        }
+        return extTagMap;
+    }
+
+    public boolean isConsumable() {
+        String isConsumable = this.getExtTagMap().get(KEY_IS_CONSUMABLE);
+        return isConsumable == null || "true".equalsIgnoreCase(isConsumable);
+    }
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
@@ -60,7 +60,7 @@ public class SortSourceClusterInfo {
             try {
                 extTagMap = MAP_SPLITTER.split(extTag);
             } catch (Throwable t) {
-                LOGGER.error(t.getMessage(), t);
+                LOGGER.error("fail to parse cluster ext tag params", t);
             }
         }
         return extTagMap;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
@@ -37,7 +37,7 @@ public class SortSourceClusterInfo {
     private static final long serialVersionUID = 1L;
     String name;
     String type;
-    String clusterTag;
+    String clusterTags;
     String extTag;
     String extParams;
     Map<String, String> extTagMap = new ConcurrentHashMap<>();
@@ -49,7 +49,7 @@ public class SortSourceClusterInfo {
                 Gson gson = new Gson();
                 extParamsMap = gson.fromJson(extParams, Map.class);
             } catch (Throwable t) {
-                LOGGER.error(t.getMessage(), t);
+                LOGGER.error("Fail to parse cluster ext params", t);
             }
         }
         return extParamsMap;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceClusterInfo.java
@@ -49,7 +49,7 @@ public class SortSourceClusterInfo {
                 Gson gson = new Gson();
                 extParamsMap = gson.fromJson(extParams, Map.class);
             } catch (Throwable t) {
-                LOGGER.error("Fail to parse cluster ext params", t);
+                LOGGER.error("fail to parse cluster ext params", t);
             }
         }
         return extParamsMap;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
@@ -37,6 +37,7 @@ public class SortSourceGroupInfo {
     String clusterTag;
     String topic;
     String extParams;
+    String mqType;
     Map<String, String> extParamsMap = new ConcurrentHashMap<>();
 
     public Map<String, String> getExtParamsMap() {
@@ -45,7 +46,7 @@ public class SortSourceGroupInfo {
                 Gson gson = new Gson();
                 extParamsMap = gson.fromJson(extParams, Map.class);
             } catch (Throwable t) {
-                LOGGER.error(t.getMessage(), t);
+                LOGGER.error("Fail to parse group ext params", t);
             }
         }
         return extParamsMap;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
@@ -46,7 +46,7 @@ public class SortSourceGroupInfo {
                 Gson gson = new Gson();
                 extParamsMap = gson.fromJson(extParams, Map.class);
             } catch (Throwable t) {
-                LOGGER.error("Fail to parse group ext params", t);
+                LOGGER.error("fail to parse group ext params", t);
             }
         }
         return extParamsMap;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.pojo.sortstandalone;
+
+import com.google.gson.Gson;
+import lombok.Data;
+import org.apache.pulsar.shade.org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Data
+public class SortSourceGroupInfo {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceGroupInfo.class);
+    private static final String KEY_SECOND_CLUSTER_TAG = "second_cluster_tag";
+    private static final String KEY_SECOND_TOPIC = "second_topic";
+
+    private static final long serialVersionUID = 1L;
+    String groupId;
+    String clusterTag;
+    String topic;
+    String extParams;
+    Map<String, String> extParamsMap = new ConcurrentHashMap<>();
+
+    public Map<String, String> getExtParamsMap() {
+        if (extParamsMap.isEmpty() && StringUtils.isNotBlank(extParams)) {
+            try {
+                Gson gson = new Gson();
+                extParamsMap = gson.fromJson(extParams, Map.class);
+            } catch (Throwable t) {
+                LOGGER.error(t.getMessage(), t);
+            }
+        }
+        return extParamsMap;
+    }
+
+    public String getSecondClusterTag() {
+        return getExtParamsMap().get(KEY_SECOND_CLUSTER_TAG);
+    }
+
+    public String getSecondTopic() {
+        return getExtParamsMap().get(KEY_SECOND_TOPIC);
+    }
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
@@ -15,22 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.service.core;
+package org.apache.inlong.manager.common.pojo.sortstandalone;
 
-import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
+import lombok.Data;
 
-/**
- * Sort source service.
- */
-public interface SortSourceService {
-
-    /**
-     * Get {@link SortSourceConfigResponse} by cluster name and task name.
-     *
-     * @param clusterName Target cluster name.
-     * @param taskName Target task name.
-     * @param md5 Last update Md5.
-     * @return SortSourceConfigResponse
-     */
-    SortSourceConfigResponse getSourceConfig(String clusterName, String taskName, String md5);
+@Data
+public class SortSourceStreamInfo {
+    private static final long serialVersionUID = 1L;
+    String sortClusterName;
+    String sortTaskName;
+    String groupId;
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.dao.mapper;
 
 import org.apache.ibatis.annotations.Param;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceClusterInfo;
 import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
 import org.springframework.stereotype.Repository;
 
@@ -44,5 +45,12 @@ public interface InlongClusterEntityMapper {
     int updateByIdSelective(InlongClusterEntity record);
 
     int deleteByPrimaryKey(Integer id);
+
+    /**
+     * Select all clusters for sort sdk.
+     *
+     * @return All cluster info.
+     */
+    List<SortSourceClusterInfo> selectAllClusters();
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.dao.mapper;
 import org.apache.ibatis.annotations.Param;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupPageRequest;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceGroupInfo;
 import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
 import org.springframework.stereotype.Repository;
 
@@ -53,5 +54,12 @@ public interface InlongGroupEntityMapper {
             @Param("modifier") String modifier);
 
     int deleteByPrimaryKey(Integer id);
+
+    /**
+     * Select all group info for sort sdk.
+     *
+     * @return All inlong group info.
+     */
+    List<SortSourceGroupInfo> selectAllGroups();
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSinkEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSinkEntityMapper.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.dao.mapper;
 
 import org.apache.ibatis.annotations.Param;
 import org.apache.inlong.manager.common.pojo.sortstandalone.SortIdInfo;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceStreamInfo;
 import org.apache.inlong.manager.common.pojo.sortstandalone.SortTaskInfo;
 import org.apache.inlong.manager.common.pojo.sink.SinkBriefResponse;
 import org.apache.inlong.manager.common.pojo.sink.SinkInfo;
@@ -128,5 +129,12 @@ public interface StreamSinkEntityMapper {
      * @return All id params
      */
     List<SortIdInfo> selectAllIdParams();
+
+    /**
+     * Select all streams for sort sdk.
+     *
+     * @return All stream info
+     */
+    List<SortSourceStreamInfo> selectAllStreams();
 
 }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -203,14 +203,10 @@
             resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceClusterInfo">
         select name,
                type,
-               cluster_tags as cluster_tag,
+               cluster_tags,
                ext_tag,
                ext_params
         from inlong_cluster
-        <where>
-            is_deleted = 0
-            AND
-            type in ('PULSAR','KAFKA','TUBE')
-        </where>
+        where is_deleted = 0
     </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -198,4 +198,19 @@
         from inlong_cluster
         where id = #{id,jdbcType=INTEGER}
     </delete>
+
+    <select id="selectAllClusters"
+            resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceClusterInfo">
+        select name,
+               type,
+               cluster_tags as cluster_tag,
+               ext_tag,
+               ext_params
+        from inlong_cluster
+        <where>
+            is_deleted = 0
+            AND
+            type in ('PULSAR','KAFKA','TUBE')
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -309,12 +309,9 @@
         select inlong_group_id as groupId,
                inlong_cluster_tag as clusterTag,
                mq_resource as topic,
-               ext_params as extParams
+               ext_params as extParams,
+               mq_type as mqType
         from inlong_group
-        <where>
-            is_deleted = 0
-            AND
-            mq_type in ('PULSAR','KAFKA','TUBE')
-        </where>
+        where is_deleted = 0
     </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -304,4 +304,17 @@
         from inlong_group
         where id = #{id,jdbcType=INTEGER}
     </delete>
+
+    <select id="selectAllGroups" resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceGroupInfo">
+        select inlong_group_id as groupId,
+               inlong_cluster_tag as clusterTag,
+               mq_resource as topic,
+               ext_params as extParams
+        from inlong_group
+        <where>
+            is_deleted = 0
+            AND
+            mq_type in ('PULSAR','KAFKA','TUBE')
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -486,9 +486,7 @@
                sort_task_name,
                inlong_group_id as groupId
         from stream_sink
-        <where>
-            is_deleted = 0
-        </where>
+        where is_deleted = 0
     </select>
 
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -480,5 +480,15 @@
             is_deleted = 0
         </where>
     </select>
+    <select id="selectAllStreams"
+            resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceStreamInfo">
+        select inlong_cluster_name as sortClusterName,
+               sort_task_name,
+               inlong_group_id as groupId
+        from stream_sink
+        <where>
+            is_deleted = 0
+        </where>
+    </select>
 
 </mapper>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -65,6 +65,7 @@ import org.apache.inlong.manager.service.repository.DataProxyConfigRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -99,6 +100,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     @Autowired
     private InlongClusterNodeEntityMapper clusterNodeMapper;
     @Autowired
+    @Lazy
     private DataProxyConfigRepository proxyRepository;
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -50,8 +50,8 @@ import java.util.stream.Collectors;
 /**
  * Use to cache the sort cluster config and reduce the number of query to database.
  */
-@Service
 @Lazy
+@Service
 public class SortClusterServiceImpl implements SortClusterService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortClusterServiceImpl.class);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -32,6 +32,7 @@ import org.apache.inlong.manager.service.core.SortClusterService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -50,6 +51,7 @@ import java.util.stream.Collectors;
  * Use to cache the sort cluster config and reduce the number of query to database.
  */
 @Service
+@Lazy
 public class SortClusterServiceImpl implements SortClusterService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortClusterServiceImpl.class);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -23,17 +23,23 @@ import org.apache.inlong.manager.service.core.SortClusterService;
 import org.apache.inlong.manager.service.core.SortSourceService;
 import org.apache.inlong.manager.service.core.SortService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 /**
  * Sort service implementation.
  */
 @Service
+@Lazy
 public class SortServiceImpl implements SortService {
 
-    @Autowired private SortSourceService sortSourceService;
+    @Autowired
+    @Lazy
+    private SortSourceService sortSourceService;
 
-    @Autowired private SortClusterService sortClusterService;
+    @Autowired
+    @Lazy
+    private SortClusterService sortClusterService;
 
     @Override
     public SortClusterResponse getClusterConfig(String clusterName, String md5) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -17,22 +17,13 @@
 
 package org.apache.inlong.manager.service.core.impl;
 
-import com.google.gson.Gson;
-import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.common.pojo.sdk.CacheZone;
-import org.apache.inlong.common.pojo.sdk.CacheZoneConfig;
-import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
 import org.apache.inlong.common.pojo.sortstandalone.SortClusterResponse;
+import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
 import org.apache.inlong.manager.service.core.SortClusterService;
-import org.apache.inlong.manager.service.core.SortService;
 import org.apache.inlong.manager.service.core.SortSourceService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.inlong.manager.service.core.SortService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Map;
 
 /**
  * Sort service implementation.
@@ -40,86 +31,18 @@ import java.util.Map;
 @Service
 public class SortServiceImpl implements SortService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SortServiceImpl.class);
-    private static final Gson GSON = new Gson();
+    @Autowired private SortSourceService sortSourceService;
 
-    private static final int RESPONSE_CODE_SUCCESS = 0;
-    private static final int RESPONSE_CODE_NO_UPDATE = 1;
-    private static final int RESPONSE_CODE_FAIL = -1;
-    private static final int RESPONSE_CODE_REQ_PARAMS_ERROR = -101;
-
-    @Autowired
-    private SortSourceService sortSourceService;
-
-    @Autowired
-    private SortClusterService sortClusterService;
+    @Autowired private SortClusterService sortClusterService;
 
     @Override
     public SortClusterResponse getClusterConfig(String clusterName, String md5) {
+
         return sortClusterService.getClusterConfig(clusterName, md5);
     }
 
     @Override
     public SortSourceConfigResponse getSourceConfig(String clusterName, String sortTaskId, String md5) {
-        // check if clusterName and sortTaskId are null.
-        if (StringUtils.isBlank(clusterName) || StringUtils.isBlank(sortTaskId)) {
-            String errMsg = "Blank cluster name or task id, return nothing";
-            return SortSourceConfigResponse.builder()
-                    .msg(errMsg)
-                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
-                    .build();
-        }
-
-        // get cacheZones
-        Map<String, CacheZone> cacheZones;
-        try {
-            cacheZones = sortSourceService.getCacheZones(clusterName, sortTaskId);
-        } catch (Exception e) {
-            String errMsg = "Get cache zones exception: " + e.getMessage();
-            LOGGER.error(errMsg, e);
-            return SortSourceConfigResponse.builder()
-                    .msg(errMsg)
-                    .code(RESPONSE_CODE_FAIL)
-                    .build();
-        }
-
-        // if there is not any cacheZones
-        if (cacheZones.isEmpty()) {
-            String errMsg = "There is not any cacheZones of cluster: " + clusterName
-                    + " , task: " + sortTaskId
-                    + " , please check the params";
-            LOGGER.error(errMsg);
-            return SortSourceConfigResponse.builder()
-                    .msg(errMsg)
-                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
-                    .build();
-        }
-
-        CacheZoneConfig data = CacheZoneConfig.builder()
-                .sortClusterName(clusterName)
-                .sortTaskId(sortTaskId)
-                .cacheZones(cacheZones)
-                .build();
-
-        // no update
-        String json = GSON.toJson(data);
-        String localMd5 = DigestUtils.md5Hex(json);
-        if (md5.equals(localMd5)) {
-            String msg = "Same md5, no update";
-            return SortSourceConfigResponse.builder()
-                    .msg(msg)
-                    .code(RESPONSE_CODE_NO_UPDATE)
-                    .md5(md5)
-                    .build();
-        }
-
-        // normal response
-        return SortSourceConfigResponse.builder()
-                .msg("success")
-                .code(RESPONSE_CODE_SUCCESS)
-                .data(data)
-                .md5(localMd5)
-                .build();
+        return sortSourceService.getSourceConfig(clusterName, sortTaskId, md5);
     }
-
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -322,15 +322,8 @@ public class SortSourceServiceImpl implements SortSourceService {
         String serviceUrl = Optional.ofNullable(param.get(KEY_SERVICE_URL))
                 .orElseThrow(() ->
                         new IllegalStateException(("there is no serviceUrl for cluster " + cluster.getName())));
-
-        String tenant = Optional.ofNullable(param.get(KEY_TENANT))
-                .orElseThrow(() ->
-                        new IllegalStateException(("there is no tenant for cluster " + cluster.getName())));
-
-        String namespace = Optional.ofNullable(param.get(KEY_NAME_SPACE))
-                .orElseThrow(() ->
-                        new IllegalStateException(("there is no namespace for cluster " + cluster.getName())));
-
+        String tenant = param.get(KEY_TENANT);
+        String namespace = param.get(KEY_NAME_SPACE);
         String authentication = Optional.ofNullable(param.get(KEY_AUTH)).orElse("");
 
         List<Topic> topics = groups.stream()
@@ -354,9 +347,12 @@ public class SortSourceServiceImpl implements SortSourceService {
             boolean isSecondTag) {
 
         String topic = isSecondTag ? groupInfo.getSecondTopic() : groupInfo.getTopic();
-        String fullTopic = tenant + '/' + namespace + '/' + topic;
+        StringBuilder fullTopic = new StringBuilder();
+        Optional.ofNullable(tenant).ifPresent(t -> fullTopic.append(t).append("/"));
+        Optional.ofNullable(namespace).ifPresent(n -> fullTopic.append(n).append("/"));
+        fullTopic.append(topic);
         return Topic.builder()
-                .topic(fullTopic)
+                .topic(fullTopic.toString())
                 .topicProperties(groupInfo.getExtParamsMap())
                 .build();
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -18,18 +18,40 @@
 package org.apache.inlong.manager.service.core.impl;
 
 import com.google.gson.Gson;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.pojo.sdk.CacheZone;
+import org.apache.inlong.common.pojo.sdk.CacheZoneConfig;
+import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
 import org.apache.inlong.common.pojo.sdk.Topic;
-import org.apache.inlong.manager.dao.entity.SortSourceConfigEntity;
-import org.apache.inlong.manager.dao.mapper.SortSourceConfigEntityMapper;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceClusterInfo;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceGroupInfo;
+import org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceStreamInfo;
+import org.apache.inlong.manager.dao.mapper.InlongClusterEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongGroupEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StreamSinkEntityMapper;
 import org.apache.inlong.manager.service.core.SortSourceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Implementation of {@link SortSourceService}.
@@ -37,96 +59,318 @@ import java.util.stream.Collectors;
 @Service
 public class SortSourceServiceImpl implements SortSourceService {
 
-    private static final String KEY_TOPIC_PARTITION_COUNT = "partitionCnt";
-    private static final String KEY_ZONE_SERVICE_URL = "serviceUrl";
-    private static final String KEY_ZONE_AUTHENTICATION = "authentication";
-    private static final String KEY_ZONE_TYPE = "zoneType";
-    private static final Gson GSON = new Gson();
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceServiceImpl.class);
+
+    private static final Gson gson = new Gson();
+    private static final Set<String> supportedCacheType = new HashSet<String>() { {
+        add("PULSAR");
+        add("KAFKA");
+        add("TUBE");
+    }};
+    private static final String KEY_SERVICE_URL = "serviceUrl";
+    private static final String KEY_AUTH = "authentication";
+    private static final String KEY_TENANT = "tenant";
+    private static final String KEY_NAME_SPACE = "namespace";
+
+    private static final int RESPONSE_CODE_SUCCESS = 0;
+    private static final int RESPONSE_CODE_NO_UPDATE = 1;
+    private static final int RESPONSE_CODE_FAIL = -1;
+    private static final int RESPONSE_CODE_REQ_PARAMS_ERROR = -101;
+
+    /** key 1: cluster name, key 2: task name, value : md5 */
+    private Map<String, Map<String, String>> sortSourceMd5Map = new ConcurrentHashMap<>();
+    /** key 1: cluster name, key 2: task name, value : source config */
+    private Map<String, Map<String, CacheZoneConfig>> sortSourceConfigMap = new ConcurrentHashMap<>();
+
+    private long reloadInterval = 60000L;
 
     @Autowired
-    private SortSourceConfigEntityMapper sortSourceConfigMapper;
+    private InlongClusterEntityMapper clusterEntityMapper;
+    @Autowired
+    private StreamSinkEntityMapper streamSinkEntityMapper;
+    @Autowired
+    private InlongGroupEntityMapper inlongGroupEntityMapper;
+
+    @PostConstruct
+    public void initialize() {
+        LOGGER.info("create repository for " + SortSourceServiceImpl.class.getSimpleName());
+        try {
+            reload();
+            setReloadTimer();
+        } catch (Throwable t) {
+            LOGGER.error("Initialize SortSourceConfigRepository error", t);
+        }
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void reload() {
+        LOGGER.debug("start to reload sort config.");
+        try {
+            reloadAllSourceConfig();
+        } catch (Throwable t) {
+            LOGGER.error(t.getMessage(), t);
+        }
+        LOGGER.debug("end to reload config");
+    }
 
     @Override
-    public Map<String, CacheZone> getCacheZones(String clusterName, String taskName) {
-        List<SortSourceConfigEntity> configList = sortSourceConfigMapper.selectByClusterAndTask(clusterName, taskName);
+    public SortSourceConfigResponse getSourceConfig(
+            String cluster,
+            String task,
+            String md5) {
 
-        // group configs by zone name
-        Map<String, List<SortSourceConfigEntity>> zoneConfigMap =
-                configList.stream().collect(Collectors.groupingBy(SortSourceConfigEntity::getZoneName));
-
-        return zoneConfigMap.values()
-                .stream()
-                .map(this::toCacheZone)
-                .collect(Collectors.toMap(CacheZone::getZoneName, cacheZone -> cacheZone));
-    }
-
-    /**
-     * Build one {@link CacheZone} from list of configs including zone config and configs of each topic.
-     *
-     * <p>
-     * The way we differ zone config and topic config is
-     * if the params <b>topic</b> in {@link SortSourceConfigEntity} is blank.
-     * If topic is blank, it's the <b>zone config</b>,
-     * otherwise, it's <b>topic config</b>.
-     * </p>
-     *
-     * @param configList List of configs.
-     * @return CacheZone.
-     */
-    private CacheZone toCacheZone(List<SortSourceConfigEntity> configList) {
-        // get list of Topic
-        List<Topic> topicList
-                = configList.stream()
-                .filter(config -> StringUtils.isNotBlank(config.getTopic()))
-                .map(this::toTopic)
-                .collect(Collectors.toList());
-
-        // get zone config
-        List<SortSourceConfigEntity> zoneConfigs
-                = configList.stream()
-                .filter(config -> StringUtils.isBlank(config.getTopic()))
-                .collect(Collectors.toList());
-
-        if (zoneConfigs.size() != 1) {
-            throw new IllegalStateException("The size of zone config should be 1, but found " + zoneConfigs.size());
+        // if cluster or task are invalid
+        if (StringUtils.isBlank(cluster) || StringUtils.isBlank(task)) {
+            String errMsg = "Blank cluster name or task name, return nothing";
+            LOGGER.error(errMsg);
+            return SortSourceConfigResponse.builder()
+                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
+                    .msg(errMsg)
+                    .build();
         }
 
-        SortSourceConfigEntity zoneConfig = zoneConfigs.get(0);
-        Map<String, String> zoneProperties = this.jsonProperty2Map(zoneConfig.getExtParams());
+        // if there is no config
+        if (!sortSourceConfigMap.containsKey(cluster) || !sortSourceConfigMap.get(cluster).containsKey(task)) {
+            String errMsg = String.format("There is no valid source config of cluster %s, task %s", cluster, task);
+            LOGGER.error(errMsg);
+            return SortSourceConfigResponse.builder()
+                    .code(RESPONSE_CODE_FAIL)
+                    .msg(errMsg)
+                    .build();
+        }
+
+        // if the same md5
+        if (sortSourceMd5Map.get(cluster).get(task).equals(md5)) {
+            return SortSourceConfigResponse.builder()
+                    .code(RESPONSE_CODE_NO_UPDATE)
+                    .msg("No update")
+                    .build();
+        }
+
+        // if there is bad config
+        if (sortSourceConfigMap.get(cluster).get(task).getCacheZones().isEmpty()) {
+            String errMsg = String.format("Find empty cache zones of cluster %s, task %s, "
+                    + "Please check the manager log", cluster, task);
+            LOGGER.error(errMsg);
+            return SortSourceConfigResponse.builder()
+                    .code(RESPONSE_CODE_FAIL)
+                    .msg(errMsg)
+                    .build();
+        }
+
+        return SortSourceConfigResponse.builder()
+                .code(RESPONSE_CODE_SUCCESS)
+                .msg("Success")
+                .data(sortSourceConfigMap.get(cluster).get(task))
+                .md5(sortSourceMd5Map.get(cluster).get(task))
+                .build();
+
+    }
+
+    private void reloadAllSourceConfig() {
+
+        // get all streams.
+        List<SortSourceStreamInfo> allStreamInfos = streamSinkEntityMapper.selectAllStreams();
+
+        // convert to Map<clusterName, Map<taskName, List<groupId>>> format.
+        Map<String, Map<String, List<String>>> groupMap = new ConcurrentHashMap<>();
+        allStreamInfos.stream()
+                .filter(dto -> dto.getSortClusterName() != null && dto.getSortTaskName() != null)
+                .forEach(stream -> {
+                    Map<String, List<String>> task2groupsMap =
+                            groupMap.computeIfAbsent(stream.getSortClusterName(), k -> new ConcurrentHashMap<>());
+                    List<String> groupIdList =
+                            task2groupsMap.computeIfAbsent(stream.getSortTaskName(), k -> new ArrayList<>());
+                    groupIdList.add(stream.getGroupId());
+                });
+
+        // get all groups. group by group id.
+        List<SortSourceGroupInfo> groupInfos = inlongGroupEntityMapper.selectAllGroups();
+        Map<String, SortSourceGroupInfo> allId2GroupInfos =
+                groupInfos.stream()
+                        .filter(dto -> dto.getGroupId() != null)
+                        .collect(Collectors.toMap(SortSourceGroupInfo::getGroupId, dto -> dto, (g1, g2) -> g1));
+
+        // get all clusters. filter by type and check if consumable, then group by cluster tag.
+        List<SortSourceClusterInfo> clusterInfos = clusterEntityMapper.selectAllClusters();
+        Map<String, List<SortSourceClusterInfo>> allTag2ClusterInfos =
+                clusterInfos.stream()
+                        .filter(dto -> dto.getClusterTag() != null)
+                        .filter(SortSourceClusterInfo::isConsumable)
+                        .filter(cluster -> supportedCacheType.contains(cluster.getType()))
+                        .collect(Collectors.groupingBy(SortSourceClusterInfo::getClusterTag));
+
+        // Prepare CacheZones for each cluster and task
+        Map<String, Map<String, String>> newMd5Map = new ConcurrentHashMap<>();
+        Map<String, Map<String, CacheZoneConfig>> newConfigMap = new ConcurrentHashMap<>();
+        groupMap.forEach((cluster, task2Group) -> {
+
+            Map<String, CacheZoneConfig> task2Config = new ConcurrentHashMap<>();
+            Map<String, String> task2Md5 = new ConcurrentHashMap<>();
+
+            task2Group.forEach((task, groupList) -> {
+                Map<String, CacheZone> cacheZones;
+                try {
+                    cacheZones = this.getCacheZones(groupList, allId2GroupInfos, allTag2ClusterInfos);
+                } catch (Throwable t) {
+                    LOGGER.error("Fail to get cacheZones of cluster {}, task {}", cluster, task);
+                    return;
+                }
+                CacheZoneConfig config = CacheZoneConfig.builder()
+                        .cacheZones(cacheZones)
+                        .sortClusterName(cluster)
+                        .sortTaskId(task)
+                        .build();
+                String jsonStr = gson.toJson(config);
+                String md5 = DigestUtils.md5Hex(jsonStr);
+                task2Config.put(task, config);
+                task2Md5.put(task, md5);
+            });
+
+            newConfigMap.put(cluster, task2Config);
+            newMd5Map.put(cluster, task2Md5);
+        });
+
+        sortSourceConfigMap = newConfigMap;
+        sortSourceMd5Map = newMd5Map;
+    }
+
+    private Map<String, CacheZone> getCacheZones(
+            List<String> groupIdList,
+            Map<String, SortSourceGroupInfo> allId2GroupInfos,
+            Map<String, List<SortSourceClusterInfo>> allTag2ClusterInfos) {
+
+        // stream of group info if group id exists.
+        List<SortSourceGroupInfo> groupInfoStream =
+                groupIdList.stream()
+                        .filter(allId2GroupInfos::containsKey)
+                        .map(allId2GroupInfos::get)
+                        .collect(Collectors.toList());
+
+        // Group them by cluster tag.
+        Map<String, List<SortSourceGroupInfo>> tag2GroupInfos =
+                groupInfoStream.stream()
+                        .collect(Collectors.groupingBy(SortSourceGroupInfo::getClusterTag));
+
+        // Group them by second cluster tag if both 2nd tag and 2nd topic exist.
+        Map<String, List<SortSourceGroupInfo>> secondTag2GroupInfos =
+                groupInfoStream.stream()
+                        .filter(group -> group.getSecondClusterTag() != null && group.getSecondTopic() != null)
+                        .collect(Collectors.groupingBy(SortSourceGroupInfo::getSecondClusterTag));
+
+        // get cache zone list.
+        List<CacheZone> firstTagCacheZoneList =
+                this.getCacheZoneListByTag(tag2GroupInfos, allTag2ClusterInfos, false);
+        List<CacheZone> secondTagCacheZoneList =
+                this.getCacheZoneListByTag(secondTag2GroupInfos, allTag2ClusterInfos, true);
+
+        // combine two cache zone list, and group by cache zone name.
+        Map<String, CacheZone> cacheZones =
+                Stream.of(firstTagCacheZoneList, secondTagCacheZoneList)
+                        .flatMap(Collection::stream)
+                        .collect(Collectors.toMap(
+                                CacheZone::getZoneName,
+                                cacheZone -> cacheZone,
+                                (zone1, zone2) -> {
+                                    zone1.getTopics().addAll(zone2.getTopics());
+                                    return zone1;
+                                }
+                        ));
+
+        return cacheZones;
+    }
+
+    private List<CacheZone> getCacheZoneListByTag(
+            Map<String, List<SortSourceGroupInfo>> tag2GroupInfos,
+            Map<String, List<SortSourceClusterInfo>> allTag2ClusterInfos,
+            boolean isSecondTag) {
+
+        // Tags of groups
+        List<String> tags = new ArrayList<>(tag2GroupInfos.keySet());
+
+        // Clusters that related to these tags
+        Map<String, List<SortSourceClusterInfo>> tag2ClusterInfos =
+                allTag2ClusterInfos.entrySet().stream()
+                        .filter(entry -> tag2GroupInfos.containsKey(entry.getKey()))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        // get CacheZone list
+        List<CacheZone> cacheZones =
+                tags.stream()
+                        .filter(tag2ClusterInfos::containsKey)
+                        .flatMap(tag -> {
+                            List<SortSourceGroupInfo> groups = tag2GroupInfos.get(tag);
+                            List<SortSourceClusterInfo> clusters = tag2ClusterInfos.get(tag);
+                            return clusters.stream()
+                                    .map(cluster -> {
+                                        CacheZone zone = null;
+                                        try {
+                                            zone = this.getCacheZone(groups, cluster, isSecondTag);
+                                        } catch (IllegalStateException e) {
+                                            LOGGER.error(e.getMessage());
+                                        }
+                                        return zone;
+                                    });
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        return cacheZones;
+    }
+
+    private CacheZone getCacheZone(
+            List<SortSourceGroupInfo> groups,
+            SortSourceClusterInfo cluster,
+            boolean isSecondTag) {
+
+        // get basic Cache zone fields
+        Map<String, String> param = cluster.getExtParamsMap();
+        String serviceUrl = Optional.ofNullable(param.get(KEY_SERVICE_URL))
+                .orElseThrow(() ->
+                        new IllegalStateException(("There is no serviceUrl for cluster " + cluster.getName())));
+
+        String tenant = Optional.ofNullable(param.get(KEY_TENANT))
+                .orElseThrow(() ->
+                        new IllegalStateException(("There is no tenant for cluster " + cluster.getName())));
+
+        String namespace = Optional.ofNullable(param.get(KEY_NAME_SPACE))
+                .orElseThrow(() ->
+                        new IllegalStateException(("There is no namespace for cluster " + cluster.getName())));
+
+        String authentication = Optional.ofNullable(param.get(KEY_AUTH)).orElse("");
+
+        List<Topic> topics = groups.stream()
+                .map(groupInfo -> getTopic(groupInfo, tenant, namespace, isSecondTag))
+                .collect(Collectors.toList());
+
         return CacheZone.builder()
-                .zoneName(zoneConfig.getZoneName())
-                .serviceUrl(zoneProperties.remove(KEY_ZONE_SERVICE_URL))
-                .authentication(zoneProperties.remove(KEY_ZONE_AUTHENTICATION))
-                .topics(topicList)
-                .zoneType(zoneProperties.remove(KEY_ZONE_TYPE))
-                .cacheZoneProperties(zoneProperties)
+                .serviceUrl(serviceUrl)
+                .authentication(authentication)
+                .cacheZoneProperties(param)
+                .zoneName(cluster.getName())
+                .zoneType(cluster.getType())
+                .topics(topics)
                 .build();
     }
 
-    /**
-     * Build one {@link Topic} from the corresponding config.
-     *
-     * @param topicConfig source config
-     * @return topic info
-     */
-    private Topic toTopic(SortSourceConfigEntity topicConfig) {
-        Map<String, String> topicProperties = this.jsonProperty2Map(topicConfig.getExtParams());
-        int partitionCnt = Integer.parseInt(topicProperties.remove(KEY_TOPIC_PARTITION_COUNT));
+    private Topic getTopic(
+            SortSourceGroupInfo groupInfo,
+            String tenant,
+            String namespace,
+            boolean isSecondTag) {
+
+        String topic = isSecondTag ? groupInfo.getSecondTopic() : groupInfo.getTopic();
+        String fullTopic = tenant + '/' + namespace + '/' + topic;
         return Topic.builder()
-                .topic(topicConfig.getTopic())
-                .partitionCnt(partitionCnt)
-                .topicProperties(topicProperties)
+                .topic(fullTopic)
+                .topicProperties(groupInfo.getExtParamsMap())
                 .build();
     }
 
     /**
-     * Convert property json string to map format.
-     *
-     * @param jsonProperty Properties in json string format.
-     * @return Properties in map format.
+     * Set reload timer at the beginning of repository.
      */
-    private Map<String, String> jsonProperty2Map(String jsonProperty) {
-        return GSON.fromJson(jsonProperty, Map.class);
+    private void setReloadTimer() {
+        ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.scheduleAtFixedRate(this::reload, reloadInterval, reloadInterval, TimeUnit.MILLISECONDS);
     }
-
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -34,6 +34,7 @@ import org.apache.inlong.manager.service.core.SortSourceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -57,6 +58,7 @@ import java.util.stream.Stream;
  * Implementation of {@link SortSourceService}.
  */
 @Service
+@Lazy
 public class SortSourceServiceImpl implements SortSourceService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceServiceImpl.class);
@@ -134,7 +136,7 @@ public class SortSourceServiceImpl implements SortSourceService {
             String errMsg = String.format("There is no valid source config of cluster %s, task %s", cluster, task);
             LOGGER.error(errMsg);
             return SortSourceConfigResponse.builder()
-                    .code(RESPONSE_CODE_FAIL)
+                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
                     .msg(errMsg)
                     .build();
         }
@@ -144,6 +146,7 @@ public class SortSourceServiceImpl implements SortSourceService {
             return SortSourceConfigResponse.builder()
                     .code(RESPONSE_CODE_NO_UPDATE)
                     .msg("No update")
+                    .md5(md5)
                     .build();
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -57,8 +57,8 @@ import java.util.stream.Stream;
 /**
  * Implementation of {@link SortSourceService}.
  */
-@Service
 @Lazy
+@Service
 public class SortSourceServiceImpl implements SortSourceService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceServiceImpl.class);
@@ -192,16 +192,17 @@ public class SortSourceServiceImpl implements SortSourceService {
         Map<String, SortSourceGroupInfo> allId2GroupInfos =
                 groupInfos.stream()
                         .filter(dto -> dto.getGroupId() != null)
+                        .filter(group -> supportedCacheType.contains(group.getMqType()))
                         .collect(Collectors.toMap(SortSourceGroupInfo::getGroupId, dto -> dto, (g1, g2) -> g1));
 
         // get all clusters. filter by type and check if consumable, then group by cluster tag.
         List<SortSourceClusterInfo> clusterInfos = clusterEntityMapper.selectAllClusters();
         Map<String, List<SortSourceClusterInfo>> allTag2ClusterInfos =
                 clusterInfos.stream()
-                        .filter(dto -> dto.getClusterTag() != null)
+                        .filter(dto -> dto.getClusterTags() != null)
                         .filter(SortSourceClusterInfo::isConsumable)
                         .filter(cluster -> supportedCacheType.contains(cluster.getType()))
-                        .collect(Collectors.groupingBy(SortSourceClusterInfo::getClusterTag));
+                        .collect(Collectors.groupingBy(SortSourceClusterInfo::getClusterTags));
 
         // Prepare CacheZones for each cluster and task
         Map<String, Map<String, String>> newMd5Map = new ConcurrentHashMap<>();

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
@@ -54,8 +54,8 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * DataProxyConfigRepository
  */
-@Repository(value = "dataProxyConfigRepository")
 @Lazy
+@Repository(value = "dataProxyConfigRepository")
 public class DataProxyConfigRepository implements IRepository {
 
     public static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(SEPARATOR).trimResults()

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
@@ -37,6 +37,7 @@ import org.apache.inlong.manager.dao.mapper.ClusterSetMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,6 +55,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * DataProxyConfigRepository
  */
 @Repository(value = "dataProxyConfigRepository")
+@Lazy
 public class DataProxyConfigRepository implements IRepository {
 
     public static final Splitter.MapSplitter MAP_SPLITTER = Splitter.on(SEPARATOR).trimResults()

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
@@ -18,8 +18,15 @@
 package org.apache.inlong.manager.service.core.impl;
 
 import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
-import org.apache.inlong.manager.dao.entity.SortSourceConfigEntity;
-import org.apache.inlong.manager.dao.mapper.SortSourceConfigEntityMapper;
+import org.apache.inlong.common.pojo.sortstandalone.SortClusterResponse;
+import org.apache.inlong.manager.dao.entity.DataNodeEntity;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
+import org.apache.inlong.manager.dao.mapper.DataNodeEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongClusterEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongGroupEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StreamSinkEntityMapper;
 import org.apache.inlong.manager.service.ServiceBaseTest;
 import org.apache.inlong.manager.service.core.SortService;
 import org.json.JSONObject;
@@ -32,8 +39,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Date;
 
 /**
  * Sort service test for {@link SortService}
@@ -43,10 +49,23 @@ public class SortServiceImplTest extends ServiceBaseTest {
 
     private static final String TEST_CLUSTER = "testCluster";
     private static final String TEST_TASK = "testTask";
+    private static final String TEST_GROUP = "testGroup";
+    private static final String TEST_TAG = "testTag";
+    private static final String TEST_TOPIC = "testTopic";
+    private static final String TEST_SINK_TYPE = "testSinkType";
+    private static final String TEST_CREATOR = "testUser";
+
     @Autowired
-    SortSourceConfigEntityMapper sourceMapper;
+    private InlongClusterEntityMapper clusterEntityMapper;
+    @Autowired
+    private StreamSinkEntityMapper streamSinkEntityMapper;
+    @Autowired
+    private InlongGroupEntityMapper inlongGroupEntityMapper;
+    @Autowired
+    private DataNodeEntityMapper dataNodeEntityMapper;
     @Autowired
     private SortService sortService;
+
 
     @Test
     @Order(1)
@@ -93,7 +112,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
     public void testSourceErrorClusterName() {
         SortSourceConfigResponse response = sortService.getSourceConfig("errCluster", "errTask", "");
         System.out.println(response.toString());
-        Assertions.assertEquals(response.getCode(), -101);
+        Assertions.assertEquals(-101, response.getCode());
         Assertions.assertNull(response.getMd5());
         Assertions.assertNull(response.getData());
         Assertions.assertNotNull(response.getMsg());
@@ -102,55 +121,141 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Test
     @Order(5)
     @Transactional
-    public void testSourceDuplicatedZoneParam() {
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", null));
-        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
-        System.out.println(response);
-        Assertions.assertEquals(-1, response.getCode());
-        Assertions.assertNull(response.getData());
+    public void testClusterEmptyParams() {
+        SortClusterResponse response = sortService.getClusterConfig("", "");
+        System.out.println(response.toString());
+        Assertions.assertEquals(response.getCode(), -101);
         Assertions.assertNull(response.getMd5());
+        Assertions.assertNull(response.getData());
+        Assertions.assertNotNull(response.getMsg());
+
+    }
+
+    @Test
+    @Order(6)
+    @Transactional
+    public void testClusterCorrectParams() {
+        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER, "");
+        JSONObject jo = new JSONObject(response);
+        System.out.println(jo);
+        Assertions.assertEquals(0, response.getCode());
+        Assertions.assertNotNull(response.getData());
+        Assertions.assertNotNull(response.getMd5());
+        Assertions.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Order(7)
+    @Transactional
+    public void testClusterSameMd5() {
+        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER, "");
+        String md5 = response.getMd5();
+        response = sortService.getClusterConfig(TEST_CLUSTER, md5);
+        System.out.println(response);
+        Assertions.assertEquals(1, response.getCode());
+        Assertions.assertEquals(md5, response.getMd5());
+        Assertions.assertNull(response.getData());
+        Assertions.assertNotNull(response.getMsg());
+    }
+
+    @Test
+    @Order(8)
+    @Transactional
+    public void testClusterErrorClusterName() {
+        SortClusterResponse response = sortService.getClusterConfig("errCluster", "");
+        System.out.println(response.toString());
+        Assertions.assertEquals(-101, response.getCode());
+        Assertions.assertNull(response.getMd5());
+        Assertions.assertNull(response.getData());
         Assertions.assertNotNull(response.getMsg());
     }
 
     @BeforeEach
-    public void prepareSourceProperties() {
-        String testZone = "testZone";
-        String testTopic = "testTopic";
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", "topic1"));
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", "topic2"));
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone1", null));
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", "topic1"));
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", "topic2"));
-        sourceMapper.insertSelective(prepareSourceEntity(TEST_CLUSTER, TEST_TASK, "testZone2", null));
+    private void prepareAll() {
+        this.prepareCluster(TEST_CLUSTER);
+        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER);
+        this.prepareGroupId(TEST_GROUP);
+        this.preparePulsar("testPulsar", true);
+        this.prepareDataNode(TEST_TASK);
     }
 
-    private SortSourceConfigEntity prepareSourceEntity(
-            String clusterName,
-            String taskName,
-            String zone,
-            String topic) {
+    private void prepareDataNode(String taskName) {
+        DataNodeEntity entity = new DataNodeEntity();
+        entity.setName(taskName);
+        entity.setType(TEST_SINK_TYPE);
+        entity.setExtParams("{\"paramKey1\":\"paramValue1\"}");
+        entity.setCreator(TEST_CREATOR);
+        entity.setInCharges(TEST_CREATOR);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setIsDeleted(0);
+        dataNodeEntityMapper.insert(entity);
+    }
 
-        Map<String, String> extParamMap = new HashMap<>();
-        extParamMap.put("param key of " + zone + topic, "param value of " + zone + topic);
+    private void prepareGroupId(String groupId) {
+        InlongGroupEntity entity = new InlongGroupEntity();
+        entity.setInlongGroupId(groupId);
+        entity.setInlongClusterTag(TEST_TAG);
+        entity.setMqResource(TEST_TOPIC);
+        entity.setMqType("PULSAR");
+        entity.setName("testName");
+        entity.setDescription("testDescription");
+        entity.setCreator(TEST_CREATOR);
+        entity.setInCharges(TEST_CREATOR);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setIsDeleted(0);
+        inlongGroupEntityMapper.insert(entity);
+    }
 
-        if (topic == null) {
-            extParamMap.put("zoneName", zone);
-            extParamMap.put("serviceUrl", "testUrl");
-            extParamMap.put("authentication", "testAuth");
-            extParamMap.put("zoneType", "testZoneType");
-        } else {
-            extParamMap.put("partitionCnt", "123");
-            extParamMap.put("topic", "testTopic");
-        }
+    private void prepareCluster(String clusterName) {
+        InlongClusterEntity entity = new InlongClusterEntity();
+        entity.setName(TEST_CLUSTER);
+        entity.setType(TEST_SINK_TYPE);
+        entity.setExtParams("{}");
+        entity.setCreator(TEST_CREATOR);
+        entity.setInCharges(TEST_CREATOR);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setIsDeleted(0);
+        clusterEntityMapper.insert(entity);
+    }
 
-        JSONObject jo = new JSONObject(extParamMap);
-        return SortSourceConfigEntity.builder()
-                .clusterName(clusterName)
-                .taskName(taskName)
-                .zoneName(zone)
-                .topic(topic)
-                .extParams(jo.toString())
-                .build();
+    private void preparePulsar(String pulsarName, boolean isConsumable) {
+        InlongClusterEntity entity = new InlongClusterEntity();
+        entity.setName(pulsarName);
+        entity.setType("PULSAR");
+        entity.setClusterTags(TEST_TAG);
+        entity.setCreator(TEST_CREATOR);
+        entity.setInCharges(TEST_CREATOR);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setIsDeleted(0);
+        StringBuilder extTag = new StringBuilder();
+        extTag.append("zone=").append(TEST_TAG)
+                .append("&producer=true")
+                .append("&consumer=").append(isConsumable? "true":"false");
+        entity.setExtTag(extTag.toString());
+        entity.setExtParams("{\"tenant\":\"testTenant\",\"namespace\":\"testNS\",\"serviceUrl\":\"testServiceUrl\","
+                + "\"authentication\":\"testAuth\",\"adminUrl\":\"testAdmin\"}");
+        clusterEntityMapper.insert(entity);
+    }
+
+    private void prepareTask(String taskName, String groupId, String clusterName) {
+        StreamSinkEntity entity = new StreamSinkEntity();
+        entity.setInlongGroupId(groupId);
+        entity.setInlongStreamId("1");
+        entity.setSinkType(TEST_SINK_TYPE);
+        entity.setSinkName(taskName);
+        entity.setInlongClusterName(clusterName);
+        entity.setDataNodeName(taskName);
+        entity.setSortTaskName(taskName);
+        entity.setCreator(TEST_CREATOR);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setIsDeleted(0);
+        entity.setExtParams("{\"delimiter\":\"|\",\"dataType\":\"text\"}");
+        streamSinkEntityMapper.insert(entity);
     }
 
 }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
@@ -66,7 +66,6 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Autowired
     private SortService sortService;
 
-
     @Test
     @Order(1)
     @Transactional
@@ -234,7 +233,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
         StringBuilder extTag = new StringBuilder();
         extTag.append("zone=").append(TEST_TAG)
                 .append("&producer=true")
-                .append("&consumer=").append(isConsumable? "true":"false");
+                .append("&consumer=").append(isConsumable ? "true" : "false");
         entity.setExtTag(extTag.toString());
         entity.setExtParams("{\"tenant\":\"testTenant\",\"namespace\":\"testNS\",\"serviceUrl\":\"testServiceUrl\","
                 + "\"authentication\":\"testAuth\",\"adminUrl\":\"testAdmin\"}");

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.dataproxy.DataProxyNodeInfo;
 import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,6 +47,7 @@ import java.util.List;
 public class DataProxyController {
 
     @Autowired
+    @Lazy
     private InlongClusterService clusterService;
 
     @PostMapping(value = "/dataproxy/getIpList")


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Fixes #4178

### Motivation

In order to support new db model and reduce the number of query to database, the interface of sort sdk config management should be refactored.

One cluster can register multiple tasks, each task represents one flow from mq to downstream sink, and each task can register multiple InlongGroupId.

### Modifications
Use local cache to maintain _**SortSourceConfigResponse**_ of all tasks.
Reload all configs each 10 seconds.

Main step:
1. Get all streams, and group them to by cluster and task
2. Get all inlong groups, and group them by groupId
3. Get all clusters, and group by cluster tag
4. Prepare CacheZones for each cluster and task

### Verifying this change

*(Please pick either of the following options)*

- [x] This change added tests and can be verified as follows:

  - Empty request params
  - Wrong request params
  - Same md5
  - Corret request params

### Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented?  JavaDocs
