### PR TITLE
[INLONG-5816][Docker] Add platform for aarch64

### DIFF
--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -57,6 +57,11 @@ for (( i=1; i<=$#; i++)); do
       echo "Wrong arch name: ${BUILD_ARCH}. Please input aarch64 or x86."
       exit 1
     fi
+    if [ "$BUILD_ARCH" = "$ARCH_AARCH64" ]; then
+      USE_PLATFORM="$PLATFORM_AARCH64"
+    else
+      USE_PLATFORM="$PLATFORM_X86"
+    fi
     shift
   elif [ "${!i}" = "-h" ] || [ "${!i}" = "--help" ]; then
     helpFunc


### PR DESCRIPTION
### Prepare a Pull Request

Add platform for aarch64
- Fixes #5816 

### Motivation

Add platform for aarch64

### Modifications

Add platform for aarch64

### Verifying this change

build-docker-images.sh lost USE_PLATFORM args.  Add platform for aarch64 can fix build no arm64 images.
I have test as follow:
<img width="768" alt="image" src="https://user-images.githubusercontent.com/100204617/188833679-e1e2c6e9-811f-4502-a28c-ad053d0feae9.png">
