### PR TITLE
[INLONG-5043][Manager] Add Apache Doris load node management

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
@@ -37,4 +37,6 @@ public class SinkType {
     public static final String TDSQLPOSTGRESQL = "TDSQLPOSTGRESQL";
     public static final String DLCICEBERG = "DLCICEBERG";
 
+    public static final String DORIS = "DORIS";
+
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
@@ -36,7 +36,6 @@ public class SinkType {
     public static final String ORACLE = "ORACLE";
     public static final String TDSQLPOSTGRESQL = "TDSQLPOSTGRESQL";
     public static final String DLCICEBERG = "DLCICEBERG";
-
     public static final String DORIS = "DORIS";
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisColumnInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisColumnInfo.java
@@ -30,4 +30,5 @@ public class DorisColumnInfo {
     private String type;
 
     private String comment;
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisColumnInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisColumnInfo.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.doris;
+
+import lombok.Data;
+
+/**
+ * Doris column info.
+ */
+@Data
+public class DorisColumnInfo {
+
+    private String name;
+
+    private String type;
+
+    private String comment;
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.doris;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Doris sink info.
+ */
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Doris sink info")
+@JsonTypeDefine(value = SinkType.DORIS)
+public class DorisSink extends StreamSink {
+
+    @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Primary key")
+    private String primaryKey;
+
+    public DorisSink(){this.setSinkType(SinkType.DORIS);}
+
+    @Override
+    public SinkRequest genSinkRequest(){return CommonBeanUtils.copyProperties(this,DorisSinkRequest::new);}
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
@@ -57,8 +57,12 @@ public class DorisSink extends StreamSink {
     @ApiModelProperty("Primary key")
     private String primaryKey;
 
-    public DorisSink(){this.setSinkType(SinkType.DORIS);}
+    public DorisSink() {
+        this.setSinkType(SinkType.DORIS);
+    }
 
     @Override
-    public SinkRequest genSinkRequest(){return CommonBeanUtils.copyProperties(this,DorisSinkRequest::new);}
+    public SinkRequest genSinkRequest() {
+        return CommonBeanUtils.copyProperties(this,DorisSinkRequest::new);
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSink.java
@@ -65,4 +65,5 @@ public class DorisSink extends StreamSink {
     public SinkRequest genSinkRequest() {
         return CommonBeanUtils.copyProperties(this,DorisSinkRequest::new);
     }
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
@@ -41,7 +41,7 @@ import java.util.Map;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DorisSinkDTO {
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     private static final Logger LOGGER = LoggerFactory.getLogger(DorisSinkDTO.class);
 
     @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
@@ -81,8 +81,9 @@ public class DorisSinkDTO {
      */
     public static DorisSinkDTO getFromJson(@NotNull String extParams) {
         try {
-            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            return OBJECT_MAPPER.readValue(extParams, DorisSinkDTO.class);
+            ObjectMapper objectMapper = new ObjectMapper().configure(
+                    DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return objectMapper.readValue(extParams, DorisSinkDTO.class);
         } catch (Exception e) {
             LOGGER.error("fetch doris sink info failed from json params: " + extParams, e);
             throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT.getMessage() + ": " + e.getMessage());
@@ -100,4 +101,5 @@ public class DorisSinkDTO {
         tableInfo.setColumns(columnList);
         return tableInfo;
     }
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.doris;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Doris sink info.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DorisSinkDTO {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final Logger LOGGER = LoggerFactory.getLogger(DorisSinkDTO.class);
+
+    @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Primary key")
+    private String primaryKey;
+
+    @ApiModelProperty("Properties for Doris")
+    private Map<String, Object> properties;
+
+    /**
+     * Get the dto instance from the request
+     */
+    public static DorisSinkDTO getFromRequest(DorisSinkRequest request) {
+        return DorisSinkDTO.builder()
+                .jdbcUrl(request.getJdbcUrl())
+                .tableName(request.getTableName())
+                .username(request.getUsername())
+                .password(request.getPassword())
+                .primaryKey(request.getPrimaryKey())
+                .properties(request.getProperties())
+                .build();
+    }
+
+    /**
+     * Get Doris sink info from JSON string
+     */
+    public static DorisSinkDTO getFromJson(@NotNull String extParams) {
+        try {
+            OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return OBJECT_MAPPER.readValue(extParams, DorisSinkDTO.class);
+        } catch (Exception e) {
+            LOGGER.error("fetch doris sink info failed from json params: " + extParams, e);
+            throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT.getMessage() + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Get Doris table info
+     */
+    public static DorisTableInfo getTableInfo(DorisSinkDTO dorisSink, List<DorisColumnInfo> columnList) {
+        DorisTableInfo tableInfo = new DorisTableInfo();
+        tableInfo.setTableName(dorisSink.getTableName());
+        tableInfo.setPrimaryKey(dorisSink.getPrimaryKey());
+        tableInfo.setUserName(dorisSink.getUsername());
+        tableInfo.setColumns(columnList);
+        return tableInfo;
+    }
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkDTO.java
@@ -44,6 +44,9 @@ public class DorisSinkDTO {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DorisSinkDTO.class);
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().configure(
+            DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
     @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
     private String jdbcUrl;
 
@@ -81,9 +84,7 @@ public class DorisSinkDTO {
      */
     public static DorisSinkDTO getFromJson(@NotNull String extParams) {
         try {
-            ObjectMapper objectMapper = new ObjectMapper().configure(
-                    DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            return objectMapper.readValue(extParams, DorisSinkDTO.class);
+            return OBJECT_MAPPER.readValue(extParams, DorisSinkDTO.class);
         } catch (Exception e) {
             LOGGER.error("fetch doris sink info failed from json params: " + extParams, e);
             throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT.getMessage() + ": " + e.getMessage());
@@ -97,7 +98,7 @@ public class DorisSinkDTO {
         DorisTableInfo tableInfo = new DorisTableInfo();
         tableInfo.setTableName(dorisSink.getTableName());
         tableInfo.setPrimaryKey(dorisSink.getPrimaryKey());
-        tableInfo.setUserName(dorisSink.getUsername());
+        tableInfo.setUsername(dorisSink.getUsername());
         tableInfo.setColumns(columnList);
         return tableInfo;
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkRequest.java
@@ -35,6 +35,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @ApiModel(value = "Doris sink request")
 @JsonTypeDefine(value = SinkType.DORIS)
 public class DorisSinkRequest extends SinkRequest {
+
     @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
     private String jdbcUrl;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisSinkRequest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.doris;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+
+/**
+ * Doris sink request.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Doris sink request")
+@JsonTypeDefine(value = SinkType.DORIS)
+public class DorisSinkRequest extends SinkRequest {
+    @ApiModelProperty("Doris JDBC URL, such as jdbc:mysql://host:port/database")
+    private String jdbcUrl;
+
+    @ApiModelProperty("Username for JDBC URL")
+    private String username;
+
+    @ApiModelProperty("User password")
+    private String password;
+
+    @ApiModelProperty("Target table name")
+    private String tableName;
+
+    @ApiModelProperty("Primary key")
+    private String primaryKey;
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
@@ -36,4 +36,5 @@ public class DorisTableInfo {
     private String userName;
 
     private List<DorisColumnInfo> columns;
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.doris;
+
+import lombok.Data;
+
+
+import java.util.List;
+
+/**
+ * Doris table info.
+ */
+@Data
+public class DorisTableInfo {
+
+    private String tableName;
+
+    private String comment;
+
+    private String primaryKey;
+
+    private String userName;
+
+    private List<DorisColumnInfo> columns;
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
@@ -33,7 +33,7 @@ public class DorisTableInfo {
 
     private String primaryKey;
 
-    private String userName;
+    private String username;
 
     private List<DorisColumnInfo> columns;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/doris/DorisTableInfo.java
@@ -19,7 +19,6 @@ package org.apache.inlong.manager.pojo.sink.doris;
 
 import lombok.Data;
 
-
 import java.util.List;
 
 /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -56,6 +56,7 @@ import org.apache.inlong.sort.protocol.node.format.Format;
 import org.apache.inlong.sort.protocol.node.format.JsonFormat;
 import org.apache.inlong.sort.protocol.node.load.ClickHouseLoadNode;
 import org.apache.inlong.sort.protocol.node.load.DLCIcebergLoadNode;
+import org.apache.inlong.sort.protocol.node.load.DorisLoadNode;
 import org.apache.inlong.sort.protocol.node.load.ElasticsearchLoadNode;
 import org.apache.inlong.sort.protocol.node.load.FileSystemLoadNode;
 import org.apache.inlong.sort.protocol.node.load.GreenplumLoadNode;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -42,6 +42,7 @@ import org.apache.inlong.manager.pojo.sink.oracle.OracleSink;
 import org.apache.inlong.manager.pojo.sink.postgresql.PostgreSQLSink;
 import org.apache.inlong.manager.pojo.sink.sqlserver.SQLServerSink;
 import org.apache.inlong.manager.pojo.sink.tdsqlpostgresql.TDSQLPostgreSQLSink;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSink;
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.sort.formats.common.StringTypeInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
@@ -135,6 +136,8 @@ public class LoadNodeUtils {
                 return createLoadNode((TDSQLPostgreSQLSink) streamSink, fieldInfos, fieldRelations, properties);
             case SinkType.DLCICEBERG:
                 return createLoadNode((DLCIcebergSink) streamSink, fieldInfos, fieldRelations, properties);
+            case SinkType.DORIS:
+                return createLoadNode((DorisSink) streamSink, fieldInfos, fieldRelations, properties);
             default:
                 throw new BusinessException(String.format("Unsupported sinkType=%s to create load node", sinkType));
         }
@@ -490,6 +493,28 @@ public class LoadNodeUtils {
                 dlcIcebergSink.getPrimaryKey(),
                 dlcIcebergSink.getCatalogUri(),
                 dlcIcebergSink.getWarehouse()
+        );
+    }
+
+    /**
+     * Create load node of Doris.
+     */
+    public static DorisLoadNode createLoadNode(DorisSink dorisSink, List<FieldInfo> fieldInfos,
+                                               List<FieldRelation> fieldRelations, Map<String, String> properties) {
+        return new DorisLoadNode(
+                dorisSink.getSinkName(),
+                dorisSink.getSinkName(),
+                fieldInfos,
+                fieldRelations,
+                null,
+                null,
+                null,
+                properties,
+                dorisSink.getJdbcUrl(),
+                dorisSink.getUsername(),
+                dorisSink.getPassword(),
+                dorisSink.getTableName(),
+                dorisSink.getPrimaryKey()
         );
     }
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -501,7 +501,7 @@ public class LoadNodeUtils {
      * Create load node of Doris.
      */
     public static DorisLoadNode createLoadNode(DorisSink dorisSink, List<FieldInfo> fieldInfos,
-                                               List<FieldRelation> fieldRelations, Map<String, String> properties) {
+            List<FieldRelation> fieldRelations, Map<String, String> properties) {
         return new DorisLoadNode(
                 dorisSink.getSinkName(),
                 dorisSink.getSinkName(),

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/doris/DorisSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/doris/DorisSinkOperator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.sink.doris;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.pojo.sink.SinkField;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSink;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSinkDTO;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSinkRequest;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
+import org.apache.inlong.manager.service.sink.AbstractSinkOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * Doris sink operator
+ */
+@Service
+public class DorisSinkOperator extends AbstractSinkOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DorisSinkOperator.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Boolean accept(String sinkType) {
+        return SinkType.DORIS.equals(sinkType);
+    }
+
+    @Override
+    protected String getSinkType() {
+        return SinkType.DORIS;
+    }
+
+    @Override
+    protected void setTargetEntity(SinkRequest request, StreamSinkEntity targetEntity) {
+        Preconditions.checkTrue(this.getSinkType().equals(request.getSinkType()),
+                ErrorCodeEnum.SINK_TYPE_NOT_SUPPORT.getMessage() + ": " + getSinkType());
+        DorisSinkRequest sinkRequest = (DorisSinkRequest) request;
+        try {
+            DorisSinkDTO dto = DorisSinkDTO.getFromRequest(sinkRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            LOGGER.error("parsing json string to sink info failed", e);
+            throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED.getMessage());
+        }
+    }
+
+    @Override
+    public StreamSink getFromEntity(StreamSinkEntity entity) {
+        DorisSink sink = new DorisSink();
+        if (entity == null) {
+            return sink;
+        }
+
+        DorisSinkDTO dto = DorisSinkDTO.getFromJson(entity.getExtParams());
+        CommonBeanUtils.copyProperties(entity, sink, true);
+        CommonBeanUtils.copyProperties(dto, sink, true);
+        List<SinkField> sinkFields = super.getSinkFields(entity.getId());
+        sink.setSinkFieldList(sinkFields);
+        return sink;
+    }
+
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/doris/DorisSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/doris/DorisSinkOperator.java
@@ -88,5 +88,4 @@ public class DorisSinkOperator extends AbstractSinkOperator {
         return sink;
     }
 
-
 }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/DorisSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/DorisSinkServiceTest.java
@@ -35,13 +35,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 public class DorisSinkServiceTest extends ServiceBaseTest {
 
     // Partial test data
-    private static final String globalGroupId = "b_group1";
-    private static final String globalStreamId = "stream1_doris";
-    private static final String globalOperator = "admin";
-    private static final String dorisJdbcUrl = "jdbc:mysql://127.0.0.1:6603/default";
-    private static final String dorisUsername = "doris_user";
-    private static final String dorisPassword = "doris_passwd";
-    private static final String dorisTableName = "doris_tbl";
+    private final String globalGroupId = "b_group1";
+    private final String globalStreamId = "stream1_doris";
+    private final String globalOperator = "admin";
+    private final String dorisJdbcUrl = "jdbc:mysql://127.0.0.1:6603/default";
+    private final String dorisUsername = "doris_user";
+    private final String dorisPassword = "doris_passwd";
+    private final String dorisTableName = "doris_tbl";
     @Autowired
     private StreamSinkService sinkService;
     @Autowired
@@ -52,18 +52,17 @@ public class DorisSinkServiceTest extends ServiceBaseTest {
      */
     public Integer saveSink(String sinkName) {
         streamServiceTest.saveInlongStream(globalGroupId, globalStreamId, globalOperator);
-        DorisSinkRequest sinkInfo = new DorisSinkRequest();
-        sinkInfo.setInlongGroupId(globalGroupId);
-        sinkInfo.setInlongStreamId(globalStreamId);
-        sinkInfo.setSinkName(sinkName);
-        sinkInfo.setSinkType(SinkType.DORIS);
-        sinkInfo.setJdbcUrl(dorisJdbcUrl);
-        sinkInfo.setUsername(dorisUsername);
-        sinkInfo.setPassword(dorisPassword);
-        sinkInfo.setTableName(dorisTableName);
-        sinkInfo.setEnableCreateResource(InlongConstants.DISABLE_CREATE_RESOURCE);
-        sinkInfo.setId((int) (Math.random() * 100000 + 1));
-        return sinkService.save(sinkInfo, globalOperator);
+        DorisSinkRequest sinkRequest = new DorisSinkRequest();
+        sinkRequest.setInlongGroupId(globalGroupId);
+        sinkRequest.setInlongStreamId(globalStreamId);
+        sinkRequest.setSinkName(sinkName);
+        sinkRequest.setSinkType(SinkType.DORIS);
+        sinkRequest.setJdbcUrl(dorisJdbcUrl);
+        sinkRequest.setUsername(dorisUsername);
+        sinkRequest.setPassword(dorisPassword);
+        sinkRequest.setTableName(dorisTableName);
+        sinkRequest.setEnableCreateResource(InlongConstants.DISABLE_CREATE_RESOURCE);
+        return sinkService.save(sinkRequest, globalOperator);
     }
 
     /**

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/DorisSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/DorisSinkServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.sink;
+
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSink;
+import org.apache.inlong.manager.pojo.sink.doris.DorisSinkRequest;
+import org.apache.inlong.manager.service.ServiceBaseTest;
+import org.apache.inlong.manager.service.core.impl.InlongStreamServiceTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Doris sink service test
+ */
+public class DorisSinkServiceTest extends ServiceBaseTest {
+
+    // Partial test data
+    private static final String globalGroupId = "b_group1";
+    private static final String globalStreamId = "stream1_doris";
+    private static final String globalOperator = "admin";
+    private static final String dorisJdbcUrl = "jdbc:mysql://127.0.0.1:6603/default";
+    private static final String dorisUsername = "doris_user";
+    private static final String dorisPassword = "doris_passwd";
+    private static final String dorisTableName = "doris_tbl";
+    @Autowired
+    private StreamSinkService sinkService;
+    @Autowired
+    private InlongStreamServiceTest streamServiceTest;
+
+    /**
+     * Save sink info.
+     */
+    public Integer saveSink(String sinkName) {
+        streamServiceTest.saveInlongStream(globalGroupId, globalStreamId, globalOperator);
+        DorisSinkRequest sinkInfo = new DorisSinkRequest();
+        sinkInfo.setInlongGroupId(globalGroupId);
+        sinkInfo.setInlongStreamId(globalStreamId);
+        sinkInfo.setSinkName(sinkName);
+        sinkInfo.setSinkType(SinkType.DORIS);
+        sinkInfo.setJdbcUrl(dorisJdbcUrl);
+        sinkInfo.setUsername(dorisUsername);
+        sinkInfo.setPassword(dorisPassword);
+        sinkInfo.setTableName(dorisTableName);
+        sinkInfo.setEnableCreateResource(InlongConstants.DISABLE_CREATE_RESOURCE);
+        sinkInfo.setId((int) (Math.random() * 100000 + 1));
+        return sinkService.save(sinkInfo, globalOperator);
+    }
+
+    /**
+     * Delete sink by sink id.
+     */
+    public void deleteSink(Integer sinkId) {
+        boolean result = sinkService.delete(sinkId, globalOperator);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    public void testListByIdentifier() {
+        Integer sinkId = this.saveSink("default1");
+        StreamSink sink = sinkService.get(sinkId);
+        Assertions.assertEquals(globalGroupId, sink.getInlongGroupId());
+        deleteSink(sinkId);
+    }
+
+    @Test
+    public void testGetAndUpdate() {
+        Integer sinkId = this.saveSink("default2");
+        StreamSink streamSink = sinkService.get(sinkId);
+        Assertions.assertEquals(globalGroupId, streamSink.getInlongGroupId());
+
+        DorisSink sink = (DorisSink) streamSink;
+        sink.setEnableCreateResource(InlongConstants.ENABLE_CREATE_RESOURCE);
+        SinkRequest request = sink.genSinkRequest();
+        boolean result = sinkService.update(request, globalOperator);
+        Assertions.assertTrue(result);
+
+        deleteSink(sinkId);
+    }
+
+}


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #5043 

### Motivation

To surport the ability to Doris data integration, we need to add Apache Doris Load Node for management
### Design
The design mainly follows the document [Manager Plugin](https://inlong.apache.org/zh-CN/docs/design_and_concept/how_to_extend_data_node_for_manager)

1. Add corresponding SinkType enumeration in enumeration type org.apache.inlong.manager.common.Enums.
2. In org.apache.inlong.manager.common.Pojo.Sink,create folder path,create the corresponding entity class.
3. In the org.Apache.Inlong.Manager.Service.Sink path, created under the corresponding tools
4. Support data source to LoadNode conversion function, reference code org.Apache. Inlong.Manager.Service.Sort.Util.LoadNodeUtils

### Implementation

1. Add DORIS in enumeration type org.apache.inlong.manager.common.enums.SinkType
2. Create folder "Doris" in org.apache.inlong.manager.common.pojo.sink, and create corresponding entity class:

- DorisSink
- DorisSinkDTO
- DorisSinkRequest
- DorisColumnInfo
- DorisTableInfo

3. Create folder "doris" in org.apache.inlong.manager.service.sink and implement the class:

- DorisSinkOperator

4. Add createLoadNode function in org.apache.inlong.manager.service.sort.util.LoadNodeUtils, it is like as follows:
`public static DorisLoadNode createLoadNode(DorisSink dorisSink, List<FieldInfo> fieldInfos,
            List<FieldRelation> fieldRelations, Map<String, String> properties){
                 \\TODO 
      }`