### PR TITLE
[INLONG-5859][TubeMQ] Remove the redundant codes in DefaultOffsetManager

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/DefaultOffsetManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/DefaultOffsetManager.java
@@ -615,20 +615,7 @@ public class DefaultOffsetManager extends AbstractDaemonService implements Offse
     }
 
     private long getAndResetTmpOffset(final String group, final String offsetCacheKey) {
-        ConcurrentHashMap<String, Long> partTmpOffsetMap = tmpOffsetMap.get(group);
-        if (partTmpOffsetMap == null) {
-            ConcurrentHashMap<String, Long> tmpMap = new ConcurrentHashMap<>();
-            partTmpOffsetMap = tmpOffsetMap.putIfAbsent(group, tmpMap);
-            if (partTmpOffsetMap == null) {
-                partTmpOffsetMap = tmpMap;
-            }
-        }
-        Long tmpOffset = partTmpOffsetMap.put(offsetCacheKey, 0L);
-        if (tmpOffset == null) {
-            return 0;
-        } else {
-            return (tmpOffset - tmpOffset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
-        }
+        return setTmpOffset(group, offsetCacheKey, 0L);
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes https://github.com/apache/inlong/issues/5859

### Motivation
The code duplication rate for method getAndResetTmpOffset and method setTmpOffset is as high as 90%.
In fact, method getAndResetTmpOffset can reuse method setTmpOffset.

### Modifications
The code duplication rate for method getAndResetTmpOffset and method setTmpOffset is as high as 90%.
In fact, method getAndResetTmpOffset can reuse method setTmpOffset.


