### PR TITLE
[INLONG-5540][Agent] Fix the NPE for MySQL binlog reader

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/BinlogReader.java
@@ -127,6 +127,7 @@ public class BinlogReader extends AbstractReader {
 
     @Override
     public void init(JobProfile jobConf) {
+        super.init(jobConf);
         jobProfile = jobConf;
         LOGGER.info("init binlog reader with jobConf {}", jobConf.toJsonStr());
         userName = jobConf.get(JOB_DATABASE_USER);


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #5540

### Motivation

When MySQL binlog reader read from binlog it will report java.lang.NullPointerException.

### Modifications

initialize the variable `readerMetric`

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
