### PR TITLE
[INLONG-5157][Manager] Fix failed to build Sort config as the relations are empty

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/LoadNodeUtils.java
@@ -84,13 +84,13 @@ public class LoadNodeUtils {
     /**
      * Create nodes of data load.
      */
-    public static List<LoadNode> createLoadNodes(List<StreamSink> streamSinks,
-            Map<String, StreamField> constantFieldMap) {
+    public static List<LoadNode> createLoadNodes(List<StreamSink> streamSinks, Map<String, StreamField> fieldMap) {
         if (CollectionUtils.isEmpty(streamSinks)) {
             return Lists.newArrayList();
         }
         return streamSinks.stream()
-                .map(s -> LoadNodeUtils.createLoadNode(s, constantFieldMap)).collect(Collectors.toList());
+                .map(sink -> LoadNodeUtils.createLoadNode(sink, fieldMap))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/NodeRelationUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/NodeRelationUtils.java
@@ -64,9 +64,8 @@ public class NodeRelationUtils {
     /**
      * Create node relation for the given stream
      */
-    public static List<NodeRelation> createNodeRelationsForStream(InlongStreamInfo streamInfo) {
-        String tempView = streamInfo.getExtParams();
-        if (StringUtils.isEmpty(tempView)) {
+    public static List<NodeRelation> createNodeRelations(InlongStreamInfo streamInfo) {
+        if (StringUtils.isEmpty(streamInfo.getExtParams())) {
             log.warn("stream node relation is empty for {}", streamInfo);
             return Lists.newArrayList();
         }
@@ -77,6 +76,18 @@ public class NodeRelationUtils {
                         Lists.newArrayList(nodeRelation.getInputNodes()),
                         Lists.newArrayList(nodeRelation.getOutputNodes())))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Create node relation from the given sources and sinks
+     */
+    public static List<NodeRelation> createNodeRelations(List<StreamSource> sources, List<StreamSink> sinks) {
+        NodeRelation relation = new NodeRelation();
+        List<String> inputs = sources.stream().map(StreamSource::getSourceName).collect(Collectors.toList());
+        List<String> outputs = sinks.stream().map(StreamSink::getSinkName).collect(Collectors.toList());
+        relation.setInputs(inputs);
+        relation.setOutputs(outputs);
+        return Lists.newArrayList(relation);
     }
 
     /**
@@ -110,7 +121,6 @@ public class NodeRelationUtils {
                 String nodeName = outputs.get(0);
                 if (joinNodes.get(nodeName) != null) {
                     TransformDefinition transformDefinition = transformTypeMap.get(nodeName);
-                    TransformNode transformNode = joinNodes.get(nodeName);
                     joinRelations.add(getNodeRelation((JoinerDefinition) transformDefinition, relation));
                     shipIterator.remove();
                 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5157

### Motivation

Failed to build Sort config as the relations are empty.

### Modifications

Create Sort StreamInfo for Lightweight mode and Standard mode.

### Verifying this change

- [x] This change is already covered by existing tests, such as:
