### PR TITLE
[INLONG-5007][Manager] Client supports getting sink details by id

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongStream.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongStream.java
@@ -52,6 +52,16 @@ public interface InlongStream {
     Map<String, StreamSink> getSinks();
 
     /**
+     * Get detail info of data sink by id.
+     */
+    StreamSink getSinkInfoById(Integer sinkId);
+
+    /**
+     * Get detail info of data sink by name.
+     */
+    StreamSink getSinkInfoByName(String sinkName);
+
+    /**
      * Return data transform node defined in stream(split,string replace etc)
      * key is transform name which must be unique within one stream scope.
      */

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongStreamImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongStreamImpl.java
@@ -413,4 +413,22 @@ public class InlongStreamImpl implements InlongStream {
         }
     }
 
+    @Override
+    public StreamSink getSinkInfoById(Integer sinkId) {
+        Preconditions.checkNotNull(sinkId, "sinkId cannot be null");
+        // Get from cache firstly
+        return this.streamSinks.values()
+                .stream()
+                .filter(streamSink -> streamSink.getId().equals(sinkId))
+                .findAny()
+                // Try to get from db, if it doesn't exist in cache
+                .orElseGet(() -> managerClient.getSinkInfo(sinkId));
+    }
+
+    @Override
+    public StreamSink getSinkInfoByName(String sinkName) {
+        Preconditions.checkNotEmpty(sinkName, "sinkName cannot be empty");
+        return this.streamSinks.get(sinkName);
+    }
+
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClient.java
@@ -443,6 +443,15 @@ public class InnerInlongManagerClient {
     }
 
     /**
+     * Get detail information of data sink.
+     */
+    public StreamSink getSinkInfo(Integer sinkId) {
+        Response<StreamSink> response = executeHttpCall(streamSinkApi.getSinkInfo(sinkId));
+        assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
      * Update the stream sink info.
      */
     public Pair<Boolean, String> updateSink(SinkRequest sinkRequest) {

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSinkApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSinkApi.java
@@ -44,4 +44,7 @@ public interface StreamSinkApi {
     Call<Response<PageInfo<StreamSink>>> listSinks(@Query("inlongGroupId") String groupId,
             @Query("inlongStreamId") String streamId, @Query("sinkType") String sinkType);
 
+    @GET("sink/get/{id}")
+    Call<Response<StreamSink>> getSinkInfo(@Path("id") Integer sinkId);
+
 }

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.client.api.ClientConfiguration;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
 import org.apache.inlong.manager.common.auth.DefaultAuthentication;
 import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.enums.SinkType;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterRequest;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupExtInfo;
@@ -688,7 +689,7 @@ class InnerInlongManagerClientTest {
                 .id(1)
                 .inlongGroupId("1")
                 .inlongStreamId("1")
-                .sinkType("MYSQL")
+                .sinkType(SinkType.SINK_MYSQL)
                 .sinkName("mysql_test")
                 // streamNode field
                 .preNodes(new HashSet<>())

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
@@ -60,6 +60,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -671,6 +672,45 @@ class InnerInlongManagerClientTest {
         request.setClusterTags("test_cluster");
         Integer clusterIndex = innerInlongManagerClient.saveCluster(request);
         Assertions.assertEquals(1, (int) clusterIndex);
+    }
+
+    @Test
+    void testGetMysqlSinkInfo() {
+        StreamSink streamSink = MySQLSink.builder()
+                // mysql field
+                .jdbcUrl("127.0.0.1:3306")
+                .username("test")
+                .password("pwd")
+                .tableName("tableName")
+                .primaryKey("id")
+                // streamSink field
+                .id(1)
+                .inlongGroupId("1")
+                .inlongStreamId("1")
+                .sinkType("MYSQL")
+                .sinkName("mysql_test")
+                // streamNode field
+                .preNodes(new HashSet<>())
+                .postNodes(new HashSet<>())
+                .fieldList(
+                        Lists.newArrayList(StreamField.builder()
+                                .fieldName("id")
+                                .fieldType("int")
+                                .build())
+                )
+                .build();
+
+        stubFor(
+                get(urlMatching("/api/inlong/manager/sink/get/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(streamSink))
+                                ))
+        );
+
+        StreamSink sinkInfo = innerInlongManagerClient.getSinkInfo(1);
+        Assertions.assertEquals(1, sinkInfo.getId());
+        Assertions.assertTrue(sinkInfo instanceof MySQLSink);
     }
 
 }

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/InnerInlongManagerClientTest.java
@@ -43,6 +43,7 @@ import org.apache.inlong.manager.common.pojo.sink.hbase.HBaseSink;
 import org.apache.inlong.manager.common.pojo.sink.hive.HiveSink;
 import org.apache.inlong.manager.common.pojo.sink.iceberg.IcebergSink;
 import org.apache.inlong.manager.common.pojo.sink.kafka.KafkaSink;
+import org.apache.inlong.manager.common.pojo.sink.mysql.MySQLSink;
 import org.apache.inlong.manager.common.pojo.sink.postgresql.PostgreSQLSink;
 import org.apache.inlong.manager.common.pojo.source.StreamSource;
 import org.apache.inlong.manager.common.pojo.source.autopush.AutoPushSource;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/mysql/MySQLSink.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sink/mysql/MySQLSink.java
@@ -19,9 +19,11 @@ package org.apache.inlong.manager.common.pojo.sink.mysql;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 import org.apache.inlong.manager.common.enums.SinkType;
 import org.apache.inlong.manager.common.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.pojo.sink.StreamSink;
@@ -32,6 +34,8 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
  * MySQL sink info
  */
 @Data
+@SuperBuilder
+@AllArgsConstructor
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @ApiModel(value = "MySQL sink info")


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5007

### Motivation

The Web already has an interface, but there is no corresponding interface on the client side

### Modifications

- Add the method that Client can query the details of the sink through the Id or Name of the sink

### Verifying this change

- [x] This change is already covered by existing tests, such as:
  - org.apache.inlong.manager.client.api.inner.InnerInlongManagerClientTest#testGetMysqlSinkInfo
