### PR TITLE
[INLONG-5409][Manager] Fix json serialization for class BaseSortConf

### DIFF
--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -66,6 +66,7 @@ import org.apache.inlong.manager.pojo.sink.iceberg.IcebergSink;
 import org.apache.inlong.manager.pojo.sink.kafka.KafkaSink;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSink;
 import org.apache.inlong.manager.pojo.sink.postgresql.PostgreSQLSink;
+import org.apache.inlong.manager.pojo.sort.FlinkSortConf;
 import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.source.autopush.AutoPushSource;
 import org.apache.inlong.manager.pojo.source.file.FileSource;
@@ -144,6 +145,7 @@ class ClientFactoryTest {
 
     @Test
     void testGetGroupInfo() {
+        FlinkSortConf flinkSortConf = new FlinkSortConf();
         InlongPulsarInfo inlongGroupResponse = InlongPulsarInfo.builder()
                 .id(1)
                 .inlongGroupId("1")
@@ -157,7 +159,7 @@ class ClientFactoryTest {
                                 .keyValue("keyValue")
                                 .build()
                         )
-                ).build();
+                ).sortConf(flinkSortConf).build();
 
         stubFor(
                 get(urlMatching("/inlong/manager/api/group/get/1.*"))

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/BaseSortConf.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/BaseSortConf.java
@@ -29,8 +29,6 @@ import lombok.Data;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, visible = true, property = "sortType")
 public abstract class BaseSortConf {
 
-    public String sortType;
-
     public abstract SortType getType();
 
     public static final String SORT_FLINK = "flink";

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/FlinkSortConf.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/FlinkSortConf.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.sort;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Maps;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -37,10 +36,6 @@ import java.util.Map;
 @JsonTypeDefine(value = BaseSortConf.SORT_FLINK)
 public class FlinkSortConf extends BaseSortConf {
 
-    @JsonIgnore
-    @ApiModelProperty(value = "Sort type")
-    private SortType type = SortType.FLINK;
-
     @ApiModelProperty("Authentication")
     private Authentication authentication;
 
@@ -52,4 +47,8 @@ public class FlinkSortConf extends BaseSortConf {
 
     @ApiModelProperty("Other properties if needed")
     private Map<String, String> properties = Maps.newHashMap();
+
+    public SortType getType() {
+        return SortType.FLINK;
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/UserDefinedSortConf.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/UserDefinedSortConf.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.sort;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.Maps;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -36,13 +35,13 @@ import java.util.Map;
 @JsonTypeDefine(value = BaseSortConf.SORT_USER_DEFINED)
 public class UserDefinedSortConf extends BaseSortConf {
 
-    @JsonIgnore
-    @ApiModelProperty(value = "Sort type")
-    private SortType type = SortType.USER_DEFINED;
-
     @ApiModelProperty("Name for user defined sort functions")
     private String sortName;
 
     @ApiModelProperty("Properties for user defined sort functions if needed")
     private Map<String, String> properties = Maps.newHashMap();
+
+    public SortType getType() {
+        return SortType.USER_DEFINED;
+    }
 }

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/BaseSortConfTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/BaseSortConfTest.java
@@ -1,0 +1,43 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sort;
+
+import org.apache.inlong.manager.common.util.JsonUtils;
+import org.apache.inlong.manager.pojo.sort.BaseSortConf.SortType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link BaseSortConf}
+ */
+public class BaseSortConfTest {
+
+    @Test
+    public void testSerde() {
+        FlinkSortConf flinkSortConf = new FlinkSortConf();
+        BaseSortConf baseSortConf = JsonUtils.parseObject(JsonUtils.toJsonString(flinkSortConf), BaseSortConf.class);
+        Assertions.assertEquals(baseSortConf.getType(), SortType.FLINK);
+
+        UserDefinedSortConf userDefinedSortConf = new UserDefinedSortConf();
+        BaseSortConf baseSortConf1 = JsonUtils.parseObject(JsonUtils.toJsonString(userDefinedSortConf),
+                BaseSortConf.class);
+        Assertions.assertEquals(baseSortConf1.getType(), SortType.USER_DEFINED);
+    }
+
+}


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-5409][Manager] Fix json serialization for class BaseSortConf

- Fixes #5409 

### Motivation

 Fix json serialization for class BaseSortConf

### Modifications

* Remove `sortType` field for BaseSortConf
* Add `getType` method for FlinkSortConf and UserDefinedSortConf
* Remove `type` field for FlinkSortConf and UserDefinedSortConf
* Add UT for BaseSortConf
