### PR TITLE
[INLONG-5188][Manager] Fix the error of creating group workflow and remove redundant settings

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/ConsumptionEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ConsumptionEntityMapper.xml
@@ -69,15 +69,11 @@
         insert into consumption (id, consumer_group, in_charges,
                                  inlong_group_id, mq_type, topic,
                                  filter_enabled, inlong_stream_id,
-                                 status, is_deleted,
-                                 creator, modifier,
-                                 create_time, modify_time, version)
+                                 status, creator, modifier)
         values (#{id, jdbcType=INTEGER}, #{consumerGroup, jdbcType=VARCHAR}, #{inCharges, jdbcType=VARCHAR},
                 #{inlongGroupId, jdbcType=VARCHAR}, #{mqType, jdbcType=VARCHAR}, #{topic, jdbcType=VARCHAR},
                 #{filterEnabled, jdbcType=INTEGER}, #{inlongStreamId, jdbcType=VARCHAR},
-                #{status, jdbcType=INTEGER}, #{isDeleted, jdbcType=INTEGER},
-                #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR},
-                #{createTime, jdbcType=TIMESTAMP}, #{modifyTime, jdbcType=TIMESTAMP}, #{version, jdbcType=INTEGER})
+                #{status, jdbcType=INTEGER}, #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.ConsumptionEntity">
@@ -116,18 +112,6 @@
             <if test="modifier != null">
                 modifier,
             </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="modifyTime != null">
-                modify_time,
-            </if>
-            <if test="isDeleted != null">
-                is_deleted,
-            </if>
-            <if test="version != null">
-                version,
-            </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
             <if test="id != null">
@@ -162,18 +146,6 @@
             </if>
             <if test="modifier != null">
                 #{modifier, jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                #{modifyTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="isDeleted != null">
-                #{isDeleted, jdbcType=INTEGER},
-            </if>
-            <if test="version != null">
-                #{version, jdbcType=INTEGER},
             </if>
         </trim>
     </insert>
@@ -211,12 +183,6 @@
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime, jdbcType=TIMESTAMP},
-            </if>
             <if test="version != null">
                 version = #{version, jdbcType=INTEGER} + 1,
             </if>
@@ -237,8 +203,6 @@
             status           = #{status, jdbcType=INTEGER},
             creator          = #{creator, jdbcType=VARCHAR},
             modifier         = #{modifier, jdbcType=VARCHAR},
-            create_time      = #{createTime, jdbcType=TIMESTAMP},
-            modify_time      = #{modifyTime, jdbcType=TIMESTAMP},
             is_deleted       = #{isDeleted, jdbcType=INTEGER},
             version          = #{version, jdbcType=INTEGER} + 1
         where id = #{id, jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ConsumptionEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ConsumptionEntityMapper.xml
@@ -183,9 +183,7 @@
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version, jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version, jdbcType=INTEGER} + 1
         </set>
         where id = #{id, jdbcType=INTEGER}
         and is_deleted = 0

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -147,9 +147,7 @@
             <if test="extParams != null">
                 ext_params = #{extParams, jdbcType=LONGVARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version, jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version, jdbcType=INTEGER} + 1
         </set>
         where id = #{id, jdbcType=INTEGER}
         and version = #{version, jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -46,14 +46,12 @@
             parameterType="org.apache.inlong.manager.dao.entity.DataNodeEntity">
         insert into data_node (id, name, type,
                                url, username, token,
-                               in_charges, status, is_deleted,
-                               creator, modifier, create_time,
-                               modify_time, ext_params, version)
+                               in_charges, status, creator,
+                               modifier, ext_params)
         values (#{id, jdbcType=INTEGER}, #{name, jdbcType=VARCHAR}, #{type, jdbcType=VARCHAR},
                 #{url, jdbcType=VARCHAR}, #{username, jdbcType=VARCHAR}, #{token, jdbcType=VARCHAR},
-                #{inCharges, jdbcType=VARCHAR}, #{status, jdbcType=INTEGER}, #{isDeleted, jdbcType=INTEGER},
-                #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR}, #{createTime, jdbcType=TIMESTAMP},
-                #{modifyTime, jdbcType=TIMESTAMP}, #{extParams, jdbcType=LONGVARCHAR}, #{version, jdbcType=INTEGER})
+                #{inCharges, jdbcType=VARCHAR}, #{status, jdbcType=INTEGER}, #{creator, jdbcType=VARCHAR},
+                #{modifier, jdbcType=VARCHAR}, #{extParams, jdbcType=LONGVARCHAR})
     </insert>
 
     <select id="selectById" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -109,8 +107,6 @@
             is_deleted  = #{isDeleted, jdbcType=INTEGER},
             creator     = #{creator, jdbcType=VARCHAR},
             modifier    = #{modifier, jdbcType=VARCHAR},
-            create_time = #{createTime, jdbcType=TIMESTAMP},
-            modify_time = #{modifyTime, jdbcType=TIMESTAMP},
             version     = #{version, jdbcType=INTEGER} + 1
         where id = #{id, jdbcType=INTEGER}
         and version = #{version, jdbcType=INTEGER}
@@ -147,12 +143,6 @@
             </if>
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                create_time = #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime, jdbcType=TIMESTAMP},
             </if>
             <if test="extParams != null">
                 ext_params = #{extParams, jdbcType=LONGVARCHAR},

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -182,9 +182,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -49,15 +49,13 @@
         insert into inlong_cluster (id, name, type,
                                     url, cluster_tags, ext_tag,
                                     token, ext_params, heartbeat,
-                                    in_charges, status, is_deleted,
-                                    creator, modifier,
-                                    create_time, modify_time, version)
+                                    in_charges, status, creator,
+                                    modifier)
         values (#{id,jdbcType=INTEGER}, #{name,jdbcType=VARCHAR}, #{type,jdbcType=VARCHAR},
                 #{url,jdbcType=VARCHAR}, #{clusterTags,jdbcType=VARCHAR}, #{extTag,jdbcType=VARCHAR},
                 #{token,jdbcType=VARCHAR}, #{extParams,jdbcType=LONGVARCHAR}, #{heartbeat,jdbcType=LONGVARCHAR},
-                #{inCharges,jdbcType=VARCHAR}, #{status,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
-                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR},
-                #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP}, #{version,jdbcType=INTEGER})
+                #{inCharges,jdbcType=VARCHAR}, #{status,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
+                #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectById" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -138,8 +136,6 @@
             is_deleted   = #{isDeleted,jdbcType=INTEGER},
             creator      = #{creator,jdbcType=VARCHAR},
             modifier     = #{modifier,jdbcType=VARCHAR},
-            create_time  = #{createTime,jdbcType=TIMESTAMP},
-            modify_time  = #{modifyTime,jdbcType=TIMESTAMP},
             version      = #{version,jdbcType=INTEGER} + 1
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
@@ -185,12 +181,6 @@
             </if>
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
             </if>
             <if test="version != null">
                 version = #{version,jdbcType=INTEGER} + 1,

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
@@ -129,9 +129,7 @@
             <if test="extParams != null">
                 ext_params = #{extParams,jdbcType=LONGVARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
     </update>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
@@ -44,13 +44,10 @@
             parameterType="org.apache.inlong.manager.dao.entity.InlongClusterNodeEntity">
         insert into inlong_cluster_node (id, parent_id, type,
                                          ip, port, ext_params,
-                                         status, is_deleted, creator,
-                                         modifier, create_time, modify_time, version)
+                                         status, creator, modifier)
         values (#{id,jdbcType=INTEGER}, #{parentId,jdbcType=INTEGER}, #{type,jdbcType=VARCHAR},
                 #{ip,jdbcType=VARCHAR}, #{port,jdbcType=INTEGER}, #{extParams,jdbcType=LONGVARCHAR},
-                #{status,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
-                #{modifier,jdbcType=VARCHAR}, #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP},
-                #{version,jdbcType=INTEGER})
+                #{status,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectById" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -129,12 +126,6 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
-            </if>
             <if test="extParams != null">
                 ext_params = #{extParams,jdbcType=LONGVARCHAR},
             </if>
@@ -155,8 +146,6 @@
             is_deleted  = #{isDeleted,jdbcType=INTEGER},
             creator     = #{creator,jdbcType=VARCHAR},
             modifier    = #{modifier,jdbcType=VARCHAR},
-            create_time = #{createTime,jdbcType=TIMESTAMP},
-            modify_time = #{modifyTime,jdbcType=TIMESTAMP},
             version     = #{version,jdbcType=INTEGER} + 1
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterTagEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterTagEntityMapper.xml
@@ -40,13 +40,11 @@
     <insert id="insert" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.InlongClusterTagEntity">
         insert into inlong_cluster_tag (id, cluster_tag, ext_params,
-                                        in_charges, status, is_deleted,
-                                        creator, modifier,
-                                        create_time, modify_time, version)
+                                        in_charges, status, creator,
+                                        modifier)
         values (#{id,jdbcType=INTEGER}, #{clusterTag,jdbcType=VARCHAR}, #{extParams,jdbcType=LONGVARCHAR},
-                #{inCharges,jdbcType=VARCHAR}, #{status,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
-                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR},
-                #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP}, #{version,jdbcType=INTEGER})
+                #{inCharges,jdbcType=VARCHAR}, #{status,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
+                #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectById" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -86,8 +84,6 @@
             is_deleted  = #{isDeleted,jdbcType=INTEGER},
             creator     = #{creator,jdbcType=VARCHAR},
             modifier    = #{modifier,jdbcType=VARCHAR},
-            create_time = #{createTime,jdbcType=TIMESTAMP},
-            modify_time = #{modifyTime,jdbcType=TIMESTAMP},
             version     = #{version,jdbcType=INTEGER} + 1
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
@@ -116,12 +112,6 @@
             </if>
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
             </if>
             <if test="version != null">
                 version = #{version,jdbcType=INTEGER} + 1,

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterTagEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterTagEntityMapper.xml
@@ -113,9 +113,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -72,9 +72,8 @@
                                   lightweight, inlong_cluster_tag,
                                   ext_params, in_charges,
                                   followers, status,
-                                  previous_status, is_deleted,
-                                  creator, modifier,
-                                  create_time, modify_time, version)
+                                  previous_status, creator,
+                                  modifier)
         values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR},
                 #{name,jdbcType=VARCHAR}, #{description,jdbcType=VARCHAR},
                 #{mqType,jdbcType=VARCHAR}, #{mqResource,jdbcType=VARCHAR},
@@ -84,9 +83,8 @@
                 #{lightweight,jdbcType=INTEGER}, #{inlongClusterTag,jdbcType=VARCHAR},
                 #{extParams,jdbcType=LONGVARCHAR}, #{inCharges,jdbcType=VARCHAR},
                 #{followers,jdbcType=VARCHAR}, #{status,jdbcType=INTEGER},
-                #{previousStatus,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
-                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR},
-                #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP}, #{version,jdbcType=INTEGER})
+                #{previousStatus,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
+                #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -220,8 +218,6 @@
             is_deleted             = #{isDeleted,jdbcType=INTEGER},
             creator                = #{creator,jdbcType=VARCHAR},
             modifier               = #{modifier,jdbcType=VARCHAR},
-            create_time            = #{createTime,jdbcType=TIMESTAMP},
-            modify_time            = #{modifyTime,jdbcType=TIMESTAMP},
             version                = #{version,jdbcType=INTEGER} + 1
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -285,9 +285,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where inlong_group_id = #{inlongGroupId, jdbcType=VARCHAR}
         and is_deleted = 0

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
@@ -65,17 +65,14 @@
                                    data_escape_char, sync_send, daily_records,
                                    daily_storage, peak_records, max_length,
                                    storage_period, ext_params, status,
-                                   previous_status, is_deleted, creator,
-                                   modifier, create_time, modify_time, version)
+                                   previous_status, creator, modifier)
         values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR}, #{inlongStreamId,jdbcType=VARCHAR},
                 #{name,jdbcType=VARCHAR}, #{description,jdbcType=VARCHAR}, #{mqResource,jdbcType=VARCHAR},
                 #{dataType,jdbcType=VARCHAR}, #{dataEncoding,jdbcType=VARCHAR}, #{dataSeparator,jdbcType=VARCHAR},
                 #{dataEscapeChar,jdbcType=VARCHAR}, #{syncSend,jdbcType=INTEGER}, #{dailyRecords,jdbcType=INTEGER},
                 #{dailyStorage,jdbcType=INTEGER}, #{peakRecords,jdbcType=INTEGER}, #{maxLength,jdbcType=INTEGER},
                 #{storagePeriod,jdbcType=INTEGER}, #{extParams,jdbcType=LONGVARCHAR}, #{status,jdbcType=INTEGER},
-                #{previousStatus,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
-                #{modifier,jdbcType=VARCHAR}, #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP},
-                #{version,jdbcType=INTEGER})
+                #{previousStatus,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.InlongStreamEntity">
@@ -138,23 +135,11 @@
             <if test="previousStatus != null">
                 previous_status,
             </if>
-            <if test="isDeleted != null">
-                is_deleted,
-            </if>
             <if test="creator != null">
                 creator,
             </if>
             <if test="modifier != null">
                 modifier,
-            </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="modifyTime != null">
-                modify_time,
-            </if>
-            <if test="version != null">
-                version,
             </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
@@ -215,23 +200,11 @@
             <if test="previousStatus != null">
                 #{previousStatus,jdbcType=INTEGER},
             </if>
-            <if test="isDeleted != null">
-                #{isDeleted,jdbcType=INTEGER},
-            </if>
             <if test="creator != null">
                 #{creator,jdbcType=VARCHAR},
             </if>
             <if test="modifier != null">
                 #{modifier,jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                #{modifyTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="version != null">
-                #{version,jdbcType=INTEGER},
             </if>
         </trim>
     </insert>
@@ -337,8 +310,6 @@
             is_deleted       = #{isDeleted, jdbcType=INTEGER},
             creator          = #{creator, jdbcType=VARCHAR},
             modifier         = #{modifier, jdbcType=VARCHAR},
-            create_time      = #{createTime, jdbcType=TIMESTAMP},
-            modify_time      = #{modifyTime, jdbcType=TIMESTAMP},
             version          = #{version, jdbcType=INTEGER} + 1
         where id = #{id, jdbcType=INTEGER}
         and version = #{version, jdbcType=INTEGER}
@@ -408,12 +379,6 @@
             </if>
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                create_time = #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime, jdbcType=TIMESTAMP},
             </if>
             <if test="version != null">
                 version = #{version, jdbcType=INTEGER} + 1,

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
@@ -380,9 +380,7 @@
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version, jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version, jdbcType=INTEGER} + 1
         </set>
         where inlong_group_id = #{inlongGroupId, jdbcType=VARCHAR}
         and inlong_stream_id = #{inlongStreamId, jdbcType=VARCHAR}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -223,16 +223,14 @@
                                  data_node_name, sort_task_name,
                                  sort_consumer_group, ext_params,
                                  operate_log, status, previous_status,
-                                 is_deleted, creator, modifier,
-                                 create_time, modify_time, version)
+                                 creator, modifier)
         values (#{id, jdbcType=INTEGER}, #{inlongGroupId, jdbcType=VARCHAR}, #{inlongStreamId, jdbcType=VARCHAR},
                 #{sinkType, jdbcType=VARCHAR}, #{sinkName, jdbcType=VARCHAR}, #{description, jdbcType=VARCHAR},
                 #{enableCreateResource, jdbcType=TINYINT}, #{inlongClusterName, jdbcType=VARCHAR},
                 #{dataNodeName, jdbcType=VARCHAR}, #{sortTaskName, jdbcType=VARCHAR},
                 #{sortConsumerGroup, jdbcType=VARCHAR}, #{extParams, jdbcType=VARCHAR},
                 #{operateLog, jdbcType=VARCHAR}, #{status, jdbcType=INTEGER}, #{previousStatus, jdbcType=INTEGER},
-                #{isDeleted, jdbcType=INTEGER}, #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR},
-                #{createTime, jdbcType=TIMESTAMP}, #{modifyTime, jdbcType=TIMESTAMP}, #{version,jdbcType=INTEGER})
+                #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.StreamSinkEntity">
@@ -283,23 +281,11 @@
             <if test="previousStatus != null">
                 previous_status,
             </if>
-            <if test="isDeleted != null">
-                is_deleted,
-            </if>
             <if test="creator != null">
                 creator,
             </if>
             <if test="modifier != null">
                 modifier,
-            </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="modifyTime != null">
-                modify_time,
-            </if>
-            <if test="version != null">
-                version,
             </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
@@ -348,23 +334,11 @@
             <if test="previousStatus != null">
                 #{previousStatus, jdbcType=INTEGER},
             </if>
-            <if test="isDeleted != null">
-                #{isDeleted, jdbcType=INTEGER},
-            </if>
             <if test="creator != null">
                 #{creator, jdbcType=VARCHAR},
             </if>
             <if test="modifier != null">
                 #{modifier, jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                #{modifyTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="version != null">
-                #{version, jdbcType=INTEGER},
             </if>
         </trim>
     </insert>
@@ -424,12 +398,6 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
-            </if>
             <if test="version != null">
                 version = #{version,jdbcType=INTEGER} + 1,
             </if>
@@ -456,8 +424,6 @@
             is_deleted             = #{isDeleted,jdbcType=INTEGER},
             creator                = #{creator,jdbcType=VARCHAR},
             modifier               = #{modifier,jdbcType=VARCHAR},
-            create_time            = #{createTime,jdbcType=TIMESTAMP},
-            modify_time            = #{modifyTime,jdbcType=TIMESTAMP},
             version                = #{version,jdbcType=INTEGER} + 1
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
@@ -467,7 +433,6 @@
         set status          = #{status,jdbcType=INTEGER},
             previous_status = status,
             operate_log     = #{operateLog,jdbcType=VARCHAR},
-            modify_time     = now()
         where id = #{id,jdbcType=INTEGER}
     </update>
     <select id="selectAllTasks" resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortTaskInfo">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -398,9 +398,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -55,17 +55,14 @@
                                    source_type, source_name, agent_ip,
                                    uuid, data_node_name, cluster_id,
                                    serialization_type, snapshot,
-                                   report_time, ext_params, version,
-                                   status, previous_status, is_deleted,
-                                   creator, modifier, create_time, modify_time)
+                                   report_time, ext_params, status,
+                                   previous_status, creator, modifier)
         values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR}, #{inlongStreamId,jdbcType=VARCHAR},
                 #{sourceType,jdbcType=VARCHAR}, #{sourceName,jdbcType=VARCHAR}, #{agentIp,jdbcType=VARCHAR},
                 #{uuid,jdbcType=VARCHAR}, #{dataNodeName,jdbcType=VARCHAR}, #{clusterId,jdbcType=INTEGER},
                 #{serializationType,jdbcType=VARCHAR}, #{snapshot,jdbcType=LONGVARCHAR},
-                #{modifyTime,jdbcType=TIMESTAMP}, #{extParams,jdbcType=LONGVARCHAR}, #{version,jdbcType=INTEGER},
-                #{status,jdbcType=INTEGER}, #{previousStatus,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
-                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR},
-                #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP})
+                #{modifyTime,jdbcType=TIMESTAMP}, #{extParams,jdbcType=LONGVARCHAR}, #{status,jdbcType=INTEGER},
+                #{previousStatus,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectById" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
@@ -282,12 +279,6 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
-            </if>
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
@@ -311,9 +302,7 @@
             previous_status    = #{previousStatus,jdbcType=INTEGER},
             is_deleted         = #{isDeleted,jdbcType=INTEGER},
             creator            = #{creator,jdbcType=VARCHAR},
-            modifier           = #{modifier,jdbcType=VARCHAR},
-            create_time        = #{createTime,jdbcType=TIMESTAMP},
-            modify_time        = #{modifyTime,jdbcType=TIMESTAMP}
+            modifier           = #{modifier,jdbcType=VARCHAR}
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
     </update>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -261,9 +261,6 @@
             <if test="extParams != null">
                 ext_params = #{extParams,jdbcType=LONGVARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
             <if test="status != null">
                 status = #{status,jdbcType=INTEGER},
             </if>
@@ -279,6 +276,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamTransformEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamTransformEntityMapper.xml
@@ -44,14 +44,12 @@
             parameterType="org.apache.inlong.manager.dao.entity.StreamTransformEntity">
         insert into stream_transform (id, inlong_group_id, inlong_stream_id,
                                       transform_name, transform_type, pre_node_names,
-                                      post_node_names, transform_definition, version,
-                                      is_deleted, creator, modifier,
-                                      create_time, modify_time)
+                                      post_node_names, transform_definition,
+                                      creator, modifier)
         values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR}, #{inlongStreamId,jdbcType=VARCHAR},
                 #{transformName,jdbcType=VARCHAR}, #{transformType,jdbcType=VARCHAR}, #{preNodeNames,jdbcType=VARCHAR},
-                #{postNodeNames,jdbcType=VARCHAR}, #{transformDefinition,jdbcType=VARCHAR}, #{version,jdbcType=INTEGER},
-                #{isDeleted,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR},
-                #{createTime,jdbcType=TIMESTAMP}, #{modifyTime,jdbcType=TIMESTAMP})
+                #{postNodeNames,jdbcType=VARCHAR}, #{transformDefinition,jdbcType=VARCHAR},
+                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.StreamTransformEntity">
@@ -81,23 +79,11 @@
             <if test="transformDefinition != null">
                 transform_definition,
             </if>
-            <if test="version != null">
-                version,
-            </if>
-            <if test="isDeleted != null">
-                is_deleted,
-            </if>
             <if test="creator != null">
                 creator,
             </if>
             <if test="modifier != null">
                 modifier,
-            </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="modifyTime != null">
-                modify_time,
             </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
@@ -125,23 +111,11 @@
             <if test="transformDefinition != null">
                 #{transformDefinition,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                #{version,jdbcType=INTEGER},
-            </if>
-            <if test="isDeleted != null">
-                #{isDeleted,jdbcType=INTEGER},
-            </if>
             <if test="creator != null">
                 #{creator,jdbcType=VARCHAR},
             </if>
             <if test="modifier != null">
                 #{modifier,jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                #{modifyTime,jdbcType=TIMESTAMP},
             </if>
         </trim>
     </insert>
@@ -180,9 +154,7 @@
             version              = #{version,jdbcType=INTEGER} + 1,
             is_deleted           = #{isDeleted,jdbcType=INTEGER},
             creator              = #{creator,jdbcType=VARCHAR},
-            modifier             = #{modifier,jdbcType=VARCHAR},
-            create_time          = #{createTime,jdbcType=TIMESTAMP},
-            modify_time          = #{modifyTime,jdbcType=TIMESTAMP}
+            modifier             = #{modifier,jdbcType=VARCHAR}
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
     </update>
@@ -221,12 +193,6 @@
             </if>
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime,jdbcType=TIMESTAMP},
             </if>
         </set>
         where id = #{id,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamTransformEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamTransformEntityMapper.xml
@@ -182,9 +182,6 @@
             <if test="transformDefinition != null">
                 transform_definition = #{transformDefinition,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
             <if test="isDeleted != null">
                 is_deleted = #{isDeleted,jdbcType=INTEGER},
             </if>
@@ -194,6 +191,7 @@
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
             </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/UserEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/UserEntityMapper.xml
@@ -100,13 +100,11 @@
         insert into user (id, name, password,
                           secret_key, public_key, private_key,
                           encrypt_version, account_type, due_date,
-                          create_time, update_time,
-                          create_by, update_by, version)
+                          create_by, update_by)
         values (#{id,jdbcType=INTEGER}, #{name,jdbcType=VARCHAR}, #{password,jdbcType=VARCHAR},
                 #{secretKey,jdbcType=VARCHAR}, #{publicKey,jdbcType=VARCHAR}, #{privateKey,jdbcType=VARCHAR},
                 #{encryptVersion,jdbcType=INTEGER}, #{accountType,jdbcType=INTEGER}, #{dueDate,jdbcType=TIMESTAMP},
-                #{createTime,jdbcType=TIMESTAMP}, #{updateTime,jdbcType=TIMESTAMP}, #{createBy,jdbcType=VARCHAR},
-                #{updateBy,jdbcType=VARCHAR}, #{version,jdbcType=INTEGER})
+                #{createBy,jdbcType=VARCHAR}, #{updateBy,jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective" parameterType="org.apache.inlong.manager.dao.entity.UserEntity">
         insert into user
@@ -138,20 +136,11 @@
             <if test="dueDate != null">
                 due_date,
             </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="updateTime != null">
-                update_time,
-            </if>
             <if test="createBy != null">
                 create_by,
             </if>
             <if test="updateBy != null">
                 update_by,
-            </if>
-            <if test="version != null">
-                version,
             </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
@@ -182,20 +171,11 @@
             <if test="dueDate != null">
                 #{dueDate,jdbcType=TIMESTAMP},
             </if>
-            <if test="createTime != null">
-                #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="updateTime != null">
-                #{updateTime,jdbcType=TIMESTAMP},
-            </if>
             <if test="createBy != null">
                 #{createBy,jdbcType=VARCHAR},
             </if>
             <if test="updateBy != null">
                 #{updateBy,jdbcType=VARCHAR},
-            </if>
-            <if test="version != null">
-                #{version,jdbcType=INTEGER},
             </if>
         </trim>
     </insert>
@@ -233,12 +213,6 @@
             <if test="dueDate != null">
                 due_date = #{dueDate,jdbcType=TIMESTAMP},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime,jdbcType=TIMESTAMP},
-            </if>
-            <if test="updateTime != null">
-                update_time = #{updateTime,jdbcType=TIMESTAMP},
-            </if>
             <if test="createBy != null">
                 create_by = #{createBy,jdbcType=VARCHAR},
             </if>
@@ -262,8 +236,6 @@
             encrypt_version = #{encryptVersion,jdbcType=INTEGER},
             account_type    = #{accountType,jdbcType=INTEGER},
             due_date        = #{dueDate,jdbcType=TIMESTAMP},
-            create_time     = #{createTime,jdbcType=TIMESTAMP},
-            update_time     = #{updateTime,jdbcType=TIMESTAMP},
             create_by       = #{createBy,jdbcType=VARCHAR},
             update_by       = #{updateBy,jdbcType=VARCHAR},
             version         = #{version,jdbcType=INTEGER} + 1

--- a/inlong-manager/manager-dao/src/main/resources/mappers/UserEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/UserEntityMapper.xml
@@ -219,9 +219,7 @@
             <if test="updateBy != null">
                 update_by = #{updateBy,jdbcType=VARCHAR},
             </if>
-            <if test="version != null">
-                version = #{version,jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version,jdbcType=INTEGER} + 1
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/WorkflowApproverEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/WorkflowApproverEntityMapper.xml
@@ -48,21 +48,17 @@
     <delete id="deleteByPrimaryKey">
         update workflow_approver
         set is_deleted = id,
-            modify_time=now(),
             modifier=#{modifier, jdbcType=VARCHAR}
         where id = #{id, jdbcType=INTEGER}
     </delete>
     <insert id="insert"
             parameterType="org.apache.inlong.manager.dao.entity.WorkflowApproverEntity">
         insert into workflow_approver (id, process_name, task_name,
-                                 filter_key, filter_value, filter_value_desc, approvers,
-                                 creator, modifier, create_time,
-                                 modify_time, is_deleted, version)
+                                       filter_key, filter_value, filter_value_desc,
+                                       approvers, creator, modifier)
         values (#{id, jdbcType=INTEGER}, #{processName, jdbcType=VARCHAR}, #{taskName, jdbcType=VARCHAR},
                 #{filterKey, jdbcType=VARCHAR}, #{filterValue, jdbcType=VARCHAR}, #{filterValueDesc, jdbcType=VARCHAR},
-                #{approvers, jdbcType=VARCHAR},
-                #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR}, #{createTime, jdbcType=TIMESTAMP},
-                #{modifyTime, jdbcType=TIMESTAMP}, #{isDeleted, jdbcType=INTEGER}, #{version, jdbcType=INTEGER})
+                #{approvers, jdbcType=VARCHAR}, #{creator, jdbcType=VARCHAR}, #{modifier, jdbcType=VARCHAR})
     </insert>
     <insert id="insertSelective"
             parameterType="org.apache.inlong.manager.dao.entity.WorkflowApproverEntity">
@@ -95,18 +91,6 @@
             <if test="modifier != null">
                 modifier,
             </if>
-            <if test="createTime != null">
-                create_time,
-            </if>
-            <if test="modifyTime != null">
-                modify_time,
-            </if>
-            <if test="isDeleted != null">
-                is_deleted,
-            </if>
-            <if test="version != null">
-                version,
-            </if>
         </trim>
         <trim prefix="values (" suffix=")" suffixOverrides=",">
             <if test="id != null">
@@ -135,18 +119,6 @@
             </if>
             <if test="modifier != null">
                 #{modifier, jdbcType=VARCHAR},
-            </if>
-            <if test="createTime != null">
-                #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                #{modifyTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="isDeleted != null">
-                #{isDeleted, jdbcType=INTEGER},
-            </if>
-            <if test="version != null">
-                #{version, jdbcType=INTEGER},
             </if>
         </trim>
     </insert>
@@ -178,12 +150,6 @@
             <if test="modifier != null">
                 modifier = #{modifier, jdbcType=VARCHAR},
             </if>
-            <if test="createTime != null">
-                create_time = #{createTime, jdbcType=TIMESTAMP},
-            </if>
-            <if test="modifyTime != null">
-                modify_time = #{modifyTime, jdbcType=TIMESTAMP},
-            </if>
             <if test="isDeleted != null">
                 is_deleted = #{isDeleted, jdbcType=INTEGER},
             </if>
@@ -205,8 +171,6 @@
             approvers    = #{approvers, jdbcType=VARCHAR},
             creator      = #{creator, jdbcType=VARCHAR},
             modifier     = #{modifier, jdbcType=VARCHAR},
-            create_time  = #{createTime, jdbcType=TIMESTAMP},
-            modify_time  = #{modifyTime, jdbcType=TIMESTAMP},
             is_deleted   = #{isDeleted, jdbcType=INTEGER},
             version      = #{version, jdbcType=INTEGER} + 1
         where id = #{id, jdbcType=INTEGER}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/WorkflowApproverEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/WorkflowApproverEntityMapper.xml
@@ -153,9 +153,7 @@
             <if test="isDeleted != null">
                 is_deleted = #{isDeleted, jdbcType=INTEGER},
             </if>
-            <if test="version != null">
-                version = #{version, jdbcType=INTEGER} + 1,
-            </if>
+            version = #{version, jdbcType=INTEGER} + 1
         </set>
         where id = #{id, jdbcType=INTEGER}
         and is_deleted = 0

--- a/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapperTest.java
+++ b/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapperTest.java
@@ -46,7 +46,8 @@ public class InlongGroupEntityMapperTest extends DaoBaseTest {
     public void selectByPrimaryKey() {
         InlongGroupEntity entity = createGroupEntity();
         groupEntityMapper.insert(entity);
-        Assertions.assertEquals(entity, groupEntityMapper.selectByPrimaryKey(entity.getId()));
+        InlongGroupEntity groupEntity = groupEntityMapper.selectByPrimaryKey(entity.getId());
+        Assertions.assertEquals(entity.getInlongGroupId(), groupEntity.getInlongGroupId());
     }
 
     private InlongGroupEntity createGroupEntity() {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/AbstractClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/AbstractClusterOperator.java
@@ -30,8 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-
 /**
  * Default operator of inlong cluster.
  */
@@ -51,11 +49,6 @@ public abstract class AbstractClusterOperator implements InlongClusterOperator {
 
         entity.setCreator(operator);
         entity.setModifier(operator);
-        Date now = new Date();
-        entity.setCreateTime(now);
-        entity.setModifyTime(now);
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
         clusterMapper.insert(entity);
 
         return entity.getId();
@@ -76,7 +69,6 @@ public abstract class AbstractClusterOperator implements InlongClusterOperator {
         // set the ext params
         this.setTargetEntity(request, entity);
         entity.setModifier(operator);
-        entity.setModifyTime(new Date());
         int rowCount = clusterMapper.updateByIdSelective(entity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
             LOGGER.error("cluster has already updated with name={}, type={}, curVersion={}", request.getName(),

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/ConsumptionServiceImpl.java
@@ -356,9 +356,9 @@ public class ConsumptionServiceImpl implements ConsumptionService {
         entity.setFilterEnabled(0);
 
         entity.setStatus(ConsumptionStatus.APPROVED.getStatus());
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
-        entity.setCreator(groupInfo.getCreator());
-        entity.setCreateTime(new Date());
+        String operator = groupInfo.getCreator();
+        entity.setCreator(operator);
+        entity.setModifier(operator);
 
         consumptionMapper.insert(entity);
 
@@ -377,13 +377,8 @@ public class ConsumptionServiceImpl implements ConsumptionService {
     private ConsumptionEntity saveConsumption(ConsumptionInfo info, String operator) {
         ConsumptionEntity entity = CommonBeanUtils.copyProperties(info, ConsumptionEntity::new);
         entity.setStatus(ConsumptionStatus.WAIT_ASSIGN.getStatus());
-        entity.setIsDeleted(0);
         entity.setCreator(operator);
         entity.setModifier(operator);
-        Date now = new Date();
-        entity.setCreateTime(now);
-        entity.setModifyTime(now);
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
 
         if (info.getId() != null) {
             consumptionMapper.updateByPrimaryKey(entity);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/DataNodeServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/DataNodeServiceImpl.java
@@ -39,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.sql.Connection;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -69,11 +68,6 @@ public class DataNodeServiceImpl implements DataNodeService {
         DataNodeEntity entity = CommonBeanUtils.copyProperties(request, DataNodeEntity::new);
         entity.setCreator(operator);
         entity.setModifier(operator);
-        Date now = new Date();
-        entity.setCreateTime(now);
-        entity.setModifyTime(now);
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
         dataNodeMapper.insert(entity);
 
         LOGGER.debug("success to save data node={}", request);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/InlongStreamServiceImpl.java
@@ -60,7 +60,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -114,8 +113,7 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         InlongStreamEntity streamEntity = CommonBeanUtils.copyProperties(request, InlongStreamEntity::new);
         streamEntity.setStatus(StreamStatus.NEW.getCode());
         streamEntity.setCreator(operator);
-        streamEntity.setCreateTime(new Date());
-        streamEntity.setVersion(InlongConstants.INITIAL_VERSION);
+        streamEntity.setModifier(operator);
 
         streamMapper.insertSelective(streamEntity);
         saveField(groupId, streamId, request.getFieldList());
@@ -477,12 +475,8 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         streamEntity.setMaxLength(1000);
 
         streamEntity.setStatus(StreamStatus.CONFIG_SUCCESSFUL.getCode());
-        streamEntity.setIsDeleted(InlongConstants.UN_DELETED);
         streamEntity.setCreator(operator);
         streamEntity.setModifier(operator);
-        Date now = new Date();
-        streamEntity.setCreateTime(now);
-        streamEntity.setModifyTime(now);
 
         streamMapper.insert(streamEntity);
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
@@ -120,7 +120,9 @@ public class UserServiceImpl implements UserService {
         entity.setAccountType(userInfo.getType());
         entity.setPassword(MD5Utils.encrypt(password));
         entity.setDueDate(DateUtils.getExpirationDate(userInfo.getValidDays()));
-        entity.setCreateBy(LoginUserUtils.getLoginUserDetail().getUsername());
+        String currentUser = LoginUserUtils.getLoginUserDetail().getUsername();
+        entity.setCreateBy(currentUser);
+        entity.setUpdateBy(currentUser);
         entity.setName(username);
         try {
             Map<String, String> keyPairs = RSAUtils.generateRSAKeyPairs();
@@ -138,8 +140,6 @@ public class UserServiceImpl implements UserService {
             throw new BusinessException(errMsg);
         }
 
-        entity.setCreateTime(new Date());
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
         Preconditions.checkTrue(userMapper.insert(entity) > 0, "Create user failed");
 
         LOGGER.debug("success to create user info={}", userInfo);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/UserServiceImpl.java
@@ -168,8 +168,8 @@ public class UserServiceImpl implements UserService {
         UserEntity updateUserEntity = userMapper.selectByPrimaryKey(updateUser.getId());
         Preconditions.checkNotNull(updateUserEntity, "User not exists with id=" + updateUser.getId());
         UserEntity targetUserEntity = getByUsername(updateUser.getUsername());
-        Preconditions.checkTrue(Objects.equals(targetUserEntity.getName(), updateUserEntity.getName())
-                        && !Objects.equals(targetUserEntity.getId(), updateUserEntity.getId()),
+        Preconditions.checkTrue(Objects.isNull(targetUserEntity)
+                        || Objects.equals(targetUserEntity.getId(), updateUserEntity.getId()),
                 "Username [" + updateUser.getUsername() + "] already exists");
         String errMsg = String.format("user has already updated with username=%s, curVersion=%s",
                 updateUser.getUsername(), updateUser.getVersion());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
@@ -40,7 +40,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -102,9 +101,6 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
 
     @Override
     public void add(WorkflowApprover approver, String operator) {
-        Date now = new Date();
-        approver.setCreateTime(now);
-        approver.setModifyTime(now);
         approver.setModifier(operator);
         approver.setCreator(operator);
 
@@ -125,7 +121,6 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
         Preconditions.checkEmpty(exist, "already exit the same config");
 
         WorkflowApproverEntity entity = CommonBeanUtils.copyProperties(approver, WorkflowApproverEntity::new);
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
         int success = this.workflowApproverMapper.insert(entity);
         Preconditions.checkTrue(success == 1, "add failed");
     }
@@ -146,7 +141,6 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
         }
         WorkflowApproverEntity update = new WorkflowApproverEntity();
         update.setId(config.getId());
-        update.setModifyTime(new Date());
         update.setModifier(operator);
         update.setApprovers(config.getApprovers());
         update.setFilterKey(config.getFilterKey().name());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/AbstractGroupOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/AbstractGroupOperator.java
@@ -34,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Date;
-
 /**
  * Default operator of inlong group.
  */
@@ -60,13 +58,8 @@ public abstract class AbstractGroupOperator implements InlongGroupOperator {
 
         // after saving, the status is set to [GROUP_WAIT_SUBMIT]
         entity.setStatus(GroupStatus.TO_BE_SUBMIT.getCode());
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
         entity.setCreator(operator);
         entity.setModifier(operator);
-        Date now = new Date();
-        entity.setCreateTime(now);
-        entity.setModifyTime(now);
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
 
         groupMapper.insert(entity);
         return groupId;
@@ -89,7 +82,6 @@ public abstract class AbstractGroupOperator implements InlongGroupOperator {
         setTargetEntity(request, entity);
 
         entity.setModifier(operator);
-        entity.setModifyTime(new Date());
         int rowCount = groupMapper.updateByIdentifierSelective(entity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
             LOGGER.error("inlong group has already updated with group id={}, curVersion={}",

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/AbstractSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/AbstractSinkOperator.java
@@ -40,7 +40,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -77,13 +76,8 @@ public abstract class AbstractSinkOperator implements StreamSinkOperator {
     public Integer saveOpt(SinkRequest request, String operator) {
         StreamSinkEntity entity = CommonBeanUtils.copyProperties(request, StreamSinkEntity::new);
         entity.setStatus(SinkStatus.NEW.getCode());
-        entity.setIsDeleted(InlongConstants.UN_DELETED);
         entity.setCreator(operator);
         entity.setModifier(operator);
-        Date now = new Date();
-        entity.setCreateTime(now);
-        entity.setModifyTime(now);
-        entity.setVersion(InlongConstants.INITIAL_VERSION);
 
         // get the ext params
         setTargetEntity(request, entity);
@@ -124,7 +118,6 @@ public abstract class AbstractSinkOperator implements StreamSinkOperator {
         entity.setPreviousStatus(entity.getStatus());
         entity.setStatus(SinkStatus.CONFIG_ING.getCode());
         entity.setModifier(operator);
-        entity.setModifyTime(new Date());
         int rowCount = sinkMapper.updateByPrimaryKeySelective(entity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
             LOGGER.error(errMsg);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/transform/StreamTransformServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/transform/StreamTransformServiceImpl.java
@@ -43,7 +43,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -83,13 +82,8 @@ public class StreamTransformServiceImpl implements StreamTransformService {
         }
         StreamTransformEntity transformEntity = CommonBeanUtils.copyProperties(request,
                 StreamTransformEntity::new);
-        transformEntity.setVersion(InlongConstants.INITIAL_VERSION);
         transformEntity.setCreator(operator);
         transformEntity.setModifier(operator);
-        Date now = new Date();
-        transformEntity.setCreateTime(now);
-        transformEntity.setModifyTime(now);
-        transformEntity.setIsDeleted(InlongConstants.UN_DELETED);
         transformMapper.insert(transformEntity);
         saveFieldOpt(transformEntity, request.getFieldList());
         return transformEntity.getId();
@@ -151,8 +145,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
         StreamTransformEntity transformEntity = CommonBeanUtils.copyProperties(request,
                 StreamTransformEntity::new);
         transformEntity.setModifier(operator);
-        transformEntity.setVersion(transformEntity.getVersion() + 1);
-        transformEntity.setModifyTime(new Date());
         int rowCount = transformMapper.updateByIdSelective(transformEntity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
             LOGGER.error(msg);
@@ -177,12 +169,10 @@ public class StreamTransformServiceImpl implements StreamTransformService {
         List<StreamTransformEntity> entityList = transformMapper.selectByRelatedId(groupId, streamId,
                 request.getTransformName());
         if (CollectionUtils.isNotEmpty(entityList)) {
-            Date now = new Date();
             for (StreamTransformEntity entity : entityList) {
                 Integer id = entity.getId();
                 entity.setIsDeleted(id);
                 entity.setModifier(operator);
-                entity.setModifyTime(now);
                 int rowCount = transformMapper.updateByIdSelective(entity);
                 if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
                     LOGGER.error("transform has already updated with groupId={}, streamId={}, name={}, curVersion={}",


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5188 

### Motivation

1、Make sure to create group workflow success.
2、Remove redundant parameter settings

### Modifications

When inserting data, the service layer will no longer set creatTime, modifyTime, isDeleted and version,
but let the database generate automatically

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [X] This change is already covered by existing tests, such as:
  *(please describe tests)*
org.apache.inlong.manager.service.cluster.InlongClusterServiceTest
- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (no)

