### PR TITLE
[INLONG-5197][Manager] Unify the HTTP request method of the OpenAPI query interface from GET to POST

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyConfigRequest.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyConfigRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.pojo.dataproxy;
+
+import lombok.Data;
+
+/**
+ * Data proxy config request info.
+ */
+@Data
+public class DataProxyConfigRequest {
+
+    /**
+     * DataProxy cluster name
+     */
+    private String clusterName;
+
+    /**
+     * DataProxy cluster tag
+     */
+    private String clusterTag;
+
+    /**
+     * DataProxy cluster md5
+     */
+    private String md5;
+
+}

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyConfigRequest.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyConfigRequest.java
@@ -18,11 +18,13 @@
 package org.apache.inlong.common.pojo.dataproxy;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Data proxy config request info.
  */
 @Data
+@NoArgsConstructor
 public class DataProxyConfigRequest {
 
     /**

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
@@ -37,6 +37,7 @@ import org.apache.inlong.dataproxy.config.holder.PropertiesConfigHolder;
 import org.apache.inlong.dataproxy.config.pojo.MQClusterConfig;
 import org.apache.inlong.dataproxy.consts.AttributeConstants;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
+import org.apache.inlong.dataproxy.utils.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -269,18 +270,23 @@ public class ConfigManager {
                 return false;
             }
 
-            HttpGet httpGet = null;
+            HttpPost httpPost = null;
             try {
-                String url = "http://" + host + ConfigConstants.MANAGER_PATH + ConfigConstants.MANAGER_GET_CONFIG_PATH
-                        + "?clusterName=" + clusterName;
-                LOG.info("start to request {} to get config info", url);
-                httpGet = new HttpGet(url);
-                httpGet.addHeader(HttpHeaders.CONNECTION, "close");
-                httpGet.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+                String url = "http://" + host + ConfigConstants.MANAGER_PATH + ConfigConstants.MANAGER_GET_CONFIG_PATH;
+                httpPost = new HttpPost(url);
+                httpPost.addHeader(HttpHeaders.CONNECTION, "close");
+                httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+
+                // http body
+                Map<String, String> params = new HashMap<>();
+                params.put("clusterName", clusterName);
+                httpPost.setEntity(HttpUtils.getEntity(params));
 
                 // request with post
-                CloseableHttpResponse response = httpClient.execute(httpGet);
+                LOG.info("start to request {} to get config info with params {}", url, params);
+                CloseableHttpResponse response = httpClient.execute(httpPost);
                 String returnStr = EntityUtils.toString(response.getEntity());
+
                 // get groupId <-> topic and m value.
                 RemoteConfigJson configJson = gson.fromJson(returnStr, RemoteConfigJson.class);
                 Map<String, String> groupIdToTopic = new HashMap<>();
@@ -335,8 +341,8 @@ public class ConfigManager {
                 LOG.error("exception caught", ex);
                 return false;
             } finally {
-                if (httpGet != null) {
-                    httpGet.releaseConnection();
+                if (httpPost != null) {
+                    httpPost.releaseConnection();
                 }
             }
             return true;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -27,6 +27,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigRequest;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyTopicInfo;
 import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.apache.inlong.dataproxy.config.holder.FileConfigHolder;
@@ -277,13 +278,13 @@ public class ConfigManager {
                 httpPost.addHeader(HttpHeaders.CONNECTION, "close");
                 httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
 
-                // http body
-                Map<String, String> params = new HashMap<>();
-                params.put("clusterName", clusterName);
-                httpPost.setEntity(HttpUtils.getEntity(params));
+                // request body
+                DataProxyConfigRequest request = new DataProxyConfigRequest();
+                request.setClusterName(clusterName);
+                httpPost.setEntity(HttpUtils.getEntity(request));
 
                 // request with post
-                LOG.info("start to request {} to get config info with params {}", url, params);
+                LOG.info("start to request {} to get config info with params {}", url, request);
                 CloseableHttpResponse response = httpClient.execute(httpPost);
                 String returnStr = EntityUtils.toString(response.getEntity());
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
@@ -41,6 +41,7 @@ import org.apache.inlong.common.pojo.dataproxy.ProxySource;
 import org.apache.inlong.common.pojo.dataproxy.RepositoryTimerTask;
 import org.apache.inlong.dataproxy.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
+import org.apache.inlong.dataproxy.utils.HttpUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -182,20 +183,25 @@ public class RemoteConfigManager implements IRepository {
      * reloadDataProxyConfig
      */
     private boolean reloadDataProxyConfig(String clusterName, String clusterTag, String host) {
-        HttpGet httpGet = null;
+        HttpPost httpPost = null;
         try {
-            String url = "http://" + host + ConfigConstants.MANAGER_PATH + ConfigConstants.MANAGER_GET_ALL_CONFIG_PATH
-                    + "?clusterName=" + clusterName + "&clusterTag=" + clusterTag;
-            if (StringUtils.isNotBlank(this.dataProxyConfigMd5)) {
-                url += "&md5=" + this.dataProxyConfigMd5;
-            }
-            LOGGER.info("start to request {} to get config info", url);
-            httpGet = new HttpGet(url);
-            httpGet.addHeader(HttpHeaders.CONNECTION, "close");
-            httpGet.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+            String url = "http://" + host + ConfigConstants.MANAGER_PATH + ConfigConstants.MANAGER_GET_ALL_CONFIG_PATH;
+            httpPost = new HttpPost(url);
+            httpPost.addHeader(HttpHeaders.CONNECTION, "close");
+            httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
 
-            // request with get
-            CloseableHttpResponse response = httpClient.execute(httpGet);
+            // http body
+            Map<String, String> params = new HashMap<>();
+            params.put("clusterName", clusterName);
+            params.put("clusterTag", clusterTag);
+            if (StringUtils.isNotBlank(this.dataProxyConfigMd5)) {
+                params.put("md5", this.dataProxyConfigMd5);
+            }
+            httpPost.setEntity(HttpUtils.getEntity(params));
+
+            // request with post
+            LOGGER.info("start to request {} to get config info with params {}", url, params);
+            CloseableHttpResponse response = httpClient.execute(httpPost);
             String returnStr = EntityUtils.toString(response.getEntity());
             LOGGER.info("end to request {} to get config info:{}", url, returnStr);
             // get groupId <-> topic and m value.
@@ -221,8 +227,8 @@ public class RemoteConfigManager implements IRepository {
             LOGGER.error("exception caught", ex);
             return false;
         } finally {
-            if (httpGet != null) {
-                httpGet.releaseConnection();
+            if (httpPost != null) {
+                httpPost.releaseConnection();
             }
         }
         return true;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -31,6 +31,7 @@ import org.apache.inlong.common.pojo.dataproxy.CacheClusterObject;
 import org.apache.inlong.common.pojo.dataproxy.CacheClusterSetObject;
 import org.apache.inlong.common.pojo.dataproxy.CacheTopicObject;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyCluster;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigRequest;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigResponse;
 import org.apache.inlong.common.pojo.dataproxy.IRepository;
 import org.apache.inlong.common.pojo.dataproxy.InLongIdObject;
@@ -190,17 +191,17 @@ public class RemoteConfigManager implements IRepository {
             httpPost.addHeader(HttpHeaders.CONNECTION, "close");
             httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
 
-            // http body
-            Map<String, String> params = new HashMap<>();
-            params.put("clusterName", clusterName);
-            params.put("clusterTag", clusterTag);
-            if (StringUtils.isNotBlank(this.dataProxyConfigMd5)) {
-                params.put("md5", this.dataProxyConfigMd5);
+            // request body
+            DataProxyConfigRequest request = new DataProxyConfigRequest();
+            request.setClusterName(clusterName);
+            request.setClusterTag(clusterTag);
+            if (StringUtils.isNotBlank(dataProxyConfigMd5)) {
+                request.setMd5(dataProxyConfigMd5);
             }
-            httpPost.setEntity(HttpUtils.getEntity(params));
+            httpPost.setEntity(HttpUtils.getEntity(request));
 
             // request with post
-            LOGGER.info("start to request {} to get config info with params {}", url, params);
+            LOGGER.info("start to request {} to get config info with params {}", url, request);
             CloseableHttpResponse response = httpClient.execute(httpPost);
             String returnStr = EntityUtils.toString(response.getEntity());
             LOGGER.info("end to request {} to get config info:{}", url, returnStr);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.utils;
+
+import com.google.gson.JsonObject;
+import org.apache.http.entity.StringEntity;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class HttpUtils {
+
+    public static final String APPLICATION_JSON = "application/json";
+
+    public static StringEntity getEntity(Map<String, String> params) throws UnsupportedEncodingException {
+        JsonObject jsonObject = new JsonObject();
+        for (Entry<String, String> pair : params.entrySet()) {
+            jsonObject.addProperty(pair.getKey(), pair.getValue());
+        }
+        StringEntity se = new StringEntity(jsonObject.toString());
+        se.setContentType(APPLICATION_JSON);
+        return se;
+    }
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
@@ -17,23 +17,19 @@
 
 package org.apache.inlong.dataproxy.utils;
 
-import com.google.gson.JsonObject;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.http.entity.StringEntity;
 
 import java.io.UnsupportedEncodingException;
-import java.util.Map;
-import java.util.Map.Entry;
 
 public class HttpUtils {
 
     public static final String APPLICATION_JSON = "application/json";
+    private static final Gson GSON = new GsonBuilder().create();
 
-    public static StringEntity getEntity(Map<String, String> params) throws UnsupportedEncodingException {
-        JsonObject jsonObject = new JsonObject();
-        for (Entry<String, String> pair : params.entrySet()) {
-            jsonObject.addProperty(pair.getKey(), pair.getValue());
-        }
-        StringEntity se = new StringEntity(jsonObject.toString());
+    public static StringEntity getEntity(Object obj) throws UnsupportedEncodingException {
+        StringEntity se = new StringEntity(GSON.toJson(obj));
         se.setContentType(APPLICATION_JSON);
         return se;
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
@@ -18,19 +18,20 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigRequest;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeResponse;
 import org.apache.inlong.manager.common.beans.Response;
 import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.apache.inlong.manager.service.repository.DataProxyConfigRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -42,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/openapi")
 @Api(tags = "Open-DataProxy-API")
+@Slf4j
 public class DataProxyController {
 
     @Autowired
@@ -50,36 +52,26 @@ public class DataProxyController {
     @Autowired
     private DataProxyConfigRepository dataProxyConfigRepository;
 
-    @GetMapping(value = "/dataproxy/getIpList/{inlongGroupId}")
+    @PostMapping(value = "/dataproxy/getIpList/{inlongGroupId}")
     @ApiOperation(value = "Get data proxy IP list by InlongGroupId")
     public Response<DataProxyNodeResponse> getIpList(@PathVariable String inlongGroupId) {
         return Response.success(clusterService.getDataProxyNodes(inlongGroupId));
     }
 
-    @GetMapping("/dataproxy/getConfig")
+    @PostMapping("/dataproxy/getConfig")
     @ApiOperation(value = "Get data proxy topic list")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "clusterTag", value = "cluster tag", dataTypeClass = String.class),
-            @ApiImplicitParam(name = "clusterName", value = "cluster name", dataTypeClass = String.class)
-    })
-    public Response<DataProxyConfig> getConfig(
-            @RequestParam(required = false) String clusterTag,
-            @RequestParam(required = true) String clusterName) {
-        DataProxyConfig config = clusterService.getDataProxyConfig(clusterTag, clusterName);
+    public Response<DataProxyConfig> getConfig(@RequestBody DataProxyConfigRequest request) {
+        DataProxyConfig config = clusterService.getDataProxyConfig(request.getClusterTag(), request.getClusterName());
         if (CollectionUtils.isEmpty(config.getMqClusterList()) || CollectionUtils.isEmpty(config.getTopicList())) {
             return Response.fail("Failed to get MQ Cluster or Topic, make sure Cluster registered or Topic existed.");
         }
         return Response.success(config);
     }
 
-    @GetMapping("/dataproxy/getAllConfig")
+    @PostMapping("/dataproxy/getAllConfig")
     @ApiOperation(value = "Get all proxy config")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "clusterName", dataTypeClass = String.class, required = true),
-            @ApiImplicitParam(name = "md5", dataTypeClass = String.class, required = true)
-    })
-    public String getAllConfig(@RequestParam String clusterName, @RequestParam(required = false) String md5) {
-        return clusterService.getAllConfig(clusterName, md5);
+    public String getAllConfig(@RequestBody DataProxyConfigRequest request) {
+        return clusterService.getAllConfig(request.getClusterName(), request.getMd5());
     }
 
     @RequestMapping(value = "/changeClusterTag", method = RequestMethod.PUT)


### PR DESCRIPTION

- Fixes #5197 

The usage of get or post seems to be not quite in line. After discussion with heal we decide to unify open api request method to POST.

