### PR TITLE
[INLONG-5375][Sort] Iceberg-inlong connector lose its meta-inf

### DIFF
--- a/inlong-sort/sort-connectors/iceberg-dlc/pom.xml
+++ b/inlong-sort/sort-connectors/iceberg-dlc/pom.xml
@@ -31,7 +31,7 @@
     <name>Apache InLong - Sort-connector-iceberg-dlc</name>
     <packaging>jar</packaging>
     <description>
-        DLC is a data lake product.It's storage is based on iceberg.
+        DLC is a data lake product. It's storage is based on iceberg.
         Here is the product: https://cloud.tencent.com/product/dlc
     </description>
 

--- a/inlong-sort/sort-connectors/iceberg-dlc/pom.xml
+++ b/inlong-sort/sort-connectors/iceberg-dlc/pom.xml
@@ -133,6 +133,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <include>org.apache.inlong:*</include>
                                     <include>org.apache.iceberg:*</include>
                                     <include>org.apache.hive:hive-exec</include>
 

--- a/inlong-sort/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-connectors/iceberg/pom.xml
@@ -81,6 +81,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
+                                    <include>org.apache.inlong:*</include>
                                     <include>org.apache.iceberg:*</include>
                                     <include>org.apache.hive:hive-exec</include>
                                     <include>org.apache.thrift:libfb303</include>


### PR DESCRIPTION

- Fixes #5375 

### Motivation

Iceberg-inlong connector lose its meta-inf

### Modifications

change two pom

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
