### PR TITLE
[INLONG-6136][Manager] Fix the docker logs command could not find log file error

### DIFF
--- a/inlong-manager/manager-docker/manager-docker.sh
+++ b/inlong-manager/manager-docker/manager-docker.sh
@@ -69,4 +69,4 @@ fi
 sh "${file_path}"/bin/startup.sh "${JAVA_OPTS}"
 sleep 3
 # keep alive
-tail -F "${file_path}"/logs/manager-web.log
+tail -F "${file_path}"/logs/manager-all.log


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6136 

### Motivation

Fix the docker logs command could not find log file error

### Modifications

Change the manager-web.log -> manager-all.log
