### PR TITLE
[INLONG-5051][Manager] Get Sort cluster allows a cluster with an empty tasks

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -40,7 +40,7 @@ import javax.annotation.PostConstruct;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -229,6 +229,7 @@ public class SortClusterServiceImpl implements SortClusterService {
                     SortSinkInfo sinkParams = taskSinkParamMap.get(task.getDataNodeName());
                     return this.getTaskConfig(taskName, type, idParams, sinkParams);
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
 
         return SortClusterConfig.builder()
@@ -255,10 +256,10 @@ public class SortClusterServiceImpl implements SortClusterService {
             List<SortIdInfo> idParams,
             SortSinkInfo sinkParams) {
 
-        Optional.ofNullable(idParams)
-                .orElseThrow(() -> new IllegalStateException(("There is no any id params of task " + taskName)));
-        Optional.ofNullable(sinkParams)
-                .orElseThrow(() -> new IllegalStateException("There is no any sink params of task " + taskName));
+        // return null if id params or sink params are empty.
+        if (idParams == null || sinkParams == null) {
+            return null;
+        }
 
         if (!type.equalsIgnoreCase(sinkParams.getType())) {
             throw new IllegalArgumentException(

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -125,13 +125,13 @@ public class SortClusterServiceImpl implements SortClusterService {
                     .build();
         }
 
-        // there is no config
+        // there is no config, but still return success.
         if (sortClusterConfigMap.get(clusterName) == null) {
             String errMsg = "There is not config for cluster " + clusterName;
             LOGGER.info(errMsg);
             return SortClusterResponse.builder()
                     .msg(errMsg)
-                    .code(RESPONSE_CODE_REQ_PARAMS_ERROR)
+                    .code(RESPONSE_CODE_SUCCESS)
                     .build();
         }
 

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
@@ -163,7 +163,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
     public void testClusterErrorClusterName() {
         SortClusterResponse response = sortService.getClusterConfig("errCluster", "");
         System.out.println(response.toString());
-        Assertions.assertEquals(-101, response.getCode());
+        Assertions.assertEquals(0, response.getCode());
         Assertions.assertNull(response.getMd5());
         Assertions.assertNull(response.getData());
         Assertions.assertNotNull(response.getMsg());


### PR DESCRIPTION
[INLONG-5051] getSortCluster API allows a cluster with empty task

- Fixes #5051

### Motivation

The case that sort-standalone request a cluster, which has empty config, should be considered as success.
To prevent the case that the last stream of this cluster is deleted, and sort-standalone recevied a non success response, it will not stop the consumption of this stream case the response code is not success.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is already covered by existing tests, such as:

### Documentation

  - Does this pull request introduce a new feature?  yes
  - If yes, how is the feature documented? JavaDocs
