### PR TITLE
[INLONG-5665][SDK] Invoke callback in each MQ message to avoid massive full gc in high load

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
@@ -55,7 +55,7 @@ public class SortClientConfig implements Serializable {
     private int ackTimeoutSec = 0;
     private volatile boolean stopConsume = false;
     private boolean isPrometheusEnabled = true;
-    private int emptyPollSleepStepMs = 50;
+    private int emptyPollSleepStepMs = 10;
     private int maxEmptyPollSleepMs = 500;
     private int emptyPollTimes = 10;
     private int cleanOldConsumerIntervalSec = 60;

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/kafka/KafkaSingleTopicFetcher.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/kafka/KafkaSingleTopicFetcher.java
@@ -276,8 +276,8 @@ public class KafkaSingleTopicFetcher extends SingleTopicFetcher {
             context.getStateCounterByTopic(topic).addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
             if (null != records && !records.isEmpty()) {
 
-                List<MessageRecord> msgs = new ArrayList<>();
                 for (ConsumerRecord<byte[], byte[]> msg : records) {
+                    List<MessageRecord> msgs = new ArrayList<>();
                     String offsetKey = getOffset(msg.partition(), msg.offset());
                     List<InLongMessage> inLongMessages = deserializer
                             .deserialize(context, topic, getMsgHeaders(msg.headers()), msg.value());
@@ -291,9 +291,9 @@ public class KafkaSingleTopicFetcher extends SingleTopicFetcher {
                             inLongMessages,
                             offsetKey, System.currentTimeMillis()));
                     context.getStateCounterByTopic(topic).addConsumeSize(msg.value().length);
+                    context.getStateCounterByTopic(topic).addMsgCount(msgs.size());
+                    handleAndCallbackMsg(msgs);
                 }
-                context.getStateCounterByTopic(topic).addMsgCount(msgs.size());
-                handleAndCallbackMsg(msgs);
                 sleepTime = 0L;
             } else {
                 context.getStateCounterByTopic(topic).addEmptyFetchTimes(1);

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarMultiTopicsFetcher.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarMultiTopicsFetcher.java
@@ -346,7 +346,6 @@ public class PulsarMultiTopicsFetcher extends MultiTopicsFetcher {
 
         private void processPulsarMsg(Messages<byte[]> messages) throws Exception {
             for (Message<byte[]> msg : messages) {
-                List<MessageRecord> msgs = new ArrayList<>();
                 String topicName = msg.getTopicName();
                 InLongTopic topic = onlineTopics.get(topicName);
                 if (Objects.isNull(topic)) {
@@ -370,7 +369,7 @@ public class PulsarMultiTopicsFetcher extends MultiTopicsFetcher {
                     ack(offsetKey);
                     continue;
                 }
-
+                List<MessageRecord> msgs = new ArrayList<>();
                 msgs.add(new MessageRecord(topic.getTopicKey(),
                         inLongMessages,
                         offsetKey, System.currentTimeMillis()));

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarSingleTopicFetcher.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarSingleTopicFetcher.java
@@ -270,8 +270,8 @@ public class PulsarSingleTopicFetcher extends SingleTopicFetcher {
 
                     context.getStateCounterByTopic(topic).addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
                     if (null != messages && messages.size() != 0) {
-                        List<MessageRecord> msgs = new ArrayList<>();
                         for (Message<byte[]> msg : messages) {
+                            List<MessageRecord> msgs = new ArrayList<>();
                             // if need seek
                             if (msg.getPublishTime() < seeker.getSeekTime()) {
                                 seeker.seek();
@@ -294,9 +294,9 @@ public class PulsarSingleTopicFetcher extends SingleTopicFetcher {
                                     inLongMessages,
                                     offsetKey, System.currentTimeMillis()));
                             context.getStateCounterByTopic(topic).addConsumeSize(msg.getData().length);
+                            context.getStateCounterByTopic(topic).addMsgCount(msgs.size());
+                            handleAndCallbackMsg(msgs);
                         }
-                        context.getStateCounterByTopic(topic).addMsgCount(msgs.size());
-                        handleAndCallbackMsg(msgs);
                         sleepTime = 0L;
                     } else {
                         context.getStateCounterByTopic(topic).addEmptyFetchTimes(1L);

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarSingleTopicFetcher.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/pulsar/PulsarSingleTopicFetcher.java
@@ -271,7 +271,6 @@ public class PulsarSingleTopicFetcher extends SingleTopicFetcher {
                     context.getStateCounterByTopic(topic).addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
                     if (null != messages && messages.size() != 0) {
                         for (Message<byte[]> msg : messages) {
-                            List<MessageRecord> msgs = new ArrayList<>();
                             // if need seek
                             if (msg.getPublishTime() < seeker.getSeekTime()) {
                                 seeker.seek();
@@ -289,7 +288,7 @@ public class PulsarSingleTopicFetcher extends SingleTopicFetcher {
                                 ack(offsetKey);
                                 continue;
                             }
-
+                            List<MessageRecord> msgs = new ArrayList<>();
                             msgs.add(new MessageRecord(topic.getTopicKey(),
                                     inLongMessages,
                                     offsetKey, System.currentTimeMillis()));

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/tube/TubeSingleTopicFetcher.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/fetcher/tube/TubeSingleTopicFetcher.java
@@ -242,8 +242,8 @@ public class TubeSingleTopicFetcher extends SingleTopicFetcher {
                     ConsumerResult message = messageConsumer.getMessage();
                     context.getStateCounterByTopic(topic).addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
                     if (null != message && TErrCodeConstants.SUCCESS == message.getErrCode()) {
-                        List<InLongMessage> msgs = new ArrayList<>();
                         for (Message msg : message.getMessageList()) {
+                            List<InLongMessage> msgs = new ArrayList<>();
                             List<InLongMessage> deserialize = deserializer
                                     .deserialize(context, topic, getAttributeMap(msg.getAttribute()),
                                             msg.getData());
@@ -255,10 +255,9 @@ public class TubeSingleTopicFetcher extends SingleTopicFetcher {
                             context.getStateCounterByTopic(topic)
                                     .addMsgCount(deserialize.size())
                                     .addConsumeSize(msg.getData().length);
+                            handleAndCallbackMsg(new MessageRecord(topic.getTopicKey(), msgs,
+                                    message.getConfirmContext(), System.currentTimeMillis()));
                         }
-
-                        handleAndCallbackMsg(new MessageRecord(topic.getTopicKey(), msgs,
-                                message.getConfirmContext(), System.currentTimeMillis()));
                         sleepTime = 0L;
                     } else {
                         context.getStateCounterByTopic(topic).addEmptyFetchTimes(1L);

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/kafka/InLongKafkaFetcherImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/kafka/InLongKafkaFetcherImpl.java
@@ -303,8 +303,8 @@ public class InLongKafkaFetcherImpl extends InLongTopicFetcher {
                     .addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
             if (null != records && !records.isEmpty()) {
 
-                List<MessageRecord> msgs = new ArrayList<>();
                 for (ConsumerRecord<byte[], byte[]> msg : records) {
+                    List<MessageRecord> msgs = new ArrayList<>();
                     String offsetKey = getOffset(msg.partition(), msg.offset());
                     List<InLongMessage> inLongMessages = deserializer
                             .deserialize(context, inLongTopic, getMsgHeaders(msg.headers()), msg.value());
@@ -321,12 +321,12 @@ public class InLongKafkaFetcherImpl extends InLongTopicFetcher {
                             .getStatistics(context.getConfig().getSortTaskId(),
                                     inLongTopic.getInLongCluster().getClusterId(), inLongTopic.getTopic())
                             .addConsumeSize(msg.value().length);
+                    context.getStatManager()
+                            .getStatistics(context.getConfig().getSortTaskId(),
+                                    inLongTopic.getInLongCluster().getClusterId(), inLongTopic.getTopic())
+                            .addMsgCount(msgs.size());
+                    handleAndCallbackMsg(msgs);
                 }
-                context.getStatManager()
-                        .getStatistics(context.getConfig().getSortTaskId(),
-                                inLongTopic.getInLongCluster().getClusterId(), inLongTopic.getTopic())
-                        .addMsgCount(msgs.size());
-                handleAndCallbackMsg(msgs);
                 sleepTime = 0L;
             } else {
                 context.getStatManager()

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/tube/InLongTubeFetcherImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/tube/InLongTubeFetcherImpl.java
@@ -270,8 +270,8 @@ public class InLongTubeFetcherImpl extends InLongTopicFetcher {
                                     inLongTopic.getInLongCluster().getClusterId(), inLongTopic.getTopic())
                             .addFetchTimeCost(System.currentTimeMillis() - startFetchTime);
                     if (null != message && TErrCodeConstants.SUCCESS == message.getErrCode()) {
-                        List<InLongMessage> msgs = new ArrayList<>();
                         for (Message msg : message.getMessageList()) {
+                            List<InLongMessage> msgs = new ArrayList<>();
                             List<InLongMessage> deserialize = deserializer
                                     .deserialize(context, inLongTopic, getAttributeMap(msg.getAttribute()),
                                             msg.getData());
@@ -284,10 +284,10 @@ public class InLongTubeFetcherImpl extends InLongTopicFetcher {
                                     .getStatistics(context.getConfig().getSortTaskId(),
                                             inLongTopic.getInLongCluster().getClusterId(), inLongTopic.getTopic())
                                     .addMsgCount(deserialize.size()).addConsumeSize(msg.getData().length);
+                            handleAndCallbackMsg(new MessageRecord(inLongTopic.getTopicKey(), msgs,
+                                    message.getConfirmContext(), System.currentTimeMillis()));
                         }
 
-                        handleAndCallbackMsg(new MessageRecord(inLongTopic.getTopicKey(), msgs,
-                                message.getConfirmContext(), System.currentTimeMillis()));
                         sleepTime = 0L;
                     } else {
                         context.getStatManager()

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/metrics/SortSdkPrometheusMetricListener.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/metrics/SortSdkPrometheusMetricListener.java
@@ -17,17 +17,19 @@
 
 package org.apache.inlong.sdk.sort.metrics;
 
-import static org.apache.inlong.common.metric.MetricItemMBean.DOMAIN_SEPARATOR;
-import static org.apache.inlong.common.metric.MetricRegister.JMX_DOMAIN;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static org.apache.inlong.common.metric.MetricItemMBean.DOMAIN_SEPARATOR;
+import static org.apache.inlong.common.metric.MetricRegister.JMX_DOMAIN;
 
 public class SortSdkPrometheusMetricListener {
 
@@ -40,9 +42,8 @@ public class SortSdkPrometheusMetricListener {
         this.metricItem = new SortSdkMetricItem(sortTaskId);
 
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        StringBuilder beanName = new StringBuilder();
-        beanName.append(JMX_DOMAIN).append(DOMAIN_SEPARATOR).append("type=SortSdk").append(",name=").append(sortTaskId);
-        String strBeanName = beanName.toString();
+        String strBeanName = JMX_DOMAIN + DOMAIN_SEPARATOR + "type=SortSdk" + ",name=" + sortTaskId +
+                metricItem.hashCode();
         try {
             ObjectName objName = new ObjectName(strBeanName);
             mbs.registerMBean(metricItem, objName);
@@ -52,26 +53,29 @@ public class SortSdkPrometheusMetricListener {
         }
 
         // consume
-        metricValueMap.put(metricItem.M_CONSUME_SIZE, metricItem.consumeSize);
-        metricValueMap.put(metricItem.M_CONSUME_MSG_COUNT, metricItem.consumeMsgCount);
+        metricValueMap.put(SortSdkMetricItem.M_CONSUME_SIZE, metricItem.consumeSize);
+        metricValueMap.put(SortSdkMetricItem.M_CONSUME_MSG_COUNT, metricItem.consumeMsgCount);
         // callback
-        metricValueMap.put(metricItem.M_CALL_BACK_COUNT, metricItem.callbackCount);
-        metricValueMap.put(metricItem.M_CALL_BACK_DONE_COUNT, metricItem.callbackDoneCount);
-        metricValueMap.put(metricItem.M_CALL_BACK_TIME_COST, metricItem.callbackTimeCost);
-        metricValueMap.put(metricItem.M_CALL_BACK_FAIL_COUNT, metricItem.callbackFailCount);
+        metricValueMap.put(SortSdkMetricItem.M_CALL_BACK_COUNT, metricItem.callbackCount);
+        metricValueMap.put(SortSdkMetricItem.M_CALL_BACK_DONE_COUNT, metricItem.callbackDoneCount);
+        metricValueMap.put(SortSdkMetricItem.M_CALL_BACK_TIME_COST, metricItem.callbackTimeCost);
+        metricValueMap.put(SortSdkMetricItem.M_CALL_BACK_FAIL_COUNT, metricItem.callbackFailCount);
         // topic
-        metricValueMap.put(metricItem.M_TOPIC_ONLINE_COUNT, metricItem.topicOnlineCount);
-        metricValueMap.put(metricItem.M_TOPIC_OFFLINE_COUNT, metricItem.topicOfflineCount);
+        metricValueMap.put(SortSdkMetricItem.M_TOPIC_ONLINE_COUNT, metricItem.topicOnlineCount);
+        metricValueMap.put(SortSdkMetricItem.M_TOPIC_OFFLINE_COUNT, metricItem.topicOfflineCount);
         // ack
-        metricValueMap.put(metricItem.M_ACK_FAIL_COUNT, metricItem.ackFailCount);
-        metricValueMap.put(metricItem.M_ACK_SUCC_COUNT, metricItem.ackSuccCount);
+        metricValueMap.put(SortSdkMetricItem.M_ACK_FAIL_COUNT, metricItem.ackFailCount);
+        metricValueMap.put(SortSdkMetricItem.M_ACK_SUCC_COUNT, metricItem.ackSuccCount);
         // request manager
-        metricValueMap.put(metricItem.M_REQUEST_MANAGER_COUNT, metricItem.requestManagerCount);
-        metricValueMap.put(metricItem.M_REQUEST_MANAGER_TIME_COST, metricItem.requestManagerTimeCost);
-        metricValueMap.put(metricItem.M_REQUEST_MANAGER_FAIL_COUNT, metricItem.requestManagerFailCount);
-        metricValueMap.put(metricItem.M_REQUEST_MANAGER_CONF_CHANAGED_COUNT, metricItem.requestManagerConfChangedCount);
-        metricValueMap.put(metricItem.M_RQUEST_MANAGER_COMMON_ERROR_COUNT, metricItem.requestManagerCommonErrorCount);
-        metricValueMap.put(metricItem.M_RQUEST_MANAGER_PARAM_ERROR_COUNT, metricItem.requestManagerParamErrorCount);
+        metricValueMap.put(SortSdkMetricItem.M_REQUEST_MANAGER_COUNT, metricItem.requestManagerCount);
+        metricValueMap.put(SortSdkMetricItem.M_REQUEST_MANAGER_TIME_COST, metricItem.requestManagerTimeCost);
+        metricValueMap.put(SortSdkMetricItem.M_REQUEST_MANAGER_FAIL_COUNT, metricItem.requestManagerFailCount);
+        metricValueMap.put(SortSdkMetricItem.M_REQUEST_MANAGER_CONF_CHANAGED_COUNT,
+                metricItem.requestManagerConfChangedCount);
+        metricValueMap.put(SortSdkMetricItem.M_RQUEST_MANAGER_COMMON_ERROR_COUNT,
+                metricItem.requestManagerCommonErrorCount);
+        metricValueMap.put(SortSdkMetricItem.M_RQUEST_MANAGER_PARAM_ERROR_COUNT,
+                metricItem.requestManagerParamErrorCount);
 
     }
 

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/metrics/SortSdkPrometheusMetricListener.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/metrics/SortSdkPrometheusMetricListener.java
@@ -42,8 +42,8 @@ public class SortSdkPrometheusMetricListener {
         this.metricItem = new SortSdkMetricItem(sortTaskId);
 
         final MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        String strBeanName = JMX_DOMAIN + DOMAIN_SEPARATOR + "type=SortSdk" + ",name=" + sortTaskId +
-                metricItem.hashCode();
+        String strBeanName = JMX_DOMAIN + DOMAIN_SEPARATOR + "type=SortSdk" + ",name=" + sortTaskId
+                + metricItem.hashCode();
         try {
             ObjectName objName = new ObjectName(strBeanName);
             mbs.registerMBean(metricItem, objName);


### PR DESCRIPTION
- Fixes #5665

### Motivation

Current strategy is that invoke callback after deserializing one batch of MQ messages, which will result in full gc in the case of high load.

Change it to invoke callback after deserializing each MQ message to reduce full gc, but it will produce times of callback invoking.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
