### PR TITLE
[INLONG-6014][Manager] Int type cannot be compared with null using ==

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
@@ -48,8 +48,8 @@ import org.springframework.stereotype.Service;
 @Service
 public class ConsumePulsarOperator extends AbstractConsumeOperator {
 
-    private static final int DLQ_RLQ_ENABLE = 1;
-    private static final int DLQ__RLQ_DISABLE = 0;
+    private static final Integer DLQ_RLQ_ENABLE = 1;
+    private static final Integer DLQ__RLQ_DISABLE = 0;
     // Topic prefix for the dead letter queue
     private static final String PREFIX_DLQ = "dlq";
     // Topic prefix for the retry letter queue
@@ -116,8 +116,8 @@ public class ConsumePulsarOperator extends AbstractConsumeOperator {
         // prerequisite for RLQ to be turned on: DLQ must be turned on.
         // it means, if DLQ is closed, RLQ cannot exist alone and must be closed.
         ConsumePulsarRequest pulsarRequest = (ConsumePulsarRequest) request;
-        boolean dlqEnable = (DLQ_RLQ_ENABLE == pulsarRequest.getIsDlq());
-        boolean rlqEnable = (DLQ_RLQ_ENABLE == pulsarRequest.getIsRlq());
+        boolean dlqEnable = DLQ_RLQ_ENABLE.equals(pulsarRequest.getIsDlq());
+        boolean rlqEnable = DLQ_RLQ_ENABLE.equals(pulsarRequest.getIsRlq());
         if (rlqEnable && !dlqEnable) {
             throw new BusinessException(ErrorCodeEnum.PULSAR_DLQ_RLQ_ERROR);
         }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6014 

### Motivation

*When an int is compared to an Integer, the Integer may be null.*

### Modifications

*Use equals to compare two numbers for the same*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
