### PR TITLE
[INLONG-5754][Sort] Fix Pulsar connecotr deserialize complex format with multiple data will cause data loss

### DIFF
--- a/inlong-sort/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/withoutadmin/PulsarFetcher.java
+++ b/inlong-sort/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/withoutadmin/PulsarFetcher.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -398,14 +399,15 @@ public class PulsarFetcher<T> {
      * @param pulsarEventTimestamp The timestamp of the pulsar record
      */
     protected void emitRecordsWithTimestamps(
-            T record,
+            Queue<T> records,
             PulsarTopicState<T> partitionState,
             MessageId offset,
             long pulsarEventTimestamp) {
         // emit the records, using the checkpoint lock to guarantee
         // atomicity of record emission and offset state update
         synchronized (checkpointLock) {
-            if (record != null) {
+            T record;
+            while ((record = records.poll()) != null) {
                 long timestamp = partitionState.extractTimestamp(record, pulsarEventTimestamp);
                 sourceContext.collectWithTimestamp(record, timestamp);
 

--- a/inlong-sort/sort-formats/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgDeserializationSchema.java
@@ -18,6 +18,7 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import com.esotericsoftware.minlog.Log;
 import com.google.common.base.Objects;
 import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -82,6 +83,7 @@ public class InLongMsgDeserializationSchema implements DeserializationSchema<Row
                 head = InLongMsgUtils.parseHead(attr);
             } catch (Throwable t) {
                 if (ignoreErrors) {
+                    Log.warn("Ignore inlong msg attr({})parse error.", attr, t);
                     continue;
                 }
                 throw new IOException(


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-5754][Sort] Fix Pulsar connecotr deserialize complex format with multiple data will cause data loss
- Fixes #5754 

### Motivation

Fix Pulsar connecotr deserialize complex format with multiple data will cause data loss

### Modifications

Beacuse before it deserialize ont message to one rowData, so it means only one record will be sended to downstream after parsing a message.
now i store all sub record in one message, and it means multiple records will be sended to downstream if message contains multiple complex record. 

