### PR TITLE
[INLONG-5589][Agent] To extend type of file data for k8s log

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -291,6 +291,7 @@ public class AgentUtils {
                 }
             }
         }
+        LOGGER.info("Path name:{} , pattern name:{}", Arrays.toString(pathNames), Arrays.toString(patternNames));
         return true;
     }
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -291,7 +291,7 @@ public class AgentUtils {
                 }
             }
         }
-        LOGGER.info("Path name:{} , pattern name:{}", Arrays.toString(pathNames), Arrays.toString(patternNames));
+        LOGGER.info("path name:{} , pattern name:{}", Arrays.toString(pathNames), Arrays.toString(patternNames));
         return true;
     }
 

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
@@ -55,17 +55,14 @@ public class AgentManager extends AbstractDaemon {
     private final TriggerManager triggerManager;
     private final TaskPositionManager taskPositionManager;
     private final HeartbeatManager heartbeatManager;
-
-
-    // jetty for config operations via http.
-    private ConfigJetty configJetty;
-
     private final ProfileFetcher fetcher;
     private final AgentConfiguration conf;
     private final Db db;
     private final LocalProfile localProfile;
     private final CommandDb commandDb;
     private final JobProfileDb jobProfileDb;
+    // jetty for config operations via http.
+    private ConfigJetty configJetty;
 
     public AgentManager() {
         conf = AgentConfiguration.getAgentConf();
@@ -99,7 +96,7 @@ public class AgentManager extends AbstractDaemon {
             return
                     (ProfileFetcher) constructor.newInstance(agentManager);
         } catch (Exception ex) {
-            LOGGER.warn("cannot find fetcher, ignore it {}", ex.getMessage());
+            LOGGER.warn("cannot find fetcher: ", ex);
         }
         return null;
     }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobWrapper.java
@@ -102,6 +102,7 @@ public class JobWrapper extends AbstractStateWrapper {
      */
     private void submitAllTasks() {
         List<Task> tasks = job.createTasks();
+        LOGGER.info("Job name is {} and task size  {}", job.getName(), tasks.size());
         tasks.forEach(task -> {
             allTasks.add(task);
             taskManager.submitTask(task);

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobWrapper.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/JobWrapper.java
@@ -102,7 +102,7 @@ public class JobWrapper extends AbstractStateWrapper {
      */
     private void submitAllTasks() {
         List<Task> tasks = job.createTasks();
-        LOGGER.info("Job name is {} and task size  {}", job.getName(), tasks.size());
+        LOGGER.info("job name is {} and task size {}", job.getName(), tasks.size());
         tasks.forEach(task -> {
             allTasks.add(task);
             taskManager.submitTask(task);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -282,7 +282,9 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
      * the fetch file command can be normal or special
      */
     private void dealWithFetchResult(TaskResult taskResult) {
-        LOGGER.info("deal with fetch result {}", taskResult);
+        if (!taskResult.getCmdConfigs().isEmpty() || !taskResult.getDataConfigs().isEmpty()) {
+            LOGGER.info("deal with fetch result {}", taskResult);
+        }
         for (DataConfig dataConfig : taskResult.getDataConfigs()) {
             TriggerProfile profile = TriggerProfile.getTriggerProfiles(dataConfig);
             LOGGER.info("the triggerProfile: {}", profile.toJsonStr());
@@ -385,7 +387,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         Collection<File> suitFiles = PluginUtils.findSuitFiles(triggerProfile);
         // filter files exited before
         List<File> pendingFiles = suitFiles.stream().filter(file ->
-                        !agentManager.getJobManager().checkJobExsit(file.getAbsolutePath()))
+                !agentManager.getJobManager().checkJobExsit(file.getAbsolutePath()))
                 .collect(Collectors.toList());
         for (File pendingFile : pendingFiles) {
             JobProfile copiedProfile = copyJobProfile(triggerProfile, dataTime,

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
@@ -56,7 +56,7 @@ public class TextFileSource extends AbstractSource {
         Collection<File> allFiles = PluginUtils.findSuitFiles(jobConf);
         List<Reader> result = new ArrayList<>();
         String filterPattern = jobConf.get(JOB_LINE_FILTER_PATTERN, DEFAULT_JOB_LINE_FILTER);
-        LOGGER.info("File splits size: {}", allFiles.size());
+        LOGGER.info("file splits size: {}", allFiles.size());
         for (File file : allFiles) {
             int startPosition = getStartPosition(jobConf, file);
             LOGGER.info("read from history position {} with job profile {}, file absolute path: {}", startPosition,

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/TextFileSource.java
@@ -56,6 +56,7 @@ public class TextFileSource extends AbstractSource {
         Collection<File> allFiles = PluginUtils.findSuitFiles(jobConf);
         List<Reader> result = new ArrayList<>();
         String filterPattern = jobConf.get(JOB_LINE_FILTER_PATTERN, DEFAULT_JOB_LINE_FILTER);
+        LOGGER.info("File splits size: {}", allFiles.size());
         for (File file : allFiles) {
             int startPosition = getStartPosition(jobConf, file);
             LOGGER.info("read from history position {} with job profile {}, file absolute path: {}", startPosition,

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/AbstractFileReader.java
@@ -48,17 +48,18 @@ public abstract class AbstractFileReader {
         List<String> lines = fileReaderOperator.stream.collect(Collectors.toList());
         if (fileReaderOperator.jobConf.hasKey(JOB_FILE_CONTENT_COLLECT_TYPE)) {
             long timestamp = System.currentTimeMillis();
+            boolean isJson = FileDataUtils.isJSON(lines.isEmpty() ? null : lines.get(0));
             if (Objects.nonNull(fileReaderOperator.metadata)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>(fileReaderOperator.metadata);
-                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data, isJson));
                     mergeData.put(DATA_CONTENT_TIME, String.valueOf(timestamp));
                     return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());
             } else if (!fileReaderOperator.jobConf.hasKey(JOB_FILE_META_FILTER_BY_LABELS)) {
                 lines = lines.stream().map(data -> {
                     Map<String, String> mergeData = new HashMap<>();
-                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data));
+                    mergeData.put(DATA_CONTENT, FileDataUtils.getK8sJsonLog(data, isJson));
                     mergeData.put(DATA_CONTENT_TIME, String.valueOf(timestamp));
                     return GSON.toJson(mergeData);
                 }).collect(Collectors.toList());

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/TextFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/TextFileReader.java
@@ -19,6 +19,8 @@
 package org.apache.inlong.agent.plugin.sources.reader.file;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -38,6 +40,8 @@ import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_LINE_END_PA
  */
 public final class TextFileReader extends AbstractFileReader {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(TextFileReader.class);
+
     private final Map<File, String> lineStringBuffer = new ConcurrentHashMap<>();
 
     public TextFileReader(FileReaderOperator fileReaderOperator) {
@@ -48,6 +52,7 @@ public final class TextFileReader extends AbstractFileReader {
         List<String> lines = Files.newBufferedReader(fileReaderOperator.file.toPath()).lines().skip(
                 fileReaderOperator.position)
                 .collect(Collectors.toList());
+        LOGGER.info("Path is {}, data reads size: {}", fileReaderOperator.file.getName(), lines.size());
         List<String> resultLines = new ArrayList<>();
         //TODO line regular expression matching
         if (fileReaderOperator.jobConf.hasKey(JOB_FILE_LINE_END_PATTERN)) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/TextFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/TextFileReader.java
@@ -52,7 +52,7 @@ public final class TextFileReader extends AbstractFileReader {
         List<String> lines = Files.newBufferedReader(fileReaderOperator.file.toPath()).lines().skip(
                 fileReaderOperator.position)
                 .collect(Collectors.toList());
-        LOGGER.info("Path is {}, data reads size: {}", fileReaderOperator.file.getName(), lines.size());
+        LOGGER.info("path is {}, data reads size {}", fileReaderOperator.file.getName(), lines.size());
         List<String> resultLines = new ArrayList<>();
         //TODO line regular expression matching
         if (fileReaderOperator.jobConf.hasKey(JOB_FILE_LINE_END_PATTERN)) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
@@ -55,14 +55,14 @@ public class FileDataUtils {
      * To judge json
      */
     public static boolean isJSON(String json) {
-        boolean flag;
+        boolean isJson;
         try {
             JsonObject convertedObject = new Gson().fromJson(json, JsonObject.class);
-            flag = convertedObject.isJsonObject();
+            isJson = convertedObject.isJsonObject();
         } catch (Exception exception) {
             return false;
         }
-        return flag;
+        return isJson;
     }
-    
+
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/FileDataUtils.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.agent.plugin.utils;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import org.apache.commons.lang3.StringUtils;
 
@@ -37,14 +38,31 @@ public class FileDataUtils {
     /**
      * Get standard log for k8s
      */
-    public static String getK8sJsonLog(String log) {
+    public static String getK8sJsonLog(String log, Boolean isJson) {
         if (!StringUtils.isNoneBlank(log)) {
             return null;
+        }
+        if (!isJson) {
+            return log;
         }
         Type type = new TypeToken<HashMap<Integer, String>>() {
         }.getType();
         Map<String, String> logJson = GSON.fromJson(log, type);
-        return logJson.get(KUBERNETES_LOG);
+        return logJson.getOrDefault(KUBERNETES_LOG, log);
     }
 
+    /**
+     * To judge json
+     */
+    public static boolean isJSON(String json) {
+        boolean flag;
+        try {
+            JsonObject convertedObject = new Gson().fromJson(json, JsonObject.class);
+            flag = convertedObject.isJsonObject();
+        } catch (Exception exception) {
+            return false;
+        }
+        return flag;
+    }
+    
 }


### PR DESCRIPTION
Support k8s log:
1. standard k8s log
2. ordinary k8s log

- Fixes #5589 

### Motivation

1. To judge json 
2. To connect data and metadata

### Modifications


### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
