### PR TITLE
[INLONG-5889][Sort] Fix the RCE vulnerability for MySQL node JDBC URL

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -105,5 +105,4 @@ public final class Constants {
 
     public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
 
-
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -94,4 +94,16 @@ public final class Constants {
                     .defaultValue(false)
                     .withDescription("Regard upsert delete as insert kind.");
 
+
+    /**
+     * It is used for jdbc url filter for avoiding url attack
+     * see also in https://su18.org/post/jdbc-connection-url-attack/
+     */
+    public static final String AUTO_DESERIALIZE = "autoDeserialize";
+
+    public static final String AUTO_DESERIALIZE_TRUE = "autoDeserialize=true";
+
+    public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
+
+
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/JdbcUrlUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/JdbcUrlUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.inlong.sort.base.util;
+
+import static org.apache.inlong.sort.base.Constants.AUTO_DESERIALIZE_FALSE;
+import static org.apache.inlong.sort.base.Constants.AUTO_DESERIALIZE_TRUE;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * utils for jdbc url
+ */
+public class JdbcUrlUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JdbcUrlUtils.class);
+
+    /**
+     * see https://su18.org/post/jdbc-connection-url-attack/
+     * @param url
+     * @return url after filtering out the invalid property
+     */
+    public static String replaceInvalidUrlProperty(String url) {
+        if (url.contains(AUTO_DESERIALIZE_TRUE)) {
+            LOG.info("url {} contains invalid property {}, replace it to {}", url,
+                AUTO_DESERIALIZE_TRUE, AUTO_DESERIALIZE_FALSE);
+            return url.replace(AUTO_DESERIALIZE_TRUE, AUTO_DESERIALIZE_FALSE);
+        }
+        return url;
+    }
+
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/JdbcUrlUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/JdbcUrlUtils.java
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.sort.base.util;
 
 import static org.apache.inlong.sort.base.Constants.AUTO_DESERIALIZE_FALSE;
 import static org.apache.inlong.sort.base.Constants.AUTO_DESERIALIZE_TRUE;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,10 +38,11 @@ public class JdbcUrlUtils {
      * @return url after filtering out the invalid property
      */
     public static String replaceInvalidUrlProperty(String url) {
-        if (url.contains(AUTO_DESERIALIZE_TRUE)) {
+        if (StringUtils.containsIgnoreCase(url, AUTO_DESERIALIZE_TRUE)) {
             LOG.info("url {} contains invalid property {}, replace it to {}", url,
                 AUTO_DESERIALIZE_TRUE, AUTO_DESERIALIZE_FALSE);
-            return url.replace(AUTO_DESERIALIZE_TRUE, AUTO_DESERIALIZE_FALSE);
+            return StringUtils.replaceIgnoreCase(url, AUTO_DESERIALIZE_TRUE,
+                AUTO_DESERIALIZE_FALSE);
         }
         return url;
     }

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/metric/TestUrlValidate.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/metric/TestUrlValidate.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.inlong.sort.base.metric;
+
+import org.apache.inlong.sort.base.util.JdbcUrlUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for validate jdbc url, see https://su18.org/post/jdbc-connection-url-attack/
+ */
+public class TestUrlValidate {
+
+    @Test
+    public void testJdbcUrlValid() {
+        final String jdbcUrl = "jdbc:mysql://localhost:8066/dbtest?detectCustomCollations=true&autoDeserialize=true";
+        final String expectResult = "jdbc:mysql://localhost:8066/dbtest?detectCustomCollations=true&autoDeserialize=false";
+        Assert.assertEquals(expectResult, JdbcUrlUtils.replaceInvalidUrlProperty(jdbcUrl));
+    }
+
+}

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/metric/TestUrlValidate.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/metric/TestUrlValidate.java
@@ -16,7 +16,6 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.sort.base.metric;
 
 import org.apache.inlong.sort.base.util.JdbcUrlUtils;
@@ -30,9 +29,18 @@ public class TestUrlValidate {
 
     @Test
     public void testJdbcUrlValid() {
-        final String jdbcUrl = "jdbc:mysql://localhost:8066/dbtest?detectCustomCollations=true&autoDeserialize=true";
-        final String expectResult = "jdbc:mysql://localhost:8066/dbtest?detectCustomCollations=true&autoDeserialize=false";
+        final String jdbcUrl = "jdbc:mysql://localhost:8066/dbtest?"
+            + "detectCustomCollations=true&autoDeserialize=true";
+        final String expectResult = "jdbc:mysql://localhost:8066/dbtest?"
+            + "detectCustomCollations=true&autoDeserialize=false";
         Assert.assertEquals(expectResult, JdbcUrlUtils.replaceInvalidUrlProperty(jdbcUrl));
+
+        final String jdbcUrlWithCase = "jdbc:mysql://localhost:8066/dbtest?"
+            + "detectCustomCollations=true&autoDeserialize=tRue";
+        final String expectResultWithoutCase = "jdbc:mysql://localhost:8066/dbtest?"
+            + "detectCustomCollations=true&autoDeserialize=false";
+        Assert.assertEquals(expectResultWithoutCase, JdbcUrlUtils.replaceInvalidUrlProperty(jdbcUrlWithCase));
+
     }
 
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableFactory.java
@@ -42,6 +42,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.inlong.sort.base.util.JdbcUrlUtils;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
@@ -59,6 +60,7 @@ import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
     public static final String IDENTIFIER = "jdbc-inlong";
+
     public static final ConfigOption<String> DIALECT_IMPL =
             ConfigOptions.key("dialect-impl")
                     .stringType()
@@ -219,6 +221,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 
     private JdbcOptions getJdbcOptions(ReadableConfig readableConfig) {
         final String url = readableConfig.get(URL);
+        JdbcUrlUtils.replaceInvalidUrlProperty(url);
         Optional<String> dialectImplOptional = readableConfig.getOptional(DIALECT_IMPL);
         Optional<JdbcDialect> jdbcDialect;
         if (dialectImplOptional.isPresent()) {

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/JdbcUrlUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/JdbcUrlUtils.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.cdc.mysql.table;
 
 import java.util.Map;
 import java.util.Properties;
+import org.apache.inlong.sort.base.Constants;
 
 /** Option utils for JDBC URL properties. */
 public class JdbcUrlUtils {
@@ -31,7 +32,7 @@ public class JdbcUrlUtils {
         Properties jdbcProperties = new Properties();
         if (hasJdbcProperties(tableOptions)) {
             tableOptions.keySet().stream()
-                    .filter(key -> key.startsWith(PROPERTIES_PREFIX))
+                    .filter(key -> key.startsWith(PROPERTIES_PREFIX) && isValid(key))
                     .forEach(
                             key -> {
                                 final String value = tableOptions.get(key);
@@ -49,4 +50,10 @@ public class JdbcUrlUtils {
     private static boolean hasJdbcProperties(Map<String, String> tableOptions) {
         return tableOptions.keySet().stream().anyMatch(k -> k.startsWith(PROPERTIES_PREFIX));
     }
+
+
+    private static boolean isValid(String key) {
+        return !key.contains(Constants.AUTO_DESERIALIZE);
+    }
+
 }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/JdbcUrlUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/JdbcUrlUtils.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.cdc.mysql.table;
 
 import java.util.Map;
 import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sort.base.Constants;
 
 /** Option utils for JDBC URL properties. */
@@ -53,7 +54,7 @@ public class JdbcUrlUtils {
 
 
     private static boolean isValid(String key) {
-        return !key.contains(Constants.AUTO_DESERIALIZE);
+        return !StringUtils.containsIgnoreCase(key, Constants.AUTO_DESERIALIZE);
     }
 
 }


### PR DESCRIPTION
- Fixes #5889

### Motivation

fix mysql load node jdbc for RCE Vulnerability

JDBC URL of MySQL was vulnerable to security attacks.

See https://su18.org/post/jdbc-connection-url-attack,

or https://pyn3rd.github.io/2022/06/06/Make-JDBC-Attacks-Brillian-Again-I

### Modifications

fix mysql load node jdbc for RCE Vulnerability

### Verifying this change

add unit test 

### Documentation

  - Does this pull request introduce a new feature? (no)