### PR TITLE
[INLONG-4977][Kubernetes] Divide persistentVolumeClaim by statefulsets

### DIFF
--- a/.github/ct.yml
+++ b/.github/ct.yml
@@ -19,4 +19,3 @@ chart-dirs:
   - 'docker'
 validate-maintainers: true
 check-version-increment: false
-timeout-minutes: 10

--- a/.github/ct.yml
+++ b/.github/ct.yml
@@ -19,3 +19,4 @@ chart-dirs:
   - 'docker'
 validate-maintainers: true
 check-version-increment: false
+timeout-minutes: 10

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -132,6 +132,7 @@ spec:
           emptyDir: {}
         {{- end }}
       restartPolicy: Always
+  # Create pvc for agent
   {{- if .Values.volumes.agent.persistence }}
   volumeClaimTemplates:
     - metadata:

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -122,7 +122,26 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /data/collect-data
+            - name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
+              mountPath: /opt/inlong-agent/.rockdb
       volumes:
         - name: data
           emptyDir: {}
+        {{- if not .Values.volumes.agent.persistence }}
+        - name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
+          emptyDir: {}
+        {{- end }}
       restartPolicy: Always
+  {{- if .Values.volumes.agent.persistence }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.agent.volumes.size }}
+        {{- if .Values.volumes.agent.storageClassName }}
+        storageClassName: "{{ .Values.volumes.agent.storageClassName }}"
+  {{- end }}
+  {{- end }}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -123,7 +123,7 @@ spec:
             - name: data
               mountPath: /data/collect-data
             - name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
-              mountPath: /opt/inlong-agent/.rockdb
+              mountPath: /opt/inlong-agent/.rocksdb
       volumes:
         - name: data
           emptyDir: {}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -143,5 +143,5 @@ spec:
             storage: {{ .Values.agent.volumes.size }}
         {{- if .Values.volumes.agent.storageClassName }}
         storageClassName: "{{ .Values.volumes.agent.storageClassName }}"
-  {{- end }}
+        {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -127,13 +127,13 @@ spec:
       volumes:
         - name: data
           emptyDir: {}
-        {{- if not .Values.volumes.agent.persistence }}
+        {{- if not .Values.agent.volumes.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
           emptyDir: {}
         {{- end }}
       restartPolicy: Always
   # Create pvc for agent
-  {{- if .Values.volumes.agent.persistence }}
+  {{- if .Values.agent.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.agent.component }}-{{ .Values.agent.volumes.name }}
@@ -142,7 +142,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.agent.volumes.size }}
-        {{- if .Values.volumes.agent.storageClassName }}
-        storageClassName: "{{ .Values.volumes.agent.storageClassName }}"
+        {{- if .Values.agent.volumes.storageClassName }}
+        storageClassName: "{{ .Values.agent.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -101,13 +101,13 @@ spec:
           - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
             mountPath: /opt/inlong-dataproxy/data
       volumes:
-      {{- if not .Values.volumes.dataproxy.persistence }}
+      {{- if not .Values.dataproxy.volumes.persistence }}
       - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
         emptyDir: {}
       {{- end }}
       restartPolicy: Always
   # Create pvc for dataproxy
-  {{- if .Values.volumes.dataproxy.persistence }}
+  {{- if .Values.dataproxy.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
@@ -116,7 +116,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.dataproxy.volumes.size }}
-        {{- if .Values.volumes.dataproxy.storageClassName }}
-        storageClassName: "{{ .Values.volumes.dataproxy.storageClassName }}"
+        {{- if .Values.dataproxy.volumes.storageClassName }}
+        storageClassName: "{{ .Values.dataproxy.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -106,7 +106,7 @@ spec:
         emptyDir: {}
       {{- end }}
       restartPolicy: Always
-  #Create pvc for dataproxy
+  # Create pvc for dataproxy
   {{- if .Values.volumes.dataproxy.persistence }}
   volumeClaimTemplates:
     - metadata:

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -106,6 +106,7 @@ spec:
         emptyDir: {}
       {{- end }}
       restartPolicy: Always
+  #Create pvc for dataproxy
   {{- if .Values.volumes.dataproxy.persistence }}
   volumeClaimTemplates:
     - metadata:

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -97,4 +97,25 @@ spec:
           ports:
             - name: {{ .Values.dataproxy.component }}-port
               containerPort: 46801
+          volumeMounts:
+          - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
+            mountPath: /opt/inlong-dataproxy/data
+      volumes:
+      {{- if not .Values.volumes.dataproxy.persistence }}
+      - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
+        emptyDir: {}
+      {{- end }}
       restartPolicy: Always
+  {{- if .Values.volumes.dataproxy.persistence }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.dataproxy.volumes.size }}
+        {{- if .Values.volumes.dataproxy.storageClassName }}
+        storageClassName: "{{ .Values.volumes.dataproxy.storageClassName }}"
+  {{- end }}
+  {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -117,5 +117,5 @@ spec:
             storage: {{ .Values.dataproxy.volumes.size }}
         {{- if .Values.volumes.dataproxy.storageClassName }}
         storageClassName: "{{ .Values.volumes.dataproxy.storageClassName }}"
-  {{- end }}
+        {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/mysql-pvc.yaml
+++ b/docker/kubernetes/templates/mysql-pvc.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if not .Values.external.mysql.enabled }}
-{{- if .Values.volumes.mysql.persistence }}
+{{- if .Values.mysql.volumes.persistence }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -26,7 +26,7 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}
 spec:
-  storageClassName: {{ .Values.volumes.mysql.storageClassName | quote }}
+  storageClassName: {{ .Values.mysql.volumes.storageClassName | quote }}
   accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:

--- a/docker/kubernetes/templates/mysql-pvc.yaml
+++ b/docker/kubernetes/templates/mysql-pvc.yaml
@@ -16,7 +16,7 @@
 #
 
 {{- if not .Values.external.mysql.enabled }}
-{{- if .Values.volumes.persistence }}
+{{- if .Values.volumes.mysql.persistence }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -26,7 +26,7 @@ metadata:
     {{- include "inlong.commonLabels" . | nindent 4 }}
     component: {{ .Values.mysql.component }}
 spec:
-  storageClassName: {{ .Values.volumes.storageClassName | quote }}
+  storageClassName: {{ .Values.volumes.mysql.storageClassName | quote }}
   accessModes: [ "ReadWriteOnce" ]
   resources:
     requests:

--- a/docker/kubernetes/templates/mysql-statefulset.yaml
+++ b/docker/kubernetes/templates/mysql-statefulset.yaml
@@ -81,14 +81,14 @@ spec:
               mountPath: /docker-entrypoint-initdb.d
       volumes:
         - name: data
-          {{- if .Values.volumes.mysql.persistence }}
+          {{- if .Values.mysql.volumes.persistence }}
           persistentVolumeClaim:
             claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-{{ .Values.mysql.volumes.name }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         - name: sql
-          {{- if .Values.volumes.mysql.persistence }}
+          {{- if .Values.mysql.volumes.persistence }}
           persistentVolumeClaim:
             claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-{{ .Values.mysql.volumes.name }}
           {{- else }}

--- a/docker/kubernetes/templates/mysql-statefulset.yaml
+++ b/docker/kubernetes/templates/mysql-statefulset.yaml
@@ -81,14 +81,14 @@ spec:
               mountPath: /docker-entrypoint-initdb.d
       volumes:
         - name: data
-          {{- if .Values.volumes.persistence }}
+          {{- if .Values.volumes.mysql.persistence }}
           persistentVolumeClaim:
             claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-{{ .Values.mysql.volumes.name }}
           {{- else }}
           emptyDir: {}
           {{- end }}
         - name: sql
-          {{- if .Values.volumes.persistence }}
+          {{- if .Values.volumes.mysql.persistence }}
           persistentVolumeClaim:
             claimName: {{ template "inlong.fullname" . }}-{{ .Values.mysql.component }}-{{ .Values.mysql.volumes.name }}
           {{- else }}

--- a/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
@@ -155,11 +155,11 @@ spec:
           configMap:
             name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-ini
             defaultMode: 0644
-        {{- if not .Values.volumes.persistence }}
+        {{- if not .Values.volumes.tubemqBroker.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.persistence }}
+  {{- if .Values.volumes.tubemqBroker.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.name }}
@@ -168,7 +168,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.tubemqBroker.volumes.size }}
-        {{- if .Values.volumes.storageClassName }}
-        storageClassName: "{{ .Values.volumes.storageClassName }}"
+        {{- if .Values.volumes.tubemqBroker.storageClassName }}
+        storageClassName: "{{ .Values.volumes.tubemqBroker.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-statefulset.yaml
@@ -155,11 +155,11 @@ spec:
           configMap:
             name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-ini
             defaultMode: 0644
-        {{- if not .Values.volumes.tubemqBroker.persistence }}
+        {{- if not .Values.tubemqBroker.volumes.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.tubemqBroker.persistence }}
+  {{- if .Values.tubemqBroker.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqBroker.component }}-{{ .Values.tubemqBroker.volumes.name }}
@@ -168,7 +168,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.tubemqBroker.volumes.size }}
-        {{- if .Values.volumes.tubemqBroker.storageClassName }}
-        storageClassName: "{{ .Values.volumes.tubemqBroker.storageClassName }}"
+        {{- if .Values.tubemqBroker.volumes.storageClassName }}
+        storageClassName: "{{ .Values.tubemqBroker.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/tubemq-master-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-master-statefulset.yaml
@@ -157,11 +157,11 @@ spec:
           configMap:
             name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
             defaultMode: 0644
-        {{- if not .Values.volumes.tubemqMaster.persistence }}
+        {{- if not .Values.tubemqMaster.volumes.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.tubemqMaster.persistence }}
+  {{- if .Values.tubemqMaster.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.name }}
@@ -170,7 +170,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.tubemqMaster.volumes.size }}
-        {{- if .Values.volumes.tubemqMaster.storageClassName }}
-        storageClassName: "{{ .Values.volumes.tubemqMaster.storageClassName }}"
+        {{- if .Values.tubemqMaster.volumes.storageClassName }}
+        storageClassName: "{{ .Values.tubemqMaster.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/tubemq-master-statefulset.yaml
+++ b/docker/kubernetes/templates/tubemq-master-statefulset.yaml
@@ -157,11 +157,11 @@ spec:
           configMap:
             name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-ini
             defaultMode: 0644
-        {{- if not .Values.volumes.persistence }}
+        {{- if not .Values.volumes.tubemqMaster.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.persistence }}
+  {{- if .Values.volumes.tubemqMaster.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.tubemqMaster.component }}-{{ .Values.tubemqMaster.volumes.name }}
@@ -170,7 +170,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.tubemqMaster.volumes.size }}
-        {{- if .Values.volumes.storageClassName }}
-        storageClassName: "{{ .Values.volumes.storageClassName }}"
+        {{- if .Values.volumes.tubemqMaster.storageClassName }}
+        storageClassName: "{{ .Values.volumes.tubemqMaster.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -127,11 +127,11 @@ spec:
             name:
               {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
             defaultMode: 0755
-        {{- if not .Values.volumes.zookeeper.persistence }}
+        {{- if not .Values.zookeeper.volumes.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.zookeeper.persistence }}
+  {{- if .Values.zookeeper.volumes.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.name }}
@@ -140,7 +140,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.zookeeper.volumes.size }}
-        {{- if .Values.volumes.zookeeper.storageClassName }}
-        storageClassName: "{{ .Values.volumes.zookeeper.storageClassName }}"
+        {{- if .Values.zookeeper.volumes.storageClassName }}
+        storageClassName: "{{ .Values.zookeeper.volumes.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/templates/zookeeper-statefulset.yaml
+++ b/docker/kubernetes/templates/zookeeper-statefulset.yaml
@@ -127,11 +127,11 @@ spec:
             name:
               {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}
             defaultMode: 0755
-        {{- if not .Values.volumes.persistence }}
+        {{- if not .Values.volumes.zookeeper.persistence }}
         - name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.name }}
           emptyDir: {}
         {{- end }}
-  {{- if .Values.volumes.persistence }}
+  {{- if .Values.volumes.zookeeper.persistence }}
   volumeClaimTemplates:
     - metadata:
         name: {{ template "inlong.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.name }}
@@ -140,7 +140,7 @@ spec:
         resources:
           requests:
             storage: {{ .Values.zookeeper.volumes.size }}
-        {{- if .Values.volumes.storageClassName }}
-        storageClassName: "{{ .Values.volumes.storageClassName }}"
+        {{- if .Values.volumes.zookeeper.storageClassName }}
+        storageClassName: "{{ .Values.volumes.zookeeper.storageClassName }}"
         {{- end }}
   {{- end }}

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -50,26 +50,6 @@ images:
     tag: latest
   pullPolicy: "IfNotPresent"
 
-volumes:
-  mysql:
-    persistence: false
-    storageClassName: "local-storage"
-  tubemqBroker:
-    persistence: false
-    storageClassName: "local-storage"
-  tubemqMaster:
-    persistence: false
-    storageClassName: "local-storage"
-  zookeeper:
-    persistence: false
-    storageClassName: "local-storage"
-  agent:
-    persistence: false
-    storageClassName: "local-storage"
-  dataproxy:
-    persistence: false
-    storageClassName: "local-storage"
-
 ingress:
   enabled: false
   hosts:
@@ -114,6 +94,8 @@ agent:
   volumes:
     name: rocksdb
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
   env:
     AGENT_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -229,6 +211,8 @@ dataproxy:
   volumes:
     name: data
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
   env:
     DATAPROXY_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -428,6 +412,8 @@ mysql:
   volumes:
     name: data
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
 
 zookeeper:
   component: "zookeeper"
@@ -486,6 +472,8 @@ zookeeper:
   volumes:
     name: data
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
   service:
     annotations:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -548,6 +536,8 @@ tubemqMaster:
   volumes:
     name: data
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
   service:
     annotations:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -628,6 +618,8 @@ tubemqBroker:
   volumes:
     name: data
     size: "10Gi"
+    persistence: false
+    storageClassName: "local-storage"
   service:
     annotations:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -51,8 +51,24 @@ images:
   pullPolicy: "IfNotPresent"
 
 volumes:
-  persistence: false
-  storageClassName: "local-storage"
+  mysql:
+    persistence: false
+    storageClassName: "local-storage"
+  tubemqBroker:
+    persistence: false
+    storageClassName: "local-storage"
+  tubemqMaster:
+    persistence: false
+    storageClassName: "local-storage"
+  zookeeper:
+    persistence: false
+    storageClassName: "local-storage"
+  agent:
+    persistence: false
+    storageClassName: "local-storage"
+  dataproxy:
+    persistence: false
+    storageClassName: "local-storage"
 
 ingress:
   enabled: false
@@ -95,6 +111,9 @@ agent:
       memory: "512Mi"
   # The agent service port
   port: 8008
+  volumes:
+    name: rockdb
+    size: "10Gi"
   env:
     AGENT_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport
@@ -207,6 +226,9 @@ dataproxy:
     externalName:
     # externalIPs is a list of IP addresses for which nodes in the cluster will also accept traffic for this service
     externalIPs:
+  volumes:
+    name: data
+    size: "10Gi"
   env:
     DATAPROXY_JVM_HEAP_OPTS: >-
       -XX:+UseContainerSupport

--- a/docker/kubernetes/values.yaml
+++ b/docker/kubernetes/values.yaml
@@ -112,7 +112,7 @@ agent:
   # The agent service port
   port: 8008
   volumes:
-    name: rockdb
+    name: rocksdb
     size: "10Gi"
   env:
     AGENT_JVM_HEAP_OPTS: >-


### PR DESCRIPTION
### Prepare a Pull Request
Divide persistentVolumeClaim by statefulsets

- Fixes #4977 

### Motivation

Divide persistentVolumeClaim by statefulsets

### Modifications

Divide persistentVolumeClaim by statefulsets

### Verifying this change

1、Divide persistentVolumeClaim by statefulsets
2、Add dataproxy persistentVolumeClaim and agent persistentVolumeClaim