### PR TITLE
[INLONG-5245][Manager] Optimize the URI paths of the WebAPI and OpenAPI

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -39,7 +39,7 @@ public class FetcherConstants {
     public static final String DEFAULT_AGENT_TDM_VIP_HTTP_PATH = "/agent/getManagerIpList";
 
     public static final String AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "agent.manager.vip.http.prefix.path";
-    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/manager/openapi";
+    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/inlong/manager/openapi";
 
     public static final String AGENT_MANAGER_TASK_HTTP_PATH = "agent.manager.task.http.path";
     public static final String DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH = "/agent/reportAndGetTask";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -36,7 +36,7 @@ public class FetcherConstants {
     public static final String AGENT_MANAGER_VIP_HTTP_PORT = "agent.manager.vip.http.port";
 
     public static final String AGENT_MANAGER_VIP_HTTP_PATH = "agent.manager.vip.http.managerIp.path";
-    public static final String DEFAULT_AGENT_TDM_VIP_HTTP_PATH = "/agent/getInLongManagerIp";
+    public static final String DEFAULT_AGENT_TDM_VIP_HTTP_PATH = "/agent/getManagerIpList";
 
     public static final String AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "agent.manager.vip.http.prefix.path";
     public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/manager/openapi";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -39,7 +39,7 @@ public class FetcherConstants {
     public static final String DEFAULT_AGENT_TDM_VIP_HTTP_PATH = "/agent/getInLongManagerIp";
 
     public static final String AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "agent.manager.vip.http.prefix.path";
-    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/api/inlong/manager/openapi";
+    public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/manager/openapi";
 
     public static final String AGENT_MANAGER_TASK_HTTP_PATH = "agent.manager.task.http.path";
     public static final String DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH = "/agent/reportAndGetTask";

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -109,7 +109,7 @@ public class HeartbeatManager extends AbstractDaemon {
     /**
      * build base url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi
+     * example - http://127.0.0.1:8080/manager/openapi
      */
     private String buildBaseUrl() {
         return "http://" + conf.get(AGENT_MANAGER_VIP_HTTP_HOST)

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -109,7 +109,7 @@ public class HeartbeatManager extends AbstractDaemon {
     /**
      * build base url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi
+     * example - http://127.0.0.1:8080/inlong/manager/openapi
      */
     private String buildBaseUrl() {
         return "http://" + conf.get(AGENT_MANAGER_VIP_HTTP_HOST)

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -154,7 +154,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build vip url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi/agent/getInLongManagerIp
+     * example - http://127.0.0.1:8080/manager/openapi/agent/getManagerIpList
      */
     private String buildVipUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_VIP_HTTP_PATH, DEFAULT_AGENT_TDM_VIP_HTTP_PATH);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -143,7 +143,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build base url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi
+     * example - http://127.0.0.1:8080/inlong/manager/openapi
      */
     private String buildBaseUrl() {
         return "http://" + conf.get(AGENT_MANAGER_VIP_HTTP_HOST)
@@ -154,7 +154,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build vip url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi/agent/getManagerIpList
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/agent/getManagerIpList
      */
     private String buildVipUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_VIP_HTTP_PATH, DEFAULT_AGENT_TDM_VIP_HTTP_PATH);
@@ -163,7 +163,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build file collect task url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi/fileAgent/getTaskConf
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/fileAgent/getTaskConf
      */
     private String buildFileCollectTaskUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_TASK_HTTP_PATH, DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH);
@@ -172,7 +172,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build ip check url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi/fileAgent/confirmAgentIp
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/fileAgent/confirmAgentIp
      */
     private String buildIpCheckUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_IP_CHECK_HTTP_PATH, DEFAULT_AGENT_TDM_IP_CHECK_HTTP_PATH);
@@ -181,7 +181,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build db collector get task url for manager according to config
      *
-     * example - http://127.0.0.1:8080/manager/openapi/dbcollector/getTask
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/dbcollector/getTask
      */
     private String buildDbCollectorGetTaskUrl(String baseUrl) {
         return baseUrl + conf

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -143,7 +143,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build base url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi
+     * example - http://127.0.0.1:8080/manager/openapi
      */
     private String buildBaseUrl() {
         return "http://" + conf.get(AGENT_MANAGER_VIP_HTTP_HOST)
@@ -154,7 +154,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build vip url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi/agent/getInLongManagerIp
+     * example - http://127.0.0.1:8080/manager/openapi/agent/getInLongManagerIp
      */
     private String buildVipUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_VIP_HTTP_PATH, DEFAULT_AGENT_TDM_VIP_HTTP_PATH);
@@ -163,7 +163,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build file collect task url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi/fileAgent/getTaskConf
+     * example - http://127.0.0.1:8080/manager/openapi/fileAgent/getTaskConf
      */
     private String buildFileCollectTaskUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_TASK_HTTP_PATH, DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH);
@@ -172,7 +172,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build ip check url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi/fileAgent/confirmAgentIp
+     * example - http://127.0.0.1:8080/manager/openapi/fileAgent/confirmAgentIp
      */
     private String buildIpCheckUrl(String baseUrl) {
         return baseUrl + conf.get(AGENT_MANAGER_IP_CHECK_HTTP_PATH, DEFAULT_AGENT_TDM_IP_CHECK_HTTP_PATH);
@@ -181,7 +181,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * build db collector get task url for manager according to config
      *
-     * example - http://127.0.0.1:8080/api/inlong/manager/openapi/dbcollector/getTask
+     * example - http://127.0.0.1:8080/manager/openapi/dbcollector/getTask
      */
     private String buildDbCollectorGetTaskUrl(String baseUrl) {
         return baseUrl + conf
@@ -381,7 +381,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         Collection<File> suitFiles = PluginUtils.findSuitFiles(triggerProfile);
         // filter files exited before
         List<File> pendingFiles = suitFiles.stream().filter(file ->
-                !agentManager.getJobManager().checkJobExsit(file.getAbsolutePath()))
+                        !agentManager.getJobManager().checkJobExsit(file.getAbsolutePath()))
                 .collect(Collectors.toList());
         for (File pendingFile : pendingFiles) {
             JobProfile copiedProfile = copyJobProfile(triggerProfile, dataTime,

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
@@ -189,10 +189,10 @@ public class ConfigManager {
             }
         }
 
-        private boolean checkWithManager(String hostUrl) {
+        private boolean checkWithManager(String host) {
             HttpGet httpGet = null;
             try {
-                String url = "http://" + hostUrl + "/manager/openapi/audit/getConfig";
+                String url = "http://" + host + "/inlong/manager/openapi/audit/getConfig";
                 LOG.info("start to request {} to get config info", url);
                 httpGet = new HttpGet(url);
                 httpGet.addHeader(HttpHeaders.CONNECTION, "close");

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
@@ -18,10 +18,6 @@
 package org.apache.inlong.audit.file;
 
 import com.google.gson.Gson;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
@@ -33,6 +29,11 @@ import org.apache.http.util.EntityUtils;
 import org.apache.inlong.audit.file.holder.PropertiesConfigHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 public class ConfigManager {
 
@@ -58,6 +59,7 @@ public class ConfigManager {
 
     /**
      * get instance for manager
+     *
      * @return
      */
     public static ConfigManager getInstance(String fileName, boolean needToCheckChanged) {
@@ -96,13 +98,13 @@ public class ConfigManager {
     /**
      * update old maps, reload local files if changed.
      *
-     * @param result        - map pending to be added
-     * @param holder        - property holder
+     * @param result - map pending to be added
+     * @param holder - property holder
      * @param addElseRemove - if add(true) else remove(false)
      * @return true if changed else false.
      */
     private boolean updatePropertiesHolder(Map<String, String> result,
-                                           PropertiesConfigHolder holder, boolean addElseRemove) {
+            PropertiesConfigHolder holder, boolean addElseRemove) {
         Map<String, String> tmpHolder = holder.forkHolder();
         boolean changed = false;
         for (Entry<String, String> entry : result.entrySet()) {
@@ -190,7 +192,7 @@ public class ConfigManager {
         private boolean checkWithManager(String hostUrl) {
             HttpGet httpGet = null;
             try {
-                String url = "http://" + hostUrl + "/api/inlong/manager/openapi/audit/getConfig";
+                String url = "http://" + hostUrl + "/manager/openapi/audit/getConfig";
                 LOG.info("start to request {} to get config info", url);
                 httpGet = new HttpGet(url);
                 httpGet.addHeader(HttpHeaders.CONNECTION, "close");

--- a/inlong-dashboard/src/setupProxy.js
+++ b/inlong-dashboard/src/setupProxy.js
@@ -24,7 +24,7 @@ const target = 'http://127.0.0.1:8083';
 
 module.exports = function (app) {
   app.use(
-    createProxyMiddleware('/manager', {
+    createProxyMiddleware('/manager/api', {
       target,
       changeOrigin: true,
       secure: false,

--- a/inlong-dashboard/src/setupProxy.js
+++ b/inlong-dashboard/src/setupProxy.js
@@ -24,7 +24,7 @@ const target = 'http://127.0.0.1:8083';
 
 module.exports = function (app) {
   app.use(
-    createProxyMiddleware('/manager/api', {
+    createProxyMiddleware('/inlong/manager/api', {
       target,
       changeOrigin: true,
       secure: false,

--- a/inlong-dashboard/src/setupProxy.js
+++ b/inlong-dashboard/src/setupProxy.js
@@ -24,7 +24,7 @@ const target = 'http://127.0.0.1:8083';
 
 module.exports = function (app) {
   app.use(
-    createProxyMiddleware('/api/inlong/manager', {
+    createProxyMiddleware('/manager', {
       target,
       changeOrigin: true,
       secure: false,

--- a/inlong-dashboard/src/utils/request.ts
+++ b/inlong-dashboard/src/utils/request.ts
@@ -33,7 +33,7 @@ export interface RequestOptions extends FetchOptions {
   noGlobalError?: boolean;
 }
 
-export const apiPrefix = '/api/inlong/manager';
+export const apiPrefix = '/manager';
 
 const extendRequest = extend({
   prefix: apiPrefix,

--- a/inlong-dashboard/src/utils/request.ts
+++ b/inlong-dashboard/src/utils/request.ts
@@ -33,7 +33,7 @@ export interface RequestOptions extends FetchOptions {
   noGlobalError?: boolean;
 }
 
-export const apiPrefix = '/manager/api';
+export const apiPrefix = '/inlong/manager/api';
 
 const extendRequest = extend({
   prefix: apiPrefix,

--- a/inlong-dashboard/src/utils/request.ts
+++ b/inlong-dashboard/src/utils/request.ts
@@ -33,7 +33,7 @@ export interface RequestOptions extends FetchOptions {
   noGlobalError?: boolean;
 }
 
-export const apiPrefix = '/manager';
+export const apiPrefix = '/manager/api';
 
 const extendRequest = extend({
   prefix: apiPrefix,

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -118,7 +118,7 @@ public class ConfigConstants {
     public static final String NETTY_WRITE_BUFFER_HIGH_WATER_MARK = "netty_write_buffer_high_water_mark";
     public static final String RECOVER_THREAD_COUNT = "recover_thread_count";
 
-    public static final String MANAGER_PATH = "/manager/openapi";
+    public static final String MANAGER_PATH = "/inlong/manager/openapi";
     public static final String MANAGER_GET_CONFIG_PATH = "/dataproxy/getConfig";
     public static final String MANAGER_GET_ALL_CONFIG_PATH = "/dataproxy/getAllConfig";
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -118,7 +118,7 @@ public class ConfigConstants {
     public static final String NETTY_WRITE_BUFFER_HIGH_WATER_MARK = "netty_write_buffer_high_water_mark";
     public static final String RECOVER_THREAD_COUNT = "recover_thread_count";
 
-    public static final String MANAGER_PATH = "/api/inlong/manager/openapi";
+    public static final String MANAGER_PATH = "/manager/openapi";
     public static final String MANAGER_GET_CONFIG_PATH = "/dataproxy/getConfig";
     public static final String MANAGER_GET_ALL_CONFIG_PATH = "/dataproxy/getAllConfig";
 

--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
@@ -62,7 +62,7 @@ public class BaseTest {
     // Pulsar topic
     public static final String TOPIC = "test_topic";
     public static final String IN_CHARGES = "test_inCharges,admin";
-    public static final String MANAGER_URL_PREFIX = "/manager/api";
+    public static final String MANAGER_URL_PREFIX = "/inlong/manager/api";
     private static final int SERVICE_PORT = 8184;
     // Manager web url
     public static final String SERVICE_URL = "127.0.0.1:" + SERVICE_PORT;

--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
@@ -23,10 +23,10 @@ import com.google.common.collect.Lists;
 import org.apache.inlong.manager.client.api.ClientConfiguration;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.common.auth.DefaultAuthentication;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.DataSeparator;
 import org.apache.inlong.manager.common.enums.FieldType;
 import org.apache.inlong.manager.common.enums.FileFormat;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.common.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.common.pojo.sink.SinkField;
@@ -45,11 +45,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 
 public class BaseTest {
 
-    private static final int SERVICE_PORT = 8184;
-    // Manager web url
-    public static final String SERVICE_URL = "127.0.0.1:" + SERVICE_PORT;
-    // Inlong user && passwd
-    public static DefaultAuthentication inlongAuth = new DefaultAuthentication("admin", "inlong");
     // Inlong group ID
     public static final String GROUP_ID = "test_group009";
     // Inlong stream ID
@@ -67,10 +62,13 @@ public class BaseTest {
     // Pulsar topic
     public static final String TOPIC = "test_topic";
     public static final String IN_CHARGES = "test_inCharges,admin";
-
+    public static final String MANAGER_URL_PREFIX = "/manager";
+    private static final int SERVICE_PORT = 8184;
+    // Manager web url
+    public static final String SERVICE_URL = "127.0.0.1:" + SERVICE_PORT;
+    // Inlong user && passwd
+    public static DefaultAuthentication inlongAuth = new DefaultAuthentication("admin", "inlong");
     public static WireMockServer wireMockServer;
-    public static final String MANAGER_URL_PREFIX = "/api/inlong/manager";
-
     public static InlongGroupInfo groupInfo;
     public static InlongClient inlongClient;
 
@@ -133,21 +131,6 @@ public class BaseTest {
     }
 
     /**
-     * Create inlong stream info
-     */
-    protected InlongStreamInfo createStreamInfo() {
-        InlongStreamInfo streamInfo = new InlongStreamInfo();
-        streamInfo.setInlongStreamId(STREAM_ID);
-        streamInfo.setName(STREAM_ID);
-        streamInfo.setDataEncoding(StandardCharsets.UTF_8.toString());
-        streamInfo.setDataSeparator(DataSeparator.VERTICAL_BAR.getSeparator());
-        // if you need strictly order for data, set to 1
-        streamInfo.setSyncSend(InlongConstants.SYNC_SEND);
-        streamInfo.setMqResource(TOPIC);
-        return streamInfo;
-    }
-
-    /**
      * Create hive sink
      */
     protected static HiveSink createHiveSink() {
@@ -167,5 +150,20 @@ public class BaseTest {
         hiveSink.setTableName("{table.name}");
         hiveSink.setSinkName("{hive.sink.name}");
         return hiveSink;
+    }
+
+    /**
+     * Create inlong stream info
+     */
+    protected InlongStreamInfo createStreamInfo() {
+        InlongStreamInfo streamInfo = new InlongStreamInfo();
+        streamInfo.setInlongStreamId(STREAM_ID);
+        streamInfo.setName(STREAM_ID);
+        streamInfo.setDataEncoding(StandardCharsets.UTF_8.toString());
+        streamInfo.setDataSeparator(DataSeparator.VERTICAL_BAR.getSeparator());
+        // if you need strictly order for data, set to 1
+        streamInfo.setSyncSend(InlongConstants.SYNC_SEND);
+        streamInfo.setMqResource(TOPIC);
+        return streamInfo;
     }
 }

--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
@@ -62,7 +62,7 @@ public class BaseTest {
     // Pulsar topic
     public static final String TOPIC = "test_topic";
     public static final String IN_CHARGES = "test_inCharges,admin";
-    public static final String MANAGER_URL_PREFIX = "/manager";
+    public static final String MANAGER_URL_PREFIX = "/manager/api";
     private static final int SERVICE_PORT = 8184;
     // Manager web url
     public static final String SERVICE_URL = "127.0.0.1:" + SERVICE_PORT;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
@@ -83,7 +83,7 @@ public class ClientUtils {
                 .build();
 
         return new Retrofit.Builder()
-                .baseUrl("http://" + host + ":" + port + "/manager/")
+                .baseUrl("http://" + host + ":" + port + "/manager/api/")
                 .addConverterFactory(JacksonConverterFactory.create(JsonUtils.OBJECT_MAPPER))
                 .client(okHttpClient)
                 .build();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
@@ -83,7 +83,7 @@ public class ClientUtils {
                 .build();
 
         return new Retrofit.Builder()
-                .baseUrl("http://" + host + ":" + port + "/manager/api/")
+                .baseUrl("http://" + host + ":" + port + "/inlong/manager/api/")
                 .addConverterFactory(JacksonConverterFactory.create(JsonUtils.OBJECT_MAPPER))
                 .client(okHttpClient)
                 .build();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
@@ -83,7 +83,7 @@ public class ClientUtils {
                 .build();
 
         return new Retrofit.Builder()
-                .baseUrl("http://" + host + ":" + port + "/api/inlong/manager/")
+                .baseUrl("http://" + host + ":" + port + "/manager/")
                 .addConverterFactory(JacksonConverterFactory.create(JsonUtils.OBJECT_MAPPER))
                 .client(okHttpClient)
                 .build();

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -128,7 +128,7 @@ class ClientFactoryTest {
     @Test
     void testGroupExist() {
         stubFor(
-                get(urlMatching("/manager/api/group/exist/123.*"))
+                get(urlMatching("/inlong/manager/api/group/exist/123.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -155,7 +155,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/manager/api/group/get/1.*"))
+                get(urlMatching("/inlong/manager/api/group/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(inlongGroupResponse)))
                         )
@@ -187,7 +187,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -223,7 +223,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -261,7 +261,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -301,7 +301,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -372,7 +372,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos)))
                                 )
@@ -387,7 +387,7 @@ class ClientFactoryTest {
     @Test
     void testListGroup4NotExist() {
         stubFor(
-                post(urlMatching("/manager/api/group/list.*"))
+                post(urlMatching("/inlong/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong group does not exist/no operation authority"))
@@ -402,7 +402,7 @@ class ClientFactoryTest {
     @Test
     void testCreateGroup() {
         stubFor(
-                post(urlMatching("/manager/api/group/save.*"))
+                post(urlMatching("/inlong/manager/api/group/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -415,7 +415,7 @@ class ClientFactoryTest {
     @Test
     void testUpdateGroup() {
         stubFor(
-                post(urlMatching("/manager/api/group/update.*"))
+                post(urlMatching("/inlong/manager/api/group/update.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -434,7 +434,7 @@ class ClientFactoryTest {
         expected.setWaitApproveCount(34524L);
         expected.setWaitAssignCount(45678L);
         stubFor(
-                get(urlMatching("/manager/api/group/countByStatus.*"))
+                get(urlMatching("/inlong/manager/api/group/countByStatus.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -463,7 +463,7 @@ class ClientFactoryTest {
         briefInfo.setInlongGroupId("testgroup");
         briefInfo.setModifyTime(new Date());
         stubFor(
-                get(urlMatching("/manager/api/group/getTopic/1.*"))
+                get(urlMatching("/inlong/manager/api/group/getTopic/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -481,7 +481,7 @@ class ClientFactoryTest {
     @Test
     void testCreateStream() {
         stubFor(
-                post(urlMatching("/manager/api/stream/save.*"))
+                post(urlMatching("/inlong/manager/api/stream/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(11)))
                         )
@@ -494,7 +494,7 @@ class ClientFactoryTest {
     @Test
     void testStreamExist() {
         stubFor(
-                get(urlMatching("/manager/api/stream/exist/123/11.*"))
+                get(urlMatching("/inlong/manager/api/stream/exist/123/11.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -532,7 +532,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/manager/api/stream/get.*"))
+                get(urlMatching("/inlong/manager/api/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(streamResponse)))
                         )
@@ -545,7 +545,7 @@ class ClientFactoryTest {
     @Test
     void testGetStream4NotExist() {
         stubFor(
-                get(urlMatching("/manager/api/stream/get.*"))
+                get(urlMatching("/inlong/manager/api/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong stream does not exist/no operation permission")))
@@ -634,7 +634,7 @@ class ClientFactoryTest {
         streamInfo.setSinkList(sinkList);
 
         stubFor(
-                post(urlMatching("/manager/api/stream/listAll.*"))
+                post(urlMatching("/inlong/manager/api/stream/listAll.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(streamInfo))))
@@ -693,7 +693,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                get(urlMatching("/manager/api/sink/list.*"))
+                get(urlMatching("/inlong/manager/api/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(sinkList))))
@@ -708,7 +708,7 @@ class ClientFactoryTest {
     @Test
     void testListSink4AllTypeShouldThrowException() {
         stubFor(
-                get(urlMatching("/manager/api/sink/list.*"))
+                get(urlMatching("/inlong/manager/api/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("groupId should not empty"))
@@ -724,7 +724,7 @@ class ClientFactoryTest {
     @Test
     void testResetGroup() {
         stubFor(
-                post(urlMatching("/manager/api/group/reset.*"))
+                post(urlMatching("/inlong/manager/api/group/reset.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -739,7 +739,7 @@ class ClientFactoryTest {
     @Test
     void testSaveCluster() {
         stubFor(
-                post(urlMatching("/manager/api/cluster/save.*"))
+                post(urlMatching("/inlong/manager/api/cluster/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -766,7 +766,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/manager/api/cluster/get/1.*"))
+                get(urlMatching("/inlong/manager/api/cluster/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(cluster))
@@ -806,7 +806,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/manager/api/sink/get/1.*"))
+                get(urlMatching("/inlong/manager/api/sink/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(streamSink))
@@ -821,7 +821,7 @@ class ClientFactoryTest {
     @Test
     void testSaveClusterTag() {
         stubFor(
-                post(urlMatching("/manager/api/cluster/tag/save.*"))
+                post(urlMatching("/inlong/manager/api/cluster/tag/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -843,7 +843,7 @@ class ClientFactoryTest {
                 .inCharges("admin")
                 .build();
         stubFor(
-                get(urlMatching("/manager/api/cluster/tag/get/1.*"))
+                get(urlMatching("/inlong/manager/api/cluster/tag/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(tagResponse))
@@ -857,7 +857,7 @@ class ClientFactoryTest {
     @Test
     void testBindTag() {
         stubFor(
-                post(urlMatching("/manager/api/cluster/bindTag.*"))
+                post(urlMatching("/inlong/manager/api/cluster/bindTag.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -873,7 +873,7 @@ class ClientFactoryTest {
     @Test
     void testSaveNode() {
         stubFor(
-                post(urlMatching("/manager/api/cluster/node/save.*"))
+                post(urlMatching("/inlong/manager/api/cluster/node/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -895,7 +895,7 @@ class ClientFactoryTest {
                 .port(46801)
                 .build();
         stubFor(
-                get(urlMatching("/manager/api/cluster/node/get/1.*"))
+                get(urlMatching("/inlong/manager/api/cluster/node/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(response))

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -128,7 +128,7 @@ class ClientFactoryTest {
     @Test
     void testGroupExist() {
         stubFor(
-                get(urlMatching("/api/inlong/manager/group/exist/123.*"))
+                get(urlMatching("/manager/group/exist/123.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -155,7 +155,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/api/inlong/manager/group/get/1.*"))
+                get(urlMatching("/manager/group/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(inlongGroupResponse)))
                         )
@@ -187,7 +187,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -223,7 +223,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -261,7 +261,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -301,7 +301,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -372,7 +372,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos)))
                                 )
@@ -387,7 +387,7 @@ class ClientFactoryTest {
     @Test
     void testListGroup4NotExist() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/list.*"))
+                post(urlMatching("/manager/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong group does not exist/no operation authority"))
@@ -402,7 +402,7 @@ class ClientFactoryTest {
     @Test
     void testCreateGroup() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/save.*"))
+                post(urlMatching("/manager/group/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -415,7 +415,7 @@ class ClientFactoryTest {
     @Test
     void testUpdateGroup() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/update.*"))
+                post(urlMatching("/manager/group/update.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -434,7 +434,7 @@ class ClientFactoryTest {
         expected.setWaitApproveCount(34524L);
         expected.setWaitAssignCount(45678L);
         stubFor(
-                get(urlMatching("/api/inlong/manager/group/countByStatus.*"))
+                get(urlMatching("/manager/group/countByStatus.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -463,7 +463,7 @@ class ClientFactoryTest {
         briefInfo.setInlongGroupId("testgroup");
         briefInfo.setModifyTime(new Date());
         stubFor(
-                get(urlMatching("/api/inlong/manager/group/getTopic/1.*"))
+                get(urlMatching("/manager/group/getTopic/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -481,7 +481,7 @@ class ClientFactoryTest {
     @Test
     void testCreateStream() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/stream/save.*"))
+                post(urlMatching("/manager/stream/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(11)))
                         )
@@ -494,7 +494,7 @@ class ClientFactoryTest {
     @Test
     void testStreamExist() {
         stubFor(
-                get(urlMatching("/api/inlong/manager/stream/exist/123/11.*"))
+                get(urlMatching("/manager/stream/exist/123/11.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -532,7 +532,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/api/inlong/manager/stream/get.*"))
+                get(urlMatching("/manager/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(streamResponse)))
                         )
@@ -545,7 +545,7 @@ class ClientFactoryTest {
     @Test
     void testGetStream4NotExist() {
         stubFor(
-                get(urlMatching("/api/inlong/manager/stream/get.*"))
+                get(urlMatching("/manager/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong stream does not exist/no operation permission")))
@@ -634,7 +634,7 @@ class ClientFactoryTest {
         streamInfo.setSinkList(sinkList);
 
         stubFor(
-                post(urlMatching("/api/inlong/manager/stream/listAll.*"))
+                post(urlMatching("/manager/stream/listAll.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(streamInfo))))
@@ -693,7 +693,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                get(urlMatching("/api/inlong/manager/sink/list.*"))
+                get(urlMatching("/manager/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(sinkList))))
@@ -708,7 +708,7 @@ class ClientFactoryTest {
     @Test
     void testListSink4AllTypeShouldThrowException() {
         stubFor(
-                get(urlMatching("/api/inlong/manager/sink/list.*"))
+                get(urlMatching("/manager/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("groupId should not empty"))
@@ -724,7 +724,7 @@ class ClientFactoryTest {
     @Test
     void testResetGroup() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/group/reset.*"))
+                post(urlMatching("/manager/group/reset.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -739,7 +739,7 @@ class ClientFactoryTest {
     @Test
     void testSaveCluster() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/cluster/save.*"))
+                post(urlMatching("/manager/cluster/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -766,7 +766,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/api/inlong/manager/cluster/get/1.*"))
+                get(urlMatching("/manager/cluster/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(cluster))
@@ -806,7 +806,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/api/inlong/manager/sink/get/1.*"))
+                get(urlMatching("/manager/sink/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(streamSink))
@@ -821,7 +821,7 @@ class ClientFactoryTest {
     @Test
     void testSaveClusterTag() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/cluster/tag/save.*"))
+                post(urlMatching("/manager/cluster/tag/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -843,7 +843,7 @@ class ClientFactoryTest {
                 .inCharges("admin")
                 .build();
         stubFor(
-                get(urlMatching("/api/inlong/manager/cluster/tag/get/1.*"))
+                get(urlMatching("/manager/cluster/tag/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(tagResponse))
@@ -857,7 +857,7 @@ class ClientFactoryTest {
     @Test
     void testBindTag() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/cluster/bindTag.*"))
+                post(urlMatching("/manager/cluster/bindTag.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -873,7 +873,7 @@ class ClientFactoryTest {
     @Test
     void testSaveNode() {
         stubFor(
-                post(urlMatching("/api/inlong/manager/cluster/node/save.*"))
+                post(urlMatching("/manager/cluster/node/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -895,7 +895,7 @@ class ClientFactoryTest {
                 .port(46801)
                 .build();
         stubFor(
-                get(urlMatching("/api/inlong/manager/cluster/node/get/1.*"))
+                get(urlMatching("/manager/cluster/node/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(response))

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -128,7 +128,7 @@ class ClientFactoryTest {
     @Test
     void testGroupExist() {
         stubFor(
-                get(urlMatching("/manager/group/exist/123.*"))
+                get(urlMatching("/manager/api/group/exist/123.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -155,7 +155,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/manager/group/get/1.*"))
+                get(urlMatching("/manager/api/group/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(inlongGroupResponse)))
                         )
@@ -187,7 +187,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -223,7 +223,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -261,7 +261,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -301,7 +301,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos))))
                         )
@@ -372,7 +372,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(new PageInfo<>(groupBriefInfos)))
                                 )
@@ -387,7 +387,7 @@ class ClientFactoryTest {
     @Test
     void testListGroup4NotExist() {
         stubFor(
-                post(urlMatching("/manager/group/list.*"))
+                post(urlMatching("/manager/api/group/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong group does not exist/no operation authority"))
@@ -402,7 +402,7 @@ class ClientFactoryTest {
     @Test
     void testCreateGroup() {
         stubFor(
-                post(urlMatching("/manager/group/save.*"))
+                post(urlMatching("/manager/api/group/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -415,7 +415,7 @@ class ClientFactoryTest {
     @Test
     void testUpdateGroup() {
         stubFor(
-                post(urlMatching("/manager/group/update.*"))
+                post(urlMatching("/manager/api/group/update.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success("1111")))
                         )
@@ -434,7 +434,7 @@ class ClientFactoryTest {
         expected.setWaitApproveCount(34524L);
         expected.setWaitAssignCount(45678L);
         stubFor(
-                get(urlMatching("/manager/group/countByStatus.*"))
+                get(urlMatching("/manager/api/group/countByStatus.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -463,7 +463,7 @@ class ClientFactoryTest {
         briefInfo.setInlongGroupId("testgroup");
         briefInfo.setModifyTime(new Date());
         stubFor(
-                get(urlMatching("/manager/group/getTopic/1.*"))
+                get(urlMatching("/manager/api/group/getTopic/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(expected))
@@ -481,7 +481,7 @@ class ClientFactoryTest {
     @Test
     void testCreateStream() {
         stubFor(
-                post(urlMatching("/manager/stream/save.*"))
+                post(urlMatching("/manager/api/stream/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(11)))
                         )
@@ -494,7 +494,7 @@ class ClientFactoryTest {
     @Test
     void testStreamExist() {
         stubFor(
-                get(urlMatching("/manager/stream/exist/123/11.*"))
+                get(urlMatching("/manager/api/stream/exist/123/11.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(true)))
                         )
@@ -532,7 +532,7 @@ class ClientFactoryTest {
                 ).build();
 
         stubFor(
-                get(urlMatching("/manager/stream/get.*"))
+                get(urlMatching("/manager/api/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(Response.success(streamResponse)))
                         )
@@ -545,7 +545,7 @@ class ClientFactoryTest {
     @Test
     void testGetStream4NotExist() {
         stubFor(
-                get(urlMatching("/manager/stream/get.*"))
+                get(urlMatching("/manager/api/stream/get.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("Inlong stream does not exist/no operation permission")))
@@ -634,7 +634,7 @@ class ClientFactoryTest {
         streamInfo.setSinkList(sinkList);
 
         stubFor(
-                post(urlMatching("/manager/stream/listAll.*"))
+                post(urlMatching("/manager/api/stream/listAll.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(streamInfo))))
@@ -693,7 +693,7 @@ class ClientFactoryTest {
         );
 
         stubFor(
-                get(urlMatching("/manager/sink/list.*"))
+                get(urlMatching("/manager/api/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(new PageInfo<>(Lists.newArrayList(sinkList))))
@@ -708,7 +708,7 @@ class ClientFactoryTest {
     @Test
     void testListSink4AllTypeShouldThrowException() {
         stubFor(
-                get(urlMatching("/manager/sink/list.*"))
+                get(urlMatching("/manager/api/sink/list.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.fail("groupId should not empty"))
@@ -724,7 +724,7 @@ class ClientFactoryTest {
     @Test
     void testResetGroup() {
         stubFor(
-                post(urlMatching("/manager/group/reset.*"))
+                post(urlMatching("/manager/api/group/reset.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -739,7 +739,7 @@ class ClientFactoryTest {
     @Test
     void testSaveCluster() {
         stubFor(
-                post(urlMatching("/manager/cluster/save.*"))
+                post(urlMatching("/manager/api/cluster/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -766,7 +766,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/manager/cluster/get/1.*"))
+                get(urlMatching("/manager/api/cluster/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(cluster))
@@ -806,7 +806,7 @@ class ClientFactoryTest {
                 .build();
 
         stubFor(
-                get(urlMatching("/manager/sink/get/1.*"))
+                get(urlMatching("/manager/api/sink/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(streamSink))
@@ -821,7 +821,7 @@ class ClientFactoryTest {
     @Test
     void testSaveClusterTag() {
         stubFor(
-                post(urlMatching("/manager/cluster/tag/save.*"))
+                post(urlMatching("/manager/api/cluster/tag/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -843,7 +843,7 @@ class ClientFactoryTest {
                 .inCharges("admin")
                 .build();
         stubFor(
-                get(urlMatching("/manager/cluster/tag/get/1.*"))
+                get(urlMatching("/manager/api/cluster/tag/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(tagResponse))
@@ -857,7 +857,7 @@ class ClientFactoryTest {
     @Test
     void testBindTag() {
         stubFor(
-                post(urlMatching("/manager/cluster/bindTag.*"))
+                post(urlMatching("/manager/api/cluster/bindTag.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(true))
@@ -873,7 +873,7 @@ class ClientFactoryTest {
     @Test
     void testSaveNode() {
         stubFor(
-                post(urlMatching("/manager/cluster/node/save.*"))
+                post(urlMatching("/manager/api/cluster/node/save.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(1))
@@ -895,7 +895,7 @@ class ClientFactoryTest {
                 .port(46801)
                 .build();
         stubFor(
-                get(urlMatching("/manager/cluster/node/get/1.*"))
+                get(urlMatching("/manager/api/cluster/node/get/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(response))

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/impl/InlongShiroImpl.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/impl/InlongShiroImpl.java
@@ -97,7 +97,7 @@ public class InlongShiroImpl implements InlongShiro {
         shiroFilterFactoryBean.setFilters(filters);
         Map<String, String> pathDefinitions = new LinkedHashMap<>();
         // login, register request
-        pathDefinitions.put("/anno/**/*", "anon");
+        pathDefinitions.put("/api/anno/**/*", "anon");
 
         // swagger api
         pathDefinitions.put("/doc.html", "anon");

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AnnoController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AnnoController.java
@@ -20,9 +20,9 @@ package org.apache.inlong.manager.web.controller;
 import io.swagger.annotations.Api;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.inlong.manager.common.beans.Response;
+import org.apache.inlong.manager.common.pojo.user.UserInfo;
 import org.apache.inlong.manager.common.pojo.user.UserLoginRequest;
 import org.apache.inlong.manager.common.pojo.user.UserRequest;
-import org.apache.inlong.manager.common.pojo.user.UserInfo;
 import org.apache.inlong.manager.common.util.LoginUserUtils;
 import org.apache.inlong.manager.service.core.UserService;
 import org.apache.shiro.SecurityUtils;
@@ -33,6 +33,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -40,6 +41,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Slf4j
 @RestController
+@RequestMapping("/api")
 @Api(tags = "User-Anno-API")
 public class AnnoController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AuditController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AuditController.java
@@ -25,6 +25,7 @@ import org.apache.inlong.manager.common.pojo.audit.AuditVO;
 import org.apache.inlong.manager.service.core.AuditService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
@@ -35,6 +36,7 @@ import java.util.List;
  * Audit controller.
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Audit-API")
 public class AuditController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/ConsumptionController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/ConsumptionController.java
@@ -39,12 +39,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Data consumption interface
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Consumption-API")
 public class ConsumptionController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
@@ -39,12 +39,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Data node controller
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Data-Node-API")
 public class DataNodeController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/HeartbeatController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/HeartbeatController.java
@@ -37,6 +37,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Heartbeat controller.
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Heartbeat-API")
 public class HeartbeatController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -53,6 +53,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Inlong cluster controller
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Inlong-Cluster-API")
 public class InlongClusterController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -50,6 +50,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Inlong group control layer
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Inlong-Group-API")
 public class InlongGroupController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongStreamController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongStreamController.java
@@ -46,6 +46,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Inlong stream control layer
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Inlong-Stream-API")
 public class InlongStreamController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamConfigLogWebController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamConfigLogWebController.java
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Stream config log controller.
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Stream-Config-Log-API")
 public class StreamConfigLogWebController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
@@ -42,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Stream sink control layer
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Stream-Sink-API")
 public class StreamSinkController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
@@ -42,6 +42,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Stream source control layer
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Stream-Source-API")
 public class StreamSourceController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamTransformController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamTransformController.java
@@ -42,6 +42,7 @@ import java.util.List;
  * Stream transform control layer
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Stream-Transform-API")
 public class StreamTransformController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
@@ -21,8 +21,8 @@ import com.github.pagehelper.PageInfo;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.apache.inlong.manager.common.beans.Response;
-import org.apache.inlong.manager.common.pojo.user.UserRequest;
 import org.apache.inlong.manager.common.pojo.user.UserInfo;
+import org.apache.inlong.manager.common.pojo.user.UserRequest;
 import org.apache.inlong.manager.common.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.common.util.LoginUserUtils;
 import org.apache.inlong.manager.service.core.UserService;
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Validated
 @RestController
+@RequestMapping("/api")
 @Api(tags = "User-Auth-API")
 public class UserController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -43,6 +44,7 @@ import java.util.List;
  */
 @Slf4j
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Workflow-Approver-API")
 public class WorkflowApproverController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowController.java
@@ -47,6 +47,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,6 +56,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @Slf4j
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Workflow-API")
 public class WorkflowController {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowEventController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowEventController.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
  * Workflow event related interface
  */
 @RestController
+@RequestMapping("/api")
 @Api(tags = "Workflow-Event-API")
 public class WorkflowEventController {
 

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -21,7 +21,7 @@ server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
 default.admin.password=inlong
-server.servlet.context-path=/manager
+server.servlet.context-path=/inlong/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
 

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -16,23 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
 default.admin.password=inlong
-server.servlet.context-path=/api/inlong/manager
+server.servlet.context-path=/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
-
 spring.main.allow-circular-references=true
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 # Serialize the Date type to a timestamp
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
 spring.jackson.time-zone=GMT+8
-
 # Configure mybatis
 mybatis.mapper-locations=classpath:mappers/*.xml
 # Global mapping, no need to write the full path of the entity class in the xml file
@@ -43,7 +39,6 @@ mybatis.configuration.map-underscore-to-camel-case=true
 pagehelper.helperDialect=mysql
 pagehelper.reasonable=true
 pagehelper.params=count=countSql
-
 # Configure http client
 common.http-client.maxTotal=5000
 common.http-client.defaultMaxPerRoute=2000
@@ -51,10 +46,8 @@ common.http-client.validateAfterInactivity=5000
 common.http-client.connectionTimeout=3000
 common.http-client.readTimeout=10000
 common.http-client.connectionRequestTimeout=3000
-
 # Configure auth plugin
 inlong.auth.type=default
-
 # Encryption config, the suffix of value must be the same as the version.
 inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
@@ -23,12 +24,15 @@ default.admin.password=inlong
 server.servlet.context-path=/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
+
 spring.main.allow-circular-references=true
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
+
 # Serialize the Date type to a timestamp
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
 spring.jackson.time-zone=GMT+8
+
 # Configure mybatis
 mybatis.mapper-locations=classpath:mappers/*.xml
 # Global mapping, no need to write the full path of the entity class in the xml file
@@ -39,6 +43,7 @@ mybatis.configuration.map-underscore-to-camel-case=true
 pagehelper.helperDialect=mysql
 pagehelper.reasonable=true
 pagehelper.params=count=countSql
+
 # Configure http client
 common.http-client.maxTotal=5000
 common.http-client.defaultMaxPerRoute=2000
@@ -46,8 +51,10 @@ common.http-client.validateAfterInactivity=5000
 common.http-client.connectionTimeout=3000
 common.http-client.readTimeout=10000
 common.http-client.connectionRequestTimeout=3000
+
 # Configure auth plugin
 inlong.auth.type=default
+
 # Encryption config, the suffix of value must be the same as the version.
 inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
@@ -58,7 +58,7 @@ public abstract class WebBaseTest extends BaseTest {
 
     public MockMvc mockMvc;
     @Resource
-    ObjectMapper objectMapper;
+    private ObjectMapper objectMapper;
     @Resource
     private WebApplicationContext context;
 

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
@@ -57,11 +57,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public abstract class WebBaseTest extends BaseTest {
 
     public MockMvc mockMvc;
-
-    @Resource
-    private WebApplicationContext context;
     @Resource
     ObjectMapper objectMapper;
+    @Resource
+    private WebApplicationContext context;
 
     @BeforeAll
     void baseSetup() {
@@ -89,7 +88,7 @@ public abstract class WebBaseTest extends BaseTest {
         loginUser.setPassword("inlong");
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/login")
+                        post("/api/anno/login")
                                 .content(JsonUtils.toJsonString(loginUser))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -143,7 +142,7 @@ public abstract class WebBaseTest extends BaseTest {
         loginUser.setPassword("inlong");
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/login")
+                        post("/api/anno/login")
                                 .content(JsonUtils.toJsonString(loginUser))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/AnnoControllerTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/AnnoControllerTest.java
@@ -60,7 +60,7 @@ class AnnoControllerTest extends WebBaseTest {
         loginUser.setPassword("test_wrong_pwd");
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/login")
+                        post("/api/anno/login")
                                 .content(JsonUtils.toJsonString(loginUser))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -83,7 +83,7 @@ class AnnoControllerTest extends WebBaseTest {
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/register")
+                        post("/api/anno/register")
                                 .content(JsonUtils.toJsonString(userInfo))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -106,7 +106,7 @@ class AnnoControllerTest extends WebBaseTest {
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/register")
+                        post("/api/anno/register")
                                 .content(JsonUtils.toJsonString(userInfo))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -124,7 +124,7 @@ class AnnoControllerTest extends WebBaseTest {
         testLogin();
 
         MvcResult mvcResult = mockMvc.perform(
-                        get("/anno/logout")
+                        get("/api/anno/logout")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
                 )
@@ -147,7 +147,7 @@ class AnnoControllerTest extends WebBaseTest {
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(
-                        post("/anno/register")
+                        post("/api/anno/register")
                                 .content(JsonUtils.toJsonString(userInfo))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/DataNodeControllerTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/DataNodeControllerTest.java
@@ -52,7 +52,7 @@ class DataNodeControllerTest extends WebBaseTest {
         logout();
         operatorLogin();
 
-        MvcResult mvcResult = postForSuccessMvcResult("/node/save", getDataNodeRequest());
+        MvcResult mvcResult = postForSuccessMvcResult("/api/node/save", getDataNodeRequest());
 
         Response<Integer> response = getResBody(mvcResult, Integer.class);
         Assertions.assertEquals("Current user [operator] has no permission to access URL", response.getErrMsg());
@@ -61,20 +61,20 @@ class DataNodeControllerTest extends WebBaseTest {
     @Test
     void testSaveAndGetAndDelete() throws Exception {
         // save
-        MvcResult mvcResult = postForSuccessMvcResult("/node/save", getDataNodeRequest());
+        MvcResult mvcResult = postForSuccessMvcResult("/api/node/save", getDataNodeRequest());
 
         Integer dataNodeId = getResBodyObj(mvcResult, Integer.class);
         Assertions.assertNotNull(dataNodeId);
 
         // get
-        MvcResult getResult = getForSuccessMvcResult("/node/get/{id}", dataNodeId);
+        MvcResult getResult = getForSuccessMvcResult("/api/node/get/{id}", dataNodeId);
 
         DataNodeResponse dataNode = getResBodyObj(getResult, DataNodeResponse.class);
         Assertions.assertNotNull(dataNode);
         Assertions.assertEquals(getDataNodeRequest().getName(), dataNode.getName());
 
         // delete
-        MvcResult deleteResult = deleteForSuccessMvcResult("/node/delete/{id}", dataNodeId);
+        MvcResult deleteResult = deleteForSuccessMvcResult("/api/node/delete/{id}", dataNodeId);
 
         Boolean success = getResBodyObj(deleteResult, Boolean.class);
         Assertions.assertTrue(success);
@@ -103,7 +103,7 @@ class DataNodeControllerTest extends WebBaseTest {
         request.setId(nodeEntity.getId());
         request.setName("test447777");
         request.setVersion(nodeEntity.getVersion());
-        MvcResult mvcResult = postForSuccessMvcResult("/node/update", request);
+        MvcResult mvcResult = postForSuccessMvcResult("/api/node/update", request);
 
         Boolean success = getResBodyObj(mvcResult, Boolean.class);
         Assertions.assertTrue(success);
@@ -114,7 +114,7 @@ class DataNodeControllerTest extends WebBaseTest {
 
     @Test
     void testUpdateFailByNoId() throws Exception {
-        MvcResult mvcResult = postForSuccessMvcResult("/node/update", getDataNodeRequest());
+        MvcResult mvcResult = postForSuccessMvcResult("/api/node/update", getDataNodeRequest());
 
         Response<Boolean> response = getResBody(mvcResult, Boolean.class);
         Assertions.assertFalse(response.isSuccess());

--- a/inlong-manager/manager-web/src/test/resources/application.properties
+++ b/inlong-manager/manager-web/src/test/resources/application.properties
@@ -21,7 +21,7 @@ server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
 default.admin.password=inlong
-server.servlet.context-path=/manager
+server.servlet.context-path=/inlong/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
 

--- a/inlong-manager/manager-web/src/test/resources/application.properties
+++ b/inlong-manager/manager-web/src/test/resources/application.properties
@@ -16,23 +16,19 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
 default.admin.password=inlong
-server.servlet.context-path=/api/inlong/manager
+server.servlet.context-path=/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
-
 spring.main.allow-circular-references=true
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
-
 # Serialize the Date type to a timestamp
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
 spring.jackson.time-zone=GMT+8
-
 # Configure mybatis
 mybatis.mapper-locations=classpath:mappers/*.xml
 # Global mapping, no need to write the full path of the entity class in the xml file
@@ -43,7 +39,6 @@ mybatis.configuration.map-underscore-to-camel-case=true
 pagehelper.helperDialect=mysql
 pagehelper.reasonable=true
 pagehelper.params=count=countSql
-
 # Configure http client
 common.http-client.maxTotal=5000
 common.http-client.defaultMaxPerRoute=2000
@@ -51,10 +46,8 @@ common.http-client.validateAfterInactivity=5000
 common.http-client.connectionTimeout=3000
 common.http-client.readTimeout=10000
 common.http-client.connectionRequestTimeout=3000
-
 # Configure auth plugin
 inlong.auth.type=default
-
 # Encryption config, the suffix of value must be the same as the version.
 inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"

--- a/inlong-manager/manager-web/src/test/resources/application.properties
+++ b/inlong-manager/manager-web/src/test/resources/application.properties
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 server.host=127.0.0.1
 server.port=8083
 default.admin.user=admin
@@ -23,12 +24,15 @@ default.admin.password=inlong
 server.servlet.context-path=/manager
 spring.application.name=InLong-Manager-Web
 spring.profiles.active=dev
+
 spring.main.allow-circular-references=true
 spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER
+
 # Serialize the Date type to a timestamp
 spring.jackson.serialization.write-dates-as-timestamps=true
 spring.jackson.date-format=yyyy-MM-dd HH:mm:ss
 spring.jackson.time-zone=GMT+8
+
 # Configure mybatis
 mybatis.mapper-locations=classpath:mappers/*.xml
 # Global mapping, no need to write the full path of the entity class in the xml file
@@ -39,6 +43,7 @@ mybatis.configuration.map-underscore-to-camel-case=true
 pagehelper.helperDialect=mysql
 pagehelper.reasonable=true
 pagehelper.params=count=countSql
+
 # Configure http client
 common.http-client.maxTotal=5000
 common.http-client.defaultMaxPerRoute=2000
@@ -46,8 +51,10 @@ common.http-client.validateAfterInactivity=5000
 common.http-client.connectionTimeout=3000
 common.http-client.readTimeout=10000
 common.http-client.connectionRequestTimeout=3000
+
 # Configure auth plugin
 inlong.auth.type=default
+
 # Encryption config, the suffix of value must be the same as the version.
 inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
@@ -67,6 +67,6 @@ public class ConfigConstants {
     public static final int FLAG_ALLOW_ENCRYPT = 1 << 6;
     public static final int FLAG_ALLOW_COMPRESS = 1 << 5;
 
-    public static final String MANAGER_DATAPROXY_API = "/api/inlong/manager/openapi/dataproxy/getIpList/";
+    public static final String MANAGER_DATAPROXY_API = "/manager/openapi/dataproxy/getIpList/";
 
 }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
@@ -67,6 +67,6 @@ public class ConfigConstants {
     public static final int FLAG_ALLOW_ENCRYPT = 1 << 6;
     public static final int FLAG_ALLOW_COMPRESS = 1 << 5;
 
-    public static final String MANAGER_DATAPROXY_API = "/manager/openapi/dataproxy/getIpList/";
+    public static final String MANAGER_DATAPROXY_API = "/inlong/manager/openapi/dataproxy/getIpList/";
 
 }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
@@ -61,7 +61,7 @@ public class ServiceDiscoveryUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceDiscoveryUtils.class);
 
-    private static final String GET_MANAGER_IP_LIST_API = "/manager/openapi/agent/getManagerIpList";
+    private static final String GET_MANAGER_IP_LIST_API = "/inlong/manager/openapi/agent/getManagerIpList";
     private static String latestManagerIPList = "";
     private static String arraySed = ",";
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ServiceDiscoveryUtils.java
@@ -61,7 +61,7 @@ public class ServiceDiscoveryUtils {
 
     private static final Logger log = LoggerFactory.getLogger(ServiceDiscoveryUtils.class);
 
-    private static final String GET_MANAGER_IP_LIST_API = "/api/inlong/manager/openapi/agent/getManagerIpList";
+    private static final String GET_MANAGER_IP_LIST_API = "/manager/openapi/agent/getManagerIpList";
     private static String latestManagerIPList = "";
     private static String arraySed = ",";
 

--- a/inlong-sort-standalone/conf/common.properties
+++ b/inlong-sort-standalone/conf/common.properties
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 clusterId=hivev3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -24,15 +25,18 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.hive.HiveSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
+
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
+
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
 #sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
 #sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler

--- a/inlong-sort-standalone/conf/common.properties
+++ b/inlong-sort-standalone/conf/common.properties
@@ -34,8 +34,8 @@ sortSourceConfig.QueryConsumeConfigType=file
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getSortSource
 
 adminTask.host=127.0.0.1
 adminTask.port=8088

--- a/inlong-sort-standalone/conf/common.properties
+++ b/inlong-sort-standalone/conf/common.properties
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 clusterId=hivev3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -25,18 +24,15 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.hive.HiveSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
-
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
-
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getSortSource
-
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler

--- a/inlong-sort-standalone/conf/es/common.properties
+++ b/inlong-sort-standalone/conf/es/common.properties
@@ -34,8 +34,8 @@ sortSourceConfig.QueryConsumeConfigType=file
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getSortSource
 
 adminTask.host=127.0.0.1
 adminTask.port=8088

--- a/inlong-sort-standalone/conf/es/common.properties
+++ b/inlong-sort-standalone/conf/es/common.properties
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 clusterId=esv3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -25,18 +24,15 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.elasticsearch.EsSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
-
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
-
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getSortSource
-
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler

--- a/inlong-sort-standalone/conf/es/common.properties
+++ b/inlong-sort-standalone/conf/es/common.properties
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 clusterId=esv3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -24,15 +25,18 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.elasticsearch.EsSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
+
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
+
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
 #sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
 #sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler

--- a/inlong-sort-standalone/conf/hive/common.properties
+++ b/inlong-sort-standalone/conf/hive/common.properties
@@ -16,6 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+
 clusterId=hivev3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -24,15 +25,18 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.hive.HiveSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
+
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
+
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
 #sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
 #sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler

--- a/inlong-sort-standalone/conf/hive/common.properties
+++ b/inlong-sort-standalone/conf/hive/common.properties
@@ -34,8 +34,8 @@ sortSourceConfig.QueryConsumeConfigType=file
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/inlong/manager/openapi/sort/getSortSource
 
 adminTask.host=127.0.0.1
 adminTask.port=8088

--- a/inlong-sort-standalone/conf/hive/common.properties
+++ b/inlong-sort-standalone/conf/hive/common.properties
@@ -16,7 +16,6 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
 clusterId=hivev3-sz-sz1
 nodeId=nodeId
 metricDomains=Sort
@@ -25,18 +24,15 @@ metricDomains.Sort.snapshotInterval=60000
 sortChannel.type=org.apache.inlong.sort.standalone.channel.BufferQueueChannel
 sortSink.type=org.apache.inlong.sort.standalone.sink.hive.HiveSink
 sortSource.type=org.apache.inlong.sort.standalone.source.sortsdk.SortSdkSource
-
 sortClusterConfig.type=file
 sortClusterConfig.file=SortClusterConfig.conf
 sortSourceConfig.QueryConsumeConfigType=file
 #sortTaskId.conf
-
 #sortClusterConfig.type=manager
 #sortSourceConfig.QueryConsumeConfigType=manager
 #managerUrlLoaderType=org.apache.inlong.sort.standalone.config.loader.CommonPropertiesManagerUrlLoader
-#sortClusterConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getClusterConfig
-#sortSourceConfig.managerUrl=http://${manager_ip:port}/api/inlong/manager/openapi/sort/getSortSource
-
+#sortClusterConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getClusterConfig
+#sortSourceConfig.managerUrl=http://${manager_ip:port}/manager/openapi/sort/getSortSource
 adminTask.host=127.0.0.1
 adminTask.port=8088
 adminTask.handler=org.apache.inlong.sdk.commons.admin.AdminJsonHandler


### PR DESCRIPTION
- Fixes #5245

There are two groups of manager controllers. The open api group url starts with "api/inlong/manager/openapi" and the web group starts with "api/inlong/manager" which is cumbersome and inconvenient.

Change them to /manager/openapi and /manager/api respectively.