### PR TITLE
[INLONG-5182][CI] Upgrade apache-rat-plugin to compatible with parallel builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1627,7 +1627,7 @@
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
-                <version>0.13</version>
+                <version>0.14</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5182

### Motivation

The current version 0.13 does not support parallel builds, a warning message will appear

After the plugin is upgraded, it can support parallel builds


![](https://user-images.githubusercontent.com/20400582/180378878-8b8d7494-d217-470b-9ab3-161e83960867.png)

### Modifications
 apache-rat-plugin version 0.13 -> 0.14


### Documentation
https://creadur.apache.org/rat/apache-rat-plugin/rat-mojo.html

