### PR TITLE
[INLONG-5875][Manager] Set the version for the issued sub-sources

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -260,6 +260,7 @@ public class AgentServiceImpl implements AgentService {
                 int op = getOp(fileEntity.getStatus());
                 int nextStatus = getNextStatus(fileEntity.getStatus());
                 fileEntity.setStatus(nextStatus);
+                fileEntity.setVersion(1);
                 if (sourceMapper.insert(fileEntity) > 0) {
                     fileTasks.add(getDataConfig(fileEntity, op));
                 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -260,8 +260,9 @@ public class AgentServiceImpl implements AgentService {
                 int op = getOp(fileEntity.getStatus());
                 int nextStatus = getNextStatus(fileEntity.getStatus());
                 fileEntity.setStatus(nextStatus);
-                fileEntity.setVersion(1);
                 if (sourceMapper.insert(fileEntity) > 0) {
+                    // refresh entity version and others.
+                    fileEntity = sourceMapper.selectById(fileEntity.getId());
                     fileTasks.add(getDataConfig(fileEntity, op));
                 }
             }


### PR DESCRIPTION

- Fixes #5875

The new sub source task version should not be copied from template task but defaults to 1.
Or else subsequent operations may fail due to version not matching.