### PR TITLE
[INLONG-5167][Manager][Agent][Dataproxy][SDK] Manager open API authentication support

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -160,6 +160,4 @@ public class CommonConstants {
 
     public static final String KEY_METRICS_INDEX = "metricsIndex";
 
-    public static final String HTTP_AUTH_HEADER = "Authorization";
-
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -160,4 +160,6 @@ public class CommonConstants {
 
     public static final String KEY_METRICS_INDEX = "metricsIndex";
 
+    public static final String HTTP_AUTH_HEADER = "Authorization";
+
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -64,6 +64,6 @@ public class FetcherConstants {
 
     public static final String VERSION = "1.0";
 
-    public static final String API_AUTH_SECRET_ID = "api.auth.secretId";
-    public static final String API_AUTH_SECRET_KEY = "api.auth.secretKey";
+    public static final String API_AUTH_SECRET_ID = "agent.manager.auth.secretId";
+    public static final String API_AUTH_SECRET_KEY = "agent.manager.auth.secretKey";
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -64,4 +64,6 @@ public class FetcherConstants {
 
     public static final String VERSION = "1.0";
 
+    public static final String API_AUTH_SECRET_ID = "api.auth.secretId";
+    public static final String API_AUTH_SECRET_KEY = "api.auth.secretKey";
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -64,6 +64,6 @@ public class FetcherConstants {
 
     public static final String VERSION = "1.0";
 
-    public static final String API_AUTH_SECRET_ID = "agent.manager.auth.secretId";
-    public static final String API_AUTH_SECRET_KEY = "agent.manager.auth.secretKey";
+    public static final String AGENT_MANAGER_AUTH_SECRET_ID = "agent.manager.auth.secretId";
+    public static final String AGENT_MANAGER_AUTH_SECRET_KEY = "agent.manager.auth.secretKey";
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
@@ -28,6 +28,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.inlong.agent.conf.AgentConfiguration;
+import org.apache.inlong.agent.constant.CommonConstants;
+import org.apache.inlong.common.util.BasicAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,6 +38,8 @@ import java.util.concurrent.TimeUnit;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_HTTP_APPLICATION_JSON;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_HTTP_SUCCESS_CODE;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_REQUEST_TIMEOUT;
+import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_ID;
+import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT;
 
 /**
@@ -52,10 +56,14 @@ public class HttpManager {
     }
 
     private final CloseableHttpClient httpClient;
+    private final String secretId;
+    private final String secretKey;
 
     public HttpManager(AgentConfiguration conf) {
         httpClient = constructHttpClient(conf.getInt(AGENT_MANAGER_REQUEST_TIMEOUT,
                 DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT));
+        secretId = conf.get(API_AUTH_SECRET_ID);
+        secretKey = conf.get(API_AUTH_SECRET_KEY);
     }
 
     /**
@@ -86,6 +94,7 @@ public class HttpManager {
     public String doSentPost(String url, Object dto) {
         try {
             HttpPost post = getHttpPost(url);
+            post.addHeader(CommonConstants.HTTP_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
             StringEntity stringEntity = new StringEntity(toJsonStr(dto));
             stringEntity.setContentType(AGENT_HTTP_APPLICATION_JSON);
             post.setEntity(stringEntity);
@@ -117,6 +126,7 @@ public class HttpManager {
     public String doSendGet(String url) {
         try {
             HttpGet get = getHttpGet(url);
+            get.addHeader(CommonConstants.HTTP_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
             CloseableHttpResponse response = httpClient.execute(get);
             String returnStr = EntityUtils.toString(response.getEntity());
             if (returnStr != null && !returnStr.isEmpty()

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
@@ -28,7 +28,6 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.inlong.agent.conf.AgentConfiguration;
-import org.apache.inlong.agent.constant.CommonConstants;
 import org.apache.inlong.common.util.BasicAuth;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +93,7 @@ public class HttpManager {
     public String doSentPost(String url, Object dto) {
         try {
             HttpPost post = getHttpPost(url);
-            post.addHeader(CommonConstants.HTTP_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
+            post.addHeader(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
             StringEntity stringEntity = new StringEntity(toJsonStr(dto));
             stringEntity.setContentType(AGENT_HTTP_APPLICATION_JSON);
             post.setEntity(stringEntity);
@@ -126,7 +125,7 @@ public class HttpManager {
     public String doSendGet(String url) {
         try {
             HttpGet get = getHttpGet(url);
-            get.addHeader(CommonConstants.HTTP_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
+            get.addHeader(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
             CloseableHttpResponse response = httpClient.execute(get);
             String returnStr = EntityUtils.toString(response.getEntity());
             if (returnStr != null && !returnStr.isEmpty()

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
@@ -37,9 +37,9 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_HTTP_APPLICATION_JSON;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_HTTP_SUCCESS_CODE;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_ID;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_REQUEST_TIMEOUT;
-import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_ID;
-import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT;
 
 /**
@@ -62,8 +62,8 @@ public class HttpManager {
     public HttpManager(AgentConfiguration conf) {
         httpClient = constructHttpClient(conf.getInt(AGENT_MANAGER_REQUEST_TIMEOUT,
                 DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT));
-        secretId = conf.get(API_AUTH_SECRET_ID);
-        secretKey = conf.get(API_AUTH_SECRET_KEY);
+        secretId = conf.get(AGENT_MANAGER_AUTH_SECRET_ID);
+        secretKey = conf.get(AGENT_MANAGER_AUTH_SECRET_KEY);
     }
 
     /**

--- a/inlong-agent/agent-core/src/test/resources/agent.properties
+++ b/inlong-agent/agent-core/src/test/resources/agent.properties
@@ -26,5 +26,5 @@ job.thread.running.core=10
 ############################
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
-api.auth.secretId=test
-api.auth.secretKey=123456
+agent.manager.auth.secretId=test
+agent.manager.auth.secretKey=123456

--- a/inlong-agent/agent-core/src/test/resources/agent.properties
+++ b/inlong-agent/agent-core/src/test/resources/agent.properties
@@ -26,3 +26,5 @@ job.thread.running.core=10
 ############################
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
+api.auth.secretId=test
+api.auth.secretKey=123456

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -84,8 +84,8 @@ public class SenderManager {
     private int ioThreadNum;
     private boolean enableBusyWait;
     private Semaphore semaphore;
-    private String apiSecretId;
-    private String apiSecretKey;
+    private String authSecretId;
+    private String authSecretKey;
 
     public SenderManager(JobProfile jobConf, String inlongGroupId, String sourcePath) {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
@@ -121,8 +121,8 @@ public class SenderManager {
                 CommonConstants.DEFAULT_PROXY_CLIENT_IO_THREAD_NUM);
         enableBusyWait = jobConf.getBoolean(CommonConstants.PROXY_CLIENT_ENABLE_BUSY_WAIT,
                 CommonConstants.DEFAULT_PROXY_CLIENT_ENABLE_BUSY_WAIT);
-        apiSecretId = conf.get(AGENT_MANAGER_AUTH_SECRET_ID);
-        apiSecretKey = conf.get(AGENT_MANAGER_AUTH_SECRET_KEY);
+        authSecretId = conf.get(AGENT_MANAGER_AUTH_SECRET_ID);
+        authSecretKey = conf.get(AGENT_MANAGER_AUTH_SECRET_KEY);
 
         this.sourcePath = sourcePath;
         this.inlongGroupId = inlongGroupId;
@@ -157,7 +157,7 @@ public class SenderManager {
     private DefaultMessageSender createMessageSender(String tagName) throws Exception {
 
         ProxyClientConfig proxyClientConfig = new ProxyClientConfig(
-                localhost, isLocalVisit, managerHost, managerPort, tagName, netTag, apiSecretId, apiSecretKey);
+                localhost, isLocalVisit, managerHost, managerPort, tagName, netTag, authSecretId, authSecretKey);
         proxyClientConfig.setTotalAsyncCallbackSize(totalAsyncBufSize);
         proxyClientConfig.setFile(isFile);
         proxyClientConfig.setAliveConnections(aliveConnectionNum);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_HOST;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_PORT;
+import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_ID;
+import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_KEY;
 
 /**
  * proxy client
@@ -82,6 +84,8 @@ public class SenderManager {
     private int ioThreadNum;
     private boolean enableBusyWait;
     private Semaphore semaphore;
+    private String apiSecretId;
+    private String apiSecretKey;
 
     public SenderManager(JobProfile jobConf, String inlongGroupId, String sourcePath) {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
@@ -117,6 +121,8 @@ public class SenderManager {
                 CommonConstants.DEFAULT_PROXY_CLIENT_IO_THREAD_NUM);
         enableBusyWait = jobConf.getBoolean(CommonConstants.PROXY_CLIENT_ENABLE_BUSY_WAIT,
                 CommonConstants.DEFAULT_PROXY_CLIENT_ENABLE_BUSY_WAIT);
+        apiSecretId = conf.get(API_AUTH_SECRET_ID);
+        apiSecretKey = conf.get(API_AUTH_SECRET_KEY);
 
         this.sourcePath = sourcePath;
         this.inlongGroupId = inlongGroupId;
@@ -151,7 +157,7 @@ public class SenderManager {
     private DefaultMessageSender createMessageSender(String tagName) throws Exception {
 
         ProxyClientConfig proxyClientConfig = new ProxyClientConfig(
-                localhost, isLocalVisit, managerHost, managerPort, tagName, netTag);
+                localhost, isLocalVisit, managerHost, managerPort, tagName, netTag, apiSecretId, apiSecretKey);
         proxyClientConfig.setTotalAsyncCallbackSize(totalAsyncBufSize);
         proxyClientConfig.setFile(isFile);
         proxyClientConfig.setAliveConnections(aliveConnectionNum);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -41,10 +41,10 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_ID;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_HOST;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_PORT;
-import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_ID;
-import static org.apache.inlong.agent.constant.FetcherConstants.API_AUTH_SECRET_KEY;
 
 /**
  * proxy client
@@ -121,8 +121,8 @@ public class SenderManager {
                 CommonConstants.DEFAULT_PROXY_CLIENT_IO_THREAD_NUM);
         enableBusyWait = jobConf.getBoolean(CommonConstants.PROXY_CLIENT_ENABLE_BUSY_WAIT,
                 CommonConstants.DEFAULT_PROXY_CLIENT_ENABLE_BUSY_WAIT);
-        apiSecretId = conf.get(API_AUTH_SECRET_ID);
-        apiSecretKey = conf.get(API_AUTH_SECRET_KEY);
+        apiSecretId = conf.get(AGENT_MANAGER_AUTH_SECRET_ID);
+        apiSecretKey = conf.get(AGENT_MANAGER_AUTH_SECRET_KEY);
 
         this.sourcePath = sourcePath;
         this.inlongGroupId = inlongGroupId;

--- a/inlong-agent/agent-plugins/src/test/resources/agent.properties
+++ b/inlong-agent/agent-plugins/src/test/resources/agent.properties
@@ -23,5 +23,5 @@ job.thread.running.core=10
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
 agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
-api.auth.secretId=test
-api.auth.secretKey=123456
+agent.manager.auth.secretId=test
+agent.manager.auth.secretKey=123456

--- a/inlong-agent/agent-plugins/src/test/resources/agent.properties
+++ b/inlong-agent/agent-plugins/src/test/resources/agent.properties
@@ -23,3 +23,5 @@ job.thread.running.core=10
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
 agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
+api.auth.secretId=test
+api.auth.secretKey=123456

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -106,6 +106,8 @@ agent.scheduled.snapshotreport=0 0/1 * * * ? *
 ############################
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
+api.auth.secretId=admin
+api.auth.secretKey=87haw3VYTPqK5fK0
 
 
 

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -106,8 +106,8 @@ agent.scheduled.snapshotreport=0 0/1 * * * ? *
 ############################
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
-api.auth.secretId=admin
-api.auth.secretKey=87haw3VYTPqK5fK0
+agent.manager.auth.secretId=admin
+agent.manager.auth.secretKey=87haw3VYTPqK5fK0
 
 
 

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
@@ -25,11 +25,17 @@ import java.util.Base64;
  */
 public class BasicAuth {
 
+    public static final String BASIC_AUTH_HEADER = "Authorization";
+    public static final String BASIC_AUTH_PREFIX = "Basic";
+    public static final String BASIC_AUTH_SEPARATOR = " ";
+    public static final String BASIC_AUTH_JOINER = ":";
+
     /**
      * Generate http basic auth credential from configured secretId and secretKey
      */
     public static String genBasicAuthCredential(String secretId, String secretKey) {
-        String credential = String.join(":", secretId, secretKey);
-        return "Basic " + Base64.getEncoder().encodeToString(credential.getBytes(StandardCharsets.UTF_8));
+        String credential = String.join(BASIC_AUTH_JOINER, secretId, secretKey);
+        return BASIC_AUTH_PREFIX + BASIC_AUTH_SEPARATOR + Base64.getEncoder()
+                .encodeToString(credential.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.common.util;
 
 import java.nio.charset.StandardCharsets;

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
@@ -3,6 +3,9 @@ package org.apache.inlong.common.util;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
+/**
+ * Basic authentication utility
+ */
 public class BasicAuth {
 
     /**

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
@@ -1,0 +1,15 @@
+package org.apache.inlong.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class BasicAuth {
+
+    /**
+     * Generate http basic auth credential from configured secretId and secretKey
+     */
+    public static String genBasicAuthCredential(String secretId, String secretKey) {
+        String credential = String.join(":", secretId, secretKey);
+        return "Basic " + Base64.getEncoder().encodeToString(credential.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -18,8 +18,10 @@
 #
 # cluter id is for future use please write 1
 cluster.id=1
-# manager open api address
+# manager open api address and auth key
 manager.hosts=127.0.0.1:8083
+api.auth.secretId=admin
+api.auth.secretKey=87haw3VYTPqK5fK0
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 # check interval of local config (millisecond)

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -20,8 +20,8 @@
 cluster.id=1
 # manager open api address and auth key
 manager.hosts=127.0.0.1:8083
-api.auth.secretId=admin
-api.auth.secretKey=87haw3VYTPqK5fK0
+manager.auth.secretId=admin
+manager.auth.secretKey=87haw3VYTPqK5fK0
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 # check interval of local config (millisecond)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/AuthUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/AuthUtils.java
@@ -34,8 +34,8 @@ public class AuthUtils {
      */
     public static String genBasicAuth() {
         Map<String, String> properties = ConfigManager.getInstance().getCommonProperties();
-        String secretId = properties.get(ConfigConstants.HTTP_AUTH_SECRET_ID);
-        String secretKey = properties.get(ConfigConstants.HTTP_AUTH_SECRET_KEY);
+        String secretId = properties.get(ConfigConstants.MANAGER_AUTH_SECRET_ID);
+        String secretKey = properties.get(ConfigConstants.MANAGER_AUTH_SECRET_KEY);
         if (StringUtils.isBlank(secretId) || StringUtils.isBlank(secretKey)) {
             LOG.error("secretId or secretKey missing");
             return null;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/AuthUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/AuthUtils.java
@@ -17,46 +17,30 @@
 
 package org.apache.inlong.dataproxy.config;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.StringUtils;
-import org.apache.commons.codec.digest.HmacUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.common.util.BasicAuth;
+import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 public class AuthUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthUtils.class);
 
-    public static String genAuthToken(final String userName, final String usrPassWord) {
-        long timestamp = System.currentTimeMillis();
-        int nonce =
-                new SecureRandom(StringUtils.getBytesUtf8(String.valueOf(timestamp)))
-                        .nextInt(Integer.MAX_VALUE);
-        String signature = getAuthSignature(userName, usrPassWord, timestamp, nonce);
-        return "manager" + " " + userName + " " + timestamp + " " + nonce + " " + signature;
-    }
-
-    private static String getAuthSignature(final String usrName,
-                                           final String usrPassWord,
-                                           long timestamp, int randomValue) {
-        Base64 base64 = new Base64();
-        StringBuilder sbuf = new StringBuilder(512);
-        byte[] baseStr =
-                base64.encode(HmacUtils.hmacSha1(usrPassWord,
-                        sbuf.append(usrName).append(timestamp).append(randomValue).toString()));
-        sbuf.delete(0, sbuf.length());
-        String signature = "";
-        try {
-            signature = URLEncoder.encode(new String(baseStr, StandardCharsets.UTF_8), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            LOG.error("exception caught", e);
+    /**
+     * Generate http basic auth credential from configured secretId and secretKey
+     */
+    public static String genBasicAuth() {
+        Map<String, String> properties = ConfigManager.getInstance().getCommonProperties();
+        String secretId = properties.get(ConfigConstants.HTTP_AUTH_SECRET_ID);
+        String secretKey = properties.get(ConfigConstants.HTTP_AUTH_SECRET_KEY);
+        if (StringUtils.isBlank(secretId) || StringUtils.isBlank(secretKey)) {
+            LOG.error("secretId or secretKey missing");
+            return null;
         }
-        return signature;
+        return BasicAuth.genBasicAuthCredential(secretId, secretKey);
     }
 
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -276,6 +276,7 @@ public class ConfigManager {
                 LOG.info("start to request {} to get config info", url);
                 httpGet = new HttpGet(url);
                 httpGet.addHeader(HttpHeaders.CONNECTION, "close");
+                httpGet.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
 
                 // request with post
                 CloseableHttpResponse response = httpClient.execute(httpGet);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -192,6 +192,7 @@ public class RemoteConfigManager implements IRepository {
             LOGGER.info("start to request {} to get config info", url);
             httpGet = new HttpGet(url);
             httpGet.addHeader(HttpHeaders.CONNECTION, "close");
+            httpGet.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
 
             // request with get
             CloseableHttpResponse response = httpClient.execute(httpGet);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -122,6 +122,6 @@ public class ConfigConstants {
     public static final String MANAGER_GET_CONFIG_PATH = "/dataproxy/getConfig";
     public static final String MANAGER_GET_ALL_CONFIG_PATH = "/dataproxy/getAllConfig";
 
-    public static final String HTTP_AUTH_SECRET_ID = "api.auth.secretId";
-    public static final String HTTP_AUTH_SECRET_KEY = "api.auth.secretKey";
+    public static final String HTTP_AUTH_SECRET_ID = "manager.auth.secretId";
+    public static final String HTTP_AUTH_SECRET_KEY = "manager.auth.secretKey";
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -122,6 +122,6 @@ public class ConfigConstants {
     public static final String MANAGER_GET_CONFIG_PATH = "/dataproxy/getConfig";
     public static final String MANAGER_GET_ALL_CONFIG_PATH = "/dataproxy/getAllConfig";
 
-    public static final String HTTP_AUTH_SECRET_ID = "manager.auth.secretId";
-    public static final String HTTP_AUTH_SECRET_KEY = "manager.auth.secretKey";
+    public static final String MANAGER_AUTH_SECRET_ID = "manager.auth.secretId";
+    public static final String MANAGER_AUTH_SECRET_KEY = "manager.auth.secretKey";
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -122,4 +122,6 @@ public class ConfigConstants {
     public static final String MANAGER_GET_CONFIG_PATH = "/dataproxy/getConfig";
     public static final String MANAGER_GET_ALL_CONFIG_PATH = "/dataproxy/getAllConfig";
 
+    public static final String HTTP_AUTH_SECRET_ID = "api.auth.secretId";
+    public static final String HTTP_AUTH_SECRET_KEY = "api.auth.secretKey";
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/auth/InlongShiro.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/auth/InlongShiro.java
@@ -19,17 +19,19 @@ package org.apache.inlong.manager.common.auth;
 
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.mgt.SecurityManager;
-import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.realm.Realm;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.apache.shiro.web.session.mgt.WebSessionManager;
 
+import java.util.Collection;
+
 public interface InlongShiro {
 
     WebSecurityManager getWebSecurityManager();
 
-    AuthorizingRealm getShiroRealm();
+    Collection<Realm> getShiroRealms();
 
     WebSessionManager getWebSessionManager();
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
@@ -126,7 +126,7 @@ public class UserServiceImpl implements UserService {
             Map<String, String> keyPairs = RSAUtils.generateRSAKeyPairs();
             String publicKey = keyPairs.get(RSAUtils.PUBLIC_KEY);
             String privateKey = keyPairs.get(RSAUtils.PRIVATE_KEY);
-            String secretKey = RandomStringUtils.randomAlphanumeric(8);
+            String secretKey = RandomStringUtils.randomAlphanumeric(16);
             Integer encryptVersion = AESUtils.getCurrentVersion(null);
             entity.setEncryptVersion(encryptVersion);
             entity.setPublicKey(AESUtils.encryptToString(publicKey.getBytes(StandardCharsets.UTF_8), encryptVersion));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
@@ -60,6 +60,8 @@ public class UserServiceImpl implements UserService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserServiceImpl.class);
 
+    private static final Integer SECRET_KEY_SIZE = 16;
+
     @Autowired
     private UserEntityMapper userMapper;
 
@@ -126,7 +128,7 @@ public class UserServiceImpl implements UserService {
             Map<String, String> keyPairs = RSAUtils.generateRSAKeyPairs();
             String publicKey = keyPairs.get(RSAUtils.PUBLIC_KEY);
             String privateKey = keyPairs.get(RSAUtils.PRIVATE_KEY);
-            String secretKey = RandomStringUtils.randomAlphanumeric(16);
+            String secretKey = RandomStringUtils.randomAlphanumeric(SECRET_KEY_SIZE);
             Integer encryptVersion = AESUtils.getCurrentVersion(null);
             entity.setEncryptVersion(encryptVersion);
             entity.setPublicKey(AESUtils.encryptToString(publicKey.getBytes(StandardCharsets.UTF_8), encryptVersion));

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -598,9 +598,9 @@ CREATE TABLE IF NOT EXISTS `user`
   DEFAULT CHARSET = utf8mb4 COMMENT ='User table';
 
 -- create default admin user, username is 'admin', password is 'inlong'
-INSERT INTO `user` (name, password, account_type, due_date, create_time, update_time, create_by, update_by)
-VALUES ('admin', '628ed559bff5ae36bd2184d4216973cf', 0, '2099-12-31 23:59:59',
-        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'inlong_init', 'inlong_init');
+INSERT INTO `user` (name, password, secret_key, account_type, due_date, create_time, update_time, create_by, update_by, encrypt_version)
+VALUES ('admin', '628ed559bff5ae36bd2184d4216973cf', '9B5DCE950F284141D5493A2DAFEBD1BFEECE075FC5F426E8B67F33F14876E2D0', 0, '2099-12-31 23:59:59',
+        CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'inlong_init', 'inlong_init', 1);
 
 -- ----------------------------
 -- Table structure for user_role

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/ShiroConfig.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/ShiroConfig.java
@@ -17,19 +17,19 @@
 
 package org.apache.inlong.manager.web.auth;
 
-import javax.annotation.Resource;
 import org.apache.inlong.manager.common.auth.InlongShiro;
-import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
 import org.apache.shiro.mgt.SecurityManager;
-import org.apache.shiro.realm.AuthorizingRealm;
+import org.apache.shiro.realm.Realm;
 import org.apache.shiro.spring.security.interceptor.AuthorizationAttributeSourceAdvisor;
 import org.apache.shiro.spring.web.ShiroFilterFactoryBean;
 import org.apache.shiro.web.mgt.DefaultWebSecurityManager;
 import org.apache.shiro.web.mgt.WebSecurityManager;
 import org.apache.shiro.web.session.mgt.DefaultWebSessionManager;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.Resource;
+import java.util.Collection;
 
 /**
  * Inlong hiro config.
@@ -41,17 +41,14 @@ public class ShiroConfig {
     private InlongShiro inLongShiro;
 
     @Bean
-    public AuthorizingRealm shiroRealm(HashedCredentialsMatcher matcher) {
-        AuthorizingRealm authorizingRealm = inLongShiro.getShiroRealm();
-        authorizingRealm.setCredentialsMatcher(matcher);
-        return authorizingRealm;
+    public Collection<Realm> shiroRealms() {
+        return inLongShiro.getShiroRealms();
     }
 
     @Bean
-    public WebSecurityManager securityManager(@Qualifier("hashedCredentialsMatcher")
-            HashedCredentialsMatcher matcher) {
+    public WebSecurityManager securityManager() {
         DefaultWebSecurityManager securityManager = (DefaultWebSecurityManager) inLongShiro.getWebSecurityManager();
-        securityManager.setRealm(shiroRealm(matcher));
+        securityManager.setRealms(shiroRealms());
         return securityManager;
     }
 
@@ -60,13 +57,6 @@ public class ShiroConfig {
         DefaultWebSessionManager sessionManager = (DefaultWebSessionManager) inLongShiro.getWebSessionManager();
         sessionManager.setGlobalSessionTimeout(1000 * 60 * 60);
         return sessionManager;
-    }
-
-    @Bean(name = "hashedCredentialsMatcher")
-    public HashedCredentialsMatcher hashedCredentialsMatcher() {
-        HashedCredentialsMatcher hashedCredentialsMatcher = (HashedCredentialsMatcher) inLongShiro
-                .getCredentialsMatcher();
-        return hashedCredentialsMatcher;
     }
 
     /**
@@ -83,6 +73,6 @@ public class ShiroConfig {
      */
     @Bean
     public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor() {
-        return inLongShiro.getAuthorizationAttributeSourceAdvisor(securityManager(hashedCredentialsMatcher()));
+        return inLongShiro.getAuthorizationAttributeSourceAdvisor(securityManager());
     }
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/ShiroConfig.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/ShiroConfig.java
@@ -38,23 +38,23 @@ import java.util.Collection;
 public class ShiroConfig {
 
     @Resource
-    private InlongShiro inLongShiro;
+    private InlongShiro inlongShiro;
 
     @Bean
     public Collection<Realm> shiroRealms() {
-        return inLongShiro.getShiroRealms();
+        return inlongShiro.getShiroRealms();
     }
 
     @Bean
     public WebSecurityManager securityManager() {
-        DefaultWebSecurityManager securityManager = (DefaultWebSecurityManager) inLongShiro.getWebSecurityManager();
+        DefaultWebSecurityManager securityManager = (DefaultWebSecurityManager) inlongShiro.getWebSecurityManager();
         securityManager.setRealms(shiroRealms());
         return securityManager;
     }
 
     @Bean
     public DefaultWebSessionManager sessionManager() {
-        DefaultWebSessionManager sessionManager = (DefaultWebSessionManager) inLongShiro.getWebSessionManager();
+        DefaultWebSessionManager sessionManager = (DefaultWebSessionManager) inlongShiro.getWebSessionManager();
         sessionManager.setGlobalSessionTimeout(1000 * 60 * 60);
         return sessionManager;
     }
@@ -64,7 +64,7 @@ public class ShiroConfig {
      */
     @Bean
     public ShiroFilterFactoryBean shiroFilter(SecurityManager securityManager) {
-        ShiroFilterFactoryBean shiroFilterFactoryBean = inLongShiro.getShiroFilter(securityManager);
+        ShiroFilterFactoryBean shiroFilterFactoryBean = inlongShiro.getShiroFilter(securityManager);
         return shiroFilterFactoryBean;
     }
 
@@ -73,6 +73,6 @@ public class ShiroConfig {
      */
     @Bean
     public AuthorizationAttributeSourceAdvisor authorizationAttributeSourceAdvisor() {
-        return inLongShiro.getAuthorizationAttributeSourceAdvisor(securityManager());
+        return inlongShiro.getAuthorizationAttributeSourceAdvisor(securityManager());
     }
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/impl/InlongShiroImpl.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/impl/InlongShiroImpl.java
@@ -52,6 +52,9 @@ import java.util.Map;
 @Component
 public class InlongShiroImpl implements InlongShiro {
 
+    private static final String FILTER_NAME_WEB = "authWeb";
+    private static final String FILTER_NAME_API = "authAPI";
+
     @Autowired
     private UserService userService;
 
@@ -88,8 +91,8 @@ public class InlongShiroImpl implements InlongShiro {
         shiroFilterFactoryBean.setSecurityManager(securityManager);
         // anon: can be accessed by anyone, authc: only authentication is successful can be accessed
         Map<String, Filter> filters = new LinkedHashMap<>();
-        filters.put("authWeb", new AuthenticationFilter());
-        filters.put("authAPI", new OpenAPIFilter());
+        filters.put(FILTER_NAME_WEB, new AuthenticationFilter());
+        filters.put(FILTER_NAME_API, new OpenAPIFilter());
         shiroFilterFactoryBean.setFilters(filters);
         Map<String, String> pathDefinitions = new LinkedHashMap<>();
         // login, register request
@@ -103,9 +106,10 @@ public class InlongShiroImpl implements InlongShiro {
         pathDefinitions.put("/swagger-resources", "anon");
 
         // openapi
-        pathDefinitions.put("/openapi/**/*", "authAPI");
+        pathDefinitions.put("/openapi/**/*", FILTER_NAME_API);
 
-        pathDefinitions.put("/**", "authWeb");
+        // other web
+        pathDefinitions.put("/**", FILTER_NAME_WEB);
 
         shiroFilterFactoryBean.setFilterChainDefinitionMap(pathDefinitions);
         return shiroFilterFactoryBean;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
@@ -31,7 +31,7 @@ import org.apache.shiro.realm.AuthenticatingRealm;
 import java.util.Date;
 
 /**
- * Web user authorization.
+ * Open api client authorization.
  */
 @Slf4j
 public class OpenAPIAuthenticatingRealm extends AuthenticatingRealm {
@@ -43,7 +43,7 @@ public class OpenAPIAuthenticatingRealm extends AuthenticatingRealm {
     }
 
     /**
-     * Login authentication
+     * Get open api authentication info
      */
     @Override
     protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
@@ -49,7 +49,7 @@ public class OpenAPIAuthenticatingRealm extends AuthenticatingRealm {
     protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)
             throws AuthenticationException {
         SecretToken upToken = (SecretToken) authenticationToken;
-        String username = upToken.getSecretID();
+        String username = upToken.getSecretId();
         UserEntity userEntity = userService.getByUsername(username);
         Preconditions.checkNotNull(userEntity, "User doesn't exist");
         Preconditions.checkTrue(userEntity.getDueDate().after(new Date()), "user has expired");

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIAuthenticatingRealm.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.auth.openapi;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.common.util.AESUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.UserEntity;
+import org.apache.inlong.manager.service.core.UserService;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.apache.shiro.authc.AuthenticationToken;
+import org.apache.shiro.authc.SimpleAuthenticationInfo;
+import org.apache.shiro.realm.AuthenticatingRealm;
+
+import java.util.Date;
+
+/**
+ * Web user authorization.
+ */
+@Slf4j
+public class OpenAPIAuthenticatingRealm extends AuthenticatingRealm {
+
+    private final UserService userService;
+
+    public OpenAPIAuthenticatingRealm(UserService userService) {
+        this.userService = userService;
+    }
+
+    /**
+     * Login authentication
+     */
+    @Override
+    protected AuthenticationInfo doGetAuthenticationInfo(AuthenticationToken authenticationToken)
+            throws AuthenticationException {
+        SecretToken upToken = (SecretToken) authenticationToken;
+        String username = upToken.getSecretID();
+        UserEntity userEntity = userService.getByUsername(username);
+        Preconditions.checkNotNull(userEntity, "User doesn't exist");
+        Preconditions.checkTrue(userEntity.getDueDate().after(new Date()), "user has expired");
+        try {
+            String secretKey = new String(
+                    AESUtils.decryptAsString(userEntity.getSecretKey(), userEntity.getEncryptVersion()));
+            return new SimpleAuthenticationInfo(username, secretKey, getName());
+        } catch (Exception e) {
+            log.error("decrypt secret key fail: ", e);
+            throw new AuthenticationException("internal error: " + e.getMessage());
+        }
+    }
+
+    public boolean supports(AuthenticationToken token) {
+        return token instanceof SecretToken;
+    }
+
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.web.auth.openapi;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.inlong.common.util.BasicAuth;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;
 import org.slf4j.Logger;
@@ -41,11 +42,6 @@ import java.util.Base64;
  */
 @Slf4j
 public class OpenAPIFilter implements Filter {
-
-    public static final String BASIC_AUTH_HEADER = "Authorization";
-    public static final String BASIC_AUTH_PREFIX = "Basic";
-    public static final String BASIC_AUTH_SEPARATOR = " ";
-    public static final String BASIC_AUTH_JOINER = ":";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenAPIFilter.class);
 
@@ -81,25 +77,25 @@ public class OpenAPIFilter implements Filter {
     }
 
     private SecretToken parseBasicAuth(HttpServletRequest servletRequest) throws Exception {
-        String basicAuth = servletRequest.getHeader(BASIC_AUTH_HEADER);
+        String basicAuth = servletRequest.getHeader(BasicAuth.BASIC_AUTH_HEADER);
         if (StringUtils.isBlank(basicAuth)) {
             log.error("basic auth is empty");
             return null;
         }
 
         // Basic auth string must be "Basic Base64(ID:Secret)"
-        String[] parts = basicAuth.split(BASIC_AUTH_SEPARATOR);
+        String[] parts = basicAuth.split(BasicAuth.BASIC_AUTH_SEPARATOR);
         if (parts.length != 2) {
             log.error("parts size error: {}", parts);
             return null;
         }
-        if (!parts[0].equals(BASIC_AUTH_PREFIX)) {
+        if (!parts[0].equals(BasicAuth.BASIC_AUTH_PREFIX)) {
             log.error("prefix error: {}", parts[0]);
             return null;
         }
 
         String joinedPair = new String(Base64.getDecoder().decode(parts[1]));
-        String[] pair = joinedPair.split(BASIC_AUTH_JOINER);
+        String[] pair = joinedPair.split(BasicAuth.BASIC_AUTH_JOINER);
         if (pair.length != 2) {
             log.error("pair format error: {}", pair);
             return null;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
@@ -37,7 +37,7 @@ import java.io.IOException;
 import java.util.Base64;
 
 /**
- * Filter of authentication.
+ * Filter of open api authentication.
  */
 @Slf4j
 public class OpenAPIFilter implements Filter {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
@@ -28,12 +28,12 @@ import org.apache.shiro.authc.AuthenticationToken;
 @AllArgsConstructor
 public class SecretToken implements AuthenticationToken {
 
-    private String secretID;
+    private String secretId;
     private String secretKey;
 
     @Override
     public Object getPrincipal() {
-        return secretID;
+        return secretId;
     }
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
@@ -21,6 +21,9 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.shiro.authc.AuthenticationToken;
 
+/**
+ * Authentication token for open api client
+ */
 @Data
 @AllArgsConstructor
 public class SecretToken implements AuthenticationToken {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/SecretToken.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.auth.openapi;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.apache.shiro.authc.AuthenticationToken;
+
+@Data
+@AllArgsConstructor
+public class SecretToken implements AuthenticationToken {
+
+    private String secretID;
+    private String secretKey;
+
+    @Override
+    public Object getPrincipal() {
+        return secretID;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return secretKey;
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
@@ -38,7 +38,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * Filter of authentication.
+ * Filter of web user authentication.
  */
 @Slf4j
 public class AuthenticationFilter implements Filter {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.auth.web;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.common.pojo.user.UserDetail;
+import org.apache.inlong.manager.common.util.LoginUserUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.UsernamePasswordToken;
+import org.apache.shiro.subject.Subject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Filter of authentication.
+ */
+@Slf4j
+public class AuthenticationFilter implements Filter {
+
+    public static final String USERNAME = "username";
+    public static final String PASSWORD = "password";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationFilter.class);
+
+    public AuthenticationFilter() {
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+
+        Subject subject = SecurityUtils.getSubject();
+        if (subject.isAuthenticated()) {
+            UserDetail loginUserDetail = (UserDetail) subject.getPrincipal();
+            doFilter(servletRequest, servletResponse, filterChain, loginUserDetail);
+            return;
+        }
+
+        try {
+            UsernamePasswordToken token = getPasswordToken(servletRequest);
+            subject.login(token);
+        } catch (Exception ex) {
+            LOGGER.error("login error, msg: {}", ex.getMessage());
+            ((HttpServletResponse) servletResponse).sendError(HttpServletResponse.SC_FORBIDDEN, ex.getMessage());
+            return;
+        }
+
+        if (!subject.isAuthenticated()) {
+            log.error("Access denied for anonymous user:{}, path:{} ", subject.getPrincipal(),
+                    httpServletRequest.getServletPath());
+            ((HttpServletResponse) servletResponse).sendError(HttpServletResponse.SC_FORBIDDEN);
+            return;
+        }
+        doFilter(servletRequest, servletResponse, filterChain, (UserDetail) subject.getPrincipal());
+    }
+
+    private void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain,
+            UserDetail userDetail) throws IOException, ServletException {
+        LoginUserUtils.setUserLoginInfo(userDetail);
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            LoginUserUtils.removeUserLoginInfo();
+        }
+    }
+
+    private UsernamePasswordToken getPasswordToken(ServletRequest servletRequest) {
+        String username = servletRequest.getParameter(USERNAME);
+        String password = servletRequest.getParameter(PASSWORD);
+        Preconditions.checkNotNull(username, "please input username");
+        Preconditions.checkNotNull(password, "please input password");
+        return new UsernamePasswordToken(username, password);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/WebAuthorizingRealm.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/WebAuthorizingRealm.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.web.auth;
+package org.apache.inlong.manager.web.auth.web;
 
 import com.google.common.collect.Sets;
 import org.apache.inlong.manager.common.enums.UserTypeEnum;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
@@ -21,6 +21,7 @@ package org.apache.inlong.sdk.dataproxy;
 import java.util.concurrent.TimeUnit;
 
 public class ConfigConstants {
+
     public static final String PROXY_SDK_VERSION = "1.2.11";
 
     public static final int ALIVE_CONNECTIONS = 3;
@@ -62,7 +63,6 @@ public class ConfigConstants {
     public static final String RECEIVE_BUFFER_SIZE = "receiveBufferSize";
     public static final String SEND_BUFFER_SIZE = "sendBufferSize";
 
-    public static final String REQUEST_HEADER_AUTHORIZATION = "Authorization";
     public static final int FLAG_ALLOW_AUTH = 1 << 7;
     public static final int FLAG_ALLOW_ENCRYPT = 1 << 6;
     public static final int FLAG_ALLOW_COMPRESS = 1 << 5;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
@@ -18,10 +18,12 @@
 
 package org.apache.inlong.sdk.dataproxy;
 
+import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sdk.dataproxy.network.ProxysdkException;
 import org.apache.inlong.sdk.dataproxy.network.Utils;
 
+@Data
 public class ProxyClientConfig {
 
     private int aliveConnections;
@@ -48,6 +50,8 @@ public class ProxyClientConfig {
     private String tlsServerCertFilePathAndName;
     private String tlsServerKey;
     private int maxTimeoutCnt = ConfigConstants.MAX_TIMEOUT_CNT;
+    private String apiSecretId;
+    private String apiSecretKey;
 
     private boolean enableSaveManagerVIps = true;
 
@@ -93,7 +97,8 @@ public class ProxyClientConfig {
 
     /*pay attention to the last url parameter ip*/
     public ProxyClientConfig(String localHost, boolean isLocalVisit, String managerIp,
-            int managerPort, String groupId, String netTag) throws ProxysdkException {
+            int managerPort, String groupId, String netTag, String apiSecretId, String apiSecretKey)
+            throws ProxysdkException {
         if (Utils.isBlank(localHost)) {
             throw new ProxysdkException("localHost is blank!");
         }
@@ -119,6 +124,8 @@ public class ProxyClientConfig {
         this.proxyUpdateMaxRetry = ConfigConstants.PROXY_UPDATE_MAX_RETRY;
         this.connectTimeoutMillis = ConfigConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
         this.setRequestTimeoutMillis(ConfigConstants.DEFAULT_SEND_BUFFER_SIZE);
+        this.apiSecretId = apiSecretId;
+        this.apiSecretKey = apiSecretKey;
     }
 
     public String getTlsServerCertFilePathAndName() {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
@@ -50,8 +50,8 @@ public class ProxyClientConfig {
     private String tlsServerCertFilePathAndName;
     private String tlsServerKey;
     private int maxTimeoutCnt = ConfigConstants.MAX_TIMEOUT_CNT;
-    private String apiSecretId;
-    private String apiSecretKey;
+    private String authSecretId;
+    private String authSecretKey;
 
     private boolean enableSaveManagerVIps = true;
 
@@ -97,7 +97,7 @@ public class ProxyClientConfig {
 
     /*pay attention to the last url parameter ip*/
     public ProxyClientConfig(String localHost, boolean isLocalVisit, String managerIp,
-            int managerPort, String groupId, String netTag, String apiSecretId, String apiSecretKey)
+            int managerPort, String groupId, String netTag, String authSecretId, String authSecretKey)
             throws ProxysdkException {
         if (Utils.isBlank(localHost)) {
             throw new ProxysdkException("localHost is blank!");
@@ -124,8 +124,8 @@ public class ProxyClientConfig {
         this.proxyUpdateMaxRetry = ConfigConstants.PROXY_UPDATE_MAX_RETRY;
         this.connectTimeoutMillis = ConfigConstants.DEFAULT_CONNECT_TIMEOUT_MILLIS;
         this.setRequestTimeoutMillis(ConfigConstants.DEFAULT_SEND_BUFFER_SIZE);
-        this.apiSecretId = apiSecretId;
-        this.apiSecretKey = apiSecretKey;
+        this.authSecretId = authSecretId;
+        this.authSecretKey = authSecretKey;
     }
 
     public String getTlsServerCertFilePathAndName() {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
@@ -730,8 +730,8 @@ public class ProxyConfigManager extends Thread {
             try {
                 httpPost = new HttpPost(url);
                 httpPost.addHeader(REQUEST_HEADER_AUTHORIZATION,
-                        BasicAuth.genBasicAuthCredential(clientConfig.getApiSecretId(),
-                                clientConfig.getApiSecretKey()));
+                        BasicAuth.genBasicAuthCredential(clientConfig.getAuthSecretId(),
+                                clientConfig.getAuthSecretKey()));
                 StringEntity se = getEntity(params);
                 httpPost.setEntity(se);
                 HttpResponse response = httpClient.execute(httpPost);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
@@ -77,8 +77,6 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-import static org.apache.inlong.sdk.dataproxy.ConfigConstants.REQUEST_HEADER_AUTHORIZATION;
-
 /**
  * This thread requests dataproxy-host list from manager, including these functions:
  * 1. request dataproxy-host, support retry
@@ -729,7 +727,7 @@ public class ProxyConfigManager extends Thread {
             LOGGER.info("Request url : " + url + ", localManagerIps : " + localManagerIps);
             try {
                 httpPost = new HttpPost(url);
-                httpPost.addHeader(REQUEST_HEADER_AUTHORIZATION,
+                httpPost.addHeader(BasicAuth.BASIC_AUTH_HEADER,
                         BasicAuth.genBasicAuthCredential(clientConfig.getAuthSecretId(),
                                 clientConfig.getAuthSecretKey()));
                 StringEntity se = getEntity(params);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
@@ -45,6 +45,7 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
+import org.apache.inlong.common.util.BasicAuth;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeInfo;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeResponse;
 import org.apache.inlong.sdk.dataproxy.ConfigConstants;
@@ -67,7 +68,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -729,14 +729,9 @@ public class ProxyConfigManager extends Thread {
             LOGGER.info("Request url : " + url + ", localManagerIps : " + localManagerIps);
             try {
                 httpPost = new HttpPost(url);
-                if (this.clientConfig.isNeedAuthentication()) {
-                    long timestamp = System.currentTimeMillis();
-                    int nonce = new SecureRandom(String.valueOf(timestamp).getBytes()).nextInt(Integer.MAX_VALUE);
-                    httpPost.setHeader(REQUEST_HEADER_AUTHORIZATION,
-                            Utils.getAuthorizenInfo(clientConfig.getUserName(),
-                                    clientConfig.getSecretKey(), timestamp, nonce));
-                }
-
+                httpPost.addHeader(REQUEST_HEADER_AUTHORIZATION,
+                        BasicAuth.genBasicAuthCredential(clientConfig.getApiSecretId(),
+                                clientConfig.getApiSecretKey()));
                 StringEntity se = getEntity(params);
                 httpPost.setEntity(se);
                 HttpResponse response = httpClient.execute(httpPost);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/HttpClientExample.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/HttpClientExample.java
@@ -18,12 +18,13 @@
 
 package org.apache.inlong.sdk.dataproxy.example;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.network.HttpProxySender;
 import org.apache.inlong.sdk.dataproxy.network.ProxysdkException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 public class HttpClientExample {
 
@@ -70,7 +71,7 @@ public class HttpClientExample {
         try {
             proxyConfig = new ProxyClientConfig(localIP, isLocalVisit, inLongManagerAddr,
                     Integer.valueOf(inLongManagerPort),
-                    dataProxyGroup, netTag);
+                    dataProxyGroup, netTag, "test", "123456");
             proxyConfig.setGroupId(dataProxyGroup);
             proxyConfig.setConfStoreBasePath(configBasePath);
             proxyConfig.setReadProxyIPFromLocal(isReadProxyIPFromLocal);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
@@ -82,7 +82,7 @@ public class TcpClientExample {
         DefaultMessageSender messageSender = null;
         try {
             dataProxyConfig = new ProxyClientConfig(localIP, isLocalVisit, inLongManagerAddr,
-                    Integer.valueOf(inLongManagerPort), dataProxyGroup, netTag);
+                    Integer.valueOf(inLongManagerPort), dataProxyGroup, netTag, "test", "123456");
             if (StringUtils.isNotEmpty(configBasePath)) {
                 dataProxyConfig.setConfStoreBasePath(configBasePath);
             }
@@ -99,7 +99,7 @@ public class TcpClientExample {
             String inlongStreamId, String messageBody, long dt) {
         SendResult result = null;
         try {
-            result = sender.sendMessage(messageBody.getBytes("utf8"),inlongGroupId, inlongStreamId,
+            result = sender.sendMessage(messageBody.getBytes("utf8"), inlongGroupId, inlongStreamId,
                     0, String.valueOf(dt), 20, TimeUnit.SECONDS);
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
@@ -38,6 +38,7 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.http.util.EntityUtils;
+import org.apache.inlong.common.util.BasicAuth;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.network.Utils;
 import org.slf4j.Logger;
@@ -52,8 +53,6 @@ import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.ArrayList;
-
-import static org.apache.inlong.sdk.dataproxy.ConfigConstants.REQUEST_HEADER_AUTHORIZATION;
 
 /**
  * Utils for service discovery
@@ -184,7 +183,7 @@ public class ServiceDiscoveryUtils {
             if (proxyClientConfig.isNeedAuthentication()) {
                 long timestamp = System.currentTimeMillis();
                 int nonce = new SecureRandom(String.valueOf(timestamp).getBytes()).nextInt(Integer.MAX_VALUE);
-                httpPost.setHeader(REQUEST_HEADER_AUTHORIZATION,
+                httpPost.setHeader(BasicAuth.BASIC_AUTH_HEADER,
                         Utils.getAuthorizenInfo(proxyClientConfig.getUserName(),
                                 proxyClientConfig.getSecretKey(), timestamp, nonce));
             }
@@ -197,7 +196,7 @@ public class ServiceDiscoveryUtils {
                 JsonObject jb = jsonParser.parse(returnStr).getAsJsonObject();
                 if (jb == null) {
                     log.warn("ServiceDiscovery updated manager ip failed, returnStr = {} jb is "
-                                    + "null ", returnStr, jb);
+                            + "null ", returnStr, jb);
                     return null;
                 }
                 JsonObject rd = jb.get("resultData").getAsJsonObject();


### PR DESCRIPTION
## Prepare a Pull Request

- Fixes #5167

## Motivation

The Manager's Open APIs are free to call from anywhere anonymously, which is not secure.

Some sort of authentication support is needed to very the identity of the clients (i.e. authorized Agent/DataProxy/SDK, etc.).

## Changes

- Open API basic auth integration with Apache Shiro.
- Client component basic auth header added.
- Default secretId & secretKey pair configuration to keep the suite ready to go out of the box.
 (User should replace with their own if they care)

## Mechanism Options

There are several ways to provide web API authentication, with the typical two described below:

### Approach 1: Basic Access Authentication

See at: https://en.wikipedia.org/wiki/Basic_access_authentication  or [rfc7617](https://www.rfc-editor.org/rfc/rfc7617)

<img width="770" alt="image" src="https://user-images.githubusercontent.com/941634/180249246-4c94ae2e-c21f-493c-8497-757e2be3f200.png">


The auth process is simple:

A) The API server side creates a secretID & secretKey pair for each client who wants access.
B) The client encodes the id & key pair (base64) in the HTTP header.
C) The server's interceptor/filter retrieves the secretID and compares the secretKey param with the true secretKey stored at some database (usually encrypted)

**Pros:**  
  - Light and easy to understand, secure enough with HTTPS
  - little extra work to use

**Cons:**  
  - Since base64 is used, it is not secure in the non-encrypted channels.  The encoded credential string is always the same.
  - So it **must be used along with HTTPS.**

### Approach 2: API Secure Signature

This is commonly used in public cloud APIs, like the one described in this [Tencent cloud approach](https://cloud.tencent.com/document/product/213/30654)  or [rfc7616](https://www.rfc-editor.org/rfc/rfc7616)

<img width="914" alt="image" src="https://user-images.githubusercontent.com/941634/180343118-8ea4796e-9940-4062-bf0f-8c9df83aa1f8.png">


The auth process is roughly like this:
A) The API server side creates a secretID  & secretKey pair for each client who wants access.
B) The client organizes the request context info (URI、domain、sorted params、body data etc) into a concatenated string. 
C) Then client use RSA or hashing to encrypt the concatenated string to a signature with the secretKey
D) The client requests the API with the signature and secretID
E) The server retrieves the secretID, finds its corresponding secretKey, and uses the same signing process as B) and C) to calculate again the signature.
F) The server compares its calculated signature and the one from the request to determine the final authenticating result.

**Pros:**
  - More secure, since **the secretKey is not transported across the network** but merely as part of the signature source.  Thus can also be used in unencrypted channels like HTTP. 
  - The signature changes every time with different request contexts.

**Cons:**
  - The concatenating and signing process is more sophisticated and cumbersome and thus error-prone.  
  - Concatenating process like B) has no standards to follow. Often more debugging time is needed for the end user.

### Other approaches
Other popular methods like the bearer token used in OAuth2.0 ([rfc6750](https://www.rfc-editor.org/rfc/rfc6750)) behaves somewhere between the above two:  the token is different with each request / session but still have the same constraint (should only be used in https).

## Design

**This PR chooses the basic auth approach (Approach 1)** for the following reasons:
1) We must always use HTTPS like every modern web applications. And we leverage it by using basic auth which is easy and sufficiently secure.
2) The open APIs exposed by the Manager are quite limited and usually read only (Most important of which includes configuration queries for Agent and DataProxy).


## Implementation

- Server:  integration with Apache Shiro by using different realms for web user auth and open API auth
- Client: HTTP standard authorization header
