### PR TITLE
[INLONG-5667][SDK] Change key value of groupId and streamId while wrapping message

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/base/pack_queue.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/base/pack_queue.cc
@@ -40,7 +40,7 @@ namespace dataproxy_sdk
     {
         data_ = new char[data_capacity_];
         memset(data_, 0x0, data_capacity_);
-        topic_desc_ = "inlong_group_id=" + inlong_group_id_ + "&inlong_stream_id=" + inlong_stream_id_;
+        topic_desc_ = "groupId=" + inlong_group_id_ + "&streamId=" + inlong_stream_id_;
         first_use_ = Utils::getCurrentMsTime();
         last_use_ = Utils::getCurrentMsTime();
         data_time_ = 0;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-5667][SDK] Change key value of groupId and streamId while wrapping message

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5667 

### Motivation

DataProxy using key "groupId" and "streamId" to get inlongGroupId and inlongStreamId of user message.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
