### PR TITLE
[INLONG-5219][Manager] Adjust the status update order of inlong group

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -430,7 +430,7 @@
         update stream_sink
         set status          = #{status,jdbcType=INTEGER},
             previous_status = status,
-            operate_log     = #{operateLog,jdbcType=VARCHAR},
+            operate_log     = #{operateLog,jdbcType=VARCHAR}
         where id = #{id,jdbcType=INTEGER}
     </update>
     <select id="selectAllTasks" resultType="org.apache.inlong.manager.common.pojo.sortstandalone.SortTaskInfo">

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -402,8 +402,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
                 Set<String> tagSet = Sets.newHashSet(entity.getClusterTags().split(InlongConstants.COMMA));
                 tagSet.add(clusterTag);
                 String updateTags = Joiner.on(",").join(tagSet);
-                InlongClusterEntity updateEntity = new InlongClusterEntity();
-                updateEntity.setId(id);
+                InlongClusterEntity updateEntity = clusterMapper.selectById(id);
                 updateEntity.setClusterTags(updateTags);
                 updateEntity.setModifier(operator);
                 int rowCount = clusterMapper.updateByIdSelective(updateEntity);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -372,20 +372,21 @@ public class InlongGroupServiceImpl implements InlongGroupService {
             throw new WorkflowListenerException("inlong group status is [wait_approval], not allowed to approve again");
         }
 
-        // update status to [GROUP_APPROVE_PASSED]
-        this.updateStatus(groupId, GroupStatus.APPROVE_PASSED.getCode(), operator);
-
         // update other info for inlong group after approve
         if (StringUtils.isNotBlank(approveRequest.getInlongClusterTag())) {
             entity.setInlongGroupId(approveRequest.getInlongGroupId());
             entity.setInlongClusterTag(approveRequest.getInlongClusterTag());
             entity.setModifier(operator);
+            entity.setStatus(GroupStatus.APPROVE_PASSED.getCode());
             int rowCount = groupMapper.updateByIdentifierSelective(entity);
             if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
                 LOGGER.error("inlong group has already updated with group id={}, curVersion={}",
                         entity.getInlongGroupId(), entity.getVersion());
                 throw new BusinessException(ErrorCodeEnum.CONFIG_EXPIRED);
             }
+        }else {
+            // update status to [GROUP_APPROVE_PASSED]
+            this.updateStatus(groupId, GroupStatus.APPROVE_PASSED.getCode(), operator);
         }
 
         LOGGER.info("success to update inlong group status after approve for groupId={}", groupId);


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #5219 

### Motivation

Make sure the workflow can enter the configuration state normally

### Modifications

Adjust the status update order of inlong group
Find cluster entities in the database before  bind cluster tag for inlong group.
### Verifying this change


- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [X] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (no)

