### PR TITLE
[INLONG-5708][DataProxy] Provide single flume channel to reduce synchronized operation

### DIFF
--- a/inlong-dataproxy/conf/dataproxy-pulsar.conf
+++ b/inlong-dataproxy/conf/dataproxy-pulsar.conf
@@ -63,6 +63,10 @@ agent1.channels.ch-msg1.capacity = 50000
 agent1.channels.ch-msg1.keep-alive = 0
 agent1.channels.ch-msg1.transactionCapacity = 200
 
+#agent1.channels.ch-msg1.type=org.apache.inlong.dataproxy.channel.BufferQueueChannel
+#agent1.channels.ch-msg1.maxBufferQueueCount=50000
+#agent1.channels.ch-msg1.maxBufferQueueSizeKb=50000
+
 agent1.channels.ch-msg2.type = memory
 agent1.channels.ch-msg2.capacity = 50000
 agent1.channels.ch-msg2.keep-alive = 0

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/BufferQueueChannel.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/BufferQueueChannel.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.channel;
+
+import com.google.common.base.Preconditions;
+
+import org.apache.flume.ChannelException;
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.channel.AbstractChannel;
+import org.apache.inlong.dataproxy.utils.BufferQueue;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * BufferQueueChannel
+ */
+public class BufferQueueChannel extends AbstractChannel {
+
+    public static final Logger LOG = LoggerFactory.getLogger(BufferQueueChannel.class);
+
+    public static final String KEY_MAX_BUFFERQUEUE_COUNT = "maxBufferQueueCount";
+    // average message size is 1KB.
+    public static final int DEFAULT_MAX_BUFFERQUEUE_COUNT = 128 * 1024;
+    public static final String KEY_MAX_BUFFERQUEUE_SIZE_KB = "maxBufferQueueSizeKb";
+    public static final int DEFAULT_MAX_BUFFERQUEUE_SIZE_KB = 128 * 1024;
+    public static final String KEY_RELOADINTERVAL = "reloadInterval";
+
+    private Context context;
+    private int maxBufferQueueCount;
+    private Semaphore countSemaphore;
+    private int maxBufferQueueSizeKb;
+    private BufferQueue<ProxyEvent> bufferQueue;
+    private ThreadLocal<ProxyTransaction> currentTransaction = new ThreadLocal<ProxyTransaction>();
+    protected Timer channelTimer;
+    private AtomicLong takeCounter = new AtomicLong(0);
+    private AtomicLong putCounter = new AtomicLong(0);
+
+    /**
+     * Constructor
+     */
+    public BufferQueueChannel() {
+    }
+
+    /**
+     * put
+     * 
+     * @param  event
+     * @throws ChannelException
+     */
+    @Override
+    public void put(Event event) throws ChannelException {
+        if (event instanceof ProxyEvent) {
+            putCounter.incrementAndGet();
+            int eventSize = event.getBody().length;
+            this.countSemaphore.acquireUninterruptibly();
+            this.bufferQueue.acquire(eventSize);
+            ProxyTransaction transaction = currentTransaction.get();
+            Preconditions.checkState(transaction != null, "No transaction exists for this thread");
+            ProxyEvent profile = (ProxyEvent) event;
+            transaction.doPut(profile);
+        }
+    }
+
+    /**
+     * take
+     * 
+     * @return                  Event
+     * @throws ChannelException
+     */
+    @Override
+    public Event take() throws ChannelException {
+        ProxyEvent event = this.bufferQueue.pollRecord();
+        if (event != null) {
+            ProxyTransaction transaction = currentTransaction.get();
+            Preconditions.checkState(transaction != null, "No transaction exists for this thread");
+            transaction.doTake(event);
+            takeCounter.incrementAndGet();
+        }
+        return event;
+    }
+
+    /**
+     * getTransaction
+     * 
+     * @return
+     */
+    @Override
+    public Transaction getTransaction() {
+        ProxyTransaction newTransaction = new ProxyTransaction(this.countSemaphore, this.bufferQueue);
+        this.currentTransaction.set(newTransaction);
+        return newTransaction;
+    }
+
+    /**
+     * start
+     */
+    @Override
+    public void start() {
+        super.start();
+        try {
+            this.setReloadTimer();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * setReloadTimer
+     */
+    protected void setReloadTimer() {
+        channelTimer = new Timer(true);
+        long reloadInterval = context.getLong(KEY_RELOADINTERVAL, 60000L);
+        TimerTask channelTask = new TimerTask() {
+
+            public void run() {
+                LOG.info("queueSize:{},availablePermits:{},maxBufferQueueCount:{},availablePermits:{},put:{},take:{}",
+                        bufferQueue.size(),
+                        bufferQueue.availablePermits(),
+                        maxBufferQueueCount,
+                        countSemaphore.availablePermits(),
+                        putCounter.getAndSet(0),
+                        takeCounter.getAndSet(0));
+            }
+        };
+        channelTimer.schedule(channelTask,
+                new Date(System.currentTimeMillis() + reloadInterval),
+                reloadInterval);
+    }
+
+    /**
+     * configure
+     * 
+     * @param context
+     */
+    @Override
+    public void configure(Context context) {
+        this.context = context;
+        this.maxBufferQueueCount = context.getInteger(KEY_MAX_BUFFERQUEUE_COUNT, DEFAULT_MAX_BUFFERQUEUE_COUNT);
+        this.countSemaphore = new Semaphore(maxBufferQueueCount, true);
+        this.maxBufferQueueSizeKb = context.getInteger(KEY_MAX_BUFFERQUEUE_SIZE_KB, DEFAULT_MAX_BUFFERQUEUE_SIZE_KB);
+        this.bufferQueue = new BufferQueue<>(maxBufferQueueSizeKb);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/ProxyTransaction.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/channel/ProxyTransaction.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.channel;
+
+import org.apache.flume.Transaction;
+import org.apache.inlong.dataproxy.utils.BufferQueue;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+/**
+ * ProfileTransaction
+ */
+public class ProxyTransaction implements Transaction {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ProxyTransaction.class);
+
+    private Semaphore countSemaphore;
+    private BufferQueue<ProxyEvent> bufferQueue;
+    private List<ProxyEvent> takeList = new ArrayList<>();
+    private List<ProxyEvent> putList = new ArrayList<>();
+
+    /**
+     * Constructor
+     * 
+     * @param countSemaphore
+     * @param bufferQueue
+     */
+    public ProxyTransaction(Semaphore countSemaphore, BufferQueue<ProxyEvent> bufferQueue) {
+        this.countSemaphore = countSemaphore;
+        this.bufferQueue = bufferQueue;
+    }
+
+    /**
+     * begin
+     */
+    @Override
+    public void begin() {
+    }
+
+    /**
+     * commit
+     */
+    @Override
+    public void commit() {
+        for (ProxyEvent event : takeList) {
+            countSemaphore.release();
+            bufferQueue.release(event.getBody().length);
+        }
+        this.takeList.clear();
+        for (ProxyEvent event : putList) {
+            this.bufferQueue.offer(event);
+        }
+        this.putList.clear();
+    }
+
+    /**
+     * rollback
+     */
+    @Override
+    public void rollback() {
+        for (ProxyEvent event : takeList) {
+            this.bufferQueue.offer(event);
+        }
+        this.takeList.clear();
+        for (ProxyEvent event : putList) {
+            countSemaphore.release();
+            bufferQueue.release(event.getBody().length);
+        }
+        this.putList.clear();
+    }
+
+    /**
+     * close
+     */
+    @Override
+    public void close() {
+    }
+
+    /**
+     * doTake
+     * 
+     * @param event
+     */
+    public void doTake(ProxyEvent event) {
+        this.takeList.add(event);
+    }
+
+    /**
+     * doPut
+     * 
+     * @param event
+     */
+    public void doPut(ProxyEvent event) {
+        this.putList.add(event);
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
@@ -23,12 +23,16 @@ import org.apache.flume.Transaction;
 import org.apache.flume.channel.MemoryChannel;
 import org.apache.flume.event.SimpleEvent;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * BufferQueueChannelTest
  * 
  */
 public class TestBufferQueueChannel {
+
+    public static final Logger LOG = LoggerFactory.getLogger(TestBufferQueueChannel.class);
 
     /**
      * testResult
@@ -62,28 +66,28 @@ public class TestBufferQueueChannel {
         // transactionSize=1
         int transactionSize = 1;
         long memoryDuration = runChannel(memoryChannel, times, transactionSize);
-        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+        LOG.info(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
                 transactionSize, memoryDuration));
         long bufferDuration = runChannel(bufferChannel, times, transactionSize);
-        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+        LOG.info(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
                 transactionSize, bufferDuration,
                 String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
         // transactionSize=10
         transactionSize = 10;
         memoryDuration = runChannel(memoryChannel, times, transactionSize);
-        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+        LOG.info(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
                 transactionSize, memoryDuration));
         bufferDuration = runChannel(bufferChannel, times, transactionSize);
-        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+        LOG.info(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
                 transactionSize, bufferDuration,
                 String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
         // transactionSize=100
         transactionSize = 100;
         memoryDuration = runChannel(memoryChannel, times, transactionSize);
-        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+        LOG.info(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
                 transactionSize, memoryDuration));
         bufferDuration = runChannel(bufferChannel, times, transactionSize);
-        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+        LOG.info(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
                 transactionSize, bufferDuration,
                 String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
     }
@@ -118,7 +122,7 @@ public class TestBufferQueueChannel {
                 takeTx.close();
             }
         } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e.getMessage(), e);
         }
         long endTime = System.currentTimeMillis();
         return endTime - startTime;

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.channel;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.apache.flume.Transaction;
+import org.apache.flume.channel.MemoryChannel;
+import org.apache.flume.event.SimpleEvent;
+import org.junit.Test;
+
+/**
+ * BufferQueueChannelTest
+ * 
+ */
+public class TestBufferQueueChannel {
+
+    /**
+     * testResult
+     * MemoryChannel,times:1000000,transactionSize:1,duration:1363<br>
+     * BufferQueueChannel,times:1000000,transactionSize:1,duration:84,gap:0.9383712399119589<br>
+     * MemoryChannel,times:1000000,transactionSize:10,duration:2818<br>
+     * BufferQueueChannel,times:1000000,transactionSize:10,duration:122,gap:0.9567068843151171<br>
+     * MemoryChannel,times:1000000,transactionSize:100,duration:19189<br>
+     * BufferQueueChannel,times:1000000,transactionSize:100,duration:687,gap:0.9641982385741831<br>
+     * @throws Exception
+     */
+    @Test
+    public void testResult() throws Exception {
+        // init
+        Context memoryContext = new Context();
+        memoryContext.put("capacity", "50000");
+        memoryContext.put("keep-alive", "0");
+        memoryContext.put("transactionCapacity", "200");
+        final MemoryChannel memoryChannel = new MemoryChannel();
+        memoryChannel.configure(memoryContext);
+        memoryChannel.start();
+        // init
+        Context bufferContext = new Context();
+        bufferContext.put("maxBufferQueueCount", "50000");
+        bufferContext.put("maxBufferQueueSizeKb", "50000");
+        final BufferQueueChannel bufferChannel = new BufferQueueChannel();
+        bufferChannel.configure(bufferContext);
+        bufferChannel.start();
+        // times
+        int times = 1000000;
+        int transactionSize = 1;
+        long memoryDuration = 0;
+        long bufferDuration = 0;
+        // transactionSize=1
+        transactionSize = 1;
+        memoryDuration = runChannel(memoryChannel, times, transactionSize);
+        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+                transactionSize, memoryDuration));
+        bufferDuration = runChannel(bufferChannel, times, transactionSize);
+        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+                transactionSize, bufferDuration,
+                String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
+        // transactionSize=10
+        transactionSize = 10;
+        memoryDuration = runChannel(memoryChannel, times, transactionSize);
+        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+                transactionSize, memoryDuration));
+        bufferDuration = runChannel(bufferChannel, times, transactionSize);
+        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+                transactionSize, bufferDuration,
+                String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
+        // transactionSize=100
+        transactionSize = 100;
+        memoryDuration = runChannel(memoryChannel, times, transactionSize);
+        System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
+                transactionSize, memoryDuration));
+        bufferDuration = runChannel(bufferChannel, times, transactionSize);
+        System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
+                transactionSize, bufferDuration,
+                String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));
+    }
+
+    /**
+     * runChannel
+     * @param channel
+     * @param times
+     * @param transactionSize
+     * @return
+     */
+    private long runChannel(Channel channel, int times, int transactionSize) {
+        long startTime = System.currentTimeMillis();
+        try {
+            SimpleEvent event = new SimpleEvent();
+            for (int i = 0; i < times; i++) {
+                // put
+                Transaction putTx = channel.getTransaction();
+                putTx.begin();
+                for (int j = 0; j < transactionSize; j++) {
+                    channel.put(event);
+                }
+                putTx.commit();
+                putTx.close();
+                // take
+                Transaction takeTx = channel.getTransaction();
+                takeTx.begin();
+                for (int j = 0; j < transactionSize; j++) {
+                    channel.take();
+                }
+                takeTx.commit();
+                takeTx.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        long endTime = System.currentTimeMillis();
+        return endTime - startTime;
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/channel/TestBufferQueueChannel.java
@@ -59,15 +59,12 @@ public class TestBufferQueueChannel {
         bufferChannel.start();
         // times
         int times = 1000000;
-        int transactionSize = 1;
-        long memoryDuration = 0;
-        long bufferDuration = 0;
         // transactionSize=1
-        transactionSize = 1;
-        memoryDuration = runChannel(memoryChannel, times, transactionSize);
+        int transactionSize = 1;
+        long memoryDuration = runChannel(memoryChannel, times, transactionSize);
         System.out.println(String.format("MemoryChannel,times:%d,transactionSize:%d,duration:%d", times,
                 transactionSize, memoryDuration));
-        bufferDuration = runChannel(bufferChannel, times, transactionSize);
+        long bufferDuration = runChannel(bufferChannel, times, transactionSize);
         System.out.println(String.format("BufferQueueChannel,times:%d,transactionSize:%d,duration:%d,gap:%s", times,
                 transactionSize, bufferDuration,
                 String.valueOf((memoryDuration - bufferDuration) * 1.0 / memoryDuration)));


### PR DESCRIPTION
### Prepare a Pull Request
- Title: [INLONG-5708][Feature][DataProxy] Provide single flume channel to reduce synchronized operation, and improve DataProxy performance
- Fixes #5708 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
