### PR TITLE
[INLONG-6003][Manager] Change the transform source node name to be MQ node in standard mode

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -127,16 +127,16 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                 relations = NodeRelationUtils.createNodeRelations(sources, sinks);
             } else {
                 relations = NodeRelationUtils.createNodeRelations(inlongStream);
-            }
 
-            // redirect transform input fields node if necessary
-            preprocessTransformList(groupInfo, sources, transformResponseList);
+                // redirect transform input fields node if necessary
+                preprocessTransformList(groupInfo, sources, transformResponseList);
+
+                // replace upstream source node id with mq node in standard mode
+                adjustNodeRelations(relations, groupInfo, sources, transformResponseList);
+            }
 
             // create extract-transform-load nodes
             List<Node> nodes = this.createNodes(sources, transformResponseList, sinks, fieldMap);
-
-            // replace upstream source node id with mq node in standard mode
-            adjustNodeRelations(relations, groupInfo, sources, transformResponseList);
 
             StreamInfo streamInfo = new StreamInfo(streamId, nodes, relations);
             sortStreamInfos.add(streamInfo);
@@ -150,12 +150,13 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
 
     private Set<String> getValidInputNodeNamesInStandardMode(List<StreamSource> mqSources,
             List<TransformResponse> transforms) {
-        Set<String> mqSourceNameSet = mqSources.stream().map(StreamSource::getSourceName).collect(Collectors.toSet());
-        Set<String> transformNameSet = transforms.stream().map(TransformResponse::getTransformName)
-                .collect(Collectors.toSet());
         Set<String> result = Sets.newHashSet();
-        result.addAll(mqSourceNameSet);
-        result.addAll(transformNameSet);
+        if (CollectionUtils.isNotEmpty(mqSources)) {
+            result.addAll(mqSources.stream().map(StreamSource::getSourceName).collect(Collectors.toSet()));
+        }
+        if (CollectionUtils.isNotEmpty(transforms)) {
+            result.addAll(transforms.stream().map(TransformResponse::getTransformName).collect(Collectors.toSet()));
+        }
         return result;
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -171,7 +171,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
         for (TransformResponse transform : transforms) {
             for (StreamField field : transform.getFieldList()) {
                 String originNodeName = field.getOriginNodeName();
-                if (!(validNameSet.contains(originNodeName))) {
+                if (!validNameSet.contains(originNodeName)) {
                     // in standard mode transform input node must either be mq source node or transform node,
                     // otherwise replace it with mq node name, which should be stream id
                     field.setOriginNodeName(mqNodeName);
@@ -193,7 +193,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             List<String> inputs = relation.getInputs();
             for (int index = 0; index < inputs.size(); ++index) {
                 String inputName = inputs.get(index);
-                if (!(validNameSet.contains(inputName))) {
+                if (!validNameSet.contains(inputName)) {
                     inputs.set(index, mqNodeName);
                 }
             }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -17,24 +17,22 @@
 
 package org.apache.inlong.manager.service.resource.sort;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.pojo.group.InlongGroupExtInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.pojo.sort.util.ExtractNodeUtils;
+import org.apache.inlong.manager.pojo.sort.util.LoadNodeUtils;
+import org.apache.inlong.manager.pojo.sort.util.NodeRelationUtils;
+import org.apache.inlong.manager.pojo.sort.util.TransformNodeUtils;
 import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.manager.pojo.transform.TransformResponse;
 import org.apache.inlong.manager.service.sink.StreamSinkService;
-import org.apache.inlong.manager.pojo.sort.util.ExtractNodeUtils;
-import org.apache.inlong.manager.pojo.sort.util.LoadNodeUtils;
-import org.apache.inlong.manager.pojo.sort.util.NodeRelationUtils;
-import org.apache.inlong.manager.pojo.sort.util.TransformNodeUtils;
 import org.apache.inlong.manager.service.source.StreamSourceService;
 import org.apache.inlong.manager.service.transform.StreamTransformService;
 import org.apache.inlong.sort.protocol.GroupInfo;
@@ -48,7 +46,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -101,8 +101,8 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
         // get sink info
         Map<String, List<StreamSink>> sinkMap = sinkService.getSinksMap(groupInfo, streamInfoList);
 
-        List<TransformResponse> transformResponses = transformService.listTransform(groupInfo.getInlongGroupId(), null);
-        Map<String, List<TransformResponse>> transformMap = transformResponses.stream()
+        List<TransformResponse> transformList = transformService.listTransform(groupInfo.getInlongGroupId(), null);
+        Map<String, List<TransformResponse>> transformMap = transformList.stream()
                 .collect(Collectors.groupingBy(TransformResponse::getInlongStreamId, HashMap::new,
                         Collectors.toCollection(ArrayList::new)));
 
@@ -113,9 +113,9 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             inlongStream.getSourceList().forEach(
                     source -> parseConstantFieldMap(source.getSourceName(), source.getFieldList(), fieldMap));
 
-            List<TransformResponse> transformResponseList = transformMap.get(streamId);
-            if (CollectionUtils.isNotEmpty(transformResponseList)) {
-                transformResponseList.forEach(
+            List<TransformResponse> transformResponses = transformMap.get(streamId);
+            if (CollectionUtils.isNotEmpty(transformResponses)) {
+                transformResponses.forEach(
                         trans -> parseConstantFieldMap(trans.getTransformName(), trans.getFieldList(), fieldMap));
             }
 
@@ -123,36 +123,40 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             List<StreamSource> sources = sourceMap.get(streamId);
             List<StreamSink> sinks = sinkMap.get(streamId);
             List<NodeRelation> relations;
-            if (CollectionUtils.isEmpty(transformResponseList)) {
+            if (CollectionUtils.isEmpty(transformResponses)) {
                 relations = NodeRelationUtils.createNodeRelations(sources, sinks);
             } else {
                 relations = NodeRelationUtils.createNodeRelations(inlongStream);
-
-                // redirect transform input fields node if necessary
-                preprocessTransformList(groupInfo, sources, transformResponseList);
-
-                // replace upstream source node id with mq node in standard mode
-                adjustNodeRelations(relations, groupInfo, sources, transformResponseList);
+                // in standard mode, replace upstream source node and transform input fields node to mq node
+                if (InlongConstants.STANDARD_MODE.equals(groupInfo.getLightweight())) {
+                    // mq node name, which is inlong stream id
+                    String mqNodeName = sources.get(0).getSourceName();
+                    Set<String> nodeNameSet = getInputNodeNames(sources, transformResponses);
+                    adjustTransformField(transformResponses, nodeNameSet, mqNodeName);
+                    adjustNodeRelations(relations, nodeNameSet, mqNodeName);
+                }
             }
 
             // create extract-transform-load nodes
-            List<Node> nodes = this.createNodes(sources, transformResponseList, sinks, fieldMap);
+            List<Node> nodes = this.createNodes(sources, transformResponses, sinks, fieldMap);
 
             StreamInfo streamInfo = new StreamInfo(streamId, nodes, relations);
             sortStreamInfos.add(streamInfo);
 
-            // rebuild joinerNode relation if transformResponseList is not empty
-            NodeRelationUtils.optimizeNodeRelation(streamInfo, transformResponseList);
+            // rebuild joinerNode relation
+            NodeRelationUtils.optimizeNodeRelation(streamInfo, transformResponses);
         }
 
         return new GroupInfo(groupInfo.getInlongGroupId(), sortStreamInfos);
     }
 
-    private Set<String> getValidInputNodeNamesInStandardMode(List<StreamSource> mqSources,
-            List<TransformResponse> transforms) {
-        Set<String> result = Sets.newHashSet();
-        if (CollectionUtils.isNotEmpty(mqSources)) {
-            result.addAll(mqSources.stream().map(StreamSource::getSourceName).collect(Collectors.toSet()));
+    /**
+     * Deduplicate to get the node names of Source and Transform.
+     */
+    private Set<String> getInputNodeNames(List<StreamSource> sources, List<TransformResponse> transforms) {
+        Set<String> result = new HashSet<>();
+        if (CollectionUtils.isNotEmpty(sources)) {
+            result.addAll(sources.stream().map(StreamSource::getSourceName).collect(Collectors.toSet()));
         }
         if (CollectionUtils.isNotEmpty(transforms)) {
             result.addAll(transforms.stream().map(TransformResponse::getTransformName).collect(Collectors.toSet()));
@@ -160,42 +164,31 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
         return result;
     }
 
-    private void preprocessTransformList(InlongGroupInfo groupInfo, List<StreamSource> sources,
-            List<TransformResponse> transforms) {
-        if (InlongConstants.LIGHTWEIGHT_MODE.equals(groupInfo.getLightweight())) {
-            return;
-        }
-
-        // set transform fields' origin node to mq node when necessary
-        String mqNodeName = sources.get(0).getSourceName();
-        Set<String> validNameSet = getValidInputNodeNamesInStandardMode(sources, transforms);
+    /**
+     * Set origin node to mq node for transform fields if necessary.
+     *
+     * In standard mode for InlongGroup, transform input node must either be
+     * mq source node or transform node, otherwise replace it with mq node name.
+     */
+    private void adjustTransformField(List<TransformResponse> transforms, Set<String> nodeNameSet, String mqNodeName) {
         for (TransformResponse transform : transforms) {
             for (StreamField field : transform.getFieldList()) {
-                String originNodeName = field.getOriginNodeName();
-                if (!validNameSet.contains(originNodeName)) {
-                    // in standard mode transform input node must either be mq source node or transform node,
-                    // otherwise replace it with mq node name, which should be stream id
+                if (!nodeNameSet.contains(field.getOriginNodeName())) {
                     field.setOriginNodeName(mqNodeName);
                 }
             }
         }
     }
 
-    private void adjustNodeRelations(List<NodeRelation> relations, InlongGroupInfo groupInfo,
-            List<StreamSource> sources, List<TransformResponse> transforms) {
-        if (InlongConstants.LIGHTWEIGHT_MODE.equals(groupInfo.getLightweight())) {
-            return;
-        }
-
-        // set relations' input node to mq node when necessary
-        String mqNodeName = sources.get(0).getSourceName();
-        Set<String> validNameSet = getValidInputNodeNamesInStandardMode(sources, transforms);
+    /**
+     * Set the input node to MQ node for NodeRelations
+     */
+    private void adjustNodeRelations(List<NodeRelation> relations, Set<String> nodeNameSet, String mqNodeName) {
         for (NodeRelation relation : relations) {
-            List<String> inputs = relation.getInputs();
-            for (int index = 0; index < inputs.size(); ++index) {
-                String inputName = inputs.get(index);
-                if (!validNameSet.contains(inputName)) {
-                    inputs.set(index, mqNodeName);
+            ListIterator<String> iterator = relation.getInputs().listIterator();
+            while (iterator.hasNext()) {
+                if (!nodeNameSet.contains(iterator.next())) {
+                    iterator.set(mqNodeName);
                 }
             }
         }
@@ -203,7 +196,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
 
     private List<Node> createNodes(List<StreamSource> sources, List<TransformResponse> transformResponses,
             List<StreamSink> sinks, Map<String, StreamField> constantFieldMap) {
-        List<Node> nodes = Lists.newArrayList();
+        List<Node> nodes = new ArrayList<>();
         nodes.addAll(ExtractNodeUtils.createExtractNodes(sources));
         nodes.addAll(TransformNodeUtils.createTransformNodes(transformResponses, constantFieldMap));
         nodes.addAll(LoadNodeUtils.createLoadNodes(sinks, constantFieldMap));
@@ -234,7 +227,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
      */
     private void addToGroupExt(InlongGroupInfo groupInfo, String value) {
         if (groupInfo.getExtList() == null) {
-            groupInfo.setExtList(Lists.newArrayList());
+            groupInfo.setExtList(new ArrayList<>());
         }
 
         InlongGroupExtInfo extInfo = new InlongGroupExtInfo();
@@ -252,7 +245,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
     private void addToStreamExt(List<InlongStreamInfo> streamInfos, String value) {
         streamInfos.forEach(streamInfo -> {
             if (streamInfo.getExtList() == null) {
-                streamInfo.setExtList(Lists.newArrayList());
+                streamInfo.setExtList(new ArrayList<>());
             }
 
             InlongStreamExtInfo extInfo = new InlongStreamExtInfo();


### PR DESCRIPTION
- Fixes #6003

### Motivation

In the beginning only **lightweight mode** supports the ETL transform nodes. Clients configure their extract/transform/load nodes  at will and what they submit is what they see so everyone is happy.

This ceases to be the case when **standard sort mode** tries to support transform nodes as well. In standard mode multiple upstream sources are collected to MQ first and are not the real extract nodes anymore. Instead the MQ cache node becomes **the real extract node**.  

This is achieved by manager through replacing the original upstream source nodes (file、binlog...) with the MQ cache node when constructing the extract node in standard mode.

However the clients are ignorant of any of this.  From their point of view nothing is changed and the MQ node is invisible to them. So in their submitted **node relation configuration** the extract node is still some upstream source node (file、binlog...) rather than the MQ cache node. This results in the incorrect DataFlow configuration:

![image](https://user-images.githubusercontent.com/941634/191929269-ecdc1d75-69b8-4844-990b-6d69352d578b.png)


### Changes
- change the transform fields's original node id to be MQ cache node
-  update the user submitted node relation to use MQ cache node as the real extract node