### PR TITLE
[INLONG-5054][Agent] Fix Agent can not import old job after reboot due to inconsistent prefix

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -198,6 +198,13 @@ public class AgentUtils {
     }
 
     /**
+     * Get job id, such as "job_1"
+     */
+    public static String getSingleJobId(String prefix, String id) {
+        return prefix + id;
+    }
+
+    /**
      * Sleep millisecond
      */
     public static void silenceSleepInMs(long millisecond) {

--- a/inlong-agent/agent-common/src/test/resources/binlogJob.json
+++ b/inlong-agent/agent-common/src/test/resources/binlogJob.json
@@ -1,0 +1,23 @@
+{
+  "job.version": 1,
+  "proxy.manager.host": "0.0.0.0",
+  "proxy.inlongStreamId": "test_binlog",
+  "job.binlogJob.password": "123456",
+  "job.binlogJob.hostname": "0.0.0.0",
+  "job.binlogJob.tableWhiteList": "[\\s\\S]*.*",
+  "job.id": "5",
+  "job.binlogJob.user": "root",
+  "proxy.manager.port": "8000",
+  "job.binlogJob.port": "3306",
+  "job.channel": "org.apache.inlong.agent.plugin.channel.MemoryChannel",
+  "job.binlogJob.serverTimezone": "UTC+8",
+  "proxy.inlongGroupId": "test_binlog",
+  "job.sink": "org.apache.inlong.agent.plugin.sinks.ProxySink",
+  "job.binlogJob.snapshot.mode": "initial",
+  "job.binlogJob.offset.intervalMs": "1000",
+  "job.binlogJob.history.filename": "/data/.history",
+  "job.op": "0",
+  "proxy.sync": false,
+  "job.source": "org.apache.inlong.agent.plugin.sources.BinlogSource",
+  "job.binlogJob.databaseWhiteList": "[\\s\\S]*.*"
+}

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/conf/ConfigJetty.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/conf/ConfigJetty.java
@@ -92,14 +92,12 @@ public class ConfigJetty implements Closeable {
                 TaskTypeEnum taskType = TaskTypeEnum
                         .getTaskType(jobProfile.getInt(JOB_SOURCE_TYPE));
                 switch (taskType) {
-                    case SQL:
-                        jobManager.submitSqlJobProfile(jobProfile);
-                        break;
                     case FILE:
                         jobManager.submitFileJobProfile(jobProfile);
                         break;
                     case KAFKA:
                     case BINLOG:
+                    case SQL:
                         jobManager.submitJobProfile(jobProfile, true);
                         break;
                     default:

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobManager.java
@@ -147,26 +147,10 @@ public class JobManager extends AbstractDaemon {
         }
         String jobId = profile.get(JOB_ID);
         if (singleJob) {
-            profile.set(JOB_INSTANCE_ID, jobId);
+            profile.set(JOB_INSTANCE_ID, AgentUtils.getSingleJobId(JOB_ID_PREFIX, jobId));
         } else {
             profile.set(JOB_INSTANCE_ID, AgentUtils.getUniqId(JOB_ID_PREFIX, jobId, index.incrementAndGet()));
         }
-        LOGGER.info("submit job profile {}", profile.toJsonStr());
-        getJobConfDb().storeJobFirstTime(profile);
-        addJob(new Job(profile));
-        return true;
-    }
-
-    /**
-     * add sql job profile
-     *
-     * @param profile job profile.
-     */
-    public boolean submitSqlJobProfile(JobProfile profile) {
-        if (isJobValid(profile)) {
-            return false;
-        }
-        profile.set(JOB_INSTANCE_ID, SQL_JOB_ID);
         LOGGER.info("submit job profile {}", profile.toJsonStr());
         getJobConfDb().storeJobFirstTime(profile);
         addJob(new Job(profile));

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -272,7 +272,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         if (profile == null) {
             return;
         }
-        agentManager.getJobManager().submitSqlJobProfile(profile);
+        agentManager.getJobManager().submitJobProfile(profile, true);
     }
 
     /**

--- a/inlong-dashboard/package-lock.json
+++ b/inlong-dashboard/package-lock.json
@@ -11486,7 +11486,7 @@
     "json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
+      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
       "requires": {
         "string-convert": "^0.2.0"
       }

--- a/inlong-dashboard/package-lock.json
+++ b/inlong-dashboard/package-lock.json
@@ -11486,7 +11486,7 @@
     "json2mq": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/json2mq/-/json2mq-0.2.0.tgz",
-      "integrity": "sha512-SzoRg7ux5DWTII9J2qkrZrqV1gt+rTaoufMxEzXbS26Uid0NwaJd123HcoB80TgubEppxxIGdNxCx50fEoEWQA==",
+      "integrity": "sha1-tje9O6nqvhIsg+lyBIOusQ0skEo=",
       "requires": {
         "string-convert": "^0.2.0"
       }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-5054][Agent] Fix Agent can not import old job after reboot due to inconsistent prefix

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5054 

### Modifications

when store single jobProfile into local db, add prefix “job_” with the job id

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
