### PR TITLE
[INLONG-5018][Manager] Support for Tube data sources

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
@@ -29,6 +29,7 @@ public enum TaskTypeEnum {
     ORACLE(7),
     SQLSERVER(8),
     MONGODB(9),
+    TUBEMQ(10)
 
 
     ;
@@ -61,6 +62,8 @@ public enum TaskTypeEnum {
                 return SQLSERVER;
             case 9:
                 return MONGODB;
+            case 10:
+                return TUBEMQ;
             default:
                 throw new RuntimeException(String.format("Unsupported taskType=%s", taskType));
         }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/SourceType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/SourceType.java
@@ -37,6 +37,7 @@ public enum SourceType {
     ORACLE("ORACLE", TaskTypeEnum.ORACLE),
     SQLSERVER("SQLSERVER", TaskTypeEnum.SQLSERVER),
     MONGODB("MONGODB", TaskTypeEnum.MONGODB),
+    TUBEMQ("TUBEMQ",TaskTypeEnum.TUBEMQ),
 
     ;
 
@@ -50,6 +51,7 @@ public enum SourceType {
     public static final String SOURCE_ORACLE = "ORACLE";
     public static final String SOURCE_SQLSERVER = "SQLSERVER";
     public static final String SOURCE_MONGODB = "MONGODB";
+    public static final String SOURCE_TUBEMQ = "TUBEMQ";
 
     @Getter
     private final String type;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSource.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSource.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.manager.common.pojo.source.tubemq;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.inlong.manager.common.enums.SourceType;
+import org.apache.inlong.manager.common.pojo.source.SourceRequest;
+import org.apache.inlong.manager.common.pojo.source.StreamSource;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+import java.util.TreeSet;
+
+/**
+ * The TubeMQ source info
+ */
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "TubeMQ source info")
+@JsonTypeDefine(value = SourceType.SOURCE_TUBEMQ)
+public class TubeMQSource extends StreamSource {
+
+    @ApiModelProperty("Master RPC of the TubeMQ")
+    private String masterRpc;
+
+    @ApiModelProperty("Topic of the TubeMQ")
+    private String topic;
+
+    @ApiModelProperty("Group of the TubeMQ")
+    private String groupId;
+
+    @ApiModelProperty("Session key of the TubeMQ")
+    private String sessionKey;
+
+    /**
+     * The tubemq consumers use this tid set to filter records reading from server.
+     */
+    @ApiModelProperty("Tid of the TubeMQ")
+    private TreeSet<String> tid;
+
+    public TubeMQSource() {
+        this.setSourceType(SourceType.TUBEMQ.name());
+    }
+
+    @Override
+    public SourceRequest genSourceRequest() {
+        return CommonBeanUtils.copyProperties(this, TubeMQSourceRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSourceDTO.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSourceDTO.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.manager.common.pojo.source.tubemq;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+
+import javax.validation.constraints.NotNull;
+import java.util.TreeSet;
+
+/**
+ * TubeMQ source info
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TubeMQSourceDTO {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @ApiModelProperty("Master RPC of the TubeMQ,127.0.0.1:8715")
+    private String masterRpc;
+
+    @ApiModelProperty("Topic of the TubeMQ")
+    private String topic;
+
+    @ApiModelProperty("Format of the TubeMQ")
+    private String format;
+
+    @ApiModelProperty("Group of the TubeMQ")
+    private String groupId;
+
+    @ApiModelProperty("Session key of the TubeMQ")
+    private String sessionKey;
+
+    /**
+     * The tubemq consumers use this tid set to filter records reading from server.
+     */
+    @ApiModelProperty("Tid of the TubeMQ")
+    private TreeSet<String> tid;
+    
+    /**
+     * Get the dto instance from the request
+     */
+    public static TubeMQSourceDTO getFromRequest(TubeMQSourceRequest request) {
+        return TubeMQSourceDTO.builder()
+                .masterRpc(request.getMasterRpc())
+                .topic(request.getTopic())
+                .format(request.getSerializationType())
+                .groupId(request.getGroupId())
+                .sessionKey(request.getSessionKey())
+                .tid(request.getTid())
+                .build();
+    }
+
+    /**
+     * Get the dto instance from the JSON string
+     */
+    public static TubeMQSourceDTO getFromJson(@NotNull String extParams) {
+        try {
+            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return OBJECT_MAPPER.readValue(extParams, TubeMQSourceDTO.class);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT.getMessage());
+        }
+    }
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSourceRequest.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/source/tubemq/TubeMQSourceRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.manager.common.pojo.source.tubemq;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.enums.SourceType;
+import org.apache.inlong.manager.common.pojo.source.SourceRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+import java.util.TreeSet;
+
+/**
+ * Request info of the TubeMQ source
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Request of the TubeMQ source")
+@JsonTypeDefine(value = SourceType.SOURCE_TUBEMQ)
+public class TubeMQSourceRequest extends SourceRequest {
+    @ApiModelProperty("Master RPC of the TubeMQ,127.0.0.1:8715")
+    private String masterRpc;
+
+    @ApiModelProperty("Topic of the TubeMQ")
+    private String topic;
+
+    @ApiModelProperty("Group of the TubeMQ")
+    private String groupId;
+
+    @ApiModelProperty("Session key of the TubeMQ")
+    private String sessionKey;
+
+    /**
+     * The tubemq consumers use this tid set to filter records reading from server.
+     */
+    @ApiModelProperty("Tid of the TubeMQ")
+    private TreeSet<String> tid;
+
+    public TubeMQSourceRequest() {
+        this.setSourceType(SourceType.TUBEMQ.name());
+    }
+    
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/ExtractNodeUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/ExtractNodeUtils.java
@@ -34,6 +34,7 @@ import org.apache.inlong.manager.common.pojo.source.oracle.OracleSource;
 import org.apache.inlong.manager.common.pojo.source.postgresql.PostgreSQLSource;
 import org.apache.inlong.manager.common.pojo.source.pulsar.PulsarSource;
 import org.apache.inlong.manager.common.pojo.source.sqlserver.SQLServerSource;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSource;
 import org.apache.inlong.manager.common.pojo.stream.StreamField;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.constant.OracleConstant.ScanStartUpMode;
@@ -47,6 +48,7 @@ import org.apache.inlong.sort.protocol.node.extract.OracleExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PostgresExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.SqlServerExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.TubeMQExtractNode;
 import org.apache.inlong.sort.protocol.node.format.AvroFormat;
 import org.apache.inlong.sort.protocol.node.format.CanalJsonFormat;
 import org.apache.inlong.sort.protocol.node.format.CsvFormat;
@@ -93,6 +95,8 @@ public class ExtractNodeUtils {
                 return createExtractNode((SQLServerSource) sourceInfo);
             case MONGODB:
                 return createExtractNode((MongoDBSource) sourceInfo);
+            case TUBEMQ:
+                return createExtractNode((TubeMQSource)sourceInfo);
             default:
                 throw new IllegalArgumentException(
                         String.format("Unsupported sourceType=%s to create extractNode", sourceType));
@@ -390,6 +394,34 @@ public class ExtractNodeUtils {
                 source.getUsername(),
                 source.getPassword(),
                 source.getDatabase()
+        );
+    }
+
+    /**
+     * Create TubeMQ extract node
+     *
+     * @param source TubeMQ source info
+     * @return TubeMQ extract node info
+     */
+    public static TubeMQExtractNode createExtractNode(TubeMQSource source) {
+        String name = source.getSourceName();
+        List<StreamField> streamFields = source.getFieldList();
+        List<FieldInfo> fieldInfos = streamFields.stream()
+                .map(streamFieldInfo -> FieldInfoUtils.parseStreamFieldInfo(streamFieldInfo, name))
+                .collect(Collectors.toList());
+        Map<String, String> properties = Maps.newHashMap();
+        return new TubeMQExtractNode(
+                name,
+                name,
+                fieldInfos,
+                null,
+                properties, 
+                source.getMasterRpc(),
+                source.getTopic(),
+                source.getSerializationType(),
+                source.getGroupId(),
+                source.getSessionKey(),
+                source.getTid()
         );
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.manager.service.source.tubemq;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.SourceType;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.pojo.source.SourceRequest;
+import org.apache.inlong.manager.common.pojo.source.StreamSource;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSource;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSourceDTO;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSourceRequest;
+import org.apache.inlong.manager.common.pojo.stream.StreamField;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.StreamSourceEntity;
+import org.apache.inlong.manager.service.source.AbstractSourceOperator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * TubeMQ source operator
+ */
+@Service
+public class TubeMQSourceOperator extends AbstractSourceOperator {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    protected void setTargetEntity(SourceRequest request, StreamSourceEntity targetEntity) {
+        TubeMQSourceRequest sourceRequest = (TubeMQSourceRequest) request;
+        CommonBeanUtils.copyProperties(sourceRequest, targetEntity, true);
+        try {
+            TubeMQSourceDTO dto = TubeMQSourceDTO.getFromRequest(sourceRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT.getMessage());
+        }
+    }
+
+    @Override
+    protected String getSourceType() {
+        return SourceType.TUBEMQ.getType();
+    }
+
+    @Override
+    public Boolean accept(SourceType sourceType) {
+        return SourceType.TUBEMQ == sourceType;
+    }
+
+    @Override
+    public StreamSource getFromEntity(StreamSourceEntity entity) {
+        TubeMQSource source = new TubeMQSource();
+        if (entity == null) {
+            return source;
+        }
+        TubeMQSourceDTO dto = TubeMQSourceDTO.getFromJson(entity.getExtParams());
+        CommonBeanUtils.copyProperties(entity, source, true);
+        CommonBeanUtils.copyProperties(dto, source, true);
+        List<StreamField> sourceFields = super.getSourceFields(entity.getId());
+        source.setFieldList(sourceFields);
+        return source;
+    }
+
+}

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/source/TubeMQSourceServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/source/TubeMQSourceServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.inlong.manager.service.core.source;
+
+import org.apache.inlong.manager.common.enums.SourceType;
+import org.apache.inlong.manager.common.pojo.source.StreamSource;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSource;
+import org.apache.inlong.manager.common.pojo.source.tubemq.TubeMQSourceRequest;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.service.ServiceBaseTest;
+import org.apache.inlong.manager.service.core.impl.InlongStreamServiceTest;
+import org.apache.inlong.manager.service.source.StreamSourceService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Tube source service test.
+ */
+public class TubeMQSourceServiceTest extends ServiceBaseTest {
+
+    @Autowired
+    private StreamSourceService sourceService;
+    @Autowired
+    private InlongStreamServiceTest streamServiceTest;
+
+    /**
+     * Save source info.
+     */
+    public Integer saveSource() {
+        streamServiceTest.saveInlongStream(GLOBAL_GROUP_ID, GLOBAL_STREAM_ID, GLOBAL_OPERATOR);
+        TubeMQSourceRequest sourceInfo = new TubeMQSourceRequest();
+        sourceInfo.setInlongGroupId(GLOBAL_GROUP_ID);
+        sourceInfo.setInlongStreamId(GLOBAL_STREAM_ID);
+        sourceInfo.setSourceName("test_tube");
+        sourceInfo.setMasterRpc("127.0.0.1:8715");
+        sourceInfo.setTopic("inlong");
+        sourceInfo.setSerializationType("json");
+        sourceInfo.setGroupId("test1");
+        sourceInfo.setSourceType(SourceType.TUBEMQ.getType());
+        return sourceService.save(sourceInfo, GLOBAL_OPERATOR);
+    }
+
+    @Test
+    public void testSaveAndDelete() {
+        Integer id = this.saveSource();
+        Assertions.assertNotNull(id);
+        boolean result = sourceService.delete(id, GLOBAL_OPERATOR);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testListByIdentifier() {
+        Integer id = this.saveSource();
+        StreamSource source = sourceService.get(id);
+        Assertions.assertEquals(GLOBAL_GROUP_ID, source.getInlongGroupId());
+        sourceService.delete(id, GLOBAL_OPERATOR);
+    }
+
+    @Test
+    public void testGetAndUpdate() {
+        Integer id = this.saveSource();
+        StreamSource response = sourceService.get(id);
+        Assertions.assertEquals(GLOBAL_GROUP_ID, response.getInlongGroupId());
+        TubeMQSource tubeMQSource = (TubeMQSource) response;
+        TubeMQSourceRequest request = CommonBeanUtils.copyProperties(tubeMQSource, TubeMQSourceRequest::new);
+        boolean result = sourceService.update(request, GLOBAL_OPERATOR);
+        Assertions.assertTrue(result);
+        sourceService.delete(id, GLOBAL_OPERATOR);
+    }
+
+}


### PR DESCRIPTION
This feature adds support for Tubes as data sources.

- Fixes #5018 

### Motivation
Data source TubeMQ are supported and can be consumed by Sort.

### Modifications

1.Update SortConfig4NormalGroupOperator
2.Add TubeMQ source bean and request

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
