### PR TITLE
[INLONG-5675][Agent] Support custom fixed ip for Agent

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -169,6 +169,8 @@ public class AgentConstants {
     public static final String AGENT_LOCAL_IP = "agent.local.ip";
     public static final String DEFAULT_LOCAL_IP = "127.0.0.1";
 
+    public static final String CUSTOM_FIXED_IP = "agent.custom.fixed.ip";
+
     public static final String AGENT_CLUSTER_NAME = "agent.cluster.name";
     public static final String AGENT_CLUSTER_TAG = "agent.cluster.tag";
     public static final String AGENT_CLUSTER_IN_CHARGES = "agent.cluster.inCharges";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -349,7 +349,8 @@ public class AgentUtils {
      * Check agent ip from manager
      */
     public static String fetchLocalIp() {
-        if (AgentConfiguration.getAgentConf().hasKey(CUSTOM_FIXED_IP)) {
+        if (AgentConfiguration.getAgentConf().hasKey(CUSTOM_FIXED_IP) && StringUtils
+                .isNoneBlank(AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP))) {
             return AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP);
         }
         return AgentConfiguration.getAgentConf().get(AGENT_LOCAL_IP, getLocalIp());

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -55,6 +55,7 @@ import static org.apache.inlong.agent.constant.AgentConstants.AGENT_ENABLE_OOM_E
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_UUID;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_UUID_OPEN;
+import static org.apache.inlong.agent.constant.AgentConstants.CUSTOM_FIXED_IP;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AGENT_LOCAL_UUID_OPEN;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_ENABLE_OOM_EXIT;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_LOCAL_IP;
@@ -348,6 +349,9 @@ public class AgentUtils {
      * Check agent ip from manager
      */
     public static String fetchLocalIp() {
+        if (AgentConfiguration.getAgentConf().hasKey(CUSTOM_FIXED_IP)) {
+            return AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP);
+        }
         return AgentConfiguration.getAgentConf().get(AGENT_LOCAL_IP, getLocalIp());
     }
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/AgentUtils.java
@@ -349,8 +349,7 @@ public class AgentUtils {
      * Check agent ip from manager
      */
     public static String fetchLocalIp() {
-        if (AgentConfiguration.getAgentConf().hasKey(CUSTOM_FIXED_IP) && StringUtils
-                .isNoneBlank(AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP))) {
+        if (StringUtils.isNoneBlank(AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP, null))) {
             return AgentConfiguration.getAgentConf().get(CUSTOM_FIXED_IP);
         }
         return AgentConfiguration.getAgentConf().get(AGENT_LOCAL_IP, getLocalIp());

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
@@ -89,4 +89,11 @@ public class TestAgentUtils {
         Assert.assertNotEquals("127.0.0.1", AgentUtils.fetchLocalIp());
         LOGGER.info("local ip is {}", AgentUtils.fetchLocalIp());
     }
+
+    @Test
+    public void testCustomFixedIp() {
+        String ip = AgentUtils.fetchLocalIp();
+        Assert.assertEquals("127.0.0.10", ip);
+        LOGGER.info("custom fixed ip  is {}", AgentUtils.fetchLocalIp());
+    }
 }

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/common/TestAgentUtils.java
@@ -93,7 +93,6 @@ public class TestAgentUtils {
     @Test
     public void testCustomFixedIp() {
         String ip = AgentUtils.fetchLocalIp();
-        Assert.assertEquals("127.0.0.10", ip);
-        LOGGER.info("custom fixed ip  is {}", AgentUtils.fetchLocalIp());
+        Assert.assertNotEquals("127.0.0.1",ip);
     }
 }

--- a/inlong-agent/agent-common/src/test/resources/agent.properties
+++ b/inlong-agent/agent-common/src/test/resources/agent.properties
@@ -23,6 +23,7 @@ job.thread.running.core=10
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
 agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
+agent.custom.fixed.ip=127.0.0.10
 
 # metrics
 metricDomains=Agent

--- a/inlong-agent/agent-common/src/test/resources/agent.properties
+++ b/inlong-agent/agent-common/src/test/resources/agent.properties
@@ -23,7 +23,7 @@ job.thread.running.core=10
 agent.manager.vip.http.host=127.0.0.1
 agent.manager.vip.http.port=8083
 agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
-agent.custom.fixed.ip=127.0.0.10
+agent.custom.fixed.ip=
 
 # metrics
 metricDomains=Agent

--- a/inlong-agent/agent-docker/agent-docker.sh
+++ b/inlong-agent/agent-docker/agent-docker.sh
@@ -38,6 +38,7 @@ agent.cluster.name=$CLUSTER_NAME
 agent.cluster.inCharges=$CLUSTER_IN_CHARGES
 agent.manager.auth.secretId=$MANAGER_OPENAPI_AUTH_ID
 agent.manager.auth.secretKey=$MANAGER_OPENAPI_AUTH_KEY
+agent.custom.fixed.ip=$CUSTOM_FIXED_IP
 EOF
 # start
 bash +x ${file_path}/bin/agent.sh start

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -51,6 +51,7 @@ agent.local.ip=127.0.0.1
 agent.local.uuid=
 agent.local.uuid.open=false
 agent.enable.oom.exit=false
+agent.custom.fixed.ip=
 
 ###########################
 # job/job manager config


### PR DESCRIPTION
Support custom fixed ip for Agent.
For example:
Ip has to fixed in the k8s.

- Fixes #5675 

### Motivation

Add config information.

### Modifications
No message.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
