### PR TITLE
[INLONG-5152][Manager][Sort] Add union parse support for FlinkSqlParser

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/NodeRelationUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sort/util/NodeRelationUtils.java
@@ -49,6 +49,7 @@ import org.apache.inlong.sort.protocol.transformation.relation.InnerJoinNodeRela
 import org.apache.inlong.sort.protocol.transformation.relation.LeftOuterJoinNodeRelation;
 import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
 import org.apache.inlong.sort.protocol.transformation.relation.RightOuterJoinNodeRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.UnionNodeRelation;
 
 import java.util.Iterator;
 import java.util.List;
@@ -72,10 +73,17 @@ public class NodeRelationUtils {
         StreamPipeline pipeline = StreamParseUtils.parseStreamPipeline(streamInfo.getExtParams(),
                 streamInfo.getInlongStreamId());
         return pipeline.getPipeline().stream()
-                .map(nodeRelation -> new NodeRelation(
-                        Lists.newArrayList(nodeRelation.getInputNodes()),
-                        Lists.newArrayList(nodeRelation.getOutputNodes())))
-                .collect(Collectors.toList());
+                .map(nodeRelation -> {
+                    if (nodeRelation.getInputNodes().size() > 1) {
+                        return new UnionNodeRelation(
+                                Lists.newArrayList(nodeRelation.getInputNodes()),
+                                Lists.newArrayList(nodeRelation.getOutputNodes()));
+                    } else {
+                        return new NodeRelation(
+                                Lists.newArrayList(nodeRelation.getInputNodes()),
+                                Lists.newArrayList(nodeRelation.getOutputNodes()));
+                    }
+                }).collect(Collectors.toList());
     }
 
     /**

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -689,16 +689,6 @@ public class FlinkSqlParser implements Parser {
         return sb.toString();
     }
 
-    private Map<String, List<FieldInfo>> genColumnFamilyMapFieldRelations(List<FieldInfo> fields) {
-        Map<String, List<FieldInfo>> columnFamilyMapFields = new HashMap<>(16);
-        for (FieldInfo field : fields) {
-            String columnFamily = field.getName().split(":")[0];
-            columnFamilyMapFields.computeIfAbsent(columnFamily, v -> new ArrayList<>())
-                    .add(field);
-        }
-        return columnFamilyMapFields;
-    }
-
     private Map<String, List<FieldRelation>> genColumnFamilyMapFieldRelations(
             Collection<FieldRelation> fieldRelations) {
         Map<String, List<FieldRelation>> columnFamilyMapFields = new LinkedHashMap<>(16);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -50,9 +50,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -230,10 +232,8 @@ public class FlinkSqlParser implements Parser {
                 String createSql = genCreateSql(node);
                 log.info("node id:{}, create table sql:\n{}", node.getId(), createSql);
                 registerTableSql(node, createSql);
-                Preconditions.checkState(relation.getInputs().size() == 1,
-                        "load node only support one input node");
                 LoadNode loadNode = (LoadNode) node;
-                String insertSql = genLoadNodeInsertSql(loadNode, nodeMap.get(relation.getInputs().get(0)));
+                String insertSql = genLoadNodeInsertSql(loadNode, relation, nodeMap);
                 log.info("node id:{}, insert sql:\n{}", node.getId(), insertSql);
                 insertSqls.add(insertSql);
                 hasParsedSet.add(node.getId());
@@ -245,31 +245,7 @@ public class FlinkSqlParser implements Parser {
                         "field relations is empty");
                 String createSql = genCreateSql(node);
                 log.info("node id:{}, create table sql:\n{}", node.getId(), createSql);
-                String selectSql;
-                if (relation instanceof JoinRelation) {
-                    // parse join relation and generate the transform sql
-                    Preconditions.checkState(relation.getInputs().size() > 1,
-                            "join must have more than one input nodes");
-                    Preconditions.checkState(relation.getOutputs().size() == 1,
-                            "join node only support one output node");
-                    JoinRelation joinRelation = (JoinRelation) relation;
-                    selectSql = genJoinSelectSql(transformNode, joinRelation, nodeMap);
-                } else if (relation instanceof UnionNodeRelation) {
-                    // parse union relation and generate the transform sql
-                    Preconditions.checkState(relation.getInputs().size() > 1,
-                            "union must have more than one input nodes");
-                    Preconditions.checkState(relation.getOutputs().size() == 1,
-                            "join node only support one output node");
-                    UnionNodeRelation unionRelation = (UnionNodeRelation) relation;
-                    selectSql = genUnionNodeSelectSql(transformNode, unionRelation, nodeMap);
-                } else {
-                    // parse base relation that one to one and generate the transform sql
-                    Preconditions.checkState(relation.getInputs().size() == 1,
-                            "simple transform only support one input node");
-                    Preconditions.checkState(relation.getOutputs().size() == 1,
-                            "join node only support one output node");
-                    selectSql = genSimpleTransformSelectSql(transformNode, relation, nodeMap);
-                }
+                String selectSql = genTransformSelectSql(transformNode, relation, nodeMap);
                 log.info("node id:{}, tansform sql:\n{}", node.getId(), selectSql);
                 registerTableSql(node, createSql + " AS\n" + selectSql);
                 hasParsedSet.add(node.getId());
@@ -278,21 +254,93 @@ public class FlinkSqlParser implements Parser {
         log.info("parse node success, node id:{}", node.getId());
     }
 
-    /**
-     * Generate transform sql
-     *
-     * @param transformNode The transform node
-     * @param unionRelation The union relation of sql
-     * @param nodeMap Store the mapping relation between node id and node
-     * @return Transform sql for this transform logic
-     */
-    private String genUnionNodeSelectSql(TransformNode transformNode,
-            UnionNodeRelation unionRelation, Map<String, Node> nodeMap) {
-        throw new UnsupportedOperationException("Union is not currently supported");
+    private String genTransformSelectSql(TransformNode transformNode, NodeRelation relation,
+            Map<String, Node> nodeMap) {
+        String selectSql;
+        if (relation instanceof JoinRelation) {
+            // parse join relation and generate the transform sql
+            JoinRelation joinRelation = (JoinRelation) relation;
+            selectSql = genJoinSelectSql(transformNode, transformNode.getFieldRelations(), joinRelation,
+                    transformNode.getFilters(), transformNode.getFilterStrategy(), nodeMap);
+        } else if (relation instanceof UnionNodeRelation) {
+            // parse union relation and generate the transform sql
+            Preconditions.checkState(transformNode.getFilters() == null
+                    || transformNode.getFilters().isEmpty(), "Filter is not supported when union");
+            Preconditions.checkState(transformNode.getClass() == TransformNode.class,
+                    String.format("union is not supported for %s", transformNode.getClass().getSimpleName()));
+            UnionNodeRelation unionRelation = (UnionNodeRelation) relation;
+            selectSql = genUnionNodeSelectSql(transformNode, transformNode.getFieldRelations(), unionRelation, nodeMap);
+        } else {
+            // parse base relation that one to one and generate the transform sql
+            Preconditions.checkState(relation.getInputs().size() == 1,
+                    "simple transform only support one input node");
+            Preconditions.checkState(relation.getOutputs().size() == 1,
+                    "join node only support one output node");
+            selectSql = genSimpleSelectSql(transformNode, transformNode.getFieldRelations(), relation,
+                    transformNode.getFilters(), transformNode.getFilterStrategy(), nodeMap);
+        }
+        return selectSql;
     }
 
-    private String genJoinSelectSql(TransformNode node,
-            JoinRelation relation, Map<String, Node> nodeMap) {
+    /**
+     * Generate select sql for union
+     *
+     * @param fieldRelations The relation of fieds
+     * @param unionRelation The union relation of sql
+     * @param nodeMap Store the mapping relation between node id and node
+     * @return Transform sql for this node logic
+     */
+    private String genUnionNodeSelectSql(Node node, List<FieldRelation> fieldRelations,
+            UnionNodeRelation unionRelation, Map<String, Node> nodeMap) {
+        Preconditions.checkState(unionRelation.getInputs().size() > 1,
+                "union must have more than one input nodes");
+        Preconditions.checkState(unionRelation.getOutputs().size() == 1,
+                "union node only support one output node");
+        // Get table name alias map by input nodes
+        Map<String, Map<String, FieldRelation>> fieldRelationMap = new HashMap<>(unionRelation.getInputs().size());
+        // Generate mapping for output field to FieldRelation
+        fieldRelations.forEach(s -> {
+            Preconditions.checkNotNull(s.getOutputField().getNodeId(),
+                    "The node id of output field is not allowed to be null when union");
+            Map<String, FieldRelation> subRelationMap = fieldRelationMap
+                    .computeIfAbsent(s.getOutputField().getNodeId(), k -> new HashMap<>());
+            subRelationMap.put(s.getOutputField().getName(), s);
+        });
+        StringBuilder sb = new StringBuilder();
+        sb.append(genUnionSingleSelectSql(unionRelation.getInputs().get(0),
+                nodeMap.get(unionRelation.getInputs().get(0)).genTableName(), node.getFields(),
+                fieldRelationMap, node));
+        String relationFormat = unionRelation.format();
+        for (int i = 1; i < unionRelation.getInputs().size(); i++) {
+            String inputId = unionRelation.getInputs().get(i);
+            sb.append("\n").append(relationFormat).append("\n")
+                    .append(genUnionSingleSelectSql(inputId, nodeMap.get(inputId).genTableName(),
+                            node.getFields(), fieldRelationMap, node));
+        }
+        return sb.toString();
+    }
+
+    private String genUnionSingleSelectSql(String inputId, String tableName, List<FieldInfo> fields,
+            Map<String, Map<String, FieldRelation>> fieldRelationMap, Node node) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT ");
+        if (node instanceof HbaseLoadNode) {
+            HbaseLoadNode hbaseLoadNode = (HbaseLoadNode) node;
+            parseHbaseLoadFieldRelation(hbaseLoadNode.getRowKey(), fieldRelationMap.get(inputId).values(), sb);
+        } else {
+            parseFieldRelations(fields, fieldRelationMap.get(inputId), sb);
+        }
+        sb.append(" FROM `").append(tableName).append("` ");
+        return sb.toString();
+    }
+
+    private String genJoinSelectSql(Node node, List<FieldRelation> fieldRelations,
+            JoinRelation relation, List<FilterFunction> filters, FilterStrategy filterStrategy,
+            Map<String, Node> nodeMap) {
+        Preconditions.checkState(relation.getInputs().size() > 1,
+                "join must have more than one input nodes");
+        Preconditions.checkState(relation.getOutputs().size() == 1,
+                "join node only support one output node");
         // Get table name alias map by input nodes
         Map<String, String> tableNameAliasMap = new HashMap<>(relation.getInputs().size());
         relation.getInputs().forEach(s -> {
@@ -302,13 +350,19 @@ public class FlinkSqlParser implements Parser {
         });
         StringBuilder sb = new StringBuilder();
         sb.append("SELECT ");
-        Map<String, FieldRelation> fieldRelationMap = new HashMap<>(node.getFieldRelations().size());
+        Map<String, FieldRelation> fieldRelationMap = new HashMap<>(fieldRelations.size());
         // Generate mapping for output field to FieldRelation
-        node.getFieldRelations().forEach(s -> {
+        fieldRelations.forEach(s -> {
             fillOutTableNameAlias(Collections.singletonList(s.getInputField()), tableNameAliasMap);
             fieldRelationMap.put(s.getOutputField().getName(), s);
         });
-        parseFieldRelations(node.getFields(), fieldRelationMap, sb);
+
+        if (node instanceof HbaseLoadNode) {
+            HbaseLoadNode hbaseLoadNode = (HbaseLoadNode) node;
+            parseHbaseLoadFieldRelation(hbaseLoadNode.getRowKey(), hbaseLoadNode.getFieldRelations(), sb);
+        } else {
+            parseFieldRelations(node.getFields(), fieldRelationMap, sb);
+        }
         if (node instanceof DistinctNode) {
             DistinctNode distinctNode = (DistinctNode) node;
             // Fill out the tablename alias for param
@@ -336,11 +390,11 @@ public class FlinkSqlParser implements Parser {
                 sb.append(" ").append(filter.format());
             }
         }
-        if (node.getFilters() != null && !node.getFilters().isEmpty()) {
+        if (filters != null && !filters.isEmpty()) {
             // Fill out the table name alias for param
-            fillOutTableNameAlias(new ArrayList<>(node.getFilters()), tableNameAliasMap);
+            fillOutTableNameAlias(new ArrayList<>(filters), tableNameAliasMap);
             // Parse filter fields to generate filter sql like 'WHERE 1=1...'
-            parseFilterFields(node.getFilterStrategy(), node.getFilters(), sb);
+            parseFilterFields(filterStrategy, filters, sb);
         }
         if (node instanceof DistinctNode) {
             // Generate distinct filter sql like 'WHERE row_num = 1'
@@ -353,7 +407,8 @@ public class FlinkSqlParser implements Parser {
      * Fill out the table name alias
      *
      * @param params The params used in filter, join condition, transform function etc.
-     * @param tableNameAliasMap The table name alias map, contains all table name alias used in this relation of nodes
+     * @param tableNameAliasMap The table name alias map, contains all table name alias used in this relation of
+     *         nodes
      */
     private void fillOutTableNameAlias(List<FunctionParam> params, Map<String, String> tableNameAliasMap) {
         for (FunctionParam param : params) {
@@ -413,25 +468,34 @@ public class FlinkSqlParser implements Parser {
     /**
      * Generate the most basic conversion sql one-to-one
      *
-     * @param node The transform node
+     * @param node The load node
+     * @param fieldRelations The relation between fields
      * @param relation Define relations between nodes, it also shows the data flow
+     * @param filters The filters
+     * @param filterStrategy The filterStrategy
      * @param nodeMap Store the mapping relation between node id and node
-     * @return Transform sql for this transform logic
+     * @return Select sql for this node logic
      */
-    private String genSimpleTransformSelectSql(TransformNode node,
-            NodeRelation relation, Map<String, Node> nodeMap) {
+    private String genSimpleSelectSql(Node node, List<FieldRelation> fieldRelations,
+            NodeRelation relation, List<FilterFunction> filters, FilterStrategy filterStrategy,
+            Map<String, Node> nodeMap) {
         StringBuilder sb = new StringBuilder();
         sb.append("SELECT ");
-        Map<String, FieldRelation> fieldRelationMap = new HashMap<>(node.getFieldRelations().size());
-        node.getFieldRelations().forEach(s -> {
+        Map<String, FieldRelation> fieldRelationMap = new HashMap<>(fieldRelations.size());
+        fieldRelations.forEach(s -> {
             fieldRelationMap.put(s.getOutputField().getName(), s);
         });
-        parseFieldRelations(node.getFields(), fieldRelationMap, sb);
+        if (node instanceof HbaseLoadNode) {
+            HbaseLoadNode hbaseLoadNode = (HbaseLoadNode) node;
+            parseHbaseLoadFieldRelation(hbaseLoadNode.getRowKey(), hbaseLoadNode.getFieldRelations(), sb);
+        } else {
+            parseFieldRelations(node.getFields(), fieldRelationMap, sb);
+        }
         if (node instanceof DistinctNode) {
             genDistinctSql((DistinctNode) node, sb);
         }
         sb.append("\n    FROM `").append(nodeMap.get(relation.getInputs().get(0)).genTableName()).append("` ");
-        parseFilterFields(node.getFilterStrategy(), node.getFilters(), sb);
+        parseFilterFields(filterStrategy, filters, sb);
         if (node instanceof DistinctNode) {
             sb = genDistinctFilterSql(node.getFields(), sb);
         }
@@ -474,7 +538,6 @@ public class FlinkSqlParser implements Parser {
                 sb.append("\n    CAST(NULL as ").append(targetType).append(") AS ").append(field.format()).append(",");
                 continue;
             }
-
             FunctionParam inputField = fieldRelation.getInputField();
             if (inputField instanceof FieldInfo) {
                 FieldInfo fieldInfo = (FieldInfo) inputField;
@@ -504,43 +567,56 @@ public class FlinkSqlParser implements Parser {
      * Generate load node insert sql
      *
      * @param loadNode The real data write node
-     * @param inputNode The input node
+     * @param relation The relation between nods
+     * @param nodeMap The node map
      * @return Insert sql
      */
-    private String genLoadNodeInsertSql(LoadNode loadNode, Node inputNode) {
+    private String genLoadNodeInsertSql(LoadNode loadNode, NodeRelation relation, Map<String, Node> nodeMap) {
         Preconditions.checkNotNull(loadNode.getFieldRelations(), "field relations is null");
         Preconditions.checkState(!loadNode.getFieldRelations().isEmpty(),
                 "field relations is empty");
-        StringBuilder sb = new StringBuilder();
-        sb.append("INSERT INTO `").append(loadNode.genTableName()).append("` ");
-        sb.append("\n    SELECT ");
-        if (loadNode instanceof HbaseLoadNode) {
-            parseHbaseLoadFieldRelation((HbaseLoadNode) loadNode, sb);
-        } else {
-            Map<String, FieldRelation> fieldRelationMap = new HashMap<>(loadNode.getFieldRelations().size());
-            loadNode.getFieldRelations().forEach(s -> {
-                fieldRelationMap.put(s.getOutputField().getName(), s);
-            });
-            parseFieldRelations(loadNode.getFields(), fieldRelationMap, sb);
-        }
-        sb.append("\n    FROM `").append(inputNode.genTableName()).append("`");
-        parseFilterFields(loadNode.getFilterStrategy(), loadNode.getFilters(), sb);
-        return sb.toString();
+        String selectSql = genLoadSelectSql(loadNode, relation, nodeMap);
+        return "INSERT INTO `" + loadNode.genTableName() + "`\n    " + selectSql;
     }
 
-    private void parseHbaseLoadFieldRelation(HbaseLoadNode hbaseLoadNode, StringBuilder sb) {
-        sb.append(hbaseLoadNode.getRowKey()).append(" as rowkey,\n");
-        List<FieldRelation> fieldRelations = hbaseLoadNode.getFieldRelations();
+    private String genLoadSelectSql(LoadNode loadNode, NodeRelation relation,
+            Map<String, Node> nodeMap) {
+        String selectSql;
+        if (relation instanceof JoinRelation) {
+            // parse join relation and generate the select sql
+            JoinRelation joinRelation = (JoinRelation) relation;
+            selectSql = genJoinSelectSql(loadNode, loadNode.getFieldRelations(), joinRelation,
+                    loadNode.getFilters(), loadNode.getFilterStrategy(), nodeMap);
+        } else if (relation instanceof UnionNodeRelation) {
+            // parse union relation and generate the select sql
+            Preconditions.checkState(loadNode.getFilters() == null || loadNode.getFilters().isEmpty(),
+                    "Filter is not supported when union");
+            UnionNodeRelation unionRelation = (UnionNodeRelation) relation;
+            selectSql = genUnionNodeSelectSql(loadNode, loadNode.getFieldRelations(), unionRelation, nodeMap);
+        } else {
+            // parse base relation that one to one and generate the select sql
+            Preconditions.checkState(relation.getInputs().size() == 1,
+                    "simple transform only support one input node");
+            Preconditions.checkState(relation.getOutputs().size() == 1,
+                    "join node only support one output node");
+            selectSql = genSimpleSelectSql(loadNode, loadNode.getFieldRelations(), relation,
+                    loadNode.getFilters(), loadNode.getFilterStrategy(), nodeMap);
+        }
+        return selectSql;
+    }
+
+    private void parseHbaseLoadFieldRelation(String rowkey, Collection<FieldRelation> fieldRelations,
+            StringBuilder sb) {
+        sb.append("CAST(").append(rowkey).append(" AS STRING) AS rowkey,\n");
         Map<String, List<FieldRelation>> columnFamilyMapFields = genColumnFamilyMapFieldRelations(
                 fieldRelations);
         for (Map.Entry<String, List<FieldRelation>> entry : columnFamilyMapFields.entrySet()) {
             StringBuilder fieldAppend = new StringBuilder(" ROW(");
             for (FieldRelation fieldRelation : entry.getValue()) {
                 FieldInfo outputField = fieldRelation.getOutputField();
-                FieldInfo inputField = (FieldInfo) fieldRelation.getInputField();
                 String targetType = TableFormatUtils.deriveLogicalType(outputField.getFormatInfo()).asSummaryString();
-                fieldAppend.append(" CAST(").append(inputField.format()).append(" AS ")
-                        .append(targetType).append(" ) ").append(",");
+                fieldAppend.append("CAST(").append(fieldRelation.getInputField().format()).append(" AS ")
+                        .append(targetType).append(")").append(", ");
             }
             if (fieldAppend.length() > 0) {
                 fieldAppend.delete(fieldAppend.lastIndexOf(","), fieldAppend.length());
@@ -590,16 +666,16 @@ public class FlinkSqlParser implements Parser {
         StringBuilder sb = new StringBuilder("CREATE TABLE `");
         sb.append(node.genTableName()).append("`(\n");
         sb.append("rowkey STRING,\n");
-        List<FieldRelation> fieldRelations = node.getFieldRelations();
+
         Map<String, List<FieldRelation>> columnFamilyMapFields = genColumnFamilyMapFieldRelations(
-                fieldRelations);
+                node.getFieldRelations());
         for (Map.Entry<String, List<FieldRelation>> entry : columnFamilyMapFields.entrySet()) {
             sb.append(entry.getKey());
             StringBuilder fieldsAppend = new StringBuilder(" Row<");
             for (FieldRelation fieldRelation : entry.getValue()) {
-                FieldInfo fieldInfo = fieldRelation.getOutputField();
-                fieldsAppend.append(fieldInfo.getName().split(":")[1]).append(" ")
-                        .append(TableFormatUtils.deriveLogicalType(fieldInfo.getFormatInfo()).asSummaryString())
+                fieldsAppend.append(fieldRelation.getOutputField().getName().split(":")[1]).append(" ")
+                        .append(TableFormatUtils.deriveLogicalType(fieldRelation.getOutputField().getFormatInfo())
+                                .asSummaryString())
                         .append(",");
             }
             if (fieldsAppend.length() > 0) {
@@ -613,13 +689,26 @@ public class FlinkSqlParser implements Parser {
         return sb.toString();
     }
 
+    private Map<String, List<FieldInfo>> genColumnFamilyMapFieldRelations(List<FieldInfo> fields) {
+        Map<String, List<FieldInfo>> columnFamilyMapFields = new HashMap<>(16);
+        for (FieldInfo field : fields) {
+            String columnFamily = field.getName().split(":")[0];
+            columnFamilyMapFields.computeIfAbsent(columnFamily, v -> new ArrayList<>())
+                    .add(field);
+        }
+        return columnFamilyMapFields;
+    }
+
     private Map<String, List<FieldRelation>> genColumnFamilyMapFieldRelations(
-            List<FieldRelation> fieldRelations) {
-        Map<String, List<FieldRelation>> columnFamilyMapFields = new HashMap<>(16);
+            Collection<FieldRelation> fieldRelations) {
+        Map<String, List<FieldRelation>> columnFamilyMapFields = new LinkedHashMap<>(16);
+        Set<String> nameSet = new HashSet<>();
         for (FieldRelation fieldRelation : fieldRelations) {
             String columnFamily = fieldRelation.getOutputField().getName().split(":")[0];
-            columnFamilyMapFields.computeIfAbsent(columnFamily, v -> new ArrayList<>())
-                    .add(fieldRelation);
+            if (nameSet.add(fieldRelation.getOutputField().getName())) {
+                columnFamilyMapFields.computeIfAbsent(columnFamily, v -> new ArrayList<>())
+                        .add(fieldRelation);
+            }
         }
         return columnFamilyMapFields;
     }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/UnionSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/UnionSqlParseTest.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.apache.inlong.sort.formats.common.FloatFormatInfo;
+import org.apache.inlong.sort.formats.common.IntFormatInfo;
+import org.apache.inlong.sort.formats.common.LongFormatInfo;
+import org.apache.inlong.sort.formats.common.StringFormatInfo;
+import org.apache.inlong.sort.formats.common.TimestampFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+import org.apache.inlong.sort.protocol.node.load.HbaseLoadNode;
+import org.apache.inlong.sort.protocol.node.transform.TransformNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.UnionNodeRelation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Test for union sql parse {@link UnionNodeRelation}
+ */
+public class UnionSqlParseTest extends AbstractTestBase {
+
+    private Node buildMySQLExtractNode(String nodeId) {
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("name", new StringFormatInfo()),
+                new FieldInfo("age", new IntFormatInfo()),
+                new FieldInfo("salary", new FloatFormatInfo()),
+                new FieldInfo("ts", new TimestampFormatInfo())
+        );
+        return new MySqlExtractNode(nodeId, "mysql_input_" + nodeId, fields, null, null,
+                "id", Collections.singletonList("mysql_table"),
+                "localhost", "inlong", "inlong",
+                "inlong", null, null, null, null);
+    }
+
+    private Node buildTransformNode() {
+        List<FieldRelation> relations = new ArrayList<>();
+        buildRelations("1", relations);
+        buildRelations("2", relations);
+        buildRelations("3", relations);
+        return new TransformNode("4", "transform_node",
+                Arrays.asList(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("name", new StringFormatInfo()),
+                        new FieldInfo("age", new IntFormatInfo()),
+                        new FieldInfo("salary", new FloatFormatInfo()),
+                        new FieldInfo("ts", new TimestampFormatInfo())
+                ), relations, null, null);
+    }
+
+    private Node buildHbaseNode() {
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("cf:id", new LongFormatInfo()),
+                new FieldInfo("cf1:name", new StringFormatInfo()),
+                new FieldInfo("cf1:age", new IntFormatInfo()),
+                new FieldInfo("cf2:salary", new FloatFormatInfo()),
+                new FieldInfo("cf2:ts", new TimestampFormatInfo())
+        );
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", "1", new LongFormatInfo()),
+                        new FieldInfo("cf1:id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("name", "1", new StringFormatInfo()),
+                        new FieldInfo("cf1:name", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("age", "2", new IntFormatInfo()),
+                        new FieldInfo("cf2:age", new IntFormatInfo())),
+                new FieldRelation(new FieldInfo("ts", "3", new TimestampFormatInfo()),
+                        new FieldInfo("cf2:ts", new TimestampFormatInfo()))
+        );
+        return new HbaseLoadNode("5", "test_hbase",
+                fields, relations, null, null, 1, null, "mytable",
+                "default", "localhost:2181", "MD5(`name`)", null,
+                null, null, null);
+    }
+
+    private Node buildHbaseNode2() {
+        List<FieldRelation> relations = new ArrayList<>();
+        buildRelations("1", relations);
+        buildRelations("2", relations);
+        buildRelations("3", relations);
+        List<FieldInfo> fields = Arrays.asList(new FieldInfo("cf1:id", new LongFormatInfo()),
+                new FieldInfo("cf1:name", new StringFormatInfo()),
+                new FieldInfo("cf1:age", new IntFormatInfo()),
+                new FieldInfo("cf2:salary", new FloatFormatInfo()),
+                new FieldInfo("cf2:ts", new TimestampFormatInfo())
+        );
+        return new HbaseLoadNode("4", "test_hbase",
+                fields, relations, null, null, 1, null, "mytable",
+                "default", "localhost:2181", "MD5(`name`)", null,
+                null, null, null);
+    }
+
+    private void buildRelations(String nodeId, List<FieldRelation> relations) {
+        relations.add(new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("cf1:id", nodeId, new LongFormatInfo())));
+        relations.add(new FieldRelation(new FieldInfo("name", new StringFormatInfo()),
+                new FieldInfo("cf1:name", nodeId, new StringFormatInfo())));
+        relations.add(new FieldRelation(new FieldInfo("age", new IntFormatInfo()),
+                new FieldInfo("cf2:age", nodeId, new IntFormatInfo())));
+        relations.add(new FieldRelation(new FieldInfo("ts", new TimestampFormatInfo()),
+                new FieldInfo("cf2:ts", nodeId, new TimestampFormatInfo())));
+    }
+
+    public NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    public NodeRelation buildUnionNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new UnionNodeRelation(inputIds, outputIds);
+    }
+
+    /**
+     * Test union sql parse
+     *
+     * @throws Exception The exception may throws when execute the case
+     */
+    @Test
+    public void testUnionSqlParse() throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode1 = buildMySQLExtractNode("1");
+        Node inputNode2 = buildMySQLExtractNode("2");
+        Node inputNode3 = buildMySQLExtractNode("3");
+        Node transformNode = buildTransformNode();
+        Node outputNode = buildHbaseNode();
+        StreamInfo streamInfo = new StreamInfo("1",
+                Arrays.asList(inputNode1, inputNode2, inputNode3, transformNode, outputNode),
+                Arrays.asList(
+                        buildUnionNodeRelation(Arrays.asList(inputNode1, inputNode2, inputNode3),
+                                Collections.singletonList(transformNode)),
+                        buildNodeRelation(Collections.singletonList(transformNode),
+                                Collections.singletonList(outputNode))
+                )
+        );
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+
+    /**
+     * Test union sql parse without transform
+     *
+     * @throws Exception The exception may throws when execute the case
+     */
+    @Test
+    public void testUnionSqlParseWithoutTransform() throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode1 = buildMySQLExtractNode("1");
+        Node inputNode2 = buildMySQLExtractNode("2");
+        Node inputNode3 = buildMySQLExtractNode("3");
+        Node outputNode = buildHbaseNode2();
+        StreamInfo streamInfo = new StreamInfo("1",
+                Arrays.asList(inputNode1, inputNode2, inputNode3, outputNode),
+                Collections.singletonList(
+                        buildUnionNodeRelation(Arrays.asList(inputNode1, inputNode2, inputNode3),
+                                Collections.singletonList(outputNode))
+                )
+        );
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/UnionSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/UnionSqlParseTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sort.parser;
 
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -158,7 +157,6 @@ public class UnionSqlParseTest extends AbstractTestBase {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(10000);
-        env.setStreamTimeCharacteristic(TimeCharacteristic.IngestionTime);
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
         Node inputNode1 = buildMySQLExtractNode("1");
         Node inputNode2 = buildMySQLExtractNode("2");


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-5152][Sort] Add union parse support for FlinkSqlParser

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #5152 

### Motivation

I want to add union parse support for FlinkSqlParser. Because the usage scenarios of sub-database and sub-tables can be processed through union, and the data reconciliation of such scenarios can be solved at the same time.

### Modifications

FlinkSqlParser will supports parsing union node relation.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
