### PR TITLE
[INLONG-5117][SortStandalone] Support specify component type from remote config

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
@@ -33,8 +33,8 @@ public class FlumeConfigGenerator {
     public static final String KEY_SORT_CHANNEL_TYPE = "sortChannel.type";
     public static final String KEY_SORT_SINK_TYPE = "sortSink.type";
     public static final String KEY_SORT_SOURCE_TYPE = "sortSource.type";
-    public static final String KEY_SDK_START_TIME = "start.time";
-    public static final String KEY_SDK_STOP_TIME = "stop.time";
+    public static final String KEY_SDK_START_TIME = "sortSdk.startTime";
+    public static final String KEY_SDK_STOP_TIME = "sortSdk.stopTime";
 
     public static Map<String, String> generateFlumeConfiguration(SortTaskConfig taskConfig) {
         Map<String, String> flumeConf = new HashMap<>();
@@ -50,9 +50,11 @@ public class FlumeConfigGenerator {
     }
 
     /**
-     * appendChannels
+     * append channels config
      *
-     * @param flumeConf
+     * @param flumeConf final config of flume
+     * @param name sort task name
+     * @param sinkParams sink params of this task
      */
     private static void appendChannels(Map<String, String> flumeConf, String name, Map<String, String> sinkParams) {
         StringBuilder builder = new StringBuilder();
@@ -68,11 +70,11 @@ public class FlumeConfigGenerator {
     }
 
     /**
-     * appendCommon
+     * appendCommon config
      *
-     * @param flumeConf
-     * @param prefix
-     * @param componentParams
+     * @param flumeConf final config of flume
+     * @param prefix prefix of common properties
+     * @param componentParams common properties
      */
     private static void appendCommon(
             Map<String, String> flumeConf,
@@ -99,9 +101,11 @@ public class FlumeConfigGenerator {
     }
 
     /**
-     * appendSinks
+     * append sink config
      *
-     * @param flumeConf
+     * @param flumeConf final config of flume
+     * @param name sort task name
+     * @param sinkParams sink params of this task
      */
     private static void appendSinks(Map<String, String> flumeConf, String name, Map<String, String> sinkParams) {
         // sinks
@@ -125,9 +129,11 @@ public class FlumeConfigGenerator {
     }
 
     /**
-     * appendSources
+     * append source config
      *
-     * @param flumeConf
+     * @param flumeConf final config of flume
+     * @param name sort task name
+     * @param sinkParams sink params of this task
      */
     private static void appendSources(
             Map<String, String> flumeConf,

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
@@ -33,8 +33,8 @@ public class FlumeConfigGenerator {
     public static final String KEY_SORT_CHANNEL_TYPE = "sortChannel.type";
     public static final String KEY_SORT_SINK_TYPE = "sortSink.type";
     public static final String KEY_SORT_SOURCE_TYPE = "sortSource.type";
-    public static final String KEY_SDK_START_TIME = "start-time";
-    public static final String KEY_SDK_STOP_TIME = "stop-time";
+    public static final String KEY_SDK_START_TIME = "start.time";
+    public static final String KEY_SDK_STOP_TIME = "stop.time";
 
     public static Map<String, String> generateFlumeConfiguration(SortTaskConfig taskConfig) {
         Map<String, String> flumeConf = new HashMap<>();

--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
@@ -22,6 +22,7 @@ import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * generator for flume config
@@ -32,17 +33,19 @@ public class FlumeConfigGenerator {
     public static final String KEY_SORT_CHANNEL_TYPE = "sortChannel.type";
     public static final String KEY_SORT_SINK_TYPE = "sortSink.type";
     public static final String KEY_SORT_SOURCE_TYPE = "sortSource.type";
+    public static final String KEY_SDK_START_TIME = "start-time";
+    public static final String KEY_SDK_STOP_TIME = "stop-time";
 
     public static Map<String, String> generateFlumeConfiguration(SortTaskConfig taskConfig) {
         Map<String, String> flumeConf = new HashMap<>();
         String name = taskConfig.getName();
         Map<String, String> sinkParams = taskConfig.getSinkParams();
         // channels
-        appendChannels(flumeConf, name);
+        appendChannels(flumeConf, name, sinkParams);
         // sinks
         appendSinks(flumeConf, name, sinkParams);
         // sources
-        appendSources(flumeConf, name);
+        appendSources(flumeConf, name, sinkParams);
         return flumeConf;
     }
 
@@ -51,14 +54,15 @@ public class FlumeConfigGenerator {
      *
      * @param flumeConf
      */
-    private static void appendChannels(Map<String, String> flumeConf, String name) {
+    private static void appendChannels(Map<String, String> flumeConf, String name, Map<String, String> sinkParams) {
         StringBuilder builder = new StringBuilder();
         String channelName = name + "Channel";
         flumeConf.put(name + ".channels", channelName);
         String prefix = builder.append(name).append(".channels.").append(channelName).append(".").toString();
         builder.setLength(0);
         String channelType = builder.append(prefix).append("type").toString();
-        String channelClass = CommonPropertiesHolder.getString(KEY_SORT_CHANNEL_TYPE);
+        String channelClass = sinkParams.getOrDefault(KEY_SORT_CHANNEL_TYPE,
+                CommonPropertiesHolder.getString(KEY_SORT_CHANNEL_TYPE));
         flumeConf.put(channelType, channelClass);
         appendCommon(flumeConf, prefix, null, name);
     }
@@ -108,7 +112,8 @@ public class FlumeConfigGenerator {
         // type
         builder.setLength(0);
         String sinkType = builder.append(prefix).append("type").toString();
-        String sinkClass = CommonPropertiesHolder.getString(KEY_SORT_SINK_TYPE);
+        String sinkClass = sinkParams.getOrDefault(KEY_SORT_SINK_TYPE,
+                CommonPropertiesHolder.getString(KEY_SORT_SINK_TYPE));
         flumeConf.put(sinkType, sinkClass);
         // channel
         builder.setLength(0);
@@ -124,7 +129,10 @@ public class FlumeConfigGenerator {
      *
      * @param flumeConf
      */
-    private static void appendSources(Map<String, String> flumeConf, String name) {
+    private static void appendSources(
+            Map<String, String> flumeConf,
+            String name, Map<String,
+            String> sinkParams) {
         // sources
         String sourceName = name + "Source";
         flumeConf.put(name + ".sources", sourceName);
@@ -133,7 +141,8 @@ public class FlumeConfigGenerator {
         // type
         builder.setLength(0);
         String sourceType = builder.append(prefix).append("type").toString();
-        String sourceClass = CommonPropertiesHolder.getString(KEY_SORT_SOURCE_TYPE);
+        String sourceClass = sinkParams.getOrDefault(KEY_SORT_SOURCE_TYPE,
+                CommonPropertiesHolder.getString(KEY_SORT_SOURCE_TYPE));
         flumeConf.put(sourceType, sourceClass);
         // channel
         builder.setLength(0);
@@ -144,7 +153,16 @@ public class FlumeConfigGenerator {
         builder.setLength(0);
         String selectorTypeKey = builder.append(prefix).append("selector.type").toString();
         flumeConf.put(selectorTypeKey, "org.apache.flume.channel.ReplicatingChannelSelector");
-        //
+        // valid msg time interval
+        builder.setLength(0);
+        String startTimeKey = builder.append(prefix).append(KEY_SDK_START_TIME).toString();
+        Optional.ofNullable(sinkParams.get(KEY_SDK_START_TIME))
+                .map(startTime -> flumeConf.put(startTimeKey, startTime));
+        builder.setLength(0);
+        String stopTimeKey = builder.append(prefix).append(KEY_SDK_STOP_TIME).toString();
+        Optional.ofNullable(sinkParams.get(KEY_SDK_STOP_TIME))
+                .map(stopTime -> flumeConf.put(stopTimeKey, stopTime));
+
         appendCommon(flumeConf, prefix, null, name);
     }
 }


### PR DESCRIPTION

- Fixes #5117

### Motivation

Current config loading strategy restricts the flexibility of sort-standalone by naming the only type of components in config file. Which means one sort-standalone node can only support a series of tasks with the same type of sink.
By specify this params into SortTask, the sort-standalone will be decoupled from node to task.

### Modifications

allow sort-standalone get type of components from remote config

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
