### PR TITLE
[INLONG-4931][Manager] Supplement inlong cluster API in manager client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -17,8 +17,18 @@
 
 package org.apache.inlong.manager.client.api;
 
+import com.github.pagehelper.PageInfo;
 import org.apache.inlong.manager.client.api.enums.SimpleGroupStatus;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
+import org.apache.inlong.manager.common.pojo.cluster.BindTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupInfo;
 
 import java.util.List;
@@ -94,4 +104,131 @@ public interface InlongClient {
      */
     InlongGroup getGroup(String groupName) throws Exception;
 
+    /**
+     * Save cluster tag.
+     *
+     * @param request cluster tag
+     * @return saved cluster tag id
+     */
+    Integer saveTag(ClusterTagRequest request);
+
+    /**
+     * Get cluster tag by id.
+     *
+     * @param id cluster tag id
+     * @return cluster tag info
+     */
+    ClusterTagResponse getTag(Integer id);
+
+    /**
+     * Paging query cluster tags according to conditions.
+     *
+     * @param request page request conditions
+     * @return cluster tag list
+     */
+    PageInfo<ClusterTagResponse> listTag(ClusterTagPageRequest request);
+
+    /**
+     * Update cluster tag.
+     *
+     * @param request cluster tag to be modified
+     * @return whether succeed
+     */
+    Boolean updateTag(ClusterTagRequest request);
+
+    /**
+     * Delete cluster tag.
+     *
+     * @param id cluster tag id to be deleted
+     * @return whether succeed
+     */
+    Boolean deleteTag(Integer id);
+
+    /**
+     * Save component cluster for Inlong.
+     *
+     * @param request cluster create request
+     * @return clusterIndex
+     */
+    Integer saveCluster(ClusterRequest request);
+
+    /**
+     * Get cluster info by id.
+     *
+     * @param id cluster id
+     * @return cluster info
+     */
+    ClusterInfo get(Integer id);
+
+    /**
+     * Paging query clusters according to conditions.
+     *
+     * @param request query conditions
+     * @return cluster list
+     */
+    ClusterInfo list(ClusterPageRequest request);
+
+    /**
+     * Update cluster information.
+     *
+     * @param request cluster to be modified
+     * @return whether succeed
+     */
+    Boolean update(ClusterRequest request);
+
+    /**
+     * Bind or unbind cluster tag for clusters.
+     *
+     * @param request cluster to be modified
+     * @return whether succeed
+     */
+    Boolean bindTag(BindTagRequest request);
+
+    /**
+     * Delete cluster information.
+     *
+     * @param id cluster id to be deleted
+     * @return whether succeed
+     */
+    Boolean delete(Integer id);
+
+    /**
+     * Save cluster node info.
+     *
+     * @param request cluster info
+     * @return id after saving
+     */
+    Integer saveNode(ClusterNodeRequest request);
+
+    /**
+     * Get cluster node info by id.
+     *
+     * @param id cluster id
+     * @return cluster info
+     */
+    ClusterNodeResponse getNode(Integer id);
+
+    /**
+     * Paging query cluster nodes according to conditions.
+     *
+     * @param request page request conditions
+     * @return cluster node list
+     */
+    PageInfo<ClusterNodeResponse> listNode(ClusterPageRequest request);
+
+    /**
+     * Update cluster node.
+     *
+     * @param request cluster node to be modified
+     * @return whether succeed
+     */
+    Boolean updateNode(ClusterNodeRequest request);
+
+    /**
+     * Delete cluster node.
+     *
+     * @param id cluster node id to be deleted
+     * @return whether succeed
+     */
+    Boolean deleteNode(Integer id);
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -30,13 +30,25 @@ import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.enums.SimpleGroupStatus;
 import org.apache.inlong.manager.client.api.enums.SimpleSourceStatus;
+import org.apache.inlong.manager.client.api.inner.client.ClientFactory;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.util.ClientUtils;
+import org.apache.inlong.manager.common.pojo.cluster.BindTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupPageRequest;
 import org.apache.inlong.manager.common.pojo.source.StreamSource;
 import org.apache.inlong.manager.common.util.HttpUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
 
 import java.util.List;
 import java.util.Map;
@@ -53,6 +65,7 @@ public class InlongClientImpl implements InlongClient {
     @Getter
     private final ClientConfiguration configuration;
     private final InlongGroupClient groupClient;
+    private final InlongClusterClient clusterClient;
 
     public InlongClientImpl(String serviceUrl, ClientConfiguration configuration) {
         Map<String, String> hostPorts = Splitter.on(URL_SPLITTER).withKeyValueSeparator(HOST_SPLITTER)
@@ -76,7 +89,9 @@ public class InlongClientImpl implements InlongClient {
             throw new RuntimeException(String.format("%s is not connective", serviceUrl));
         }
         this.configuration = configuration;
-        groupClient = ClientUtils.getClientFactory(configuration).getGroupClient();
+        ClientFactory clientFactory = ClientUtils.getClientFactory(configuration);
+        groupClient = clientFactory.getGroupClient();
+        clusterClient = clientFactory.getClusterClient();
     }
 
     @Override
@@ -127,6 +142,106 @@ public class InlongClientImpl implements InlongClient {
             return new BlankInlongGroup();
         }
         return new InlongGroupImpl(groupInfo, configuration);
+    }
+
+    @Override
+    public Integer saveTag(ClusterTagRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster request cannot be empty");
+        Preconditions.checkNotNull(request.getClusterTag(), "cluster tag cannot be empty");
+        return clusterClient.saveTag(request);
+    }
+
+    @Override
+    public ClusterTagResponse getTag(Integer id) {
+        Preconditions.checkNotNull(id, "inlong cluster tag id cannot be empty");
+        return clusterClient.getTag(id);
+    }
+
+    @Override
+    public PageInfo<ClusterTagResponse> listTag(ClusterTagPageRequest request) {
+        return clusterClient.listTag(request);
+    }
+
+    @Override
+    public Boolean updateTag(ClusterTagRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster request cannot be empty");
+        Preconditions.checkNotNull(request.getClusterTag(), "inlong cluster tag cannot be empty");
+        Preconditions.checkNotNull(request.getId(), "cluster tag id cannot be empty");
+        return clusterClient.updateTag(request);
+    }
+
+    @Override
+    public Boolean deleteTag(Integer id) {
+        Preconditions.checkNotNull(id, "cluster tag id cannot be empty");
+        return clusterClient.deleteTag(id);
+    }
+
+    @Override
+    public Integer saveCluster(ClusterRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster request cannot be empty");
+        return clusterClient.saveCluster(request);
+    }
+
+    @Override
+    public ClusterInfo get(Integer id) {
+        Preconditions.checkNotNull(id, "inlong cluster id cannot be empty");
+        return clusterClient.get(id);
+    }
+
+    @Override
+    public ClusterInfo list(ClusterPageRequest request) {
+        return clusterClient.list(request);
+    }
+
+    @Override
+    public Boolean update(ClusterRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster info cannot be empty");
+        Preconditions.checkNotNull(request.getId(), "inlong cluster id cannot be empty");
+        return clusterClient.update(request);
+    }
+
+    @Override
+    public Boolean bindTag(BindTagRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster info cannot be empty");
+        Preconditions.checkNotNull(request.getClusterTag(), "cluster tag cannot be empty");
+        return clusterClient.bindTag(request);
+    }
+
+    @Override
+    public Boolean delete(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id cannot be empty");
+        return clusterClient.delete(id);
+    }
+
+    @Override
+    public Integer saveNode(ClusterNodeRequest request) {
+        Preconditions.checkNotNull(request, "cluster node info cannot be empty");
+        return clusterClient.saveNode(request);
+    }
+
+    @Override
+    public ClusterNodeResponse getNode(Integer id) {
+        Preconditions.checkNotNull(id, "cluster node id cannot be empty");
+        return clusterClient.getNode(id);
+    }
+
+    @Override
+    public PageInfo<ClusterNodeResponse> listNode(ClusterPageRequest request) {
+        Preconditions.checkNotNull(request.getParentId(), "Cluster id cannot be empty");
+        return clusterClient.listNode(request);
+    }
+
+    @Override
+    public Boolean updateNode(ClusterNodeRequest request) {
+        Preconditions.checkNotNull(request, "inlong cluster node cannot be empty");
+        Preconditions.checkNotNull(request.getId(), "cluster node id cannot be empty");
+        return clusterClient.updateNode(request);
+    }
+
+    @Override
+    public Boolean deleteNode(Integer id) {
+        Preconditions.checkNotNull(id, "cluster node id cannot be empty");
+        return clusterClient.deleteNode(id);
     }
 
     private SimpleGroupStatus recheckGroupStatus(SimpleGroupStatus groupStatus, List<StreamSource> sources) {

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -17,11 +17,20 @@
 
 package org.apache.inlong.manager.client.api.inner.client;
 
+import com.github.pagehelper.PageInfo;
 import org.apache.inlong.manager.client.api.ClientConfiguration;
 import org.apache.inlong.manager.client.api.service.InlongClusterApi;
 import org.apache.inlong.manager.client.api.util.ClientUtils;
 import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.cluster.BindTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.common.util.Preconditions;
 
 /**
@@ -36,7 +45,70 @@ public class InlongClusterClient {
     }
 
     /**
-     * Save component cluster for Inlong
+     * Save cluster tag.
+     *
+     * @param request cluster tag
+     * @return saved cluster tag id
+     */
+    public Integer saveTag(ClusterTagRequest request) {
+        Response<Integer> response = ClientUtils.executeHttpCall(inlongClusterApi.saveTag(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Get cluster tag by id.
+     *
+     * @param id cluster tag id
+     * @return cluster tag info
+     */
+    public ClusterTagResponse getTag(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<ClusterTagResponse> response = ClientUtils.executeHttpCall(inlongClusterApi.getTag(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Paging query cluster tags according to conditions.
+     *
+     * @param request page request conditions
+     * @return cluster tag list
+     */
+    public PageInfo<ClusterTagResponse> listTag(ClusterTagPageRequest request) {
+        Response<PageInfo<ClusterTagResponse>> response = ClientUtils.executeHttpCall(
+                inlongClusterApi.listTag(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Update cluster tag.
+     *
+     * @param request cluster tag to be modified
+     * @return whether succeed
+     */
+    public Boolean updateTag(ClusterTagRequest request) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.updateTag(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Delete cluster tag.
+     *
+     * @param id cluster tag id to be deleted
+     * @return whether succeed
+     */
+    public Boolean deleteTag(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.deleteTag(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Save component cluster for Inlong.
      *
      * @param request cluster create request
      * @return clusterIndex
@@ -48,5 +120,130 @@ public class InlongClusterClient {
         Response<Integer> clusterIndexResponse = ClientUtils.executeHttpCall(inlongClusterApi.save(request));
         ClientUtils.assertRespSuccess(clusterIndexResponse);
         return clusterIndexResponse.getData();
+    }
+
+    /**
+     * Get cluster info by id.
+     *
+     * @param id cluster id
+     * @return cluster info
+     */
+    public ClusterInfo get(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<ClusterInfo> clusterInfoResponse = ClientUtils.executeHttpCall(inlongClusterApi.get(id));
+        ClientUtils.assertRespSuccess(clusterInfoResponse);
+        return clusterInfoResponse.getData();
+    }
+
+    /**
+     * Paging query clusters according to conditions.
+     *
+     * @param request query conditions
+     * @return cluster list
+     */
+    public ClusterInfo list(ClusterPageRequest request) {
+        Response<ClusterInfo> clusterInfoResponse = ClientUtils.executeHttpCall(inlongClusterApi.list(request));
+        ClientUtils.assertRespSuccess(clusterInfoResponse);
+        return clusterInfoResponse.getData();
+    }
+
+    /**
+     * Update cluster information.
+     *
+     * @param request cluster to be modified
+     * @return whether succeed
+     */
+    public Boolean update(ClusterRequest request) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.update(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Bind or unbind cluster tag for clusters.
+     *
+     * @param request cluster to be modified
+     * @return whether succeed
+     */
+    public Boolean bindTag(BindTagRequest request) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.bindTag(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Delete cluster information.
+     *
+     * @param id cluster id to be deleted
+     * @return whether succeed
+     */
+    public Boolean delete(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.delete(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Save cluster node info.
+     *
+     * @param request cluster info
+     * @return id after saving
+     */
+    public Integer saveNode(ClusterNodeRequest request) {
+        Response<Integer> response = ClientUtils.executeHttpCall(inlongClusterApi.saveNode(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Get cluster node info by id.
+     *
+     * @param id cluster id
+     * @return cluster info
+     */
+    public ClusterNodeResponse getNode(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<ClusterNodeResponse> response = ClientUtils.executeHttpCall(inlongClusterApi.getNode(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Paging query cluster nodes according to conditions.
+     *
+     * @param request page request conditions
+     * @return cluster node list
+     */
+    public PageInfo<ClusterNodeResponse> listNode(ClusterPageRequest request) {
+        Response<PageInfo<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(
+                inlongClusterApi.listNode(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Update cluster node.
+     *
+     * @param request cluster node to be modified
+     * @return whether succeed
+     */
+    public Boolean updateNode(ClusterNodeRequest request) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.updateNode(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Delete cluster node.
+     *
+     * @param id cluster node id to be deleted
+     * @return whether succeed
+     */
+    public Boolean deleteNode(Integer id) {
+        Preconditions.checkNotNull(id, "cluster id should not be empty");
+        Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.deleteNode(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
     }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -17,15 +17,71 @@
 
 package org.apache.inlong.manager.client.api.service;
 
+import com.github.pagehelper.PageInfo;
 import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.cluster.BindTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterPageRequest;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagPageRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagResponse;
 import retrofit2.Call;
 import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
 import retrofit2.http.POST;
+import retrofit2.http.Path;
 
 public interface InlongClusterApi {
+
+    @POST("/cluster/tag/save")
+    Call<Response<Integer>> saveTag(@Body ClusterTagRequest request);
+
+    @GET("/cluster/tag/get/{id}")
+    Call<Response<ClusterTagResponse>> getTag(@Path("id") Integer id);
+
+    @POST("/cluster/tag/list")
+    Call<Response<PageInfo<ClusterTagResponse>>> listTag(@Body ClusterTagPageRequest request);
+
+    @POST("/cluster/tag/update")
+    Call<Response<Boolean>> updateTag(@Body ClusterTagRequest request);
+
+    @DELETE("/cluster/tag/delete/{id}")
+    Call<Response<Boolean>> deleteTag(@Path("id") Integer id);
 
     @POST("cluster/save")
     Call<Response<Integer>> save(@Body ClusterRequest request);
 
+    @GET("/cluster/get/{id}")
+    Call<Response<ClusterInfo>> get(@Path("id") Integer id);
+
+    @POST("/cluster/list")
+    Call<Response<ClusterInfo>> list(@Body ClusterPageRequest request);
+
+    @POST("/cluster/update")
+    Call<Response<Boolean>> update(@Body ClusterRequest request);
+
+    @POST("/cluster/bindTag")
+    Call<Response<Boolean>> bindTag(@Body BindTagRequest request);
+
+    @DELETE("/cluster/delete/{id}")
+    Call<Response<Boolean>> delete(@Path("id") Integer id);
+
+    @POST("/cluster/node/save")
+    Call<Response<Integer>> saveNode(@Body ClusterNodeRequest request);
+
+    @GET("/cluster/node/get/{id}")
+    Call<Response<ClusterNodeResponse>> getNode(@Path("id") Integer id);
+
+    @POST("/cluster/node/list")
+    Call<Response<PageInfo<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
+
+    @POST("/cluster/node/update")
+    Call<Response<Boolean>> updateNode(@Body ClusterNodeRequest request);
+
+    @DELETE("/cluster/node/delete/{id}")
+    Call<Response<Boolean>> deleteNode(@Path("id") Integer id);
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -37,51 +37,51 @@ import retrofit2.http.Path;
 
 public interface InlongClusterApi {
 
-    @POST("/cluster/tag/save")
+    @POST("cluster/tag/save")
     Call<Response<Integer>> saveTag(@Body ClusterTagRequest request);
 
-    @GET("/cluster/tag/get/{id}")
+    @GET("cluster/tag/get/{id}")
     Call<Response<ClusterTagResponse>> getTag(@Path("id") Integer id);
 
-    @POST("/cluster/tag/list")
+    @POST("cluster/tag/list")
     Call<Response<PageInfo<ClusterTagResponse>>> listTag(@Body ClusterTagPageRequest request);
 
-    @POST("/cluster/tag/update")
+    @POST("cluster/tag/update")
     Call<Response<Boolean>> updateTag(@Body ClusterTagRequest request);
 
-    @DELETE("/cluster/tag/delete/{id}")
+    @DELETE("cluster/tag/delete/{id}")
     Call<Response<Boolean>> deleteTag(@Path("id") Integer id);
 
     @POST("cluster/save")
     Call<Response<Integer>> save(@Body ClusterRequest request);
 
-    @GET("/cluster/get/{id}")
+    @GET("cluster/get/{id}")
     Call<Response<ClusterInfo>> get(@Path("id") Integer id);
 
-    @POST("/cluster/list")
+    @POST("cluster/list")
     Call<Response<ClusterInfo>> list(@Body ClusterPageRequest request);
 
-    @POST("/cluster/update")
+    @POST("cluster/update")
     Call<Response<Boolean>> update(@Body ClusterRequest request);
 
-    @POST("/cluster/bindTag")
+    @POST("cluster/bindTag")
     Call<Response<Boolean>> bindTag(@Body BindTagRequest request);
 
-    @DELETE("/cluster/delete/{id}")
+    @DELETE("cluster/delete/{id}")
     Call<Response<Boolean>> delete(@Path("id") Integer id);
 
-    @POST("/cluster/node/save")
+    @POST("cluster/node/save")
     Call<Response<Integer>> saveNode(@Body ClusterNodeRequest request);
 
-    @GET("/cluster/node/get/{id}")
+    @GET("cluster/node/get/{id}")
     Call<Response<ClusterNodeResponse>> getNode(@Path("id") Integer id);
 
-    @POST("/cluster/node/list")
+    @POST("cluster/node/list")
     Call<Response<PageInfo<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
 
-    @POST("/cluster/node/update")
+    @POST("cluster/node/update")
     Call<Response<Boolean>> updateNode(@Body ClusterNodeRequest request);
 
-    @DELETE("/cluster/node/delete/{id}")
+    @DELETE("cluster/node/delete/{id}")
     Call<Response<Boolean>> deleteNode(@Path("id") Integer id);
 }

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -34,8 +34,16 @@ import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
 import org.apache.inlong.manager.client.api.util.ClientUtils;
 import org.apache.inlong.manager.common.auth.DefaultAuthentication;
 import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.SinkType;
+import org.apache.inlong.manager.common.pojo.cluster.BindTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterNodeResponse;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.common.pojo.cluster.ClusterTagResponse;
+import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterInfo;
 import org.apache.inlong.manager.common.pojo.cluster.pulsar.PulsarClusterRequest;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupExtInfo;
@@ -691,6 +699,32 @@ class ClientFactoryTest {
     }
 
     @Test
+    void testGetCluster() {
+        ClusterInfo cluster = PulsarClusterInfo.builder()
+                .id(1)
+                .name("test_cluster")
+                .url("127.0.0.1")
+                .clusterTags("test_cluster_tag")
+                .type(ClusterType.PULSAR)
+                .adminUrl("http://127.0.0.1:8080")
+                .tenant("public")
+                .build();
+
+        stubFor(
+                get(urlMatching("/api/inlong/manager/cluster/get/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(cluster))
+                                )
+                        )
+        );
+
+        ClusterInfo clusterInfo = clusterClient.get(1);
+        Assertions.assertEquals(1, clusterInfo.getId());
+        Assertions.assertTrue(clusterInfo instanceof PulsarClusterInfo);
+    }
+
+    @Test
     void testGetMysqlSinkInfo() {
         StreamSink streamSink = MySQLSink.builder()
                 // mysql field
@@ -729,4 +763,91 @@ class ClientFactoryTest {
         Assertions.assertTrue(sinkInfo instanceof MySQLSink);
     }
 
+    @Test
+    void testSaveClusterTag() {
+        stubFor(
+                post(urlMatching("/api/inlong/manager/cluster/tag/save.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(1))
+                                )
+                        )
+        );
+        ClusterTagRequest request = new ClusterTagRequest();
+        request.setClusterTag("test_cluster");
+        Integer tagId = clusterClient.saveTag(request);
+        Assertions.assertEquals(1, tagId);
+    }
+
+    @Test
+    void testGetClusterTag() {
+        ClusterTagResponse tagResponse = ClusterTagResponse.builder()
+                .id(1)
+                .clusterTag("test_cluster")
+                .creator("admin")
+                .inCharges("admin")
+                .build();
+        stubFor(
+                get(urlMatching("/api/inlong/manager/cluster/tag/get/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(tagResponse))
+                                )
+                        )
+        );
+        ClusterTagResponse clusterTagInfo = clusterClient.getTag(1);
+        Assertions.assertNotNull(clusterTagInfo);
+    }
+
+    @Test
+    void testBindTag() {
+        stubFor(
+                post(urlMatching("/api/inlong/manager/cluster/bindTag.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(true))
+                                )
+                        )
+        );
+        BindTagRequest request = new BindTagRequest();
+        request.setClusterTag("test_cluster_tag");
+        Boolean isBind = clusterClient.bindTag(request);
+        Assertions.assertTrue(isBind);
+    }
+
+    @Test
+    void testSaveNode() {
+        stubFor(
+                post(urlMatching("/api/inlong/manager/cluster/node/save.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(1))
+                                )
+                        )
+        );
+        ClusterNodeRequest request = new ClusterNodeRequest();
+        request.setType(ClusterType.PULSAR);
+        Integer nodeId = clusterClient.saveNode(request);
+        Assertions.assertEquals(1, nodeId);
+    }
+
+    @Test
+    void testGetNode() {
+        ClusterNodeResponse response = ClusterNodeResponse.builder()
+                .id(1)
+                .type(ClusterType.DATA_PROXY)
+                .ip("127.0.0.1")
+                .port(46801)
+                .build();
+        stubFor(
+                get(urlMatching("/api/inlong/manager/cluster/node/get/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(response))
+                                )
+                        )
+        );
+        ClusterNodeResponse clientNode = clusterClient.getNode(1);
+        Assertions.assertEquals(1, clientNode.getId());
+    }
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterInfo.java
@@ -24,6 +24,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Date;
 
@@ -31,6 +32,7 @@ import java.util.Date;
  * Inlong cluster info
  */
 @Data
+@SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @ApiModel("Inlong cluster info")

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterNodeResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterNodeResponse.java
@@ -20,7 +20,10 @@ package org.apache.inlong.manager.common.pojo.cluster;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
@@ -28,6 +31,9 @@ import java.util.Date;
  * Inlong cluster node response
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel("Cluster node response")
 public class ClusterNodeResponse {
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterTagResponse.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/ClusterTagResponse.java
@@ -20,7 +20,10 @@ package org.apache.inlong.manager.common.pojo.cluster;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
@@ -28,6 +31,9 @@ import java.util.Date;
  * Inlong cluster tag response
  */
 @Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel("Cluster tag response")
 public class ClusterTagResponse {
 
@@ -59,3 +65,4 @@ public class ClusterTagResponse {
     private Date modifyTime;
 
 }
+

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterInfo.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/pojo/cluster/pulsar/PulsarClusterInfo.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import lombok.experimental.SuperBuilder;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
@@ -31,6 +32,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
  * Inlong cluster info for Pulsar
  */
 @Data
+@SuperBuilder
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeDefine(value = ClusterType.PULSAR)


### PR DESCRIPTION
### [INLONG-4931][Manager] Supplement inlong cluster api in manager client

- Fixes #4931 

### Motivation

Supplement the api that the manager web has but the client does not have.

### Modifications

Supplement inlong cluster api in manager client.

### Verifying this change

- [x] This change is already covered by existing tests, such as:
org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java