### PR TITLE
[INLONG-6094][Kubernetes] Add liveness reliability for modules

### DIFF
--- a/docker/kubernetes/templates/agent-statefulset.yaml
+++ b/docker/kubernetes/templates/agent-statefulset.yaml
@@ -122,6 +122,13 @@ spec:
           ports:
             - name: {{ .Values.agent.component }}-port
               containerPort: 8008
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.agent.component }}-port
+            initialDelaySeconds: 10
+            failureThreshold: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: data
               mountPath: /data/collect-data

--- a/docker/kubernetes/templates/audit-statefulset.yaml
+++ b/docker/kubernetes/templates/audit-statefulset.yaml
@@ -133,6 +133,13 @@ spec:
           ports:
             - name: {{ .Values.audit.component }}-port
               containerPort: 10081
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.audit.component }}-port
+            initialDelaySeconds: 10
+            failureThreshold: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
             - name: data
               mountPath: /data/collect-data

--- a/docker/kubernetes/templates/dashboard-statefulset.yaml
+++ b/docker/kubernetes/templates/dashboard-statefulset.yaml
@@ -92,5 +92,12 @@ spec:
           ports:
             - name: {{ .Values.dashboard.component }}-port
               containerPort: 80
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.dashboard.component }}-port
+            initialDelaySeconds: 10
+            failureThreshold: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
       restartPolicy: Always
 {{- end }}

--- a/docker/kubernetes/templates/dataproxy-statefulset.yaml
+++ b/docker/kubernetes/templates/dataproxy-statefulset.yaml
@@ -100,6 +100,13 @@ spec:
           ports:
             - name: {{ .Values.dataproxy.component }}-port
               containerPort: 46801
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.dataproxy.component }}-port
+            initialDelaySeconds: 10
+            failureThreshold: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
           volumeMounts:
           - name: {{ template "inlong.fullname" . }}-{{ .Values.dataproxy.component }}-{{ .Values.dataproxy.volumes.name }}
             mountPath: /opt/inlong-dataproxy/data

--- a/docker/kubernetes/templates/manager-statefulset.yaml
+++ b/docker/kubernetes/templates/manager-statefulset.yaml
@@ -115,5 +115,12 @@ spec:
           ports:
             - name: {{ .Values.manager.component }}-port
               containerPort: 8083
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.manager.component }}-port
+            initialDelaySeconds: 10
+            failureThreshold: 2
+            periodSeconds: 10
+            timeoutSeconds: 5
       restartPolicy: Always
 {{- end }}


### PR DESCRIPTION
### Prepare a Pull Request

Add liveness reliability for modules.
- Fixes #6094 

### Motivation

Add liveness reliability for modules

### Modifications

Add liveness reliability for modules

### Verifying this change

Add liveness reliability for modules. Every modules automatically pull up after process stopped by accident.