### PR TITLE
[INLONG-5281][TubeMQ] Reconnect to tubemq server if StandbyException is thrown

### DIFF
--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/heartbeat.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/heartbeat.go
@@ -129,9 +129,9 @@ func (h *heartbeatManager) consumerHB2Master() {
 				return
 			}
 		}
+		h.consumer.masterHBRetry = 0
+		h.processHBResponseM2C(rsp)
 	}
-	h.consumer.masterHBRetry = 0
-	h.processHBResponseM2C(rsp)
 	h.resetMasterHeartbeat()
 }
 

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/client.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/rpc/client.go
@@ -99,8 +99,5 @@ func (c *rpcClient) doRequest(ctx context.Context, address string,
 	}
 
 	v := rsp.(*codec.TubeMQRPCResponse)
-	if v.ResponseException != nil {
-		return nil, errs.New(errs.RetResponseException, v.ResponseException.String())
-	}
 	return v.ResponseBody, nil
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util/util.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/util/util.go
@@ -120,7 +120,7 @@ func SplitToMap(source string, step1 string, step2 string) map[string]string {
 func IsValidString(s string) (bool, error) {
 	if matched, _ := regexp.Match("^[a-zA-Z]\\w+$", []byte(s)); !matched {
 		return false,
-			errors.New(fmt.Sprintf("illegal parameter: %s must begin with a letter, " +
+			errors.New(fmt.Sprintf("illegal parameter: %s must begin with a letter, "+
 				"can only contain characters,numbers,and underscores", s))
 	}
 	return true, nil


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5281 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*
Reconnect to tubemq server if StandbyException is thrown
### Modifications

*Describe the modifications you've done.*
if StandbyException is returned from the tubemq server, try to reconnect to the another master.
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
