### PR TITLE
[INLONG-5936][Manager] Fix return type of cluster API

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -174,7 +174,7 @@ public interface InlongClient {
      * @param request query conditions
      * @return cluster list
      */
-    ClusterInfo list(ClusterPageRequest request);
+    PageResult<ClusterInfo> list(ClusterPageRequest request);
 
     /**
      * Update cluster information.

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -201,7 +201,7 @@ public class InlongClientImpl implements InlongClient {
     }
 
     @Override
-    public ClusterInfo list(ClusterPageRequest request) {
+    public PageResult<ClusterInfo> list(ClusterPageRequest request) {
         return clusterClient.list(request);
     }
 

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -141,10 +141,10 @@ public class InlongClusterClient {
      * @param request query conditions
      * @return cluster list
      */
-    public ClusterInfo list(ClusterPageRequest request) {
-        Response<ClusterInfo> clusterInfoResponse = ClientUtils.executeHttpCall(inlongClusterApi.list(request));
-        ClientUtils.assertRespSuccess(clusterInfoResponse);
-        return clusterInfoResponse.getData();
+    public PageResult<ClusterInfo> list(ClusterPageRequest request) {
+        Response<PageResult<ClusterInfo>> response = ClientUtils.executeHttpCall(inlongClusterApi.list(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
     }
 
     /**

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -59,7 +59,7 @@ public interface InlongClusterApi {
     Call<Response<ClusterInfo>> get(@Path("id") Integer id);
 
     @POST("cluster/list")
-    Call<Response<ClusterInfo>> list(@Body ClusterPageRequest request);
+    Call<Response<PageResult<ClusterInfo>>> list(@Body ClusterPageRequest request);
 
     @POST("cluster/update")
     Call<Response<Boolean>> update(@Body ClusterRequest request);


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5936 

### Motivation

![image](https://user-images.githubusercontent.com/58519431/191155428-396f30af-bda8-4678-adc4-f91414714a9b.png)
![image](https://user-images.githubusercontent.com/58519431/191155460-f2696c83-09a4-4d87-99d8-0e740f432964.png)

It should return `Call<Response<PageResult<ClusterInfo>>>`.

### Modifications

Modify return type to `Call<Response<PageResult<ClusterInfo>>>`.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
