### PR TITLE
[INLONG-5088][Manager] Support only consumes the MQ cluster with the same tag

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -224,7 +224,7 @@ public class SortSourceServiceImpl implements SortSourceService {
                 validClusterInfos.putAll(allTag2ClusterInfos);
             }
 
-            // prepare
+            // prepare the new config and md5
             Map<String, CacheZoneConfig> task2Config = new ConcurrentHashMap<>();
             Map<String, String> task2Md5 = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
[INLONG-5088][Manager]  SortSource Service support only consume the MQ cluster with the same tag
- Fixes #5088 

### Motivation

Current getSortSource API will return all the stream of the given task, without consider whether the MQ cluster of these streams match the task or not.


### Modifications

SortSource Service support only consume the MQ cluster with the same tag

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is already covered by existing tests, such as:
SortServiceImplTest

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? JavaDocs
