### PR TITLE
[INLONG-5724][CI] Skip the apache-rat-plugin when building the docker-compose

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1749,6 +1749,9 @@
                         <exclude>**/tubemq-client-go/go.mod</exclude>
                         <!-- Go sum -->
                         <exclude>**/tubemq-client-go/go.sum</exclude>
+                        <!-- Docker build-->
+                        <exclude>**/docker/docker-compose/**/**</exclude>
+
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixes #5724