### PR TITLE
[INLONG-5992][Sort] Fix runtimeContext not initialized in JDBC and ES when reload metric status

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -24,6 +24,7 @@ import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.inlong.audit.AuditImp;
 import org.apache.inlong.sort.base.Constants;
+import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -53,14 +54,16 @@ public class SinkMetricData implements MetricData {
     private Counter dirtyBytes;
     private Meter numRecordsOutPerSecond;
     private Meter numBytesOutPerSecond;
+    private RegisteredMetric registeredMetric;
 
     public SinkMetricData(MetricOption option, MetricGroup metricGroup) {
         this.metricGroup = metricGroup;
         this.labels = option.getLabels();
+        this.registeredMetric = option.getRegisteredMetric();
 
         ThreadSafeCounter recordsOutCounter = new ThreadSafeCounter();
         ThreadSafeCounter bytesOutCounter = new ThreadSafeCounter();
-        switch (option.getRegisteredMetric()) {
+        switch (registeredMetric) {
             case DIRTY:
                 registerMetricsForDirtyBytes(new ThreadSafeCounter());
                 registerMetricsForDirtyRecords(new ThreadSafeCounter());
@@ -291,18 +294,41 @@ public class SinkMetricData implements MetricData {
 
     @Override
     public String toString() {
-        return "SinkMetricData{"
-                + "metricGroup=" + metricGroup
-                + ", labels=" + labels
-                + ", auditImp=" + auditImp
-                + ", numRecordsOut=" + numRecordsOut.getCount()
-                + ", numBytesOut=" + numBytesOut.getCount()
-                + ", numRecordsOutForMeter=" + numRecordsOutForMeter.getCount()
-                + ", numBytesOutForMeter=" + numBytesOutForMeter.getCount()
-                + ", dirtyRecords=" + dirtyRecords.getCount()
-                + ", dirtyBytes=" + dirtyBytes.getCount()
-                + ", numRecordsOutPerSecond=" + numRecordsOutPerSecond.getRate()
-                + ", numBytesOutPerSecond=" + numBytesOutPerSecond.getRate()
-                + '}';
+        switch (registeredMetric) {
+            case DIRTY:
+                 return "SinkMetricData{"
+                        + "metricGroup=" + metricGroup
+                        + ", labels=" + labels
+                        + ", auditImp=" + auditImp
+                        + ", dirtyRecords=" + dirtyRecords.getCount()
+                        + ", dirtyBytes=" + dirtyBytes.getCount()
+                        + '}';
+            case NORMAL:
+                return "SinkMetricData{"
+                        + "metricGroup=" + metricGroup
+                        + ", labels=" + labels
+                        + ", auditImp=" + auditImp
+                        + ", numRecordsOut=" + numRecordsOut.getCount()
+                        + ", numBytesOut=" + numBytesOut.getCount()
+                        + ", numRecordsOutForMeter=" + numRecordsOutForMeter.getCount()
+                        + ", numBytesOutForMeter=" + numBytesOutForMeter.getCount()
+                        + ", numRecordsOutPerSecond=" + numRecordsOutPerSecond.getRate()
+                        + ", numBytesOutPerSecond=" + numBytesOutPerSecond.getRate()
+                        + '}';
+            default:
+                return "SinkMetricData{"
+                        + "metricGroup=" + metricGroup
+                        + ", labels=" + labels
+                        + ", auditImp=" + auditImp
+                        + ", numRecordsOut=" + numRecordsOut.getCount()
+                        + ", numBytesOut=" + numBytesOut.getCount()
+                        + ", numRecordsOutForMeter=" + numRecordsOutForMeter.getCount()
+                        + ", numBytesOutForMeter=" + numBytesOutForMeter.getCount()
+                        + ", dirtyRecords=" + dirtyRecords.getCount()
+                        + ", dirtyBytes=" + dirtyBytes.getCount()
+                        + ", numRecordsOutPerSecond=" + numRecordsOutPerSecond.getRate()
+                        + ", numBytesOutPerSecond=" + numBytesOutPerSecond.getRate()
+                        + '}';
+        }
     }
 }

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/ElasticsearchSinkBase.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/ElasticsearchSinkBase.java
@@ -293,6 +293,7 @@ public abstract class ElasticsearchSinkBase<T, C extends AutoCloseable> extends 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
         // no initialization needed
+        elasticsearchSinkFunction.setRuntimeContext(getRuntimeContext());
         elasticsearchSinkFunction.initializeState(context);
     }
 

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/ElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/ElasticsearchSinkFunction.java
@@ -69,4 +69,8 @@ public interface ElasticsearchSinkFunction<T> extends Serializable, Function {
     default void snapshotState(FunctionSnapshotContext context) throws Exception {
 
     }
+
+    default  void setRuntimeContext(RuntimeContext ctx) {
+
+    }
 }

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -118,6 +118,11 @@ public class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<R
     }
 
     @Override
+    public void setRuntimeContext(RuntimeContext ctx) {
+        this.runtimeContext = ctx;
+    }
+
+    @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
         if (this.inlongMetric != null) {
             this.metricStateListState = context.getOperatorStateStore().getUnionListState(

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/GenericJdbcSinkFunction.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/GenericJdbcSinkFunction.java
@@ -60,7 +60,8 @@ public class GenericJdbcSinkFunction<T> extends RichSinkFunction<T>
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
-            outputFormat.initializeState(context);
+        outputFormat.setRuntimeContext(getRuntimeContext());
+        outputFormat.initializeState(context);
     }
 
     @Override


### PR DESCRIPTION

- Fixes #5992 

### Motivation

Fix runtimeContext not initialized in JDBC and ES when reload metric status

### Modifications

JDBC connector and ES connector

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
