### PR TITLE
[INLONG-4915][Manager] Add Pulsar source type and improve connector jar discovery mechanism

### DIFF
--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -198,7 +198,7 @@ public class FlinkService {
         final File jarFile = new File(localJarPath);
         final String[] programArgs = genProgramArgsV2(flinkInfo, flinkConfig);
 
-        List<URL> classPaths = flinkInfo.getConnectorJarPaths().stream().map(p -> {
+        List<URL> connectorJars = flinkInfo.getConnectorJarPaths().stream().map(p -> {
             try {
                 return new File(p).toURI().toURL();
             } catch (MalformedURLException e) {
@@ -210,10 +210,11 @@ public class FlinkService {
                 .setConfiguration(configuration)
                 .setEntryPointClassName(Constants.ENTRYPOINT_CLASS)
                 .setJarFile(jarFile)
-                .setUserClassPaths(classPaths)
+                .setUserClassPaths(connectorJars)
                 .setArguments(programArgs)
                 .setSavepointRestoreSettings(settings).build();
         JobGraph jobGraph = PackagedProgramUtils.createJobGraph(program, configuration, parallelism, false);
+        jobGraph.addJars(connectorJars);
 
         RestClusterClient<StandaloneClusterId> client = getFlinkClient();
         CompletableFuture<JobID> result = client.submitJob(jobGraph);

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/ConnectorJarType.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/ConnectorJarType.java
@@ -40,6 +40,8 @@ public enum ConnectorJarType {
 
     SQLSERVER_SOURCE("sqlserverExtract", "sqlserver-cdc"),
 
+    PULSAR_SOURCE("pulsarExtract", "pulsar"),
+
     /**
      * load datasource type
      */


### PR DESCRIPTION
- Fix #4915

### Motivation

1. The pulsar source jar selector enum is missing. Add it so the jars are correctly selected when the Pulsar is used as the source node.

2. The current job submits implementation requires the dependent jars to be all present on the Flink node. This is not convenient when the Flink nodes are different from the manager nodes:
<img width="967" alt="image" src="https://user-images.githubusercontent.com/941634/177766426-20c5887e-5681-4d8b-9b90-2ce9868ac93f.png">


### Modifications
Rather than placing jars before the job submits, it's more flexible and straightforward to just upload the dependent connectors with the job jar:
<img width="953" alt="image" src="https://user-images.githubusercontent.com/941634/177766934-ea5f08f9-43c3-41c8-8468-2b5622b953aa.png">

Pros:   Easy to use. Less concern about jar management.  New connectors are supported anytime.
Cons:  Need to upload more files thus extra network overhead.
