### PR TITLE
[INLONG-5127][Manager] Rename second_xxx to backup_xxx in sort-standalone management interface

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Data
 public class SortSourceGroupInfo {
     private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceGroupInfo.class);
-    private static final String KEY_SECOND_CLUSTER_TAG = "second_cluster_tag";
-    private static final String KEY_SECOND_TOPIC = "second_topic";
+    private static final String KEY_BACK_UP_CLUSTER_TAG = "back_up_cluster_tag";
+    private static final String KEY_BACK_UP_TOPIC = "back_up_topic";
 
     private static final long serialVersionUID = 1L;
     String groupId;
@@ -52,11 +52,11 @@ public class SortSourceGroupInfo {
         return extParamsMap;
     }
 
-    public String getSecondClusterTag() {
-        return getExtParamsMap().get(KEY_SECOND_CLUSTER_TAG);
+    public String getBackUpClusterTag() {
+        return getExtParamsMap().get(KEY_BACK_UP_CLUSTER_TAG);
     }
 
-    public String getSecondTopic() {
-        return getExtParamsMap().get(KEY_SECOND_TOPIC);
+    public String getBackUpTopic() {
+        return getExtParamsMap().get(KEY_BACK_UP_TOPIC);
     }
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceGroupInfo.java
@@ -29,8 +29,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Data
 public class SortSourceGroupInfo {
     private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceGroupInfo.class);
-    private static final String KEY_BACK_UP_CLUSTER_TAG = "back_up_cluster_tag";
-    private static final String KEY_BACK_UP_TOPIC = "back_up_topic";
+    private static final String KEY_BACKUP_CLUSTER_TAG = "backup_cluster_tag";
+    private static final String KEY_BACKUP_TOPIC = "backup_topic";
 
     private static final long serialVersionUID = 1L;
     String groupId;
@@ -52,11 +52,11 @@ public class SortSourceGroupInfo {
         return extParamsMap;
     }
 
-    public String getBackUpClusterTag() {
-        return getExtParamsMap().get(KEY_BACK_UP_CLUSTER_TAG);
+    public String getBackupClusterTag() {
+        return getExtParamsMap().get(KEY_BACKUP_CLUSTER_TAG);
     }
 
-    public String getBackUpTopic() {
-        return getExtParamsMap().get(KEY_BACK_UP_TOPIC);
+    public String getBackupTopic() {
+        return getExtParamsMap().get(KEY_BACKUP_TOPIC);
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -29,16 +29,16 @@ import org.springframework.stereotype.Service;
 /**
  * Sort service implementation.
  */
-@Service
 @Lazy
+@Service
 public class SortServiceImpl implements SortService {
 
-    @Autowired
     @Lazy
+    @Autowired
     private SortSourceService sortSourceService;
 
-    @Autowired
     @Lazy
+    @Autowired
     private SortClusterService sortClusterService;
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -272,8 +272,8 @@ public class SortSourceServiceImpl implements SortSourceService {
 
         // Group them by back up cluster tag if both 2nd tag and 2nd topic exist.
         Map<String, List<SortSourceGroupInfo>> backupTag2GroupInfos = groupInfoStream.stream()
-                .filter(group -> group.getBackUpClusterTag() != null && group.getBackUpTopic() != null)
-                .collect(Collectors.groupingBy(SortSourceGroupInfo::getBackUpClusterTag));
+                .filter(group -> group.getBackupClusterTag() != null && group.getBackupTopic() != null)
+                .collect(Collectors.groupingBy(SortSourceGroupInfo::getBackupClusterTag));
 
         // get cache zone list.
         List<CacheZone> firstTagCacheZoneList =
@@ -364,7 +364,7 @@ public class SortSourceServiceImpl implements SortSourceService {
             String namespace,
             boolean isBackupTag) {
 
-        String topic = isBackupTag ? groupInfo.getBackUpTopic() : groupInfo.getTopic();
+        String topic = isBackupTag ? groupInfo.getBackupTopic() : groupInfo.getTopic();
         StringBuilder fullTopic = new StringBuilder();
         Optional.ofNullable(tenant).ifPresent(t -> fullTopic.append(t).append("/"));
         Optional.ofNullable(namespace).ifPresent(n -> fullTopic.append(n).append("/"));

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/SortServiceImplTest.java
@@ -111,7 +111,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
     public void testSourceErrorClusterName() {
         SortSourceConfigResponse response = sortService.getSourceConfig("errCluster", "errTask", "");
         System.out.println(response.toString());
-        Assertions.assertEquals(-101, response.getCode());
+        Assertions.assertEquals(0, response.getCode());
         Assertions.assertNull(response.getMd5());
         Assertions.assertNull(response.getData());
         Assertions.assertNotNull(response.getMsg());


### PR DESCRIPTION

- Fixes #5127 

### Motivation

Rename second_xxx to backup_xxx in sort-standalone management interface

### Modifications

Rename second_xxx to backup_xxx in sort-standalone management interface

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
