### PR TITLE
[INLONG-5432][Manager] Return the type of the MQ cluster when processing the getConfig method

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/MQClusterInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/MQClusterInfo.java
@@ -27,6 +27,7 @@ public class MQClusterInfo {
 
     private String url;
     private String token;
+    private String mqType;
     private Map<String, String> params = new HashMap<>();
 
     public String getUrl() {
@@ -43,6 +44,14 @@ public class MQClusterInfo {
 
     public void setToken(String token) {
         this.token = token;
+    }
+
+    public String getMqType() {
+        return mqType;
+    }
+
+    public void setMqType(String mqType) {
+        this.mqType = mqType;
     }
 
     public Map<String, String> getParams() {

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -128,6 +128,12 @@
             <if test="clusterTag != null and clusterTag != ''">
                 and find_in_set(#{clusterTag, jdbcType=VARCHAR}, cluster_tags)
             </if>
+            <if test="clusterTagList != null and clusterTagList.size()>0">
+                and
+                <foreach item="item" index="index" collection="clusterTagList" open="(" close=")" separator="or">
+                    find_in_set(#{item}, cluster_tags)
+                </foreach>
+            </if>
             <if test="extTag != null and extTag != ''">
                 and ext_tag = #{extTag, jdbcType=VARCHAR}
             </if>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -119,7 +119,7 @@
             <if test="type != null and type != ''">
                 and `type` = #{type, jdbcType=VARCHAR}
             </if>
-            <if test="typeList != null and typeList.size()>0">
+            <if test="typeList != null and typeList.size() > 0">
                 and `type` in
                 <foreach item="item" index="index" collection="typeList" open="(" close=")" separator=",">
                     #{item}
@@ -128,7 +128,7 @@
             <if test="clusterTag != null and clusterTag != ''">
                 and find_in_set(#{clusterTag, jdbcType=VARCHAR}, cluster_tags)
             </if>
-            <if test="clusterTagList != null and clusterTagList.size()>0">
+            <if test="clusterTagList != null and clusterTagList.size() > 0">
                 and
                 <foreach item="item" index="index" collection="clusterTagList" open="(" close=")" separator="or">
                     find_in_set(#{item}, cluster_tags)

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -737,6 +737,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
             MQClusterInfo clusterInfo = new MQClusterInfo();
             clusterInfo.setUrl(cluster.getUrl());
             clusterInfo.setToken(cluster.getToken());
+            clusterInfo.setMqType(cluster.getType());
             Map<String, String> configParams = GSON.fromJson(cluster.getExtParams(), Map.class);
             clusterInfo.setParams(configParams);
             mqSet.add(clusterInfo);


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5432 

### Motivation

Return the type of the MQ cluster when processing the getConfig method

### Modifications

Return the type of the MQ cluster when processing the getConfig method

`mqType` is added to the returned information.

The mq type returned is `TUBEMQ` and `PULSAR`.

### Verifying this change

*(Please pick either of the following options)*

- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)
