### PR TITLE
[INLONG-5805][Sort] Fix incorrect interceptor initialization

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
@@ -33,8 +33,9 @@ public class FlumeConfigGenerator {
     public static final String KEY_SORT_CHANNEL_TYPE = "sortChannel.type";
     public static final String KEY_SORT_SINK_TYPE = "sortSink.type";
     public static final String KEY_SORT_SOURCE_TYPE = "sortSource.type";
-    public static final String KEY_SDK_START_TIME = "sortSdk.startTime";
-    public static final String KEY_SDK_STOP_TIME = "sortSdk.stopTime";
+    public static final String KEY_SORT_INTERCEPTOR_TYPE = "interceptor.type";
+    public static final String KEY_ROLLBACK_START_TIME = "rollback.startTime";
+    public static final String KEY_ROLLBACK_STOP_TIME = "rollback.stopTime";
 
     public static Map<String, String> generateFlumeConfiguration(SortTaskConfig taskConfig) {
         Map<String, String> flumeConf = new HashMap<>();
@@ -161,12 +162,24 @@ public class FlumeConfigGenerator {
         flumeConf.put(selectorTypeKey, "org.apache.flume.channel.ReplicatingChannelSelector");
         // valid msg time interval
         builder.setLength(0);
-        String startTimeKey = builder.append(prefix).append(KEY_SDK_START_TIME).toString();
-        Optional.ofNullable(sinkParams.get(KEY_SDK_START_TIME))
+        String interceptorKey = builder.append(prefix).append("interceptors").toString();
+        String interceptorName = name + "Interceptor";
+        flumeConf.put(interceptorKey, interceptorName);
+
+        builder.setLength(0);
+        String interceptorType = builder.append(prefix).append("interceptors.").append(interceptorName)
+                .append(".type").toString();
+        Optional.ofNullable(CommonPropertiesHolder.getString(KEY_SORT_INTERCEPTOR_TYPE))
+                .map(type -> flumeConf.put(interceptorType, type));
+        builder.setLength(0);
+        String startTimeKey = builder.append(prefix).append("interceptors.").append(interceptorName).append(".")
+                .append(KEY_ROLLBACK_START_TIME).toString();
+        Optional.ofNullable(CommonPropertiesHolder.getString(KEY_ROLLBACK_START_TIME))
                 .map(startTime -> flumeConf.put(startTimeKey, startTime));
         builder.setLength(0);
-        String stopTimeKey = builder.append(prefix).append(KEY_SDK_STOP_TIME).toString();
-        Optional.ofNullable(sinkParams.get(KEY_SDK_STOP_TIME))
+        String stopTimeKey = builder.append(prefix).append("interceptors.").append(interceptorName).append(".")
+                .append(KEY_ROLLBACK_STOP_TIME).toString();
+        Optional.ofNullable(CommonPropertiesHolder.getString(KEY_ROLLBACK_STOP_TIME))
                 .map(stopTime -> flumeConf.put(stopTimeKey, stopTime));
 
         appendCommon(flumeConf, prefix, null, name);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -108,8 +108,8 @@ public final class SortSdkSource extends AbstractSource
      */
     @Override
     public synchronized void start() {
-        LOG.info("start to SortSdkSource:{}", taskName);
         int sortSdkClientNum = CommonPropertiesHolder.getInteger(KEY_SORT_SDK_CLIENT_NUM, DEFAULT_SORT_SDK_CLIENT_NUM);
+        LOG.info("start to SortSdkSource:{}, client num is {}", taskName, sortSdkClientNum);
         for (int i = 0; i < sortSdkClientNum; i++) {
             this.sortClients.add(this.newClient(taskName));
         }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #5805

### Motivation

The configuration to init flume interceptors is lack of a key to specify the type of interceptors.
Which result in incorret init of interceptors.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
