### PR TITLE
[INLONG-5312][Sort] Add unified inlong.metric parameter injection support for nodes

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/InLongMetric.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/InLongMetric.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol;
+
+/**
+ * The class is the abstract of InLong Metric.
+ * We agree that the key of the inlong metric report is `inlong.metric`,
+ * and its value is format by `groupId&streamId&nodeId`.
+ * If node implements this interface, we will inject the key and value into the corresponding Sort-Connectors
+ * during flink sql parser
+ */
+public interface InLongMetric {
+
+    /**
+     * The key of metric, it must be `inlong.metric` here.
+     */
+    String METRIC_KEY = "inlong.metric";
+
+    /**
+     * The value format, it must be `groupId&streamId&nodeId` here.
+     * The groupId is the id of InLong Group
+     * The streamId is the id of InLong Stream
+     * The nodeId is the id of InLong Source or Sink
+     */
+    String METRIC_VALUE_FORMAT = "%s&%s&%s";
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/InlongMetric.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/InlongMetric.java
@@ -18,13 +18,13 @@
 package org.apache.inlong.sort.protocol;
 
 /**
- * The class is the abstract of InLong Metric.
+ * The class is the abstract of Inlong Metric.
  * We agree that the key of the inlong metric report is `inlong.metric`,
  * and its value is format by `groupId&streamId&nodeId`.
  * If node implements this interface, we will inject the key and value into the corresponding Sort-Connectors
  * during flink sql parser
  */
-public interface InLongMetric {
+public interface InlongMetric {
 
     /**
      * The key of metric, it must be `inlong.metric` here.
@@ -33,9 +33,9 @@ public interface InLongMetric {
 
     /**
      * The value format, it must be `groupId&streamId&nodeId` here.
-     * The groupId is the id of InLong Group
-     * The streamId is the id of InLong Stream
-     * The nodeId is the id of InLong Source or Sink
+     * The groupId is the id of Inlong Group
+     * The streamId is the id of Inlong Stream
+     * The nodeId is the id of Inlong Source or Sink
      */
     String METRIC_VALUE_FORMAT = "%s&%s&%s";
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/HBaseConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/HBaseConstant.java
@@ -25,7 +25,7 @@ public class HBaseConstant {
 
     public static final String CONNECTOR = "connector";
 
-    public static final String HBASE_2 = "hbase-2.2";
+    public static final String HBASE_2 = "hbase-2.2-inlong";
 
     public static final String TABLE_NAME = "table-name";
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/PostgresConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/PostgresConstant.java
@@ -25,7 +25,7 @@ public class PostgresConstant {
 
     public static final String CONNECTOR = "connector";
 
-    public static final String POSTGRES_CDC = "postgres-cdc";
+    public static final String POSTGRES_CDC = "postgres-cdc-inlong";
 
     public static final String DATABASE_NAME = "database-name";
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
@@ -28,7 +28,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.common.enums.MetaField;
 import org.apache.inlong.sort.protocol.FieldInfo;
-import org.apache.inlong.sort.protocol.InLongMetric;
+import org.apache.inlong.sort.protocol.InlongMetric;
 import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
@@ -47,7 +47,7 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("mysqlExtract")
 @Data
-public class MySqlExtractNode extends ExtractNode implements Metadata, InLongMetric, Serializable {
+public class MySqlExtractNode extends ExtractNode implements Metadata, InlongMetric, Serializable {
 
     private static final long serialVersionUID = -5521981462461235277L;
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
@@ -28,6 +28,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.common.enums.MetaField;
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InLongMetric;
 import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
@@ -46,7 +47,7 @@ import java.util.Set;
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("mysqlExtract")
 @Data
-public class MySqlExtractNode extends ExtractNode implements Metadata, Serializable {
+public class MySqlExtractNode extends ExtractNode implements Metadata, InLongMetric, Serializable {
 
     private static final long serialVersionUID = -5521981462461235277L;
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
@@ -101,7 +101,7 @@ public class PostgresExtractNode extends ExtractNode implements Metadata, InLong
      *
      * @return options
      * @see <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/postgres-cdc.html">postgres
-     *         cdc</a>
+     * cdc</a>
      */
     @Override
     public Map<String, String> tableOptions() {

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.common.enums.MetaField;
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InLongMetric;
 import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.constant.PostgresConstant;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
@@ -46,7 +47,7 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("postgresExtract")
 @Data
-public class PostgresExtractNode extends ExtractNode implements Metadata, Serializable {
+public class PostgresExtractNode extends ExtractNode implements Metadata, InLongMetric, Serializable {
 
     private static final long serialVersionUID = 1L;
     @JsonProperty("primaryKey")
@@ -100,7 +101,7 @@ public class PostgresExtractNode extends ExtractNode implements Metadata, Serial
      *
      * @return options
      * @see <a href="https://ververica.github.io/flink-cdc-connectors/master/content/connectors/postgres-cdc.html">postgres
-     * cdc</a>
+     *         cdc</a>
      */
     @Override
     public Map<String, String> tableOptions() {

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PostgresExtractNode.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.common.enums.MetaField;
 import org.apache.inlong.sort.protocol.FieldInfo;
-import org.apache.inlong.sort.protocol.InLongMetric;
+import org.apache.inlong.sort.protocol.InlongMetric;
 import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.constant.PostgresConstant;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
@@ -47,7 +47,7 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("postgresExtract")
 @Data
-public class PostgresExtractNode extends ExtractNode implements Metadata, InLongMetric, Serializable {
+public class PostgresExtractNode extends ExtractNode implements Metadata, InlongMetric, Serializable {
 
     private static final long serialVersionUID = 1L;
     @JsonProperty("primaryKey")

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HbaseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HbaseLoadNode.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InLongMetric;
 import org.apache.inlong.sort.protocol.constant.HBaseConstant;
 import org.apache.inlong.sort.protocol.enums.FilterStrategy;
 import org.apache.inlong.sort.protocol.node.LoadNode;
@@ -44,7 +45,7 @@ import java.util.Map;
 @JsonTypeName("hbaseLoad")
 @Data
 @NoArgsConstructor
-public class HbaseLoadNode extends LoadNode implements Serializable {
+public class HbaseLoadNode extends LoadNode implements InLongMetric, Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HbaseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/HbaseLoadNode.java
@@ -27,7 +27,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.sort.protocol.FieldInfo;
-import org.apache.inlong.sort.protocol.InLongMetric;
+import org.apache.inlong.sort.protocol.InlongMetric;
 import org.apache.inlong.sort.protocol.constant.HBaseConstant;
 import org.apache.inlong.sort.protocol.enums.FilterStrategy;
 import org.apache.inlong.sort.protocol.node.LoadNode;
@@ -45,7 +45,7 @@ import java.util.Map;
 @JsonTypeName("hbaseLoad")
 @Data
 @NoArgsConstructor
-public class HbaseLoadNode extends LoadNode implements InLongMetric, Serializable {
+public class HbaseLoadNode extends LoadNode implements InlongMetric, Serializable {
 
     private static final long serialVersionUID = 1L;
 

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -29,7 +29,7 @@ import org.apache.inlong.sort.parser.result.FlinkSqlParseResult;
 import org.apache.inlong.sort.parser.result.ParseResult;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.GroupInfo;
-import org.apache.inlong.sort.protocol.InLongMetric;
+import org.apache.inlong.sort.protocol.InlongMetric;
 import org.apache.inlong.sort.protocol.MetaFieldInfo;
 import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.StreamInfo;
@@ -144,7 +144,7 @@ public class FlinkSqlParser implements Parser {
         Preconditions.checkState(!streamInfo.getRelations().isEmpty(), "relations is empty");
         log.info("start parse stream, streamId:{}", streamInfo.getStreamId());
         // Inject the `inlong.metric` for ExtractNode or LoadNode
-        injectInLongMetric(streamInfo);
+        injectInlongMetric(streamInfo);
         Map<String, Node> nodeMap = new HashMap<>(streamInfo.getNodes().size());
         streamInfo.getNodes().forEach(s -> {
             Preconditions.checkNotNull(s.getId(), "node id is null");
@@ -167,8 +167,8 @@ public class FlinkSqlParser implements Parser {
      *
      * @param streamInfo The encapsulation of nodes and node relations
      */
-    private void injectInLongMetric(StreamInfo streamInfo) {
-        streamInfo.getNodes().stream().filter(node -> node instanceof InLongMetric).forEach(node -> {
+    private void injectInlongMetric(StreamInfo streamInfo) {
+        streamInfo.getNodes().stream().filter(node -> node instanceof InlongMetric).forEach(node -> {
             Map<String, String> properties = node.getProperties();
             if (properties == null) {
                 properties = new LinkedHashMap<>();
@@ -181,8 +181,8 @@ public class FlinkSqlParser implements Parser {
                             node.getClass().getSimpleName()));
                 }
             }
-            properties.put(InLongMetric.METRIC_KEY,
-                    String.format(InLongMetric.METRIC_VALUE_FORMAT, groupInfo.getGroupId(),
+            properties.put(InlongMetric.METRIC_KEY,
+                    String.format(InlongMetric.METRIC_VALUE_FORMAT, groupInfo.getGroupId(),
                             streamInfo.getStreamId(), node.getId()));
         });
     }

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -172,6 +172,14 @@ public class FlinkSqlParser implements Parser {
             Map<String, String> properties = node.getProperties();
             if (properties == null) {
                 properties = new LinkedHashMap<>();
+                if (node instanceof LoadNode) {
+                    ((LoadNode) node).setProperties(properties);
+                } else if (node instanceof ExtractNode) {
+                    ((ExtractNode) node).setProperties(properties);
+                } else {
+                    throw new UnsupportedOperationException(String.format("Unsupported inlong metric for: %s",
+                            node.getClass().getSimpleName()));
+                }
             }
             properties.put(InLongMetric.METRIC_KEY,
                     String.format(InLongMetric.METRIC_VALUE_FORMAT, groupInfo.getGroupId(),
@@ -803,7 +811,7 @@ public class FlinkSqlParser implements Parser {
                 MetaFieldInfo metaFieldInfo = (MetaFieldInfo) field;
                 Metadata metadataNode = (Metadata) node;
                 if (!metadataNode.supportedMetaFields().contains(metaFieldInfo.getMetaField())) {
-                    throw new UnsupportedOperationException(String.format("Unsupport meta field for %s: %s",
+                    throw new UnsupportedOperationException(String.format("Unsupported meta field for %s: %s",
                             metadataNode.getClass().getSimpleName(), metaFieldInfo.getMetaField()));
                 }
                 sb.append(metadataNode.format(metaFieldInfo.getMetaField()));


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-5312][Sort] Add unified inlong.metric parameter injection support for nodes

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #5312 

### Motivation

At present, many connectors support indicator reporting, but we have not added relevant metric reporting parameters at the entrance. And so, I add unified `inlong.metric` parameter injection support for nodes.

### Modifications

The metric parameter `inlong.metric` will be added to the node options auto if it has implemented the interface InLongMetric.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
