### PR TITLE
[INLONG-5533][Agent] Support structured output in the Kubernetes

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
@@ -54,8 +54,11 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_FILE_LINE_END_PATTERN = "job.fileJob.line.endPattern";
     public static final String JOB_FILE_CONTENT_COLLECT_TYPE = "job.fileJob.contentCollectType";
     public static final String JOB_FILE_META_ENV_LIST = "job.fileJob.envList";
-    public static final String JOB_FILE_DATA_SOURCE_COLUMN_SEPARATOR = "job.fileJob.dataSeparator";
     public static final String JOB_FILE_META_FILTER_BY_LABELS = "job.fileJob.filterMetaByLabels";
+    public static final String JOB_FILE_PROPERTIES = "job.fileJob.properties";
+    public static final String JOB_FILE_DATA_SOURCE_COLUMN_SEPARATOR = "job.fileJob.dataSeparator";
+    public static final String JOB_FILE_DATA_CONTENT = "_content_";
+    public static final String JOB_FILE_DATA_CONTENT_TIME = "_time_";
 
     //Binlog job
     public static final String JOB_DATABASE_USER = "job.binlogJob.user";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
@@ -57,8 +57,6 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_FILE_META_FILTER_BY_LABELS = "job.fileJob.filterMetaByLabels";
     public static final String JOB_FILE_PROPERTIES = "job.fileJob.properties";
     public static final String JOB_FILE_DATA_SOURCE_COLUMN_SEPARATOR = "job.fileJob.dataSeparator";
-    public static final String JOB_FILE_DATA_CONTENT = "_content_";
-    public static final String JOB_FILE_DATA_CONTENT_TIME = "_time_";
 
     //Binlog job
     public static final String JOB_DATABASE_USER = "job.binlogJob.user";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/KubernetesConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/KubernetesConstants.java
@@ -39,6 +39,8 @@ public class KubernetesConstants {
     public static final String METADATA_POD_UID = "_pod_uid_";
     public static final String METADATA_POD_NAME = "_pod_name_";
     public static final String METADATA_POD_LABEL = "_pod_label_";
+    public static final String DATA_CONTENT = "_content_";
+    public static final String DATA_CONTENT_TIME = "_time_";
 
 
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/KubernetesConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/KubernetesConstants.java
@@ -18,7 +18,7 @@
 package org.apache.inlong.agent.constant;
 
 /**
- *  k8s information
+ * k8s information
  */
 public class KubernetesConstants {
 
@@ -31,6 +31,14 @@ public class KubernetesConstants {
     public static final String POD_NAME = "pod.name";
     public static final String CONTAINER_NAME = "container.name";
     public static final String CONTAINER_ID = "container.id";
+
+    // k8s metadata
+    public static final String METADATA_CONTAINER_ID = "_container_id_";
+    public static final String METADATA_CONTAINER_NAME = "_container_name_";
+    public static final String METADATA_NAMESPACE = "_namespace_";
+    public static final String METADATA_POD_UID = "_pod_uid_";
+    public static final String METADATA_POD_NAME = "_pod_name_";
+    public static final String METADATA_POD_LABEL = "_pod_label_";
 
 
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
@@ -27,18 +27,17 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_CONTENT_COLLECT_TYPE;
-import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_DATA_CONTENT;
-import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_DATA_CONTENT_TIME;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_META_FILTER_BY_LABELS;
+import static org.apache.inlong.agent.constant.KubernetesConstants.DATA_CONTENT;
+import static org.apache.inlong.agent.constant.KubernetesConstants.DATA_CONTENT_TIME;
 
 /**
  * File reader template
  */
 public abstract class AbstractFileReader {
 
-    public FileReaderOperator fileReaderOperator;
-
     private static final Gson GSON = new Gson();
+    public FileReaderOperator fileReaderOperator;
 
     public abstract void getData() throws Exception;
 
@@ -52,15 +51,15 @@ public abstract class AbstractFileReader {
             if (Objects.nonNull(fileReaderOperator.metadata)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>(fileReaderOperator.metadata);
-                    mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
-                    mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
+                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(DATA_CONTENT_TIME, String.valueOf(timestamp));
                     return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());
             } else if (!fileReaderOperator.jobConf.hasKey(JOB_FILE_META_FILTER_BY_LABELS)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>();
-                    mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
-                    mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
+                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(DATA_CONTENT_TIME, String.valueOf(timestamp));
                     return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());
             }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
@@ -38,6 +38,8 @@ public abstract class AbstractFileReader {
 
     public FileReaderOperator fileReaderOperator;
 
+    private static final Gson GSON = new Gson();
+
     public abstract void getData() throws Exception;
 
     public void mergeData(FileReaderOperator fileReaderOperator) {
@@ -47,20 +49,19 @@ public abstract class AbstractFileReader {
         List<String> lines = fileReaderOperator.stream.collect(Collectors.toList());
         if (fileReaderOperator.jobConf.hasKey(JOB_FILE_CONTENT_COLLECT_TYPE)) {
             long timestamp = System.currentTimeMillis();
-            Gson gson = new Gson();
             if (Objects.nonNull(fileReaderOperator.metadata)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>(fileReaderOperator.metadata);
                     mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
                     mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
-                    return gson.toJson(mergeData);
+                    return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());
             } else if (!fileReaderOperator.jobConf.hasKey(JOB_FILE_META_FILTER_BY_LABELS)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>();
                     mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
                     mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
-                    return gson.toJson(mergeData);
+                    return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());
             }
         }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
@@ -17,10 +17,19 @@
 
 package org.apache.inlong.agent.plugin.sources.reader.file;
 
-import org.apache.inlong.agent.plugin.utils.MetaDataUtils;
+import com.google.gson.Gson;
+import org.apache.inlong.agent.plugin.utils.FileDataUtils;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_CONTENT_COLLECT_TYPE;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_DATA_CONTENT;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_DATA_CONTENT_TIME;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_META_FILTER_BY_LABELS;
 
 /**
  * File reader template
@@ -35,9 +44,26 @@ public abstract class AbstractFileReader {
         if (null == fileReaderOperator.metadata) {
             return;
         }
-
         List<String> lines = fileReaderOperator.stream.collect(Collectors.toList());
-        lines.forEach(data -> data = MetaDataUtils.concatString(data, fileReaderOperator.metadata));
+        if (fileReaderOperator.jobConf.hasKey(JOB_FILE_CONTENT_COLLECT_TYPE)) {
+            long timestamp = System.currentTimeMillis();
+            Gson gson = new Gson();
+            if (Objects.nonNull(fileReaderOperator.metadata)) {
+                lines = lines.stream().map(data -> {
+                    Map<String, String> mergeData = new HashMap<>(fileReaderOperator.metadata);
+                    mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
+                    return gson.toJson(mergeData);
+                }).collect(Collectors.toList());
+            } else if (!fileReaderOperator.jobConf.hasKey(JOB_FILE_META_FILTER_BY_LABELS)) {
+                lines = lines.stream().map(data -> {
+                    Map<String, String> mergeData = new HashMap<>();
+                    mergeData.put(JOB_FILE_DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(JOB_FILE_DATA_CONTENT_TIME, String.valueOf(timestamp));
+                    return gson.toJson(mergeData);
+                }).collect(Collectors.toList());
+            }
+        }
         fileReaderOperator.stream = lines.stream();
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/FileReaderOperator.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/FileReaderOperator.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -58,7 +59,7 @@ public class FileReaderOperator extends AbstractReader {
     public int position;
     public String md5;
     public Stream<String> stream;
-    public String metadata;
+    public Map<String, String> metadata;
     public JobProfile jobConf;
     private Iterator<String> iterator;
     private long timeout;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
@@ -60,6 +60,7 @@ import static org.apache.inlong.agent.constant.KubernetesConstants.POD_NAME;
 public final class KubernetesFileReader extends AbstractFileReader {
 
     private static final Logger log = LoggerFactory.getLogger(KubernetesFileReader.class);
+    private static final Gson GSON = new Gson();
 
     private KubernetesClient client;
 
@@ -74,6 +75,7 @@ public final class KubernetesFileReader extends AbstractFileReader {
         try {
             client = getKubernetesClient();
         } catch (IOException e) {
+            e.printStackTrace();
             log.error("Get k8s client error: {}", e.getMessage());
         }
         fileReaderOperator.metadata = getK8sMetadata(fileReaderOperator.jobConf);
@@ -129,7 +131,6 @@ public final class KubernetesFileReader extends AbstractFileReader {
         Pod pod = client.pods().inNamespace(k8sInfo.get(NAMESPACE)).withName(k8sInfo.get(POD_NAME)).get();
         PodList podList = client.pods().inNamespace(k8sInfo.get(NAMESPACE))
                 .withLabels(MetaDataUtils.getPodLabels(jobConf)).list();
-        Gson gson = new Gson();
         Map<String, String> metadata = new HashMap<>();
         podList.getItems().forEach(data -> {
             if (data.equals(pod)) {
@@ -138,7 +139,7 @@ public final class KubernetesFileReader extends AbstractFileReader {
                 metadata.put(METADATA_CONTAINER_ID, k8sInfo.get(CONTAINER_ID));
                 metadata.put(METADATA_POD_NAME, k8sInfo.get(POD_NAME));
                 metadata.put(METADATA_POD_UID, pod.getMetadata().getUid());
-                metadata.put(METADATA_POD_LABEL, gson.toJson(pod.getMetadata().getLabels()));
+                metadata.put(METADATA_POD_LABEL, GSON.toJson(pod.getMetadata().getLabels()));
             }
         });
         return metadata;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources.reader.file;
 
-import io.fabric8.kubernetes.api.model.ObjectMeta;
+import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.Config;
@@ -26,20 +26,31 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.inlong.agent.conf.JobProfile;
 import org.apache.inlong.agent.constant.CommonConstants;
 import org.apache.inlong.agent.plugin.utils.MetaDataUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
+import static org.apache.inlong.agent.constant.KubernetesConstants.CONTAINER_ID;
+import static org.apache.inlong.agent.constant.KubernetesConstants.CONTAINER_NAME;
 import static org.apache.inlong.agent.constant.KubernetesConstants.HTTPS;
 import static org.apache.inlong.agent.constant.KubernetesConstants.KUBERNETES_SERVICE_HOST;
 import static org.apache.inlong.agent.constant.KubernetesConstants.KUBERNETES_SERVICE_PORT;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_CONTAINER_ID;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_CONTAINER_NAME;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_NAMESPACE;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_POD_LABEL;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_POD_NAME;
+import static org.apache.inlong.agent.constant.KubernetesConstants.METADATA_POD_UID;
 import static org.apache.inlong.agent.constant.KubernetesConstants.NAMESPACE;
 import static org.apache.inlong.agent.constant.KubernetesConstants.POD_NAME;
 
@@ -60,13 +71,16 @@ public final class KubernetesFileReader extends AbstractFileReader {
         if (Objects.nonNull(client) && Objects.nonNull(fileReaderOperator.metadata)) {
             return;
         }
-        client = getKubernetesClient();
-        Map<String, String> k8sInfo = MetaDataUtils.getLogInfo(fileReaderOperator.file.getName());
-        ObjectMeta objectMeta = getPodMetadata(k8sInfo.get(NAMESPACE), k8sInfo.get(POD_NAME));
-        fileReaderOperator.metadata = Objects.nonNull(objectMeta) ? objectMeta.toString() : null;
+        try {
+            client = getKubernetesClient();
+        } catch (IOException e) {
+            log.error("Get k8s client error: {}", e.getMessage());
+        }
+        fileReaderOperator.metadata = getK8sMetadata(fileReaderOperator.jobConf);
     }
 
-    private KubernetesClient getKubernetesClient() {
+    // TODO only support default config in the POD
+    private KubernetesClient getKubernetesClient() throws IOException {
         String ip = System.getProperty(KUBERNETES_SERVICE_HOST);
         String port = System.getProperty(KUBERNETES_SERVICE_PORT);
         if (Objects.isNull(ip) || Objects.isNull(port)) {
@@ -74,8 +88,13 @@ public final class KubernetesFileReader extends AbstractFileReader {
             return null;
         }
         String maserUrl = HTTPS.concat(ip).concat(CommonConstants.AGENT_COLON).concat(port);
-        Config cofig = new ConfigBuilder().withMasterUrl(maserUrl).build();
-        return new KubernetesClientBuilder().withConfig(cofig).build();
+        Config config = new ConfigBuilder()
+                .withMasterUrl(maserUrl)
+                .withCaCertFile(Config.KUBERNETES_SERVICE_ACCOUNT_CA_CRT_PATH)
+                .withOauthToken(new String(
+                        Files.readAllBytes((new File(Config.KUBERNETES_SERVICE_ACCOUNT_TOKEN_PATH)).toPath())))
+                .build();
+        return new KubernetesClientBuilder().withConfig(config).build();
     }
 
     /**
@@ -92,11 +111,36 @@ public final class KubernetesFileReader extends AbstractFileReader {
     /**
      * get pod metadata by namespace and pod name
      */
-    public ObjectMeta getPodMetadata(String namespace, String podName) {
-        List<ObjectMeta> objectMetas = client.pods().list().getItems().stream().map(Pod::getMetadata)
-                .filter(data -> data.getName().equalsIgnoreCase(podName) && data.getNamespace()
-                        .equalsIgnoreCase(namespace)).collect(Collectors.toList());
-        return CollectionUtils.isNotEmpty(objectMetas) ? objectMetas.get(0) : null;
+    public Map<String, String> getK8sMetadata(JobProfile jobConf) {
+        if (Objects.isNull(jobConf)) {
+            return null;
+        }
+        Map<String, String> k8sInfo = MetaDataUtils.getLogInfo(fileReaderOperator.file.getName());
+        if (k8sInfo.isEmpty()) {
+            return null;
+        }
+        List<String> namespaces = MetaDataUtils.getNamespace(jobConf);
+        if (Objects.isNull(namespaces) || namespaces.isEmpty()) {
+            return null;
+        }
+        if (!namespaces.contains(k8sInfo.get(NAMESPACE))) {
+            return null;
+        }
+        Pod pod = client.pods().inNamespace(k8sInfo.get(NAMESPACE)).withName(k8sInfo.get(POD_NAME)).get();
+        PodList podList = client.pods().inNamespace(k8sInfo.get(NAMESPACE))
+                .withLabels(MetaDataUtils.getPodLabels(jobConf)).list();
+        Gson gson = new Gson();
+        Map<String, String> metadata = new HashMap<>();
+        podList.getItems().forEach(data -> {
+            if (data.equals(pod)) {
+                metadata.put(METADATA_NAMESPACE, k8sInfo.get(NAMESPACE));
+                metadata.put(METADATA_CONTAINER_NAME, k8sInfo.get(CONTAINER_NAME));
+                metadata.put(METADATA_CONTAINER_ID, k8sInfo.get(CONTAINER_ID));
+                metadata.put(METADATA_POD_NAME, k8sInfo.get(POD_NAME));
+                metadata.put(METADATA_POD_UID, pod.getMetadata().getUid());
+                metadata.put(METADATA_POD_LABEL, gson.toJson(pod.getMetadata().getLabels()));
+            }
+        });
+        return metadata;
     }
-
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
@@ -75,8 +75,7 @@ public final class KubernetesFileReader extends AbstractFileReader {
         try {
             client = getKubernetesClient();
         } catch (IOException e) {
-            e.printStackTrace();
-            log.error("Get k8s client error: {}", e.getMessage());
+            log.error("Get k8s client error: ", e);
         }
         fileReaderOperator.metadata = getK8sMetadata(fileReaderOperator.jobConf);
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
@@ -30,17 +30,20 @@ import java.util.Map;
  */
 public class FileDataUtils {
 
-    public static final  String KUBERNETES_LOG = "log";
+    public static final String KUBERNETES_LOG = "log";
 
-    // Get standard log for k8s
+    private static final Gson GSON = new Gson();
+
+    /**
+     * Get standard log for k8s
+     */
     public static String getK8sJsonLog(String log) {
         if (!StringUtils.isNoneBlank(log)) {
             return null;
         }
-        Gson gson = new Gson();
         Type type = new TypeToken<HashMap<Integer, String>>() {
         }.getType();
-        Map<String, String> logJson = gson.fromJson(log, type);
+        Map<String, String> logJson = GSON.fromJson(log, type);
         return logJson.get(KUBERNETES_LOG);
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
+
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * File job utils
+ */
+public class FileDataUtils {
+
+    public static final  String KUBERNETES_LOG = "log";
+
+    // Get standard log for k8s
+    public static String getK8sJsonLog(String log) {
+        if (!StringUtils.isNoneBlank(log)) {
+            return null;
+        }
+        Gson gson = new Gson();
+        Type type = new TypeToken<HashMap<Integer, String>>() {
+        }.getType();
+        Map<String, String> logJson = gson.fromJson(log, type);
+        return logJson.get(KUBERNETES_LOG);
+    }
+
+}

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
@@ -42,6 +42,8 @@ import static org.apache.inlong.agent.constant.KubernetesConstants.POD_NAME;
  */
 public class MetaDataUtils {
 
+    private static final Gson GSON = new Gson();
+
     /**
      * standard log for k8s
      *
@@ -74,8 +76,7 @@ public class MetaDataUtils {
         String labels = jobProfile.get(JOB_FILE_META_FILTER_BY_LABELS);
         Type type = new TypeToken<HashMap<Integer, String>>() {
         }.getType();
-        Gson gson = new Gson();
-        return gson.fromJson(labels, type);
+        return GSON.fromJson(labels, type);
     }
 
     public static List<String> getNamespace(JobProfile jobProfile) {
@@ -85,8 +86,7 @@ public class MetaDataUtils {
         String property = jobProfile.get(JOB_FILE_PROPERTIES);
         Type type = new TypeToken<HashMap<Integer, String>>() {
         }.getType();
-        Gson gson = new Gson();
-        Map<String, String> properties = gson.fromJson(property, type);
+        Map<String, String> properties = GSON.fromJson(property, type);
         return properties.keySet().stream().map(data -> {
             if (data.contains(NAMESPACE)) {
                 return properties.get(data);
@@ -107,8 +107,7 @@ public class MetaDataUtils {
         String property = jobProfile.get(JOB_FILE_PROPERTIES);
         Type type = new TypeToken<HashMap<Integer, String>>() {
         }.getType();
-        Gson gson = new Gson();
-        Map<String, String> properties = gson.fromJson(property, type);
+        Map<String, String> properties = GSON.fromJson(property, type);
         List<String> podName = properties.keySet().stream().map(data -> {
             if (data.contains(POD_NAME)) {
                 return properties.get(data);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
@@ -17,12 +17,21 @@
 
 package org.apache.inlong.agent.plugin.utils;
 
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.agent.conf.JobProfile;
 import org.apache.inlong.agent.constant.CommonConstants;
 
+import java.lang.reflect.Type;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_META_FILTER_BY_LABELS;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_PROPERTIES;
 import static org.apache.inlong.agent.constant.KubernetesConstants.CONTAINER_ID;
 import static org.apache.inlong.agent.constant.KubernetesConstants.CONTAINER_NAME;
 import static org.apache.inlong.agent.constant.KubernetesConstants.NAMESPACE;
@@ -35,7 +44,7 @@ public class MetaDataUtils {
 
     /**
      * standard log for k8s
-     * 
+     *
      * get pod_name,namespace,container_name,container_id
      */
     public static Map<String, String> getLogInfo(String fileName) {
@@ -53,10 +62,59 @@ public class MetaDataUtils {
         return podInf;
     }
 
-    public static String concatString(String str1, String str2) {
-        if (!StringUtils.isNoneBlank(str2)) {
-            return str1;
+    /**
+     * standard log for k8s
+     *
+     * get labels of pod
+     */
+    public static Map<String, String> getPodLabels(JobProfile jobProfile) {
+        if (Objects.isNull(jobProfile) || !jobProfile.hasKey(JOB_FILE_META_FILTER_BY_LABELS)) {
+            return null;
         }
-        return str1.concat("\n").concat(str2);
+        String labels = jobProfile.get(JOB_FILE_META_FILTER_BY_LABELS);
+        Type type = new TypeToken<HashMap<Integer, String>>() {
+        }.getType();
+        Gson gson = new Gson();
+        return gson.fromJson(labels, type);
+    }
+
+    public static List<String> getNamespace(JobProfile jobProfile) {
+        if (Objects.isNull(jobProfile) || !jobProfile.hasKey(JOB_FILE_PROPERTIES)) {
+            return null;
+        }
+        String property = jobProfile.get(JOB_FILE_PROPERTIES);
+        Type type = new TypeToken<HashMap<Integer, String>>() {
+        }.getType();
+        Gson gson = new Gson();
+        Map<String, String> properties = gson.fromJson(property, type);
+        return properties.keySet().stream().map(data -> {
+            if (data.contains(NAMESPACE)) {
+                return properties.get(data);
+            }
+            return null;
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+    }
+
+    /**
+     * standard log for k8s
+     *
+     * get name of pod
+     */
+    public static String getPodName(JobProfile jobProfile) {
+        if (Objects.isNull(jobProfile) || !jobProfile.hasKey(JOB_FILE_PROPERTIES)) {
+            return null;
+        }
+        String property = jobProfile.get(JOB_FILE_PROPERTIES);
+        Type type = new TypeToken<HashMap<Integer, String>>() {
+        }.getType();
+        Gson gson = new Gson();
+        Map<String, String> properties = gson.fromJson(property, type);
+        List<String> podName = properties.keySet().stream().map(data -> {
+            if (data.contains(POD_NAME)) {
+                return properties.get(data);
+            }
+            return null;
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+        return podName.isEmpty() ? null : podName.get(0);
     }
 }


### PR DESCRIPTION
File collects in the k8s, data, and metadata of k8s need to connect a message.

- Fixes #5533 

### Motivation
File data and k8s metadata to connect a message.

```
{
"_content_":"data",
"_time_":"time",
"_pod_name_":"test"
}
```

### Modifications

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.