### PR TITLE
[INLONG-6026][Audit] Fix the executed error of ClickHouse audit SQL file

### DIFF
--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
@@ -17,10 +17,10 @@
 
 package org.apache.inlong.audit.db.entities;
 
-import java.sql.Timestamp;
-
 import lombok.Getter;
 import lombok.Setter;
+
+import java.sql.Timestamp;
 
 @Getter
 @Setter
@@ -30,13 +30,14 @@ public class ClickHouseDataPo {
     private String dockerId;
     private String threadId;
     private Timestamp sdkTs;
-    private long packetId;
+    private Long packetId;
     private Timestamp logTs;
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
-    private long count;
-    private long size;
-    private long delay;
+    private Long count;
+    private Long size;
+    private Long delay;
     private Timestamp updateTime;
+
 }

--- a/inlong-audit/audit-store/src/main/resources/sql/apache_inlong_audit_clickhouse.sql
+++ b/inlong-audit/audit-store/src/main/resources/sql/apache_inlong_audit_clickhouse.sql
@@ -15,30 +15,31 @@
  * limitations under the License.
  */
 
-SET NAMES utf8mb4;
-SET FOREIGN_KEY_CHECKS = 0;
-SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
-SET time_zone = "+00:00";
-
+-- ----------------------------
+-- Database for InLong Audit
+-- ----------------------------
 CREATE DATABASE IF NOT EXISTS apache_inlong_audit;
+
 USE apache_inlong_audit;
 
-CREATE TABLE `audit_data`
+-- ----------------------------
+-- Table structure for audit_data
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `audit_data`
 (
-    `ip`               String COMMENT 'client ip',
-    `docker_id`        String COMMENT 'client docker id',
-    `thread_id`        String COMMENT 'client thread id',
-    `sdk_ts`           DateTime COMMENT 'sdk timestamp',
-    `packet_id`        Int64 COMMENT 'packet id',
-    `log_ts`           DateTime COMMENT 'log timestamp',
-    `inlong_group_id`  String COMMENT 'inlong group id',
-    `inlong_stream_id` String COMMENT 'inlong stream id',
-    `audit_id`         String COMMENT 'audit id',
-    `count`            Int64 COMMENT 'msg count',
-    `size`             Int64 COMMENT 'msg size',
-    `delay`            Int64 COMMENT 'msg delay',
-    `update_time`       DateTime COMMENT 'update time'
-)
-ENGINE = MergeTree
-ORDER BY inlong_group_id
-SETTINGS index_granularity = 8192;
+    `ip`               String COMMENT 'Client IP',
+    `docker_id`        String COMMENT 'Client docker id',
+    `thread_id`        String COMMENT 'Client thread id',
+    `sdk_ts`           DateTime COMMENT 'SDK timestamp',
+    `packet_id`        Int64 COMMENT 'Packet id',
+    `log_ts`           DateTime COMMENT 'Log timestamp',
+    `inlong_group_id`  String COMMENT 'The target inlong group id',
+    `inlong_stream_id` String COMMENT 'The target inlong stream id',
+    `audit_id`         String COMMENT 'Audit id',
+    `count`            Int64 COMMENT 'Message count',
+    `size`             Int64 COMMENT 'Message size',
+    `delay`            Int64 COMMENT 'Message delay',
+    `update_time`      DateTime COMMENT 'Update time'
+) ENGINE = MergeTree
+      ORDER BY inlong_group_id
+      SETTINGS index_granularity = 8192;

--- a/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
+++ b/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
@@ -15,30 +15,31 @@
  * limitations under the License.
  */
 
-SET NAMES utf8mb4;
-SET FOREIGN_KEY_CHECKS = 0;
-SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
-SET time_zone = "+00:00";
-
+-- ----------------------------
+-- Database for InLong Audit
+-- ----------------------------
 CREATE DATABASE IF NOT EXISTS apache_inlong_audit;
+
 USE apache_inlong_audit;
 
-CREATE TABLE `audit_data`
+-- ----------------------------
+-- Table structure for audit_data
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `audit_data`
 (
-    `ip`               String COMMENT 'client ip',
-    `docker_id`        String COMMENT 'client docker id',
-    `thread_id`        String COMMENT 'client thread id',
-    `sdk_ts`           DateTime COMMENT 'sdk timestamp',
-    `packet_id`        Int64 COMMENT 'packet id',
-    `log_ts`           DateTime COMMENT 'log timestamp',
-    `inlong_group_id`  String COMMENT 'inlong group id',
-    `inlong_stream_id` String COMMENT 'inlong stream id',
-    `audit_id`         String COMMENT 'audit id',
-    `count`            Int64 COMMENT 'msg count',
-    `size`             Int64 COMMENT 'msg size',
-    `delay`            Int64 COMMENT 'msg delay',
-    `update_time`       DateTime COMMENT 'update time'
-)
-ENGINE = MergeTree
-ORDER BY inlong_group_id
-SETTINGS index_granularity = 8192;
+    `ip`               String COMMENT 'Client IP',
+    `docker_id`        String COMMENT 'Client docker id',
+    `thread_id`        String COMMENT 'Client thread id',
+    `sdk_ts`           DateTime COMMENT 'SDK timestamp',
+    `packet_id`        Int64 COMMENT 'Packet id',
+    `log_ts`           DateTime COMMENT 'Log timestamp',
+    `inlong_group_id`  String COMMENT 'The target inlong group id',
+    `inlong_stream_id` String COMMENT 'The target inlong stream id',
+    `audit_id`         String COMMENT 'Audit id',
+    `count`            Int64 COMMENT 'Message count',
+    `size`             Int64 COMMENT 'Message size',
+    `delay`            Int64 COMMENT 'Message delay',
+    `update_time`      DateTime COMMENT 'Update time'
+) ENGINE = MergeTree
+      ORDER BY inlong_group_id
+      SETTINGS index_granularity = 8192;


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-6026][Audit] Fix the executed error of ClickHouse audit SQL file

- Fixes #6026

### Motivation

ClickHouse not support those operations, remove them.

```
SET NAMES utf8mb4;
SET FOREIGN_KEY_CHECKS = 0;
SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
SET time_zone = "+00:00";
```

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
