### PR TITLE
[INLONG-5098][CI] Use maven parallel build feature to improve project workflow build speed

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          mvn --batch-mode --update-snapshots -e -V -T 1C clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         env:
           CI: false
 

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -75,7 +75,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build Docker images
-        run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
+        run: mvn --batch-mode --update-snapshots -e -V -T 1C clean package -DskipTests -Pdocker
         env:
           CI: false
 

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -81,7 +81,7 @@ jobs:
           CI: false
 
       - name: Unit test with Maven
-        run: mvn --batch-mode --update-snapshots -e -V test
+        run: mvn --batch-mode --update-snapshots -e -V -T 1C test
         env:
           CI: false
 

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -76,7 +76,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn --batch-mode --update-snapshots -e -V -T 1C clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         env:
           CI: false
 

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -81,7 +81,7 @@ jobs:
           CI: false
 
       - name: Unit test with Maven
-        run: mvn --batch-mode --update-snapshots -e -V -T 1C test
+        run: mvn --batch-mode --update-snapshots -e -V test
         env:
           CI: false
 

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          mvn --batch-mode --update-snapshots -e -V -T 1C clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
         env:
           CI: false
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5098 

### Motivation

CI build takes a long time to execute, and the speed can be improved by Maven parallel compilation

### Modifications

maven execution parameters

### Verifying this change

### Documentation

we can refer this, https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
