### PR TITLE
[INLONG-5990][Manager] Command tools add CRUD for inlong cluster tag

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -110,7 +110,7 @@ public class CreateCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 Integer clusterId = clusterClient.saveCluster(request);
                 if (clusterId != null) {
-                    System.out.println("Create cluster success! ID:" + clusterId);
+                    System.out.println("Create cluster success! ID: " + clusterId);
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());
@@ -136,7 +136,7 @@ public class CreateCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 Integer tagId = clusterClient.saveTag(request);
                 if (tagId != null) {
-                    System.out.println("Create cluster tag success! ID:" + tagId);
+                    System.out.println("Create cluster tag success! ID: " + tagId);
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.client.cli;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.FileConverter;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.InlongStreamBuilder;
@@ -28,6 +27,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.pojo.CreateGroupConf;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
 
 import java.io.File;
 import java.util.List;
@@ -45,6 +45,7 @@ public class CreateCommand extends AbstractCommand {
         super("create");
         jcommander.addCommand("group", new CreateGroup());
         jcommander.addCommand("cluster", new CreateCluster());
+        jcommander.addCommand("cluster-tag", new CreateClusterTag());
     }
 
     @Parameters(commandDescription = "Create group by json file")
@@ -69,10 +70,6 @@ public class CreateCommand extends AbstractCommand {
                     content = input;
                 } else {
                     content = ClientUtils.readFile(file);
-                    if (StringUtils.isBlank(content)) {
-                        System.out.println("Create group failed: file was empty!");
-                        return;
-                    }
                 }
                 // first extract group config from the file passed in
                 CreateGroupConf groupConf = objectMapper.readValue(content, CreateGroupConf.class);
@@ -105,18 +102,44 @@ public class CreateCommand extends AbstractCommand {
         private File file;
 
         @Override
-        void run() throws Exception {
-            String content = ClientUtils.readFile(file);
-            if (StringUtils.isBlank(content)) {
-                System.out.println("Create cluster failed: file was empty!");
-                return;
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                Integer clusterId = clusterClient.saveCluster(request);
+                if (clusterId != null) {
+                    System.out.println("Create cluster success! ID:" + clusterId);
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
             }
-            ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
-            ClientUtils.initClientFactory();
-            InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
-            Integer clusterId = clusterClient.saveCluster(request);
-            if (clusterId != null) {
-                System.out.println("Create cluster success! ID:" + clusterId);
+        }
+    }
+
+    @Parameters(commandDescription = "Create cluster tag by json file")
+    private static class CreateClusterTag extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                ClusterTagRequest request = objectMapper.readValue(content, ClusterTagRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                Integer tagId = clusterClient.saveTag(request);
+                if (tagId != null) {
+                    System.out.println("Create cluster tag success! ID:" + tagId);
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
             }
         }
     }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -40,6 +40,7 @@ public class DeleteCommand extends AbstractCommand {
         super("delete");
         jcommander.addCommand("group", new DeleteGroup());
         jcommander.addCommand("cluster", new DeleteCluster());
+        jcommander.addCommand("cluster-tag", new DeleteClusterTag());
     }
 
     @Parameters(commandDescription = "Delete group by group id")
@@ -82,6 +83,29 @@ public class DeleteCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.delete(clusterId)) {
                     System.out.println("Delete cluster success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Delete cluster tag by tag id")
+    private static class DeleteClusterTag extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster tag id")
+        private int tagId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.deleteTag(tagId)) {
+                    System.out.println("Delete cluster tag success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
@@ -54,6 +55,7 @@ public class DescribeCommand extends AbstractCommand {
         jcommander.addCommand("sink", new DescribeSink());
         jcommander.addCommand("source", new DescribeSource());
         jcommander.addCommand("cluster", new DescribeCluster());
+        jcommander.addCommand("cluster-tag", new DescribeClusterTag());
     }
 
     @Parameters(commandDescription = "Get stream details")
@@ -178,6 +180,28 @@ public class DescribeCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 ClusterInfo clusterInfo = clusterClient.get(clusterId);
                 PrintUtils.printJson(clusterInfo);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster tag details")
+    private static class DescribeClusterTag extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster tag id")
+        private int tagId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                ClusterTagResponse tagInfo = clusterClient.getTag(tagId);
+                PrintUtils.printJson(tagInfo);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
+import org.apache.inlong.manager.client.cli.pojo.ClusterTagInfo;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.pojo.SinkInfo;
 import org.apache.inlong.manager.client.cli.pojo.SourceInfo;
@@ -34,6 +35,8 @@ import org.apache.inlong.manager.client.cli.validator.ClusterTypeValidator;
 import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.ClusterPageRequest;
+import org.apache.inlong.manager.pojo.cluster.ClusterTagPageRequest;
+import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
@@ -60,6 +63,7 @@ public class ListCommand extends AbstractCommand {
         jcommander.addCommand("sink", new ListSink());
         jcommander.addCommand("source", new ListSource());
         jcommander.addCommand("cluster", new ListCluster());
+        jcommander.addCommand("cluster-tag", new ListClusterTag());
     }
 
     @Parameters(commandDescription = "Get stream summary information")
@@ -201,6 +205,30 @@ public class ListCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 PageResult<ClusterInfo> clusterInfo = clusterClient.list(request);
                 PrintUtils.print(clusterInfo.getList(), org.apache.inlong.manager.client.cli.pojo.ClusterInfo.class);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster tag summary information")
+    private static class ListClusterTag extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-ct", "--tag"}, description = "cluster tag")
+        private String tag;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                ClusterTagPageRequest request = new ClusterTagPageRequest();
+                request.setKeyword(tag);
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                PageResult<ClusterTagResponse> tagInfo = clusterClient.listTag(request);
+                PrintUtils.print(tagInfo.getList(), ClusterTagInfo.class);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -26,6 +26,7 @@ import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
+import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
 
 import java.io.File;
@@ -45,6 +46,7 @@ public class UpdateCommand extends AbstractCommand {
         super("update");
         jcommander.addCommand("group", new UpdateCommand.UpdateGroup());
         jcommander.addCommand("cluster", new UpdateCommand.UpdateCluster());
+        jcommander.addCommand("cluster-tag", new UpdateCommand.UpdateClusterTag());
     }
 
     @Parameters(commandDescription = "Update group by json file")
@@ -75,7 +77,7 @@ public class UpdateCommand extends AbstractCommand {
                 group.update(sortConf);
                 System.out.println("Update group success!");
             } catch (Exception e) {
-                e.printStackTrace();
+                System.out.println(e.getMessage());
             }
         }
     }
@@ -93,10 +95,6 @@ public class UpdateCommand extends AbstractCommand {
         void run() {
             try {
                 String content = ClientUtils.readFile(file);
-                if (StringUtils.isBlank(content)) {
-                    System.out.println("Update cluster failed: file was empty!");
-                    return;
-                }
                 ClusterRequest request = objectMapper.readValue(content, ClusterRequest.class);
                 ClientUtils.initClientFactory();
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
@@ -104,7 +102,32 @@ public class UpdateCommand extends AbstractCommand {
                     System.out.println("Update cluster success!");
                 }
             } catch (Exception e) {
-                e.printStackTrace();
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Update cluster tag by json file")
+    private static class UpdateClusterTag extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                ClusterTagRequest request = objectMapper.readValue(content, ClusterTagRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.updateTag(request)) {
+                    System.out.println("Update cluster tag success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
             }
         }
     }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterTagInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterTagInfo.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.cli.pojo;
+
+import lombok.Data;
+
+/**
+ * Cluster tag info, including cluster tag name, status, etc.
+ */
+@Data
+public class ClusterTagInfo {
+
+    private Integer id;
+    private String clusterTag;
+    private String extParams;
+    private String inCharges;
+    private Integer status;
+}

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/ClientUtils.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/ClientUtils.java
@@ -21,6 +21,7 @@ import org.apache.inlong.manager.client.api.ClientConfiguration;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
 import org.apache.inlong.manager.client.api.inner.client.ClientFactory;
 import org.apache.inlong.manager.common.auth.DefaultAuthentication;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -59,9 +60,8 @@ public class ClientUtils {
      * Get the file content.
      */
     public static String readFile(File file) {
-        if (!file.exists()) {
-            System.out.println("File does not exist.");
-            return null;
+        if (!file.exists() || file.length() == 0) {
+            throw new BusinessException("File does not exist or is empty.");
         }
         StringBuilder stringBuilder = new StringBuilder();
         try (Reader reader = new InputStreamReader(Files.newInputStream(file.toPath()))) {


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5990 

### Motivation

Command tools add CRUD for inlong cluster tag.

### Modifications

1.Add CRUD for inlong cluster tag.
2.Modify exception judgment in `org.apache.inlong.manager.client.cli.util.ClientUtils#readFile`

### Verifying this change

1. managerctl list cluster-tag
```
cluster-tag      Get cluster tag summary information
      Usage: cluster-tag [options]
        Options:
          --tag
            cluster tag
```

2. managerctl describe cluster-tag
```
cluster-tag      Get cluster tag details
      Usage: cluster-tag [options]
        Options:
        * -id, --id
            cluster tag id
```

3. managerctl create cluster-tag
```
cluster-tag      Create cluster tag by json file
      Usage: cluster-tag [options]
        Options:
          -f, --file
            json file
```

4. managerctl update cluster-tag
```
cluster-tag      Update cluster tag by json file
      Usage: cluster-tag [options]
        Options:
          -f, --file
            json file
```

5. managerctl delete cluster-tag
```
cluster-tag      Delete cluster tag by tag id
      Usage: cluster-tag [options]
        Options:
        * -id, --id
            cluster tag id
```
