### PR TITLE
[INLONG-6047][Agent] Fix file could not be matched in the k8s

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
@@ -115,7 +115,7 @@ public final class KubernetesFileReader extends AbstractFileReader {
             return null;
         }
         Map<String, String> k8sInfo = MetaDataUtils.getLogInfo(fileReaderOperator.file.getName());
-        log.info("file name is:{},k8s information size:{}", fileReaderOperator.file.getName(), k8sInfo.size());
+        log.info("file name is: {}, k8s information size: {}", fileReaderOperator.file.getName(), k8sInfo.size());
         Map<String, String> metadata = new HashMap<>();
         if (k8sInfo.isEmpty()) {
             return metadata;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/reader/file/KubernetesFileReader.java
@@ -115,7 +115,7 @@ public final class KubernetesFileReader extends AbstractFileReader {
             return null;
         }
         Map<String, String> k8sInfo = MetaDataUtils.getLogInfo(fileReaderOperator.file.getName());
-        log.info("k8s information size:{}", k8sInfo.size());
+        log.info("file name is:{},k8s information size:{}", fileReaderOperator.file.getName(), k8sInfo.size());
         Map<String, String> metadata = new HashMap<>();
         if (k8sInfo.isEmpty()) {
             return metadata;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
@@ -51,13 +51,15 @@ public class MetaDataUtils {
     // standard log path for k8s
     private static final String FILE_NAME_PATTERN = "(^[-a-zA-Z0-9]+)_([a-zA-Z0-9-]+)_([a-zA-Z0-9-]+)(.log)";
 
+    private static final Pattern PATTERN = Pattern.compile(FILE_NAME_PATTERN);
+
     /**
      * standard log for k8s
      *
      * get pod_name,namespace,container_name,container_id
      */
     public static Map<String, String> getLogInfo(String fileName) {
-        Matcher matcher = Pattern.compile(FILE_NAME_PATTERN).matcher(fileName);
+        Matcher matcher = PATTERN.matcher(fileName);
         Map<String, String> podInf = new HashMap<>();
         if (StringUtils.isBlank(fileName) || !matcher.matches()) {
             return podInf;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
@@ -81,12 +81,6 @@ public class MetaDataUtils {
         return podInf;
     }
 
-    public static void main(String[] args) {
-        System.out.println(getLogInfo(
-                "testcase-0_xb-test240_testcase2-8050825882878a0aef05cd597abb09917a1e090d09f4d1ed288488311ca0309c.log")
-                .values());
-    }
-
     /**
      * standard log for k8s
      *

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/MetaDataUtils.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_META_FILTER_BY_LABELS;
@@ -47,7 +49,7 @@ public class MetaDataUtils {
     private static final String LOG_MARK = ".log";
 
     // standard log path for k8s
-    private static final String STANDARD_OUT = "/var/log/containers";
+    private static final String FILE_NAME_PATTERN = "(^[-a-zA-Z0-9]+)_([a-zA-Z0-9-]+)_([a-zA-Z0-9-]+)(.log)";
 
     /**
      * standard log for k8s
@@ -55,8 +57,9 @@ public class MetaDataUtils {
      * get pod_name,namespace,container_name,container_id
      */
     public static Map<String, String> getLogInfo(String fileName) {
+        Matcher matcher = Pattern.compile(FILE_NAME_PATTERN).matcher(fileName);
         Map<String, String> podInf = new HashMap<>();
-        if (StringUtils.isBlank(fileName) || !fileName.contains(STANDARD_OUT)) {
+        if (StringUtils.isBlank(fileName) || !matcher.matches()) {
             return podInf;
         }
         // file name example: /var/log/containers/<pod_name>_<namespace>_<container_name>-<continer_id>.log
@@ -76,6 +79,12 @@ public class MetaDataUtils {
         podInf.put(CONTAINER_NAME, containerName);
         podInf.put(CONTAINER_ID, containerId);
         return podInf;
+    }
+
+    public static void main(String[] args) {
+        System.out.println(getLogInfo(
+                "testcase-0_xb-test240_testcase2-8050825882878a0aef05cd597abb09917a1e090d09f4d1ed288488311ca0309c.log")
+                .values());
     }
 
     /**

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/utils/MetaDataUtilsTest.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/utils/MetaDataUtilsTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.utils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * metadata of k8s utils test
+ */
+public class MetaDataUtilsTest {
+
+    @Test
+    public void getLogInfo() {
+        String fileName = "testcase-0_xb-test240_testcase2"
+                + "-8050825882878a0aef05cd597abb09917a1e090d09f4d1ed288488311ca0309c.log";
+        Map<String, String> metaMap = MetaDataUtils.getLogInfo(fileName);
+        Assert.assertEquals(4, metaMap.size());
+    }
+}


### PR DESCRIPTION
 Fix file could not be matched in the k8s.
 Add a Regular Expression.
- Fixes #6047 

### Motivation
The file name in the soft link path must be matched with the regular.

### Modifications

Add a util

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
