### PR TITLE
[INLONG-5246][Manager] Return all cluster nodes under the same tag and type

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -635,19 +635,20 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         // if more than one data proxy cluster, currently takes first
         // TODO consider the data proxy load and re-balance
         InlongClusterEntity clusterEntity = clusterList.get(0);
-        Integer clusterId = clusterEntity.getId();
-        List<InlongClusterNodeEntity> nodeList = clusterNodeMapper.selectByParentId(clusterId);
         List<DataProxyNodeInfo> nodeInfos = new ArrayList<>();
-        for (InlongClusterNodeEntity nodeEntity : nodeList) {
-            DataProxyNodeInfo nodeInfo = new DataProxyNodeInfo();
-            nodeInfo.setId(nodeEntity.getId());
-            nodeInfo.setIp(nodeEntity.getIp());
-            nodeInfo.setPort(nodeEntity.getPort());
-            nodeInfos.add(nodeInfo);
+        for (InlongClusterEntity entity : clusterList) {
+            List<InlongClusterNodeEntity> nodeList = clusterNodeMapper.selectByParentId(entity.getId());
+            for (InlongClusterNodeEntity nodeEntity : nodeList) {
+                DataProxyNodeInfo nodeInfo = new DataProxyNodeInfo();
+                nodeInfo.setId(nodeEntity.getId());
+                nodeInfo.setIp(nodeEntity.getIp());
+                nodeInfo.setPort(nodeEntity.getPort());
+                nodeInfos.add(nodeInfo);
+            }
         }
 
         DataProxyNodeResponse response = new DataProxyNodeResponse();
-        response.setClusterId(clusterId);
+        response.setClusterId(clusterEntity.getId());
         response.setNodeList(nodeInfos);
 
         if (LOGGER.isDebugEnabled()) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -634,7 +634,6 @@ public class InlongClusterServiceImpl implements InlongClusterService {
 
         // if more than one data proxy cluster, currently takes first
         // TODO consider the data proxy load and re-balance
-        InlongClusterEntity clusterEntity = clusterList.get(0);
         List<DataProxyNodeInfo> nodeInfos = new ArrayList<>();
         for (InlongClusterEntity entity : clusterList) {
             List<InlongClusterNodeEntity> nodeList = clusterNodeMapper.selectByParentId(entity.getId());
@@ -648,7 +647,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         }
 
         DataProxyNodeResponse response = new DataProxyNodeResponse();
-        response.setClusterId(clusterEntity.getId());
+        response.setClusterId(clusterList.get(0).getId());
         response.setNodeList(nodeInfos);
 
         if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION

### Prepare a Pull Request

- Fixes #5246 

### Motivation

Ensure that the agent can get the dataproxy node.

### Modifications

 Return all cluster nodes under the same cluster tag and type to the agent instead of return first.

### Verifying this change


- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)

