### PR TITLE
[INLONG-5165][Manager] Getting Sort source collects wrong topic properties of each stream

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
@@ -45,7 +45,7 @@ public class SortSourceStreamInfo {
                 Gson gson = new Gson();
                 extParamsMap = gson.fromJson(extParams, Map.class);
             } catch (Throwable t) {
-                LOGGER.error(t.getMessage(), t);
+                LOGGER.error("fail to parse source stream ext params", t);
                 extParamsMap = new ConcurrentHashMap<>();
             }
         }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/sortstandalone/SortSourceStreamInfo.java
@@ -17,12 +17,38 @@
 
 package org.apache.inlong.manager.common.pojo.sortstandalone;
 
+import com.google.gson.Gson;
 import lombok.Data;
+import org.apache.pulsar.shade.org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Data
 public class SortSourceStreamInfo {
     private static final long serialVersionUID = 1L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceStreamInfo.class);
     String sortClusterName;
     String sortTaskName;
     String groupId;
+    String extParams;
+    Map<String, String> extParamsMap;
+
+    public Map<String, String> getExtParamsMap() {
+        if (extParamsMap != null) {
+            return extParamsMap;
+        }
+        if (StringUtils.isNotBlank(extParams)) {
+            try {
+                Gson gson = new Gson();
+                extParamsMap = gson.fromJson(extParams, Map.class);
+            } catch (Throwable t) {
+                LOGGER.error(t.getMessage(), t);
+                extParamsMap = new ConcurrentHashMap<>();
+            }
+        }
+        return extParamsMap;
+    }
 }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -484,7 +484,8 @@
             resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortSourceStreamInfo">
         select inlong_cluster_name as sortClusterName,
                sort_task_name,
-               inlong_group_id as groupId
+               inlong_group_id as groupId,
+               ext_params
         from stream_sink
         where is_deleted = 0
     </select>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -40,7 +40,7 @@
         <module>sort-connectors</module>
         <module>sort-core</module>
         <module>sort-dist</module>
-        <!--<module>sort-end-to-end-tests</module>-->
+        <module>sort-end-to-end-tests</module>
     </modules>
     <properties>
         <debezium.version>1.5.4.Final</debezium.version>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -40,7 +40,7 @@
         <module>sort-connectors</module>
         <module>sort-core</module>
         <module>sort-dist</module>
-        <module>sort-end-to-end-tests</module>
+        <!--<module>sort-end-to-end-tests</module>-->
     </modules>
     <properties>
         <debezium.version>1.5.4.Final</debezium.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5165

### Motivation

The TopicProperties in SortSourceConfig, which is used to config sort sdk, collects wrong topic properties.
The correct topic properties of each stream should be maintain by ext_params in Stream_Sink , instead of Inlong_Group

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is already covered by existing tests, such as:
SortServiceImplTest

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs

