### PR TITLE
[INLONG-5371][Manager] Add data node API in the manager client

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/DataNode.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/DataNode.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeResponse;
+
+public interface DataNode {
+
+    /**
+     * Save data node.
+     *
+     * @param request data node info
+     * @return cluster id after saving
+     */
+    Integer save(DataNodeRequest request);
+
+    /**
+     * Get data node by id.
+     *
+     * @param id node id
+     * @return node info
+     */
+    DataNodeResponse get(Integer id);
+
+    /**
+     * Paging query nodes according to conditions.
+     *
+     * @param request page request conditions
+     * @return node list
+     */
+    PageInfo<DataNodeResponse> list(DataNodeRequest request);
+
+    /**
+     * Update data node.
+     *
+     * @param request node info to be modified
+     * @return whether succeed
+     */
+    public Boolean update(DataNodeRequest request);
+
+    /**
+     * Delete data node.
+     *
+     * @param id node id to be deleted
+     * @return whether succeed
+     */
+    Boolean delete(Integer id);
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/DataNodeImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/DataNodeImpl.java
@@ -38,33 +38,36 @@ public class DataNodeImpl implements DataNode {
 
     @Override
     public Integer save(DataNodeRequest request) {
-        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
-        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        Preconditions.checkNotNull(request, "request cannot be null");
+        Preconditions.checkNotEmpty(request.getName(), "data node name cannot be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type cannot be empty");
         return dataNodeClient.save(request);
     }
 
     @Override
     public DataNodeResponse get(Integer id) {
-        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Preconditions.checkNotNull(id, "data node id cannot be null");
         return dataNodeClient.get(id);
     }
 
     @Override
     public PageInfo<DataNodeResponse> list(DataNodeRequest request) {
+        Preconditions.checkNotNull(request, "request cannot be null");
         return dataNodeClient.list(request);
     }
 
     @Override
     public Boolean update(DataNodeRequest request) {
-        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
-        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
-        Preconditions.checkNotNull(request.getId(), "data node id should not be empty");
+        Preconditions.checkNotNull(request, "request cannot be null");
+        Preconditions.checkNotEmpty(request.getName(), "data node name cannot be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type cannot be empty");
+        Preconditions.checkNotNull(request.getId(), "data node id cannot be null");
         return dataNodeClient.update(request);
     }
 
     @Override
     public Boolean delete(Integer id) {
-        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Preconditions.checkNotNull(id, "data node id cannot be null");
         return dataNodeClient.delete(id);
     }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/DataNodeImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/DataNodeImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.impl;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.client.api.ClientConfiguration;
+import org.apache.inlong.manager.client.api.DataNode;
+import org.apache.inlong.manager.client.api.inner.client.ClientFactory;
+import org.apache.inlong.manager.client.api.inner.client.DataNodeClient;
+import org.apache.inlong.manager.client.api.util.ClientUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeResponse;
+
+public class DataNodeImpl implements DataNode {
+
+    private final DataNodeClient dataNodeClient;
+
+    public DataNodeImpl(ClientConfiguration configuration) {
+        ClientFactory clientFactory = ClientUtils.getClientFactory(configuration);
+        this.dataNodeClient = clientFactory.getDataNodeClient();
+    }
+
+    @Override
+    public Integer save(DataNodeRequest request) {
+        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        return dataNodeClient.save(request);
+    }
+
+    @Override
+    public DataNodeResponse get(Integer id) {
+        Preconditions.checkNotNull(id, "data node id should not be empty");
+        return dataNodeClient.get(id);
+    }
+
+    @Override
+    public PageInfo<DataNodeResponse> list(DataNodeRequest request) {
+        return dataNodeClient.list(request);
+    }
+
+    @Override
+    public Boolean update(DataNodeRequest request) {
+        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        Preconditions.checkNotNull(request.getId(), "data node id should not be empty");
+        return dataNodeClient.update(request);
+    }
+
+    @Override
+    public Boolean delete(Integer id) {
+        Preconditions.checkNotNull(id, "data node id should not be empty");
+        return dataNodeClient.delete(id);
+    }
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/ClientFactory.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/ClientFactory.java
@@ -40,6 +40,8 @@ public class ClientFactory {
 
     private final WorkflowClient workflowClient;
 
+    private final DataNodeClient dataNodeClient;
+
     public ClientFactory(ClientConfiguration configuration) {
         groupClient = new InlongGroupClient(configuration);
         streamClient = new InlongStreamClient(configuration);
@@ -48,5 +50,6 @@ public class ClientFactory {
         clusterClient = new InlongClusterClient(configuration);
         transformClient = new StreamTransformClient(configuration);
         workflowClient = new WorkflowClient(configuration);
+        dataNodeClient = new DataNodeClient(configuration);
     }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/DataNodeClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/DataNodeClient.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.inner.client;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.client.api.ClientConfiguration;
+import org.apache.inlong.manager.client.api.service.DataNodeApi;
+import org.apache.inlong.manager.client.api.util.ClientUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeResponse;
+
+/**
+ * Client for {@link DataNodeApi}.
+ */
+public class DataNodeClient {
+
+    private final DataNodeApi dataNodeApi;
+
+    public DataNodeClient(ClientConfiguration configuration) {
+        dataNodeApi = ClientUtils.createRetrofit(configuration).create(DataNodeApi.class);
+    }
+
+    /**
+     * Save data node.
+     *
+     * @param request data node info
+     * @return cluster id after saving
+     */
+    public Integer save(DataNodeRequest request) {
+        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        Response<Integer> response = ClientUtils.executeHttpCall(dataNodeApi.save(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Get data node by id.
+     *
+     * @param id node id
+     * @return node info
+     */
+    public DataNodeResponse get(Integer id) {
+        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Response<DataNodeResponse> response = ClientUtils.executeHttpCall(dataNodeApi.get(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Paging query nodes according to conditions.
+     *
+     * @param request page request conditions
+     * @return node list
+     */
+    public PageInfo<DataNodeResponse> list(DataNodeRequest request) {
+        Response<PageInfo<DataNodeResponse>> response = ClientUtils.executeHttpCall(dataNodeApi.list(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Update data node.
+     *
+     * @param request node info to be modified
+     * @return whether succeed
+     */
+    public Boolean update(DataNodeRequest request) {
+        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        Preconditions.checkNotNull(request.getId(), "data node id should not be empty");
+        Response<Boolean> response = ClientUtils.executeHttpCall(dataNodeApi.update(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Delete data node.
+     *
+     * @param id node id to be deleted
+     * @return whether succeed
+     */
+    public Boolean delete(Integer id) {
+        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Response<Boolean> response = ClientUtils.executeHttpCall(dataNodeApi.delete(id));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/DataNodeClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/DataNodeClient.java
@@ -44,8 +44,9 @@ public class DataNodeClient {
      * @return cluster id after saving
      */
     public Integer save(DataNodeRequest request) {
-        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
-        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
+        Preconditions.checkNotNull(request, "request cannot be null");
+        Preconditions.checkNotEmpty(request.getName(), "data node name cannot be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type cannot be empty");
         Response<Integer> response = ClientUtils.executeHttpCall(dataNodeApi.save(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
@@ -58,7 +59,7 @@ public class DataNodeClient {
      * @return node info
      */
     public DataNodeResponse get(Integer id) {
-        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Preconditions.checkNotNull(id, "data node id cannot be null");
         Response<DataNodeResponse> response = ClientUtils.executeHttpCall(dataNodeApi.get(id));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
@@ -71,6 +72,7 @@ public class DataNodeClient {
      * @return node list
      */
     public PageInfo<DataNodeResponse> list(DataNodeRequest request) {
+        Preconditions.checkNotNull(request, "request cannot be null");
         Response<PageInfo<DataNodeResponse>> response = ClientUtils.executeHttpCall(dataNodeApi.list(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
@@ -83,9 +85,10 @@ public class DataNodeClient {
      * @return whether succeed
      */
     public Boolean update(DataNodeRequest request) {
-        Preconditions.checkNotEmpty(request.getName(), "data node name should not be empty");
-        Preconditions.checkNotEmpty(request.getType(), "data node type should not be empty");
-        Preconditions.checkNotNull(request.getId(), "data node id should not be empty");
+        Preconditions.checkNotNull(request, "request cannot be null");
+        Preconditions.checkNotEmpty(request.getName(), "data node name cannot be empty");
+        Preconditions.checkNotEmpty(request.getType(), "data node type cannot be empty");
+        Preconditions.checkNotNull(request.getId(), "data node id cannot be null");
         Response<Boolean> response = ClientUtils.executeHttpCall(dataNodeApi.update(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
@@ -98,7 +101,7 @@ public class DataNodeClient {
      * @return whether succeed
      */
     public Boolean delete(Integer id) {
-        Preconditions.checkNotNull(id, "data node id should not be empty");
+        Preconditions.checkNotNull(id, "data node id cannot be null");
         Response<Boolean> response = ClientUtils.executeHttpCall(dataNodeApi.delete(id));
         ClientUtils.assertRespSuccess(response);
         return response.getData();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/DataNodeApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/DataNodeApi.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import com.github.pagehelper.PageInfo;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeResponse;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+public interface DataNodeApi {
+
+    @POST("node/save")
+    Call<Response<Integer>> save(@Body DataNodeRequest request);
+
+    @GET("node/get/{id}")
+    Call<Response<DataNodeResponse>> get(@Path("id") Integer id);
+
+    @POST("node/list")
+    Call<Response<PageInfo<DataNodeResponse>>> list(@Body DataNodeRequest request);
+
+    @POST("node/update")
+    Call<Response<Boolean>> update(@Body DataNodeRequest request);
+
+    @DELETE("node/delete/{id}")
+    Call<Response<Boolean>> delete(@Path("id") Integer id);
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/DataNodeResponse.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/DataNodeResponse.java
@@ -20,7 +20,10 @@ package org.apache.inlong.manager.pojo.node;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
@@ -28,6 +31,9 @@ import java.util.Date;
  * Data node response
  */
 @Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @ApiModel("Data node response")
 public class DataNodeResponse {
 


### PR DESCRIPTION
### [INLONG-5371][Manager] Add data node API in the manager client

- Fixes #5371 

### Motivation

Supplement the API that the manager web exists but the client does not exist for manager client.

### Modifications

Add data node API in the manager client

### Verifying this change
- [x] This change added tests and can be verified as follows:
- org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testSaveDataNode

- org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testGetDataNode

- org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testListDataNode

- org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testUpdateDataNode

- org.apache.inlong.manager.client.api.inner.ClientFactoryTest#testDeleteDataNode