### PR TITLE
[INLONG-5605][Sort] Fix bug when primary Key and routing-feild are null in Elasticsearch 7 connector

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
@@ -112,7 +112,6 @@ public class ElasticsearchLoadNode extends LoadNode implements Serializable {
         options.put("index", index);
         options.put("password", password);
         options.put("username", username);
-        options.put("routing.field-name", primaryKey);
         return options;
     }
 


### PR DESCRIPTION

- Fixes #5605 

### Motivation

Fix bug when primary Key and routing-feild are null in Elasticsearch 7 connector

### Modifications

remove the default value of routing.field-name
