### PR TITLE
[INLONG-5698][Manager] Fixed the DataProxy cluster tag was restored after the manager was restarted

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongClusterEntityMapper.java
@@ -40,6 +40,8 @@ public interface InlongClusterEntityMapper {
     List<InlongClusterEntity> selectByKey(@Param("clusterTag") String clusterTag, @Param("name") String name,
             @Param("type") String type);
 
+    InlongClusterEntity selectByNameAndType(@Param("name") String name, @Param("type") String type);
+
     List<InlongClusterEntity> selectByCondition(ClusterPageRequest request);
 
     /**

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterEntityMapper.xml
@@ -105,6 +105,21 @@
         </where>
         order by modify_time desc
     </select>
+    <select id="selectByNameAndType" resultType="org.apache.inlong.manager.dao.entity.InlongClusterEntity">
+        select
+        <include refid="Base_Column_List"/>
+        from inlong_cluster
+        <where>
+            is_deleted = 0
+            <if test="type != null and type != ''">
+                and type = #{type, jdbcType=VARCHAR}
+            </if>
+            <if test="name != null and name != ''">
+                and name = #{name, jdbcType=VARCHAR}
+            </if>
+        </where>
+        order by modify_time desc
+    </select>
     <select id="selectByCondition"
             parameterType="org.apache.inlong.manager.pojo.cluster.ClusterPageRequest"
             resultType="org.apache.inlong.manager.dao.entity.InlongClusterEntity">

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
@@ -43,7 +43,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -158,7 +157,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         final String type = componentHeartbeat.getComponentType();
         final String clusterTag = componentHeartbeat.getClusterTag();
         InlongClusterEntity entity = clusterMapper.selectByNameAndType(clusterName, type);
-        if (!Objects.isNull(entity)) {
+        if (null != entity) {
             // TODO Load balancing needs to be considered.
             InlongClusterOperator operator = clusterOperatorFactory.getInstance(entity.getType());
             return operator.getFromEntity(entity);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
@@ -24,7 +24,6 @@ import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Scheduler;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.heartbeat.AbstractHeartbeatManager;
 import org.apache.inlong.common.heartbeat.ComponentHeartbeat;
@@ -44,7 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -158,12 +157,11 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         final String clusterName = componentHeartbeat.getClusterName();
         final String type = componentHeartbeat.getComponentType();
         final String clusterTag = componentHeartbeat.getClusterTag();
-        List<InlongClusterEntity> entities = clusterMapper.selectByKey(clusterTag, clusterName, type);
-        if (CollectionUtils.isNotEmpty(entities)) {
+        InlongClusterEntity entity = clusterMapper.selectByNameAndType(clusterName, type);
+        if (!Objects.isNull(entity)) {
             // TODO Load balancing needs to be considered.
-            InlongClusterEntity cluster = entities.get(0);
-            InlongClusterOperator operator = clusterOperatorFactory.getInstance(cluster.getType());
-            return operator.getFromEntity(cluster);
+            InlongClusterOperator operator = clusterOperatorFactory.getInstance(entity.getType());
+            return operator.getFromEntity(entity);
         }
 
         InlongClusterEntity cluster = new InlongClusterEntity();


### PR DESCRIPTION

### Prepare a Pull Request
- Fixes #5698 

### Motivation

Make sure the dataproxy cluster tag was not restored to the default after the manager was restarted.

### Modifications

After receiving the cluster heartbeat information, if there is a cluster with the same name, the information will not be modified.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)
