### PR TITLE
[INLONG-6004][Manager] Command tools add CRUD for inlong cluster node

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -146,7 +146,7 @@ public class CreateCommand extends AbstractCommand {
         }
     }
 
-    @Parameters(commandDescription = "Create cluster Node by json file")
+    @Parameters(commandDescription = "Create cluster node by json file")
     private static class CreateClusterNode extends AbstractCommandRunner {
 
         @Parameter()

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -26,6 +26,7 @@ import org.apache.inlong.manager.client.api.InlongStreamBuilder;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.pojo.CreateGroupConf;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
 
@@ -46,6 +47,7 @@ public class CreateCommand extends AbstractCommand {
         jcommander.addCommand("group", new CreateGroup());
         jcommander.addCommand("cluster", new CreateCluster());
         jcommander.addCommand("cluster-tag", new CreateClusterTag());
+        jcommander.addCommand("cluster-node", new CreateClusterNode());
     }
 
     @Parameters(commandDescription = "Create group by json file")
@@ -137,6 +139,32 @@ public class CreateCommand extends AbstractCommand {
                 Integer tagId = clusterClient.saveTag(request);
                 if (tagId != null) {
                     System.out.println("Create cluster tag success! ID: " + tagId);
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Create cluster Node by json file")
+    private static class CreateClusterNode extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                ClusterNodeRequest request = objectMapper.readValue(content, ClusterNodeRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                Integer nodeId = clusterClient.saveNode(request);
+                if (nodeId != null) {
+                    System.out.println("Create cluster node success! ID: " + nodeId);
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -120,7 +120,7 @@ public class DeleteCommand extends AbstractCommand {
         @Parameter()
         private List<String> params;
 
-        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster tag id")
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster node id")
         private int nodeId;
 
         @Override

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -41,6 +41,7 @@ public class DeleteCommand extends AbstractCommand {
         jcommander.addCommand("group", new DeleteGroup());
         jcommander.addCommand("cluster", new DeleteCluster());
         jcommander.addCommand("cluster-tag", new DeleteClusterTag());
+        jcommander.addCommand("cluster-node", new DeleteClusterNode());
     }
 
     @Parameters(commandDescription = "Delete group by group id")
@@ -106,6 +107,29 @@ public class DeleteCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.deleteTag(tagId)) {
                     System.out.println("Delete cluster tag success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Delete cluster node by node id")
+    private static class DeleteClusterNode extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster tag id")
+        private int nodeId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.deleteNode(nodeId)) {
+                    System.out.println("Delete cluster node success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
@@ -210,7 +210,7 @@ public class DescribeCommand extends AbstractCommand {
         }
     }
 
-    @Parameters(commandDescription = "Get cluster Node details")
+    @Parameters(commandDescription = "Get cluster node details")
     private static class DescribeClusterNode extends AbstractCommandRunner {
 
         @Parameter()

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.pojo.cluster.ClusterNodeResponse;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo;
@@ -56,6 +57,7 @@ public class DescribeCommand extends AbstractCommand {
         jcommander.addCommand("source", new DescribeSource());
         jcommander.addCommand("cluster", new DescribeCluster());
         jcommander.addCommand("cluster-tag", new DescribeClusterTag());
+        jcommander.addCommand("cluster-node", new DescribeClusterNode());
     }
 
     @Parameters(commandDescription = "Get stream details")
@@ -202,6 +204,28 @@ public class DescribeCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 ClusterTagResponse tagInfo = clusterClient.getTag(tagId);
                 PrintUtils.printJson(tagInfo);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster Node details")
+    private static class DescribeClusterNode extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "cluster node id")
+        private int nodeId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                ClusterNodeResponse nodeInfo = clusterClient.getNode(nodeId);
+                PrintUtils.printJson(nodeInfo);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
+import org.apache.inlong.manager.client.cli.pojo.ClusterNodeInfo;
 import org.apache.inlong.manager.client.cli.pojo.ClusterTagInfo;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.pojo.SinkInfo;
@@ -34,6 +35,7 @@ import org.apache.inlong.manager.client.cli.util.PrintUtils;
 import org.apache.inlong.manager.client.cli.validator.ClusterTypeValidator;
 import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.pojo.cluster.ClusterNodeResponse;
 import org.apache.inlong.manager.pojo.cluster.ClusterPageRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagPageRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
@@ -64,6 +66,7 @@ public class ListCommand extends AbstractCommand {
         jcommander.addCommand("source", new ListSource());
         jcommander.addCommand("cluster", new ListCluster());
         jcommander.addCommand("cluster-tag", new ListClusterTag());
+        jcommander.addCommand("cluster-node", new ListClusterNode());
     }
 
     @Parameters(commandDescription = "Get stream summary information")
@@ -217,7 +220,7 @@ public class ListCommand extends AbstractCommand {
         @Parameter()
         private List<String> params;
 
-        @Parameter(names = {"-ct", "--tag"}, description = "cluster tag")
+        @Parameter(names = {"--tag"}, description = "cluster tag")
         private String tag;
 
         @Override
@@ -229,6 +232,34 @@ public class ListCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 PageResult<ClusterTagResponse> tagInfo = clusterClient.listTag(request);
                 PrintUtils.print(tagInfo.getList(), ClusterTagInfo.class);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get cluster node summary information")
+    private static class ListClusterNode extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"--tag"}, description = "cluster tag")
+        private String tag;
+
+        @Parameter(names = {"--type"}, description = "cluster type")
+        private String type;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                ClusterPageRequest request = new ClusterPageRequest();
+                request.setClusterTag(tag);
+                request.setType(type);
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                PageResult<ClusterNodeResponse> nodeInfo = clusterClient.listNode(request);
+                PrintUtils.print(nodeInfo.getList(), ClusterNodeInfo.class);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -25,6 +25,7 @@ import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
@@ -47,6 +48,7 @@ public class UpdateCommand extends AbstractCommand {
         jcommander.addCommand("group", new UpdateCommand.UpdateGroup());
         jcommander.addCommand("cluster", new UpdateCommand.UpdateCluster());
         jcommander.addCommand("cluster-tag", new UpdateCommand.UpdateClusterTag());
+        jcommander.addCommand("cluster-node", new UpdateCommand.UpdateClusterNode());
     }
 
     @Parameters(commandDescription = "Update group by json file")
@@ -125,6 +127,31 @@ public class UpdateCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.updateTag(request)) {
                     System.out.println("Update cluster tag success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Update cluster node by json file")
+    private static class UpdateClusterNode extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-f", "--file"}, description = "json file", converter = FileConverter.class)
+        private File file;
+
+        @Override
+        void run() {
+            try {
+                String content = ClientUtils.readFile(file);
+                ClusterNodeRequest request = objectMapper.readValue(content, ClusterNodeRequest.class);
+                ClientUtils.initClientFactory();
+                InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
+                if (clusterClient.updateNode(request)) {
+                    System.out.println("Update cluster node success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterNodeInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/ClusterNodeInfo.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.cli.pojo;
+
+import lombok.Data;
+
+@Data
+public class ClusterNodeInfo {
+
+    private String type;
+    private String ip;
+    private Integer port;
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6004 

### Motivation

Command tools add CRUD for inlong cluster node.

### Modifications

1..Add CRUD for inlong cluster tag.

### Verifying this change

1. managerctl list cluster-node
```
cluster-node      Get cluster node summary information
      Usage: cluster-node [options]
        Options:
          --tag
            cluster tag
          --type
            cluster type
```

2. managerctl describe cluster-node
```
cluster-node      Get cluster node details
      Usage: cluster-node [options]
        Options:
        * -id, --id
            cluster node id
```

3. managerctl create cluster-node
```
cluster-node      Create cluster node by json file
      Usage: cluster-node [options]
        Options:
          -f, --file
            json file
```

4. managerctl update cluster-node
```
cluster-node      Update cluster node by json file
      Usage: cluster-node [options]
        Options:
          -f, --file
            json file
```

5. managerctl delete cluster-node
```
cluster-node      Delete cluster node by node id
      Usage: cluster-node [options]
        Options:
        * -id, --id
            cluster node id
```