### PR TITLE
[INLONG-5637][Sort] Fix kafka load node npe error

### DIFF
--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/FlinkKafkaProducer.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/FlinkKafkaProducer.java
@@ -928,10 +928,8 @@ public class FlinkKafkaProducer<IN>
     }
 
     private void sendOutMetrics(Long rowSize, Long dataSize) {
-        if (metricData.getNumRecordsOut() != null) {
+        if (metricData != null) {
             metricData.getNumRecordsOut().inc(rowSize);
-        }
-        if (metricData.getNumBytesOut() != null) {
             metricData.getNumBytesOut().inc(dataSize);
         }
     }
@@ -939,8 +937,6 @@ public class FlinkKafkaProducer<IN>
     private void sendDirtyMetrics(Long rowSize, Long dataSize) {
         if (metricData.getDirtyRecords() != null) {
             metricData.getDirtyRecords().inc(rowSize);
-        }
-        if (metricData.getDirtyBytes() != null) {
             metricData.getDirtyBytes().inc(dataSize);
         }
     }

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/FlinkKafkaProducer.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/FlinkKafkaProducer.java
@@ -935,7 +935,7 @@ public class FlinkKafkaProducer<IN>
     }
 
     private void sendDirtyMetrics(Long rowSize, Long dataSize) {
-        if (metricData.getDirtyRecords() != null) {
+        if (metricData != null) {
             metricData.getDirtyRecords().inc(rowSize);
             metricData.getDirtyBytes().inc(dataSize);
         }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-5637][Sort] Fix kafka load node npe error

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #5637

### Motivation

Fix the npe error of kafka load node

### Modifications

Update the logic  of sendOutMetrics and sendDirtyMetrics in FlinkKafkaProducer.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
