### PR TITLE
[INLONG-5657][Release] Change the tag of Docker images to 1.3.0

### DIFF
--- a/conf/inlong.conf
+++ b/conf/inlong.conf
@@ -35,7 +35,7 @@ tube_manager_url=127.0.0.1:8080
 
 ############## Dashboard Configuration ##############
 # dashboard docker image
-dashboard_docker_image=inlong/dashboard:latest
+dashboard_docker_image=inlong/dashboard:1.3.0
 # dashboard service port
 dashboard_mapping_port=80
 

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     command: bin/pulsar standalone
 
   manager:
-    image: inlong/manager
+    image: inlong/manager:1.3.0
     container_name: manager
     depends_on:
       mysql:
@@ -60,7 +60,7 @@ services:
       - AUDIT_PROXY_URL=audit:10081
 
   webisite:
-    image: inlong/dashboard
+    image: inlong/dashboard:1.3.0
     container_name: dashboard
     depends_on:
       - manager
@@ -70,7 +70,7 @@ services:
       - MANAGER_API_ADDRESS=manager:8083
 
   dataproxy:
-    image: inlong/dataproxy:latest
+    image: inlong/dataproxy:1.3.0
     container_name: dataproxy
     depends_on:
       - manager
@@ -83,7 +83,7 @@ services:
       - MQ_TYPE=pulsar
 
   agent:
-    image: inlong/agent:latest
+    image: inlong/agent:1.3.0
     container_name: agent
     depends_on:
       - manager
@@ -100,7 +100,7 @@ services:
       - ./collect-data:/data/collect-data
 
   audit:
-    image: inlong/audit:latest
+    image: inlong/audit:1.3.0
     container_name: audit
     depends_on:
       mysql:

--- a/inlong-agent/agent-docker/README.md
+++ b/inlong-agent/agent-docker/README.md
@@ -3,7 +3,7 @@ InLong Agent is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/agent:latest
+docker pull inlong/agent:1.3.0
 ```
 
 ##### Start Container

--- a/inlong-audit/audit-docker/README.md
+++ b/inlong-audit/audit-docker/README.md
@@ -3,7 +3,7 @@ InLong Audit is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/audit:latest
+docker pull inlong/audit:1.3.0
 ```
 
 ##### Start Container

--- a/inlong-dataproxy/dataproxy-docker/README.md
+++ b/inlong-dataproxy/dataproxy-docker/README.md
@@ -3,7 +3,7 @@ InLong DataProxy is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/dataproxy:latest
+docker pull inlong/dataproxy:1.3.0
 ```
 
 ##### Start Container

--- a/inlong-manager/manager-docker/README.md
+++ b/inlong-manager/manager-docker/README.md
@@ -5,7 +5,7 @@ InLong Manager is available for development and experience.
 ### Pull Image
 
 ```
-docker pull inlong/manager:latest
+docker pull inlong/manager:1.3.0
 ```
 
 ### Start Container

--- a/inlong-tubemq/tubemq-docker/tubemq-all/README.md
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/README.md
@@ -3,7 +3,7 @@ TubeMQ standalone is available for development and experience.
 
 ##### Pull Image
 ```
-docker pull inlong/tubemq-all:latest
+docker pull inlong/tubemq-all:1.3.0
 ```
 
 ##### Start Standalone Container


### PR DESCRIPTION
- Fixes #5657 

### Motivation

[INLONG-5657][Release] Change the tag of Docker images to 1.3.0

### Modifications

[INLONG-5657][Release] Change the tag of Docker images to 1.3.0

### Verifying this change

### Documentation

  - Does this pull request introduce a new feature? (no)