### PR TITLE
[INLONG-5645][CVE] Bump pagehelper from 5.3.0 to 5.3.1 to fix SQL injection vulnerability

### DIFF
--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -759,7 +759,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.slf4j:jul-to-slf4j:1.7.36 - JUL to SLF4J bridge (https://github.com/qos-ch/slf4j/tree/v_1.7.36), (MIT License)
   org.projectlombok:lombok:1.18.22 - Project Lombok (https://projectlombok.org), (The MIT License)
   org.mockito:mockito-core:3.12.4 - (https://github.com/mockito/mockito/tree/v3.12.4), (MIT License)
-  com.github.pagehelper:pagehelper:5.3.0 - PageHelper 5 (https://github.com/pagehelper/Mybatis-PageHelper/tree/v5.3.0), (MIT License)
+  com.github.pagehelper:pagehelper:5.3.1 - PageHelper 5 (https://github.com/pagehelper/Mybatis-PageHelper/tree/v5.3.1), (MIT License)
   com.github.pagehelper:pagehelper-spring-boot-autoconfigure:1.4.2 - PageHelper Spring Boot AutoConfigure (https://github.com/pagehelper/Mybatis-PageHelper/tree/v3.2.0), (MIT License)
   com.github.pagehelper:pagehelper-spring-boot-starter:1.4.2 - PageHelper Spring Boot Starter (https://github.com/pagehelper/Mybatis-PageHelper/tree/v3.2.0), (MIT License)
   com.github.scopt:scopt_2.11:3.5.0 - scopt (https://github.com/scopt/scopt/tree/v3.5.0), (MIT License)

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
         <spring.plugin.version>2.6.6</spring.plugin.version>
         <spring.fox.version>3.0.0</spring.fox.version>
         <pagehelper.springboot.version>1.4.2</pagehelper.springboot.version>
-        <pagehelper.version>5.3.0</pagehelper.version>
+        <pagehelper.version>5.3.1</pagehelper.version>
 
         <h2.version>2.1.210</h2.version>
         <h2.mysql.version>2.0.0</h2.mysql.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5645

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
