### PR TITLE
[INLONG-5052][Manager] The workflow that failed to execute still failed, but returned success

### DIFF
--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
@@ -68,6 +68,8 @@ public class TaskServiceImpl implements TaskService {
         WorkflowContext context = workflowContextBuilder
                 .buildContextForTask(taskId, WorkflowAction.COMPLETE, remark, operator);
         processorExecutor.executeComplete(context.getActionContext().getTask(), context);
+        ServiceTask serviceTask = (ServiceTask) context.getActionContext().getTask();
+        serviceTask.initListeners(context);
         return context;
     }
 

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
@@ -23,6 +23,7 @@ import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.core.ProcessorExecutor;
 import org.apache.inlong.manager.workflow.core.TaskService;
 import org.apache.inlong.manager.workflow.core.WorkflowContextBuilder;
+import org.apache.inlong.manager.workflow.definition.ServiceTask;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/core/impl/TaskServiceImpl.java
@@ -68,9 +68,9 @@ public class TaskServiceImpl implements TaskService {
     public WorkflowContext complete(Integer taskId, String remark, String operator) {
         WorkflowContext context = workflowContextBuilder
                 .buildContextForTask(taskId, WorkflowAction.COMPLETE, remark, operator);
-        processorExecutor.executeComplete(context.getActionContext().getTask(), context);
         ServiceTask serviceTask = (ServiceTask) context.getActionContext().getTask();
         serviceTask.initListeners(context);
+        processorExecutor.executeComplete(context.getActionContext().getTask(), context);
         return context;
     }
 


### PR DESCRIPTION
### Prepare a Pull Request



- Fixes #5052

### Motivation

Ensure that the re executed workflow will no longer behave as successful execution and go to the next step in the case of failure

### Modifications

Add  listeners for workflowtask on the interface where you click execute again

### Verifying this change

*(Please pick either of the following options)*

- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)
