### PR TITLE
[INLONG-6113][Sort] Mysql cdc connector support read table schema when using debezium function

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/MetaField.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/MetaField.java
@@ -60,9 +60,14 @@ public enum MetaField {
     OP_TYPE,
 
     /**
-     * MySQL binlog data Row. Currently, it is used for MySQL database.
+     * Represents a canal json of a record in database (in string format)
      */
     DATA,
+
+    /**
+     * Represents a canal json of a record in database (in bytes format)
+     */
+    DATA_BYTES,
 
     /**
      * The value of the field before update. Currently, it is used for MySQL database.

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/Metadata.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/Metadata.java
@@ -76,9 +76,9 @@ public interface Metadata {
         String metadataType;
         switch (metaField) {
             case TABLE_NAME:
-            case DATA:
             case DATABASE_NAME:
             case OP_TYPE:
+            case DATA:
             case COLLECTION_NAME:
             case SCHEMA_NAME:
                 metadataType = "STRING";
@@ -104,6 +104,9 @@ public interface Metadata {
                 break;
             case UPDATE_BEFORE:
                 metadataType = "ARRAY<MAP<STRING, STRING>>";
+                break;
+            case DATA_BYTES:
+                metadataType = "BYTES";
                 break;
             default:
                 throw new UnsupportedOperationException(String.format("Unsupport meta field for %s: %s",

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
@@ -268,6 +268,7 @@ public class MySqlExtractNode extends ExtractNode implements Metadata, InlongMet
                 metadataKey = "meta.op_type";
                 break;
             case DATA:
+            case DATA_BYTES:
                 metadataKey = "meta.data";
                 break;
             case IS_DDL:
@@ -305,8 +306,9 @@ public class MySqlExtractNode extends ExtractNode implements Metadata, InlongMet
 
     @Override
     public Set<MetaField> supportedMetaFields() {
-        return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME, MetaField.DATA, MetaField.DATABASE_NAME,
-                MetaField.OP_TYPE, MetaField.OP_TS, MetaField.IS_DDL, MetaField.TS, MetaField.SQL_TYPE,
-                MetaField.MYSQL_TYPE, MetaField.PK_NAMES, MetaField.BATCH_ID, MetaField.UPDATE_BEFORE);
+        return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME, MetaField.DATA,
+            MetaField.DATABASE_NAME, MetaField.OP_TYPE, MetaField.OP_TS, MetaField.IS_DDL,
+            MetaField.TS, MetaField.SQL_TYPE, MetaField.MYSQL_TYPE, MetaField.PK_NAMES,
+            MetaField.BATCH_ID, MetaField.UPDATE_BEFORE, MetaField.DATA_BYTES);
     }
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/SqlServerExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/SqlServerExtractNode.java
@@ -139,6 +139,6 @@ public class SqlServerExtractNode extends ExtractNode implements InlongMetric, M
     @Override
     public Set<MetaField> supportedMetaFields() {
         return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME, MetaField.DATABASE_NAME,
-                MetaField.SCHEMA_NAME, MetaField.OP_TS);
+                MetaField.SCHEMA_NAME, MetaField.OP_TS, MetaField.DATA_BYTES);
     }
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/SqlServerExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/SqlServerExtractNode.java
@@ -139,6 +139,6 @@ public class SqlServerExtractNode extends ExtractNode implements InlongMetric, M
     @Override
     public Set<MetaField> supportedMetaFields() {
         return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME, MetaField.DATABASE_NAME,
-                MetaField.SCHEMA_NAME, MetaField.OP_TS, MetaField.DATA_BYTES);
+                MetaField.SCHEMA_NAME, MetaField.OP_TS);
     }
 }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNodeTest.java
@@ -60,6 +60,7 @@ public class MySqlExtractNodeTest extends SerializeBaseTest<MySqlExtractNode> {
         formatMap.put(MetaField.PK_NAMES, "ARRAY<STRING> METADATA FROM 'meta.pk_names' VIRTUAL");
         formatMap.put(MetaField.BATCH_ID, "BIGINT METADATA FROM 'meta.batch_id' VIRTUAL");
         formatMap.put(MetaField.UPDATE_BEFORE, "ARRAY<MAP<STRING, STRING>> METADATA FROM 'meta.update_before' VIRTUAL");
+        formatMap.put(MetaField.DATA_BYTES, "BYTES METADATA FROM 'meta.data' VIRTUAL");
         MySqlExtractNode node = getTestObject();
         boolean formatEquals = true;
         for (MetaField metaField : node.supportedMetaFields()) {

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
@@ -24,6 +24,7 @@ import io.debezium.embedded.Connect;
 import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.spi.OffsetCommitPolicy;
 import io.debezium.heartbeat.Heartbeat;
+import io.debezium.relational.history.TableChanges.TableChange;
 import org.apache.commons.collections.map.LinkedMap;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -463,6 +464,15 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                                     sourceMetricData.outputMetricsWithEstimate(record.value());
                                 }
                                 deserializer.deserialize(record, out);
+                            }
+
+                            @Override
+                            public void deserialize(SourceRecord record, Collector<T> out,
+                                TableChange tableSchema) throws Exception {
+                                if (sourceMetricData != null) {
+                                    sourceMetricData.outputMetricsWithEstimate(record.value());
+                                }
+                                deserializer.deserialize(record, out, tableSchema);
                             }
 
                             @Override

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/internal/FlinkDatabaseSchemaHistory.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/internal/FlinkDatabaseSchemaHistory.java
@@ -58,7 +58,7 @@ public class FlinkDatabaseSchemaHistory implements DatabaseHistory {
     private final FlinkJsonTableChangeSerializer tableChangesSerializer =
             new FlinkJsonTableChangeSerializer();
 
-    private ConcurrentMap<TableId, SchemaRecord> latestTables;
+    public static ConcurrentMap<TableId, SchemaRecord> latestTables;
     private String instanceName;
     private DatabaseHistoryListener listener;
     private boolean storeOnlyMonitoredTablesDdl;

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
@@ -429,7 +429,8 @@ public enum MySqlReadableMetadata {
 
     /**
      * get sql type from table schema, represents the jdbc data type
-     * @param tableSchema
+     *
+     * @param tableSchema table schema
      */
     public static Map<String, Integer> getSqlType(@Nullable TableChanges.TableChange tableSchema) {
         if (tableSchema == null) {
@@ -437,13 +438,9 @@ public enum MySqlReadableMetadata {
         }
         Map<String, Integer> sqlType = new HashMap<>();
         final Table table = tableSchema.getTable();
-        table.columns()
-            .forEach(
-                column -> {
-                    sqlType.put(
-                        column.name(),
-                        column.jdbcType());
-                });
+        table.columns().forEach(
+                column -> sqlType.put(column.name(), column.jdbcType())
+        );
         return sqlType;
     }
 

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
@@ -32,6 +32,8 @@ public class CanalJson {
     private long ts;
     private String sql;
     private Map<String, String> mysqlType;
+    private Map<String, Integer> sqlType;
+
     private boolean isDdl;
     private List<String> pkNames;
 
@@ -111,5 +113,16 @@ public class CanalJson {
         this.pkNames = pkNames;
     }
 
+    public Map<String, Integer> getSqlType() {
+        return sqlType;
+    }
+
+    public void setSqlType(Map<String, Integer> sqlType) {
+        this.sqlType = sqlType;
+    }
+
+    public boolean isDdl() {
+        return isDdl;
+    }
 }
 


### PR DESCRIPTION
- Fixes #6113 

### Motivation

The Mysql Connector for extracting data now doesn't support reading table schema when there is no primary key specified.
Canal Json requires field names called mysqlType and sqlType which contains information in table schema
The pr modifies the implementation of debezium function to get table schema from debezium databaseHistory

### Modifications

1 Add a new meta field called DATA_BYTES to represent the canal presentation of a record
2 make the table schema contained in databasehistory static
3 fill canal json with info from table schema

### Verifying this change

run AllMigrateTest