### PR TITLE
[INLONG-5102][Manager] Command tools add CRUD for inlong cluster

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -114,9 +114,9 @@ public class CreateCommand extends AbstractCommand {
             ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
             ClientUtils.initClientFactory();
             InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
-            Integer isSave = clusterClient.saveCluster(request);
-            if (isSave != null) {
-                System.out.println("Create cluster success! ID:" + isSave);
+            Integer clusterId = clusterClient.saveCluster(request);
+            if (clusterId != null) {
+                System.out.println("Create cluster success! ID:" + clusterId);
             }
         }
     }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -24,10 +24,13 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.InlongStreamBuilder;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.pojo.CreateGroupConf;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 
 import java.io.File;
+import java.util.List;
 
 /**
  * Create resource by json file.
@@ -36,18 +39,19 @@ import java.io.File;
 public class CreateCommand extends AbstractCommand {
 
     @Parameter()
-    private java.util.List<String> params;
+    private List<String> params;
 
     public CreateCommand() {
         super("create");
         jcommander.addCommand("group", new CreateGroup());
+        jcommander.addCommand("cluster", new CreateCluster());
     }
 
     @Parameters(commandDescription = "Create group by json file")
     private static class CreateGroup extends AbstractCommandRunner {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-f", "--file"},
                 converter = FileConverter.class,
@@ -87,6 +91,32 @@ public class CreateCommand extends AbstractCommand {
             } catch (Exception e) {
                 System.out.println("Create group failed!");
                 System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Create cluster by json file")
+    private static class CreateCluster extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() throws Exception {
+            String content = ClientUtils.readFile(file);
+            if (StringUtils.isBlank(content)) {
+                System.out.println("Create cluster failed: file was empty!");
+                return;
+            }
+            ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
+            ClientUtils.initClientFactory();
+            InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+            Integer isSave = clusterClient.saveCluster(request);
+            if (isSave != null) {
+                System.out.println("Create cluster success! ID:" + isSave);
             }
         }
     }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 
 import java.util.List;
@@ -37,7 +38,8 @@ public class DeleteCommand extends AbstractCommand {
 
     public DeleteCommand() {
         super("delete");
-        jcommander.addCommand("group", new DeleteCommand.DeleteGroup());
+        jcommander.addCommand("group", new DeleteGroup());
+        jcommander.addCommand("cluster", new DeleteCluster());
     }
 
     @Parameters(commandDescription = "Delete group by group id")
@@ -60,6 +62,29 @@ public class DeleteCommand extends AbstractCommand {
                 System.out.println("delete group success");
             } catch (Exception e) {
                 System.out.format("Delete group failed! message: %s \n", e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Delete cluster by cluster id")
+    private static class DeleteCluster extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster id")
+        private int clusterId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.delete(clusterId)) {
+                    System.out.println("Delete cluster success");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
             }
         }
     }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -59,7 +59,7 @@ public class DeleteCommand extends AbstractCommand {
                 InlongClient inlongClient = ClientUtils.getClient();
                 InlongGroup group = inlongClient.getGroup(inlongGroupId);
                 group.delete();
-                System.out.println("delete group success");
+                System.out.println("Delete group success!");
             } catch (Exception e) {
                 System.out.format("Delete group failed! message: %s \n", e.getMessage());
             }
@@ -81,7 +81,7 @@ public class DeleteCommand extends AbstractCommand {
                 ClientUtils.initClientFactory();
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.delete(clusterId)) {
-                    System.out.println("Delete cluster success");
+                    System.out.println("Delete cluster success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.client.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
@@ -26,6 +27,7 @@ import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
+import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
@@ -42,7 +44,7 @@ import java.util.List;
 public class DescribeCommand extends AbstractCommand {
 
     @Parameter()
-    private java.util.List<String> params;
+    private List<String> params;
 
     public DescribeCommand() {
         super("describe");
@@ -51,13 +53,14 @@ public class DescribeCommand extends AbstractCommand {
         jcommander.addCommand("group", new DescribeGroup());
         jcommander.addCommand("sink", new DescribeSink());
         jcommander.addCommand("source", new DescribeSource());
+        jcommander.addCommand("cluster", new DescribeCluster());
     }
 
     @Parameters(commandDescription = "Get stream details")
     private static class DescribeStream extends AbstractCommandRunner {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-g", "--group"}, required = true, description = "inlong group id")
         private String groupId;
@@ -79,7 +82,7 @@ public class DescribeCommand extends AbstractCommand {
     private static class DescribeGroup extends AbstractCommandRunner {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-s", "--status"}, description = "inlong group status")
         private int status;
@@ -99,6 +102,7 @@ public class DescribeCommand extends AbstractCommand {
                 pageRequest.setKeyword(group);
                 PageResult<InlongGroupBriefInfo> pageInfo = groupClient.listGroups(pageRequest);
                 PrintUtils.print(pageInfo.getList(), GroupInfo.class);
+                pageInfo.getList().forEach(PrintUtils::printJson);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }
@@ -109,7 +113,7 @@ public class DescribeCommand extends AbstractCommand {
     private static class DescribeSink extends AbstractCommandRunner {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-s", "--stream"}, required = true, description = "inlong stream id")
         private String stream;
@@ -134,7 +138,7 @@ public class DescribeCommand extends AbstractCommand {
     private static class DescribeSource extends AbstractCommandRunner {
 
         @Parameter()
-        private java.util.List<String> params;
+        private List<String> params;
 
         @Parameter(names = {"-s", "--stream"}, required = true, description = "inlong stream id")
         private String stream;
@@ -152,6 +156,28 @@ public class DescribeCommand extends AbstractCommand {
                 StreamSourceClient sourceClient = ClientUtils.clientFactory.getSourceClient();
                 List<StreamSource> sources = sourceClient.listSources(group, stream, type);
                 sources.forEach(PrintUtils::printJson);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster details")
+    private static class DescribeCluster extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster id")
+        private int clusterId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                ClusterInfo clusterInfo = clusterClient.get(clusterId);
+                PrintUtils.printJson(clusterInfo);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.client.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
@@ -29,7 +30,10 @@ import org.apache.inlong.manager.client.cli.pojo.SourceInfo;
 import org.apache.inlong.manager.client.cli.pojo.StreamInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
+import org.apache.inlong.manager.client.cli.validator.ClusterTypeValidator;
 import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
+import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.pojo.cluster.ClusterPageRequest;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
@@ -55,6 +59,7 @@ public class ListCommand extends AbstractCommand {
         jcommander.addCommand("group", new ListGroup());
         jcommander.addCommand("sink", new ListSink());
         jcommander.addCommand("source", new ListSource());
+        jcommander.addCommand("cluster", new ListCluster());
     }
 
     @Parameters(commandDescription = "Get stream summary information")
@@ -168,6 +173,34 @@ public class ListCommand extends AbstractCommand {
                 StreamSourceClient sourceClient = ClientUtils.clientFactory.getSourceClient();
                 List<StreamSource> streamSources = sourceClient.listSources(group, stream, type);
                 PrintUtils.print(streamSources, SourceInfo.class);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster summary information")
+    private static class ListCluster extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"--type"}, description = "cluster type", validateWith = ClusterTypeValidator.class)
+        private String type;
+
+        @Parameter(names = {"--tag"}, description = "cluster tag")
+        private String tag;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                ClusterPageRequest request = new ClusterPageRequest();
+                request.setType(type);
+                request.setClusterTag(tag);
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                PageResult<ClusterInfo> clusterInfo = clusterClient.list(request);
+                PrintUtils.print(clusterInfo.getList(), org.apache.inlong.manager.client.cli.pojo.ClusterInfo.class);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -19,10 +19,13 @@ package org.apache.inlong.manager.client.cli;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.converters.FileConverter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
+import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
 
 import java.io.File;
@@ -41,6 +44,7 @@ public class UpdateCommand extends AbstractCommand {
     public UpdateCommand() {
         super("update");
         jcommander.addCommand("group", new UpdateCommand.UpdateGroup());
+        jcommander.addCommand("cluster", new UpdateCommand.UpdateCluster());
     }
 
     @Parameters(commandDescription = "Update group by json file")
@@ -70,6 +74,35 @@ public class UpdateCommand extends AbstractCommand {
                 BaseSortConf sortConf = objectMapper.readValue(fileContent, BaseSortConf.class);
                 group.update(sortConf);
                 System.out.println("update group success");
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Update cluster by json file")
+    private static class UpdateCluster extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                if (StringUtils.isBlank(content)) {
+                    System.out.println("Update cluster failed: file was empty!");
+                    return;
+                }
+                ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.update(request)) {
+                    System.out.println("update cluster success");
+                }
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -70,10 +70,10 @@ public class UpdateCommand extends AbstractCommand {
                     System.out.println("Update group failed: file was empty!");
                     return;
                 }
-                // first extract groupconfig from the file passed in
+                // first extract group config from the file passed in
                 BaseSortConf sortConf = objectMapper.readValue(fileContent, BaseSortConf.class);
                 group.update(sortConf);
-                System.out.println("update group success");
+                System.out.println("Update group success!");
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -101,7 +101,7 @@ public class UpdateCommand extends AbstractCommand {
                 ClientUtils.initClientFactory();
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.update(request)) {
-                    System.out.println("update cluster success");
+                    System.out.println("Update cluster success!");
                 }
             } catch (Exception e) {
                 e.printStackTrace();

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterInfo.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.manager.client.cli.pojo;
 
 import lombok.Data;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterInfo.java
@@ -1,0 +1,17 @@
+package org.apache.inlong.manager.client.cli.pojo;
+
+import lombok.Data;
+
+/**
+ * Cluster info, including cluster name, cluster type, etc.
+ */
+@Data
+public class ClusterInfo {
+
+    private int id;
+    private String name;
+    private String type;
+    private String url;
+    private String clusterTags;
+    private Integer status;
+}

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
@@ -28,17 +28,6 @@ public class ClusterTypeValidator implements IParameterValidator {
 
     @Override
     public void validate(String name, String value) throws ParameterException {
-        switch (value) {
-            case ClusterType.PULSAR:
-            case ClusterType.DATAPROXY:
-            case ClusterType.TUBEMQ:
-            case ClusterType.AGENT:
-            case ClusterType.KAFKA:
-                return;
-            default:
-                String msg = "should be one of the following values:\n"
-                        + "\tPULSAR, DATAPROXY, TUBEMQ, AGENT, KAFKA";
-                throw new ParameterException("Parameter " + name + msg);
-        }
+        ClusterType.forType(value);
     }
 }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.manager.client.cli.validator;
 
 import com.beust.jcommander.IParameterValidator;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
@@ -28,6 +28,10 @@ public class ClusterTypeValidator implements IParameterValidator {
 
     @Override
     public void validate(String name, String value) throws ParameterException {
-        ClusterType.forType(value);
+        try {
+            ClusterType.checkType(value);
+        } catch (Exception e) {
+            throw new ParameterException(e.getMessage());
+        }
     }
 }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/ClusterTypeValidator.java
@@ -1,0 +1,27 @@
+package org.apache.inlong.manager.client.cli.validator;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+import org.apache.inlong.manager.common.enums.ClusterType;
+
+/**
+ * Class for cluster type verification.
+ */
+public class ClusterTypeValidator implements IParameterValidator {
+
+    @Override
+    public void validate(String name, String value) throws ParameterException {
+        switch (value) {
+            case ClusterType.PULSAR:
+            case ClusterType.DATAPROXY:
+            case ClusterType.TUBEMQ:
+            case ClusterType.AGENT:
+            case ClusterType.KAFKA:
+                return;
+            default:
+                String msg = "should be one of the following values:\n"
+                        + "\tPULSAR, DATAPROXY, TUBEMQ, AGENT, KAFKA";
+                throw new ParameterException("Parameter " + name + msg);
+        }
+    }
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -154,6 +154,8 @@ public class InlongClusterClient {
      * @return whether succeed
      */
     public Boolean update(ClusterRequest request) {
+        Preconditions.checkNotNull(request.getId(), "inlong cluster id cannot be empty");
+
         Response<Boolean> response = ClientUtils.executeHttpCall(inlongClusterApi.update(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.manager.common.enums;
 
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,13 +43,17 @@ public class ClusterType {
         }
     };
 
-    public static String forType(String clusterType) {
-        for (String type : TYPE_SET) {
-            if (type.equals(clusterType)) {
-                return type;
-            }
+    /**
+     * Check whether the cluster type is supported
+     *
+     * @param clusterType cluster type
+     * @return cluster type
+     */
+    public static String checkType(String clusterType) {
+        if (TYPE_SET.contains(clusterType)) {
+            return clusterType;
         }
-        throw new IllegalArgumentException(String.format("Unsupported cluster type=%s, "
-                + "supported cluster types are: %s.", clusterType, TYPE_SET));
+        throw new BusinessException(String.format("Unsupported cluster type=%s,"
+                + " supported cluster types are: %s", clusterType, TYPE_SET));
     }
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.manager.common.enums;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Constant of cluster type.
  */
@@ -27,4 +30,24 @@ public class ClusterType {
     public static final String PULSAR = "PULSAR";
     public static final String DATAPROXY = "DATAPROXY";
     public static final String KAFKA = "KAFKA";
+
+    private static final Set<String> TYPE_SET = new HashSet<String>() {
+        {
+            add(ClusterType.AGENT);
+            add(ClusterType.TUBEMQ);
+            add(ClusterType.PULSAR);
+            add(ClusterType.DATAPROXY);
+            add(ClusterType.KAFKA);
+        }
+    };
+
+    public static String forType(String clusterType) {
+        for (String type : TYPE_SET) {
+            if (type.equals(clusterType)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException(String.format("Unsupported cluster type=%s, "
+                + "supported cluster types are: AGENT, TUBEMQ, PULSAR, DATAPROXY, KAFKA.", clusterType));
+    }
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ClusterType.java
@@ -48,6 +48,6 @@ public class ClusterType {
             }
         }
         throw new IllegalArgumentException(String.format("Unsupported cluster type=%s, "
-                + "supported cluster types are: AGENT, TUBEMQ, PULSAR, DATAPROXY, KAFKA.", clusterType));
+                + "supported cluster types are: %s.", clusterType, TYPE_SET));
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5102 

### Motivation

Manager tools supports CRUD for inlong cluster.

### Modifications

1.Add CRUD for inlong cluster.
2.Add cluster type parameter validation.
2.Add cluster id validation in `org.apache.inlong.manager.client.api.inner.client.InlongClusterClient#update`.

### Verifying this change

1. managerctl list cluster
```
cluster      Get cluster summary information
      Usage: cluster [options]
        Options:
          --tag
            cluster tag
          --type
            cluster type
```
2. managerctl describe cluster
```
cluster      Get cluster details
      Usage: cluster [options]
        Options:
        * -id, --id
            cluster id
```
3. managerctl create cluster
```
cluster      Create cluster by json file
      Usage: cluster [options]
        Options:
          -f, --file
            json file
```
4. managerctl update cluster
```
cluster      Update cluster by json file
      Usage: cluster [options]
        Options:
          -f, --file
            json file
```
5. managerctl delete cluster
```
cluster      Delete cluster by cluster id
      Usage: cluster [options]
        Options:
        * -id, --id
            cluster id
```
