### PR TITLE
[INLONG-4929][Manager] Add stream source API in Manager client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongStream.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongStream.java
@@ -122,4 +122,6 @@ public interface InlongStream {
      */
     InlongStream update();
 
+    StreamSource getSourceById(int sourceId);
+
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongStreamImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongStreamImpl.java
@@ -456,4 +456,13 @@ public class InlongStreamImpl implements InlongStream {
         return this.streamSinks.get(sinkName);
     }
 
+    @Override
+    public StreamSource getSourceById(int sourceId) {
+        Preconditions.checkNotNull(sourceId, "sinkId cannot be null");
+        return this.streamSources.values()
+                .stream()
+                .filter(streamSource -> streamSource.getId().equals(sourceId))
+                .findAny()
+                .orElseGet(() -> sourceClient.get(sourceId));
+    }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/StreamSourceClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/StreamSourceClient.java
@@ -87,4 +87,11 @@ public class StreamSourceClient {
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }
+
+    public StreamSource get(int id) {
+        Preconditions.checkTrue(id > 0, "sourceId is illegal");
+        Response<StreamSource> response = ClientUtils.executeHttpCall(streamSourceApi.get(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/StreamSourceApi.java
@@ -44,4 +44,6 @@ public interface StreamSourceApi {
     @DELETE("source/delete/{id}")
     Call<Response<Boolean>> deleteSource(@Path("id") Integer sourceId);
 
+    @GET("source/get/{id}")
+    Call<Response<StreamSource>> get(@Path("id") Integer id);
 }

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -922,7 +922,7 @@ class ClientFactoryTest {
                 .agentIp("127.0.0.1")
                 .inlongClusterName("test_cluster")
                 .user("root")
-                .password("root")
+                .password("pwd")
                 .hostname("127.0.0.1")
                 .port(3306)
                 .build();

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -31,6 +31,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
+import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
 import org.apache.inlong.manager.client.api.util.ClientUtils;
 import org.apache.inlong.manager.common.auth.DefaultAuthentication;
 import org.apache.inlong.manager.common.consts.MQType;
@@ -101,6 +102,7 @@ class ClientFactoryTest {
     private static WireMockServer wireMockServer;
     private static InlongGroupClient groupClient;
     private static InlongStreamClient streamClient;
+    private static StreamSourceClient sourceClient;
     private static StreamSinkClient sinkClient;
     private static InlongClusterClient clusterClient;
 
@@ -117,6 +119,7 @@ class ClientFactoryTest {
         ClientFactory clientFactory = ClientUtils.getClientFactory(inlongClient.getConfiguration());
         groupClient = clientFactory.getGroupClient();
         streamClient = clientFactory.getStreamClient();
+        sourceClient = clientFactory.getSourceClient();
         sinkClient = clientFactory.getSinkClient();
         streamClient = clientFactory.getStreamClient();
         clusterClient = clientFactory.getClusterClient();
@@ -906,5 +909,33 @@ class ClientFactoryTest {
         );
         ClusterNodeResponse clientNode = clusterClient.getNode(1);
         Assertions.assertEquals(1, clientNode.getId());
+    }
+
+    @Test
+    void testGetStreamSourceById() {
+        StreamSource streamSource = MySQLBinlogSource.builder()
+                .id(1)
+                .inlongGroupId("test_group")
+                .inlongStreamId("test_stream")
+                .sourceType(SourceType.MYSQL_BINLOG)
+                .sourceName("test_source")
+                .agentIp("127.0.0.1")
+                .inlongClusterName("test_cluster")
+                .user("root")
+                .password("root")
+                .hostname("127.0.0.1")
+                .port(3306)
+                .build();
+
+        stubFor(
+                get(urlMatching("/inlong/manager/api/source/get/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(streamSource))
+                                ))
+        );
+        StreamSource sourceInfo = sourceClient.get(1);
+        Assertions.assertEquals(1, sourceInfo.getId());
+        Assertions.assertTrue(sourceInfo instanceof MySQLBinlogSource);
     }
 }


### PR DESCRIPTION
### [INLONG-4929][Manager] Add stream source api in manager client

- Fixes #4929 

### Motivation

Supplement the API that the manager web exists but the client does not exist for manager client.

### Modifications

Add get stream source by id API  in manager client.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is already covered by existing tests, such as:
  org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testGetStreamSourceById
