### PR TITLE
[INLONG-5611][Manager] Set the sink status after updating the sink info

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/StreamStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/StreamStatus.java
@@ -24,7 +24,6 @@ public enum StreamStatus {
 
     DRAFT(0, "draft"),
 
-    // Stream related status
     NEW(100, "new"),
     CONFIG_ING(110, "in configure"),
     CONFIG_FAILED(120, "configuration failed"),
@@ -47,12 +46,12 @@ public enum StreamStatus {
         this.description = description;
     }
 
-    public Integer getCode() {
-        return code;
-    }
-
-    public String getDescription() {
-        return description;
+    /**
+     * Checks whether the given status allows the update.
+     */
+    public static boolean notAllowedUpdate(StreamStatus status) {
+        return status == StreamStatus.CONFIG_ING || status == StreamStatus.SUSPENDING
+                || status == StreamStatus.RESTARTING || status == StreamStatus.DELETING;
     }
 
     public static StreamStatus forCode(int code) {
@@ -62,6 +61,14 @@ public enum StreamStatus {
             }
         }
         throw new IllegalStateException(String.format("Illegal code=%s for StreamStatus", code));
+    }
+
+    public Integer getCode() {
+        return code;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSinkEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSinkEntityMapper.java
@@ -129,9 +129,7 @@ public interface StreamSinkEntityMapper {
      */
     List<SortSourceStreamInfo> selectAllStreams();
 
-    int updateByPrimaryKeySelective(StreamSinkEntity record);
-
-    int updateByPrimaryKey(StreamSinkEntity record);
+    int updateByIdSelective(StreamSinkEntity record);
 
     int updateStatus(StreamSinkEntity entity);
 

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -370,8 +370,7 @@
         where is_deleted = 0
     </select>
 
-    <update id="updateByPrimaryKeySelective"
-            parameterType="org.apache.inlong.manager.dao.entity.StreamSinkEntity">
+    <update id="updateByIdSelective" parameterType="org.apache.inlong.manager.dao.entity.StreamSinkEntity">
         update stream_sink
         <set>
             <if test="inlongGroupId != null">
@@ -411,16 +410,11 @@
                 operate_log = #{operateLog,jdbcType=VARCHAR},
             </if>
             <if test="status != null">
+                previous_status = status,
                 status = #{status,jdbcType=INTEGER},
-            </if>
-            <if test="previousStatus != null">
-                previous_status = #{previousStatus,jdbcType=INTEGER},
             </if>
             <if test="isDeleted != null">
                 is_deleted = #{isDeleted,jdbcType=INTEGER},
-            </if>
-            <if test="creator != null">
-                creator = #{creator,jdbcType=VARCHAR},
             </if>
             <if test="modifier != null">
                 modifier = #{modifier,jdbcType=VARCHAR},
@@ -429,29 +423,6 @@
         </set>
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
-    </update>
-    <update id="updateByPrimaryKey" parameterType="org.apache.inlong.manager.dao.entity.StreamSinkEntity">
-        update stream_sink
-        set inlong_group_id        = #{inlongGroupId,jdbcType=VARCHAR},
-            inlong_stream_id       = #{inlongStreamId,jdbcType=VARCHAR},
-            sink_type              = #{sinkType,jdbcType=VARCHAR},
-            sink_name              = #{sinkName,jdbcType=VARCHAR},
-            description            = #{description,jdbcType=VARCHAR},
-            enable_create_resource = #{enableCreateResource,jdbcType=TINYINT},
-            inlong_cluster_name    = #{inlongClusterName,jdbcType=VARCHAR},
-            data_node_name         = #{dataNodeName,jdbcType=VARCHAR},
-            sort_task_name         = #{sortTaskName,jdbcType=VARCHAR},
-            sort_consumer_group    = #{sortConsumerGroup,jdbcType=VARCHAR},
-            ext_params             = #{extParams,jdbcType=VARCHAR},
-            operate_log            = #{operateLog,jdbcType=VARCHAR},
-            status                 = #{status,jdbcType=INTEGER},
-            previous_status        = #{previousStatus,jdbcType=INTEGER},
-            is_deleted             = #{isDeleted,jdbcType=INTEGER},
-            creator                = #{creator,jdbcType=VARCHAR},
-            modifier               = #{modifier,jdbcType=VARCHAR},
-            version                = #{version,jdbcType=INTEGER} + 1
-        where id = #{id,jdbcType=INTEGER}
-          and version = #{version,jdbcType=INTEGER}
     </update>
     <update id="updateStatus" parameterType="org.apache.inlong.manager.dao.entity.StreamSinkEntity">
         update stream_sink

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkFieldEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkFieldEntityMapper.xml
@@ -69,7 +69,7 @@
     </insert>
     <insert id="insertAll">
         insert into stream_sink_field (
-        id, inlong_group_id,
+        inlong_group_id,
         inlong_stream_id, sink_id,
         sink_type, field_name,
         field_type, field_comment,
@@ -82,7 +82,7 @@
         values
         <foreach collection="list" index="index" item="item" separator=",">
             (
-            #{item.id,jdbcType=INTEGER}, #{item.inlongGroupId,jdbcType=VARCHAR},
+            #{item.inlongGroupId,jdbcType=VARCHAR},
             #{item.inlongStreamId,jdbcType=VARCHAR}, #{item.sinkId,jdbcType=INTEGER},
             #{item.sinkType,jdbcType=VARCHAR}, #{item.fieldName,jdbcType=VARCHAR},
             #{item.fieldType,jdbcType=VARCHAR}, #{item.fieldComment,jdbcType=VARCHAR},

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/ck/ClickHouseResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/ck/ClickHouseResourceOperator.java
@@ -19,15 +19,15 @@ package org.apache.inlong.manager.service.resource.sink.ck;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
-import org.apache.inlong.manager.common.enums.SinkStatus;
 import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.enums.SinkStatus;
 import org.apache.inlong.manager.common.exceptions.WorkflowException;
-import org.apache.inlong.manager.pojo.sink.ck.ClickHouseColumnInfo;
-import org.apache.inlong.manager.pojo.sink.ck.ClickHouseTableInfo;
-import org.apache.inlong.manager.pojo.sink.SinkInfo;
-import org.apache.inlong.manager.pojo.sink.ck.ClickHouseSinkDTO;
 import org.apache.inlong.manager.dao.entity.StreamSinkFieldEntity;
 import org.apache.inlong.manager.dao.mapper.StreamSinkFieldEntityMapper;
+import org.apache.inlong.manager.pojo.sink.SinkInfo;
+import org.apache.inlong.manager.pojo.sink.ck.ClickHouseColumnInfo;
+import org.apache.inlong.manager.pojo.sink.ck.ClickHouseSinkDTO;
+import org.apache.inlong.manager.pojo.sink.ck.ClickHouseTableInfo;
 import org.apache.inlong.manager.service.resource.sink.SinkResourceOperator;
 import org.apache.inlong.manager.service.sink.StreamSinkService;
 import org.slf4j.Logger;
@@ -135,7 +135,7 @@ public class ClickHouseResourceOperator implements SinkResourceOperator {
             throw new WorkflowException(errMsg);
         }
 
-        LOGGER.info("success create ClickHouse table for data sind [" + sinkInfo.getId() + "]");
+        LOGGER.info("success create ClickHouse table for sink id [" + sinkInfo.getId() + "]");
     }
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkOperator.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.service.sink;
 
 import com.github.pagehelper.Page;
+import org.apache.inlong.manager.common.enums.SinkStatus;
 import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.sink.SinkField;
@@ -74,9 +75,10 @@ public interface StreamSinkOperator {
      * Update the sink info.
      *
      * @param request sink info needs to update
+     * @param nextStatus next status
      * @param operator name of the operator
      */
-    void updateOpt(SinkRequest request, String operator);
+    void updateOpt(SinkRequest request, SinkStatus nextStatus, String operator);
 
     /**
      * Update the sink fields.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
@@ -230,11 +230,6 @@ public class StreamSinkServiceImpl implements StreamSinkService {
                 throw new BusinessException(String.format(err, sinkName, groupId, streamId));
             }
         }
-        List<SinkField> fields = request.getSinkFieldList();
-        // Remove id in sinkField before saving or updating
-        if (CollectionUtils.isNotEmpty(fields)) {
-            fields.forEach(sinkField -> sinkField.setId(null));
-        }
 
         SinkStatus nextStatus = null;
         boolean streamSuccess = StreamStatus.CONFIG_SUCCESSFUL.getCode().equals(streamEntity.getStatus());


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5611

### Motivation

Set the sink status after updating the sink info.

### Modifications

After updating the stream sink info, if the status of inlong stream was CONFIG_SUCCESSFUL or CONFIG_FAILED, change the sink status to CONFIG_ING, otherwise not change the sink status.

1. If the stream status was CONFIG_SUCCESSFUL, no matter what status of the sink, all changing to CONFIG_ING, and start the CREATE_STREAM_PROCESS, after the process will change the sink status to CONFIG_SUCCESSFUL or CONFIG_FAILED.

2. If the stream status was CONFIG_FAILED, it means there are some errors occurred, the user must fix it first, and in this situation, sink status also need to be CONFIG_ING, it tells the user that the sink info was updated success, and begin to configuring. Only after the stream error was fixed, the sink status will change to CONFIG_SUCCESSFUL or CONFIG_FAILED.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
