### PR TITLE
[INLONG-6001][Manager] Ensure that the newly created sink under the successful stream can be configured normally

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
@@ -24,7 +24,6 @@ import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
-import org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm;
 import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
 import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
 import org.apache.inlong.manager.service.resource.sort.SortConfigOperator;
@@ -62,7 +61,7 @@ public class StreamSortConfigListener implements SortOperateListener {
         ProcessForm processForm = context.getProcessForm();
         String className = processForm.getClass().getSimpleName();
         String groupId = processForm.getInlongGroupId();
-        if (processForm instanceof GroupResourceProcessForm || processForm instanceof StreamResourceProcessForm) {
+        if (processForm instanceof StreamResourceProcessForm) {
             LOGGER.info("accept sort config listener as the process is {} for groupId [{}]", className, groupId);
             return true;
         } else {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
@@ -18,8 +18,6 @@
 package org.apache.inlong.manager.service.listener.sort;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.inlong.manager.common.consts.InlongConstants;
-import org.apache.inlong.manager.common.consts.MQType;
 import org.apache.inlong.manager.common.enums.GroupOperateType;
 import org.apache.inlong.manager.common.enums.TaskEvent;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
@@ -62,18 +60,15 @@ public class StreamSortConfigListener implements SortOperateListener {
     @Override
     public boolean accept(WorkflowContext context) {
         ProcessForm processForm = context.getProcessForm();
+        String className = processForm.getClass().getSimpleName();
         String groupId = processForm.getInlongGroupId();
-        if (!(processForm instanceof GroupResourceProcessForm)) {
-            LOGGER.warn("zookeeper enabled was [false] for groupId [{}]", groupId);
+        if (processForm instanceof GroupResourceProcessForm || processForm instanceof StreamResourceProcessForm) {
+            LOGGER.info("accept sort config listener as the process is {} for groupId [{}]", className, groupId);
+            return true;
+        } else {
+            LOGGER.info("not accept sort config listener as the process is {} for groupId [{}]", className, groupId);
             return false;
         }
-
-        GroupResourceProcessForm groupResourceForm = (GroupResourceProcessForm) processForm;
-        InlongGroupInfo groupInfo = groupResourceForm.getGroupInfo();
-        boolean enable = InlongConstants.ENABLE_ZK.equals(groupInfo.getEnableZookeeper())
-                && !MQType.NONE.equals(groupInfo.getMqType());
-        LOGGER.info("zookeeper enabled was [{}] for groupId [{}]", enable, groupId);
-        return enable;
     }
 
     @Override


### PR DESCRIPTION

### Prepare a Pull Request
- Fixes #6001 

### Motivation
Ensure that the newly created sink under the successfully configured stream can be configured normally

### Modifications

Judge the stream status when saving. If the configuration is successful, the sink configuration process will be triggered

### Verifying this change


- [X] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? (no)

