### PR TITLE
[INLONG-6063][Manager] Utilize ClickHouse and Iceberg data node

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeDTO.java
@@ -15,74 +15,42 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.ck;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.validation.constraints.NotNull;
 
 /**
- * Hive data node info
+ * ClickHouse data node info
  */
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
-@ApiModel("Hive data node info")
-public class HiveDataNodeDTO {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(HiveDataNodeDTO.class);
+@ApiModel("ClickHouse data node info")
+public class ClickHouseDataNodeDTO {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(); // thread safe
-
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
-
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
-    private String warehouse;
-
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
 
     /**
      * Get the dto instance from the request
      */
-    public static HiveDataNodeDTO getFromRequest(HiveDataNodeRequest request) throws Exception {
-        return HiveDataNodeDTO.builder()
-                .hiveVersion(request.getHiveVersion())
-                .hiveConfDir(request.getHiveConfDir())
-                .hdfsPath(request.getHdfsPath())
-                .warehouse(request.getWarehouse())
-                .hdfsUgi(request.getHdfsUgi())
-                .build();
+    public static ClickHouseDataNodeDTO getFromRequest(ClickHouseDataNodeRequest request) throws Exception {
+        return ClickHouseDataNodeDTO.builder().build();
     }
 
     /**
      * Get the dto instance from the JSON string.
      */
-    public static HiveDataNodeDTO getFromJson(@NotNull String extParams) {
+    public static ClickHouseDataNodeDTO getFromJson(@NotNull String extParams) {
         try {
             OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            return OBJECT_MAPPER.readValue(extParams, HiveDataNodeDTO.class);
+            return OBJECT_MAPPER.readValue(extParams, ClickHouseDataNodeDTO.class);
         } catch (Exception e) {
-            LOGGER.error("Failed to extract additional parameters for hive data node: ", e);
             throw new BusinessException(ErrorCodeEnum.GROUP_INFO_INCORRECT.getMessage());
         }
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeInfo.java
@@ -15,44 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.ck;
 
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
-import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 
 /**
- * Hive data node request
+ * ClickHouse data node info
  */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeDefine(value = DataNodeType.HIVE)
-@ApiModel("Hive data node request")
-public class HiveDataNodeRequest extends DataNodeRequest {
+@JsonTypeDefine(value = DataNodeType.CLICKHOUSE)
+@ApiModel("ClickHouse data node info")
+public class ClickHouseDataNodeInfo extends DataNodeInfo {
 
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
-
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
-    private String warehouse;
-
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
-
-    public HiveDataNodeRequest() {
-        this.setType(DataNodeType.HIVE);
+    public ClickHouseDataNodeInfo() {
+        this.setType(DataNodeType.CLICKHOUSE);
     }
 
+    @Override
+    public ClickHouseDataNodeRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, ClickHouseDataNodeRequest::new);
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/ck/ClickHouseDataNodeRequest.java
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.ck;
 
 import io.swagger.annotations.ApiModel;
-import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -27,32 +26,17 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 
 /**
- * Hive data node request
+ * ClickHouse data node request
  */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeDefine(value = DataNodeType.HIVE)
-@ApiModel("Hive data node request")
-public class HiveDataNodeRequest extends DataNodeRequest {
+@JsonTypeDefine(value = DataNodeType.CLICKHOUSE)
+@ApiModel("ClickHouse data node request")
+public class ClickHouseDataNodeRequest extends DataNodeRequest {
 
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
-
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
-    private String warehouse;
-
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
-
-    public HiveDataNodeRequest() {
-        this.setType(DataNodeType.HIVE);
+    public ClickHouseDataNodeRequest() {
+        this.setType(DataNodeType.CLICKHOUSE);
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeDTO.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.iceberg;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,56 +33,45 @@ import org.slf4j.LoggerFactory;
 import javax.validation.constraints.NotNull;
 
 /**
- * Hive data node info
+ * Iceberg data node info
  */
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel("Hive data node info")
-public class HiveDataNodeDTO {
+@ApiModel("Iceberg data node info")
+public class IcebergDataNodeDTO {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HiveDataNodeDTO.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(IcebergDataNodeDTO.class);
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper(); // thread safe
 
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
+    @ApiModelProperty("Catalog type, like: HIVE, HADOOP, default is HIVE")
+    @Builder.Default
+    private String catalogType = "HIVE";
 
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
+    @ApiModelProperty("Iceberg data warehouse dir")
     private String warehouse;
-
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
 
     /**
      * Get the dto instance from the request
      */
-    public static HiveDataNodeDTO getFromRequest(HiveDataNodeRequest request) throws Exception {
-        return HiveDataNodeDTO.builder()
-                .hiveVersion(request.getHiveVersion())
-                .hiveConfDir(request.getHiveConfDir())
-                .hdfsPath(request.getHdfsPath())
+    public static IcebergDataNodeDTO getFromRequest(IcebergDataNodeRequest request) throws Exception {
+        return IcebergDataNodeDTO.builder()
+                .catalogType(request.getCatalogType())
                 .warehouse(request.getWarehouse())
-                .hdfsUgi(request.getHdfsUgi())
                 .build();
     }
 
     /**
      * Get the dto instance from the JSON string.
      */
-    public static HiveDataNodeDTO getFromJson(@NotNull String extParams) {
+    public static IcebergDataNodeDTO getFromJson(@NotNull String extParams) {
         try {
             OBJECT_MAPPER.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-            return OBJECT_MAPPER.readValue(extParams, HiveDataNodeDTO.class);
+            return OBJECT_MAPPER.readValue(extParams, IcebergDataNodeDTO.class);
         } catch (Exception e) {
-            LOGGER.error("Failed to extract additional parameters for hive data node: ", e);
+            LOGGER.error("Failed to extract additional parameters for iceberg data node: ", e);
             throw new BusinessException(ErrorCodeEnum.GROUP_INFO_INCORRECT.getMessage());
         }
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeInfo.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.iceberg;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -23,36 +23,32 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
-import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 
 /**
- * Hive data node request
+ * Iceberg data node info
  */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeDefine(value = DataNodeType.HIVE)
-@ApiModel("Hive data node request")
-public class HiveDataNodeRequest extends DataNodeRequest {
+@JsonTypeDefine(value = DataNodeType.ICEBERG)
+@ApiModel("Iceberg data node info")
+public class IcebergDataNodeInfo extends DataNodeInfo {
 
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
+    @ApiModelProperty("Catalog type, like: HIVE, HADOOP, default is HIVE")
+    private String catalogType = "HIVE";
 
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
+    @ApiModelProperty("Iceberg data warehouse dir")
     private String warehouse;
 
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
-
-    public HiveDataNodeRequest() {
-        this.setType(DataNodeType.HIVE);
+    public IcebergDataNodeInfo() {
+        this.setType(DataNodeType.ICEBERG);
     }
 
+    @Override
+    public IcebergDataNodeRequest genRequest() {
+        return CommonBeanUtils.copyProperties(this, IcebergDataNodeRequest::new);
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeRequest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.pojo.node.hive;
+package org.apache.inlong.manager.pojo.node.iceberg;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -33,25 +33,16 @@ import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeDefine(value = DataNodeType.HIVE)
-@ApiModel("Hive data node request")
-public class HiveDataNodeRequest extends DataNodeRequest {
+@ApiModel("Iceberg data node request")
+public class IcebergDataNodeRequest extends DataNodeRequest {
 
-    @ApiModelProperty("Version for Hive, such as: 3.2.1")
-    private String hiveVersion;
+    @ApiModelProperty("Catalog type, like: HIVE, HADOOP, default is HIVE")
+    private String catalogType = "HIVE";
 
-    @ApiModelProperty("Config directory of Hive on HDFS, needed by sort in light mode, must include hive-site.xml")
-    private String hiveConfDir;
-
-    @ApiModelProperty("HDFS default FS, such as: hdfs://127.0.0.1:9000")
-    private String hdfsPath;
-
-    @ApiModelProperty("Hive warehouse path, such as: /user/hive/warehouse/")
+    @ApiModelProperty("Iceberg data warehouse dir")
     private String warehouse;
 
-    @ApiModelProperty("User and group information for writing data to HDFS")
-    private String hdfsUgi;
-
-    public HiveDataNodeRequest() {
+    public IcebergDataNodeRequest() {
         this.setType(DataNodeType.HIVE);
     }
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/iceberg/IcebergDataNodeRequest.java
@@ -27,12 +27,12 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 
 /**
- * Hive data node request
+ * Iceberg data node request
  */
 @Data
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-@JsonTypeDefine(value = DataNodeType.HIVE)
+@JsonTypeDefine(value = DataNodeType.ICEBERG)
 @ApiModel("Iceberg data node request")
 public class IcebergDataNodeRequest extends DataNodeRequest {
 
@@ -43,7 +43,7 @@ public class IcebergDataNodeRequest extends DataNodeRequest {
     private String warehouse;
 
     public IcebergDataNodeRequest() {
-        this.setType(DataNodeType.HIVE);
+        this.setType(DataNodeType.ICEBERG);
     }
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/ck/ClickHouseDataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/ck/ClickHouseDataNodeOperator.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.node.ck;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.DataNodeEntity;
+import org.apache.inlong.manager.pojo.node.DataNodeInfo;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.ck.ClickHouseDataNodeDTO;
+import org.apache.inlong.manager.pojo.node.ck.ClickHouseDataNodeInfo;
+import org.apache.inlong.manager.pojo.node.ck.ClickHouseDataNodeRequest;
+import org.apache.inlong.manager.service.node.AbstractDataNodeOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ClickHouseDataNodeOperator extends AbstractDataNodeOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClickHouseDataNodeOperator.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Boolean accept(String dataNodeType) {
+        return getDataNodeType().equals(dataNodeType);
+    }
+
+    @Override
+    public String getDataNodeType() {
+        return DataNodeType.CLICKHOUSE;
+    }
+
+    @Override
+    public DataNodeInfo getFromEntity(DataNodeEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(ErrorCodeEnum.DATA_NODE_NOT_FOUND);
+        }
+
+        ClickHouseDataNodeInfo ckDataNodeInfo = new ClickHouseDataNodeInfo();
+        CommonBeanUtils.copyProperties(entity, ckDataNodeInfo);
+        if (StringUtils.isNotBlank(entity.getExtParams())) {
+            ClickHouseDataNodeDTO dto = ClickHouseDataNodeDTO.getFromJson(entity.getExtParams());
+            CommonBeanUtils.copyProperties(dto, ckDataNodeInfo);
+        }
+
+        return ckDataNodeInfo;
+    }
+
+    @Override
+    protected void setTargetEntity(DataNodeRequest request, DataNodeEntity targetEntity) {
+        ClickHouseDataNodeRequest ckDataNodeRequest = (ClickHouseDataNodeRequest) request;
+        CommonBeanUtils.copyProperties(ckDataNodeRequest, targetEntity, true);
+        try {
+            ClickHouseDataNodeDTO dto = ClickHouseDataNodeDTO.getFromRequest(ckDataNodeRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            LOGGER.error("failed to set entity for hive data node: ", e);
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT.getMessage());
+        }
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/iceberg/IcebergDataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/iceberg/IcebergDataNodeOperator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.node.iceberg;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.DataNodeEntity;
+import org.apache.inlong.manager.pojo.node.DataNodeInfo;
+import org.apache.inlong.manager.pojo.node.DataNodeRequest;
+import org.apache.inlong.manager.pojo.node.iceberg.IcebergDataNodeDTO;
+import org.apache.inlong.manager.pojo.node.iceberg.IcebergDataNodeInfo;
+import org.apache.inlong.manager.pojo.node.iceberg.IcebergDataNodeRequest;
+import org.apache.inlong.manager.service.node.AbstractDataNodeOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class IcebergDataNodeOperator extends AbstractDataNodeOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(IcebergDataNodeOperator.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Boolean accept(String dataNodeType) {
+        return getDataNodeType().equals(dataNodeType);
+    }
+
+    @Override
+    public String getDataNodeType() {
+        return DataNodeType.ICEBERG;
+    }
+
+    @Override
+    public DataNodeInfo getFromEntity(DataNodeEntity entity) {
+        if (entity == null) {
+            throw new BusinessException(ErrorCodeEnum.DATA_NODE_NOT_FOUND);
+        }
+
+        IcebergDataNodeInfo icebergDataNodeInfo = new IcebergDataNodeInfo();
+        CommonBeanUtils.copyProperties(entity, icebergDataNodeInfo);
+        if (StringUtils.isNotBlank(entity.getExtParams())) {
+            IcebergDataNodeDTO dto = IcebergDataNodeDTO.getFromJson(entity.getExtParams());
+            CommonBeanUtils.copyProperties(dto, icebergDataNodeInfo);
+        }
+
+        LOGGER.debug("success to get iceberg data node from entity");
+        return icebergDataNodeInfo;
+    }
+
+    @Override
+    protected void setTargetEntity(DataNodeRequest request, DataNodeEntity targetEntity) {
+        IcebergDataNodeRequest icebergDataNodeRequest = (IcebergDataNodeRequest) request;
+        CommonBeanUtils.copyProperties(icebergDataNodeRequest, targetEntity, true);
+        try {
+            IcebergDataNodeDTO dto = IcebergDataNodeDTO.getFromRequest(icebergDataNodeRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            LOGGER.error("failed to set entity for iceberg data node: ", e);
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT.getMessage());
+        }
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/hive/HiveResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/hive/HiveResourceOperator.java
@@ -86,12 +86,7 @@ public class HiveResourceOperator implements SinkResourceOperator {
     }
 
     private HiveSinkDTO getHiveInfo(SinkInfo sinkInfo) {
-        HiveSinkDTO hiveInfo = new HiveSinkDTO();
-
-        if (StringUtils.isNotBlank(sinkInfo.getExtParams())) {
-            HiveSinkDTO userSinkInfo = HiveSinkDTO.getFromJson(sinkInfo.getExtParams());
-            CommonBeanUtils.copyProperties(userSinkInfo, hiveInfo);
-        }
+        HiveSinkDTO hiveInfo = HiveSinkDTO.getFromJson(sinkInfo.getExtParams());
 
         // read from data node if not supplied by user
         if (StringUtils.isBlank(hiveInfo.getJdbcUrl())) {
@@ -101,7 +96,6 @@ public class HiveResourceOperator implements SinkResourceOperator {
                     dataNodeName, sinkInfo.getSinkType());
             CommonBeanUtils.copyProperties(dataNodeInfo, hiveInfo);
             hiveInfo.setJdbcUrl(dataNodeInfo.getUrl());
-            hiveInfo.setUsername(dataNodeInfo.getUsername());
             hiveInfo.setPassword(dataNodeInfo.getToken());
         }
         return hiveInfo;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/iceberg/IcebergResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/iceberg/IcebergResourceOperator.java
@@ -18,16 +18,21 @@
 package org.apache.inlong.manager.service.resource.sink.iceberg;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.SinkStatus;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.exceptions.WorkflowException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.pojo.node.iceberg.IcebergDataNodeInfo;
 import org.apache.inlong.manager.pojo.sink.SinkInfo;
 import org.apache.inlong.manager.pojo.sink.iceberg.IcebergColumnInfo;
 import org.apache.inlong.manager.pojo.sink.iceberg.IcebergSinkDTO;
 import org.apache.inlong.manager.pojo.sink.iceberg.IcebergTableInfo;
 import org.apache.inlong.manager.dao.entity.StreamSinkFieldEntity;
 import org.apache.inlong.manager.dao.mapper.StreamSinkFieldEntityMapper;
+import org.apache.inlong.manager.service.node.DataNodeOperateHelper;
 import org.apache.inlong.manager.service.resource.sink.SinkResourceOperator;
 import org.apache.inlong.manager.service.sink.StreamSinkService;
 import org.slf4j.Logger;
@@ -48,10 +53,14 @@ public class IcebergResourceOperator implements SinkResourceOperator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IcebergResourceOperator.class);
 
+    private static final String CATALOG_TYPE_HIVE = "HIVE";
+
     @Autowired
     private StreamSinkService sinkService;
     @Autowired
     private StreamSinkFieldEntityMapper sinkFieldMapper;
+    @Autowired
+    private DataNodeOperateHelper dataNodeHelper;
 
     @Override
     public Boolean accept(String sinkType) {
@@ -78,11 +87,27 @@ public class IcebergResourceOperator implements SinkResourceOperator {
         this.createTable(sinkInfo);
     }
 
+    private IcebergSinkDTO getIcebergInfo(SinkInfo sinkInfo) {
+        IcebergSinkDTO icebergInfo = IcebergSinkDTO.getFromJson(sinkInfo.getExtParams());
+
+        // read uri from data node if not supplied by user
+        if (StringUtils.isBlank(icebergInfo.getCatalogUri())
+                && icebergInfo.getCatalogType().equals(CATALOG_TYPE_HIVE)) {
+            String dataNodeName = sinkInfo.getDataNodeName();
+            Preconditions.checkNotEmpty(dataNodeName, "iceberg catalog uri not specified and data node is empty");
+            IcebergDataNodeInfo dataNodeInfo = (IcebergDataNodeInfo) dataNodeHelper.getDataNodeInfo(
+                    dataNodeName, sinkInfo.getSinkType());
+            CommonBeanUtils.copyProperties(dataNodeInfo, icebergInfo);
+            icebergInfo.setCatalogUri(dataNodeInfo.getUrl());
+        }
+        return icebergInfo;
+    }
+
     private void createTable(SinkInfo sinkInfo) {
         LOGGER.info("begin to create iceberg table for sinkInfo={}", sinkInfo);
 
         // Get all info from config
-        IcebergSinkDTO icebergInfo = IcebergSinkDTO.getFromJson(sinkInfo.getExtParams());
+        IcebergSinkDTO icebergInfo = getIcebergInfo(sinkInfo);
         List<IcebergColumnInfo> columnInfoList = getColumnList(sinkInfo);
         if (CollectionUtils.isEmpty(columnInfoList)) {
             throw new IllegalArgumentException("no iceberg columns specified");

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/iceberg/IcebergResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/iceberg/IcebergResourceOperator.java
@@ -92,7 +92,7 @@ public class IcebergResourceOperator implements SinkResourceOperator {
 
         // read uri from data node if not supplied by user
         if (StringUtils.isBlank(icebergInfo.getCatalogUri())
-                && icebergInfo.getCatalogType().equals(CATALOG_TYPE_HIVE)) {
+                && CATALOG_TYPE_HIVE.equals(icebergInfo.getCatalogType())) {
             String dataNodeName = sinkInfo.getDataNodeName();
             Preconditions.checkNotEmpty(dataNodeName, "iceberg catalog uri not specified and data node is empty");
             IcebergDataNodeInfo dataNodeInfo = (IcebergDataNodeInfo) dataNodeHelper.getDataNodeInfo(

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/AbstractSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/AbstractSinkOperator.java
@@ -35,6 +35,7 @@ import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.service.node.DataNodeOperateHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,6 +58,8 @@ public abstract class AbstractSinkOperator implements StreamSinkOperator {
     protected StreamSinkEntityMapper sinkMapper;
     @Autowired
     protected StreamSinkFieldEntityMapper sinkFieldMapper;
+    @Autowired
+    protected DataNodeOperateHelper dataNodeHelper;
 
     /**
      * Setting the parameters of the latest entity.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/ck/ClickHouseSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/ck/ClickHouseSinkOperator.java
@@ -18,9 +18,11 @@
 package org.apache.inlong.manager.service.sink.ck;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.pojo.node.ck.ClickHouseDataNodeInfo;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
@@ -82,6 +84,15 @@ public class ClickHouseSinkOperator extends AbstractSinkOperator {
         }
 
         ClickHouseSinkDTO dto = ClickHouseSinkDTO.getFromJson(entity.getExtParams());
+        if (StringUtils.isBlank(dto.getJdbcUrl())) {
+            Preconditions.checkNotEmpty(entity.getDataNodeName(),
+                    "clickhouse jdbc url unspecified and data node is empty");
+            ClickHouseDataNodeInfo dataNodeInfo = (ClickHouseDataNodeInfo) dataNodeHelper.getDataNodeInfo(
+                    entity.getDataNodeName(), entity.getSinkType());
+            CommonBeanUtils.copyProperties(dataNodeInfo, dto, true);
+            dto.setJdbcUrl(dataNodeInfo.getUrl());
+            dto.setPassword(dataNodeInfo.getToken());
+        }
         CommonBeanUtils.copyProperties(entity, sink, true);
         CommonBeanUtils.copyProperties(dto, sink, true);
         List<SinkField> sinkFields = super.getSinkFields(entity.getId());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hive/HiveSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hive/HiveSinkOperator.java
@@ -18,9 +18,11 @@
 package org.apache.inlong.manager.service.sink.hive;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.pojo.node.hive.HiveDataNodeInfo;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
@@ -81,6 +83,15 @@ public class HiveSinkOperator extends AbstractSinkOperator {
         }
 
         HiveSinkDTO dto = HiveSinkDTO.getFromJson(entity.getExtParams());
+        if (StringUtils.isBlank(dto.getJdbcUrl())) {
+            Preconditions.checkNotEmpty(entity.getDataNodeName(),
+                    "hive jdbc url unspecified and data node is empty");
+            HiveDataNodeInfo dataNodeInfo = (HiveDataNodeInfo) dataNodeHelper.getDataNodeInfo(
+                    entity.getDataNodeName(), entity.getSinkType());
+            CommonBeanUtils.copyProperties(dataNodeInfo, dto, true);
+            dto.setJdbcUrl(dataNodeInfo.getUrl());
+            dto.setPassword(dataNodeInfo.getToken());
+        }
         CommonBeanUtils.copyProperties(entity, sink, true);
         CommonBeanUtils.copyProperties(dto, sink, true);
         List<SinkField> sinkFields = super.getSinkFields(entity.getId());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/iceberg/IcebergSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/iceberg/IcebergSinkOperator.java
@@ -87,7 +87,7 @@ public class IcebergSinkOperator extends AbstractSinkOperator {
         }
 
         IcebergSinkDTO dto = IcebergSinkDTO.getFromJson(entity.getExtParams());
-        if (StringUtils.isBlank(dto.getCatalogUri()) && dto.getCatalogType().equals(CATALOG_TYPE_HIVE)) {
+        if (StringUtils.isBlank(dto.getCatalogUri()) && CATALOG_TYPE_HIVE.equals(dto.getCatalogType())) {
             Preconditions.checkNotEmpty(entity.getDataNodeName(),
                     "iceberg catalog uri unspecified and data node is empty");
             IcebergDataNodeInfo dataNodeInfo = (IcebergDataNodeInfo) dataNodeHelper.getDataNodeInfo(

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/iceberg/IcebergSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/iceberg/IcebergSinkOperator.java
@@ -18,10 +18,12 @@
 package org.apache.inlong.manager.service.sink.iceberg;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.FieldType;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.pojo.node.iceberg.IcebergDataNodeInfo;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
@@ -47,6 +49,8 @@ import java.util.List;
 public class IcebergSinkOperator extends AbstractSinkOperator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IcebergSinkOperator.class);
+
+    private static final String CATALOG_TYPE_HIVE = "HIVE";
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -83,6 +87,15 @@ public class IcebergSinkOperator extends AbstractSinkOperator {
         }
 
         IcebergSinkDTO dto = IcebergSinkDTO.getFromJson(entity.getExtParams());
+        if (StringUtils.isBlank(dto.getCatalogUri()) && dto.getCatalogType().equals(CATALOG_TYPE_HIVE)) {
+            Preconditions.checkNotEmpty(entity.getDataNodeName(),
+                    "iceberg catalog uri unspecified and data node is empty");
+            IcebergDataNodeInfo dataNodeInfo = (IcebergDataNodeInfo) dataNodeHelper.getDataNodeInfo(
+                    entity.getDataNodeName(), entity.getSinkType());
+            CommonBeanUtils.copyProperties(dataNodeInfo, dto, true);
+            dto.setCatalogUri(dataNodeInfo.getUrl());
+        }
+
         CommonBeanUtils.copyProperties(entity, sink, true);
         CommonBeanUtils.copyProperties(dto, sink, true);
         List<SinkField> sinkFields = super.getSinkFields(entity.getId());

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/DataNodeServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/DataNodeServiceTest.java
@@ -48,7 +48,6 @@ public class DataNodeServiceTest extends ServiceBaseTest {
         request.setToken(password);
         request.setDescription("test cluster");
         request.setInCharges(GLOBAL_OPERATOR);
-        request.setJdbcUrl("127.0.0.1");
         request.setToken("123456");
         return dataNodeService.save(request, GLOBAL_OPERATOR);
     }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/HiveSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/HiveSinkServiceTest.java
@@ -38,6 +38,7 @@ public class HiveSinkServiceTest extends ServiceBaseTest {
     private final String globalStreamId = "stream1";
     private final String globalOperator = "admin";
     private final String sinkName = "default";
+    private final String jdbcUrl = "127.0.0.1:8080";
 
     @Autowired
     private StreamSinkService sinkService;
@@ -56,6 +57,7 @@ public class HiveSinkServiceTest extends ServiceBaseTest {
         sinkInfo.setSinkType(SinkType.HIVE);
         sinkInfo.setEnableCreateResource(InlongConstants.DISABLE_CREATE_RESOURCE);
         sinkInfo.setSinkName(sinkName);
+        sinkInfo.setJdbcUrl(jdbcUrl);
         return sinkService.save(sinkInfo, globalOperator);
     }
 

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/IcebergSinkServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sink/IcebergSinkServiceTest.java
@@ -56,6 +56,7 @@ public class IcebergSinkServiceTest extends ServiceBaseTest {
         sinkInfo.setDataPath("hdfs://127.0.0.1:8020/data");
         sinkInfo.setSinkName(sinkName);
         sinkInfo.setId((int) (Math.random() * 100000 + 1));
+        sinkInfo.setCatalogUri("thrift://127.0.0.1:9000");
         return sinkService.save(sinkInfo, globalOperator);
     }
 


### PR DESCRIPTION
- Fixes #6063

Modifications:
- read from data node  when ck url is not supplied
- read from iceberg data node when iceberg catalog uri is not supplied
- remove jdbc url from hive data node because it's the same as url in base class.
