### PR TITLE
[INLONG-5094][SortStandalone]  Implements time interval interceptor

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -1,20 +1,18 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.inlong.sort.standalone.rollback;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -48,6 +48,7 @@ public class TimeBasedFilterInterceptor implements Interceptor {
     public TimeBasedFilterInterceptor(long startTime, long stopTime) {
         this.startTime = startTime;
         this.stopTime = stopTime;
+        logger.info("create TimeBasedFilterInterceptor successfully.");
     }
 
     @Override

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -103,7 +103,6 @@ public class TimeBasedFilterInterceptor implements Interceptor {
 
         @Override
         public Interceptor build() {
-            logger.info("creating TimeBasedFilterInterceptor.");
             return new TimeBasedFilterInterceptor(startTime, stopTime);
         }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -53,7 +53,7 @@ public class TimeBasedFilterInterceptor implements Interceptor {
 
     @Override
     public void initialize() {
-        //no-op
+        // no-op
     }
 
     @Override
@@ -83,7 +83,7 @@ public class TimeBasedFilterInterceptor implements Interceptor {
 
     @Override
     public void close() {
-        //no-op
+        // no-op
     }
 
     public static class Builder implements Interceptor.Builder  {

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -41,8 +41,7 @@ import java.util.stream.Collectors;
  */
 public class TimeBasedFilterInterceptor implements Interceptor {
 
-    private static final Logger logger = LoggerFactory
-            .getLogger(TimeBasedFilterInterceptor.class);
+    private static final Logger logger = LoggerFactory.getLogger(TimeBasedFilterInterceptor.class);
     private final long startTime;
     private final long stopTime;
 
@@ -86,6 +85,10 @@ public class TimeBasedFilterInterceptor implements Interceptor {
         // no-op
     }
 
+    /**
+     * Builder of {@link TimeBasedFilterInterceptor}.
+     * Should be configured before build called.
+     */
     public static class Builder implements Interceptor.Builder  {
 
         private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -19,13 +19,28 @@
 
 package org.apache.inlong.sort.standalone.rollback;
 
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.interceptor.Interceptor;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
+/**
+ * Interceptor that filters events selectively based on a configured time interval.
+ * Usually, it's used to roll back data in a certain time interval.
+ * It supports config either one of start, stop time or both of them.
+ * Multiple TimeBasedFilterInterceptor can be chained together to create more complex time intervals.
+ */
 public class TimeBasedFilterInterceptor implements Interceptor {
 
     private static final Logger logger = LoggerFactory
@@ -40,21 +55,82 @@ public class TimeBasedFilterInterceptor implements Interceptor {
 
     @Override
     public void initialize() {
-
+        //no-op
     }
 
     @Override
     public Event intercept(Event event) {
-        return null;
+        long logTime;
+        if (event instanceof ProfileEvent) {
+            ProfileEvent profile = (ProfileEvent) event;
+            logTime = profile.getRawLogTime();
+        } else {
+            logTime = NumberUtils.toLong(event.getHeaders().get(Constants.HEADER_KEY_MSG_TIME),
+                    System.currentTimeMillis());
+        }
+
+        if (logTime > stopTime || logTime < startTime) {
+            return null;
+        }
+        return event;
     }
 
     @Override
     public List<Event> intercept(List<Event> events) {
-        return null;
+        return events.stream()
+                .map(this::intercept)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     @Override
     public void close() {
-
+        //no-op
     }
+
+    public static class Builder implements Interceptor.Builder  {
+
+        private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        private static final String START_TIME = "start-time";
+        private static final long DEFAULT_START_TIME = 0L;
+        private static final String STOP_TIME = "stop-time";
+        private static final long DEFAULT_STOP_TIME = Long.MAX_VALUE;
+
+        private long startTime;
+        private long stopTime;
+
+        @Override
+        public Interceptor build() {
+            logger.info("creating TimeBasedFilterInterceptor.");
+            return new TimeBasedFilterInterceptor(startTime, stopTime);
+        }
+
+        @Override
+        public void configure(Context context) {
+             startTime = Optional.ofNullable(context.getString(START_TIME))
+                    .map(s -> {
+                        logger.info("config TimeBasedFilterInterceptor, start time is {}", s);
+                        try {
+                            return DATE_FORMAT.parse(s).getTime();
+                        } catch (ParseException e) {
+                            logger.error("parse start time failed, plz check the format of start time : {}", s);
+                        }
+                        return DEFAULT_START_TIME;
+                    })
+                    .orElse(DEFAULT_START_TIME);
+
+             stopTime = Optional.ofNullable(context.getString(STOP_TIME))
+                    .map(s -> {
+                        logger.info("config TimeBasedFilterInterceptor, stop time is {}", s);
+                        try {
+                            return DATE_FORMAT.parse(s).getTime();
+                        } catch (ParseException e) {
+                            logger.error("parse stop time failed, plz check the format of stop time : {}", s);
+                        }
+                        return DEFAULT_STOP_TIME;
+                    })
+                    .orElse(DEFAULT_STOP_TIME);
+        }
+    }
+
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/rollback/TimeBasedFilterInterceptor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.inlong.sort.standalone.rollback;
+
+import org.apache.flume.Event;
+import org.apache.flume.interceptor.Interceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class TimeBasedFilterInterceptor implements Interceptor {
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(TimeBasedFilterInterceptor.class);
+    private final long startTime;
+    private final long stopTime;
+
+    public TimeBasedFilterInterceptor(long startTime, long stopTime) {
+        this.startTime = startTime;
+        this.stopTime = stopTime;
+    }
+
+    @Override
+    public void initialize() {
+
+    }
+
+    @Override
+    public Event intercept(Event event) {
+        return null;
+    }
+
+    @Override
+    public List<Event> intercept(List<Event> events) {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+}


### PR DESCRIPTION

- Fixes #5094

### Motivation

Implements time interval interceptor to support Sort-standalone rollback sender

### Modifications

Implements time interval interceptor

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
