### PR TITLE
[INLONG-4998][Agent] Avoid to create PrometheusMetric repeatedly

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/PluginPrometheusMetric.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/PluginPrometheusMetric.java
@@ -33,32 +33,32 @@ public class PluginPrometheusMetric implements PluginMetric {
     public static final String SEND_SUCCESS_NUM_COUNTER_NAME = "send_success_num_count";
 
     // agent-counters
-    private final Counter readNumCounter = Counter.build()
+    private static final Counter READ_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + READ_NUM_COUNTER_NAME)
             .help("The total number of reads.")
             .labelNames("tag")
             .register();
-    private final Counter sendNumCounter = Counter.build()
+    private static final Counter SEND_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + SEND_NUM_COUNTER_NAME)
             .help("The total number of sends.")
             .labelNames("tag")
             .register();
-    private final Counter readFailedNumCounter = Counter.build()
+    private static final Counter READ_FAILED_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + READ_FAILED_NUM_COUNTER_NAME)
             .help("The total number of failed reads.")
             .labelNames("tag")
             .register();
-    private final Counter sendFailedNumCounter = Counter.build()
+    private static final Counter SEND_FAILED_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + SEND_FAILED_NUM_COUNTER_NAME)
             .help("The total number of failed sends.")
             .labelNames("tag")
             .register();
-    private final Counter readSuccessNumCounter = Counter.build()
+    private static final Counter READ_SUCCESS_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + READ_SUCCESS_NUM_COUNTER_NAME)
             .help("The total number of successful reads.")
             .labelNames("tag")
             .register();
-    private final Counter sendSuccessNumCounter = Counter.build()
+    private static final Counter SEND_SUCCESS_NUM_COUNTER = Counter.build()
             .name(AGENT_PLUGIN_METRICS_PREFIX + SEND_SUCCESS_NUM_COUNTER_NAME)
             .help("The total number of successful sends.")
             .labelNames("tag")
@@ -77,66 +77,66 @@ public class PluginPrometheusMetric implements PluginMetric {
 
     @Override
     public void incReadNum() {
-        readNumCounter.labels(tagName).inc();
+        READ_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getReadNum() {
-        return (long) readNumCounter.labels(tagName).get();
+        return (long) READ_NUM_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incSendNum() {
-        sendNumCounter.labels(tagName).inc();
+        SEND_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSendNum() {
-        return (long) sendNumCounter.labels(tagName).get();
+        return (long) SEND_NUM_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incReadFailedNum() {
-        readFailedNumCounter.labels(tagName).inc();
+        READ_FAILED_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getReadFailedNum() {
-        return (long) readFailedNumCounter.labels(tagName).get();
+        return (long) READ_FAILED_NUM_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incSendFailedNum() {
-        sendFailedNumCounter.labels(tagName).inc();
+        SEND_FAILED_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSendFailedNum() {
-        return (long) sendFailedNumCounter.labels(tagName).get();
+        return (long) SEND_FAILED_NUM_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incReadSuccessNum() {
-        readSuccessNumCounter.labels(tagName).inc();
+        READ_SUCCESS_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getReadSuccessNum() {
-        return (long) readSuccessNumCounter.labels(tagName).get();
+        return (long) READ_SUCCESS_NUM_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incSendSuccessNum() {
-        sendSuccessNumCounter.labels(tagName).inc();
+        SEND_SUCCESS_NUM_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public void incSendSuccessNum(int delta) {
-        sendSuccessNumCounter.labels(tagName).inc(delta);
+        SEND_SUCCESS_NUM_COUNTER.labels(tagName).inc(delta);
     }
 
     @Override
     public long getSendSuccessNum() {
-        return (long) sendSuccessNumCounter.labels(tagName).get();
+        return (long) SEND_SUCCESS_NUM_COUNTER.labels(tagName).get();
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/SinkPrometheusMetric.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/SinkPrometheusMetric.java
@@ -30,13 +30,13 @@ public class SinkPrometheusMetric implements SinkMetric {
 
     private final String tagName;
 
-    private final Counter sinkSuccessCounter = Counter.build()
+    private static final Counter SINK_SUCCESS_COUNTER = Counter.build()
             .name(AGENT_SINK_METRICS_PREFIX + SINK_SUCCESS_COUNTER_NAME)
             .help("The success message count in agent sink since agent started.")
             .labelNames("tag")
             .register();
 
-    private final Counter sinkFailCounter = Counter.build()
+    private static final Counter SINK_FAIL_COUNTER = Counter.build()
             .name(AGENT_SINK_METRICS_PREFIX + SINK_FAIL_COUNTER_NAME)
             .help("The failed message count in agent sink since agent started.")
             .labelNames("tag")
@@ -53,21 +53,21 @@ public class SinkPrometheusMetric implements SinkMetric {
 
     @Override
     public void incSinkSuccessCount() {
-        sinkSuccessCounter.labels(tagName).inc();
+        SINK_SUCCESS_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSinkSuccessCount() {
-        return (long) sinkSuccessCounter.labels(tagName).get();
+        return (long) SINK_SUCCESS_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incSinkFailCount() {
-        sinkFailCounter.labels(tagName).inc();
+        SINK_FAIL_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSinkFailCount() {
-        return (long) sinkFailCounter.labels(tagName).get();
+        return (long) SINK_FAIL_COUNTER.labels(tagName).get();
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/SourcePrometheusMetric.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/metrics/SourcePrometheusMetric.java
@@ -27,12 +27,12 @@ public class SourcePrometheusMetric implements SourceMetric {
     public static final String SOURCE_FAIL_COUNTER_NAME = "fail_count";
 
     // agent-source-counters
-    private final Counter sourceSuccessCounter = Counter.build()
+    private static final Counter SOURCE_SUCCESS_COUNTER = Counter.build()
             .name(AGENT_SOURCE_METRICS_PREFIX + SOURCE_SUCCESS_COUNTER_NAME)
             .help("The success message count in agent source since agent started.")
             .labelNames("tag")
             .register();
-    private final Counter sourceFailCounter = Counter.build()
+    private static final Counter SOURCE_FAIL_COUNTER = Counter.build()
             .name(AGENT_SOURCE_METRICS_PREFIX + SOURCE_FAIL_COUNTER_NAME)
             .help("The failed message count in agent source since agent started.")
             .labelNames("tag")
@@ -51,21 +51,21 @@ public class SourcePrometheusMetric implements SourceMetric {
 
     @Override
     public void incSourceSuccessCount() {
-        sourceSuccessCounter.labels(tagName).inc();
+        SOURCE_SUCCESS_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSourceSuccessCount() {
-        return (long) sourceSuccessCounter.labels(tagName).get();
+        return (long) SOURCE_SUCCESS_COUNTER.labels(tagName).get();
     }
 
     @Override
     public void incSourceFailCount() {
-        sourceFailCounter.labels(tagName).inc();
+        SOURCE_FAIL_COUNTER.labels(tagName).inc();
     }
 
     @Override
     public long getSourceFailCount() {
-        return (long) sourceFailCounter.labels(tagName).get();
+        return (long) SOURCE_FAIL_COUNTER.labels(tagName).get();
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-4998][Agent] Create PrometheusMetric repeatedly

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #4998 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
