### PR TITLE
[INLONG-5834][DataProxy] Fix the mistake for the sink metric in MQ Zone

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/AbstractZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/AbstractZoneSinkContext.java
@@ -318,7 +318,7 @@ public abstract class AbstractZoneSinkContext {
             metricItem.sendSuccessCount.addAndGet(count);
             metricItem.sendSuccessSize.addAndGet(size);
             currentRecord.getEvents().forEach((event) -> {
-                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_READ_SUCCESS, event);
+                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_SEND_SUCCESS, event);
             });
             if (sendTime > 0) {
                 long currentTime = System.currentTimeMillis();
@@ -367,7 +367,7 @@ public abstract class AbstractZoneSinkContext {
     }
 
     /**
-     * addReadFailMetric
+     * addSendFailMetric
      */
     public void addSendFailMetric() {
         Map<String, String> dimensions = new HashMap<>();
@@ -377,7 +377,7 @@ public abstract class AbstractZoneSinkContext {
         long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
         dimensions.put(DataProxyMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
         DataProxyMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
-        metricItem.readFailCount.incrementAndGet();
+        metricItem.sendFailCount.incrementAndGet();
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5834

### Motivation

Recenetly I learned how inlong to do audit and discover some mistake, so just fix it

### Modifications

1. AUDIT_ID_DATAPROXY_READ_SUCCESS -> AUDIT_ID_DATAPROXY_SEND_SUCCESS
2. readFailCount -> sendFailCount


### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  no
