### PR TITLE
[INLONG-6160][Sort] Support dynamic partition for KafkaLoadNode

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/KafkaConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/KafkaConstant.java
@@ -41,10 +41,48 @@ public class KafkaConstant {
 
     /**
      * upsert-kafka
-     * 
+     *
      * @see <a href="https://nightlies.apache.org/flink/flink-docs-release-1.13/zh/docs/connectors/table/upsert-kafka/">
      *         Upsert Kafka</a>
      */
     public static final String UPSERT_KAFKA = "upsert-kafka-inlong";
 
+    /**
+     * The Raw Data Hash Partitioner is used to extract partition from raw data(bytes array):
+     * It needs a partitionPattern used to parse the pattern and a format 'canal-jon' or 'debezium-json'
+     * to deserialization the raw data(bytes array)
+     * This partitioner will extract primary key from raw data as the partition key used hash if the 'partitionPattern'
+     * equals 'PRIMARY_KEY' else it will parse partition key from raw data.
+     */
+    public static final String RAW_HASH = "raw-hash";
+
+    /**
+     * The parallelism of sink
+     */
+    public static final String SINK_PARALLELISM = "sink.parallelism";
+
+    /**
+     * Ignore the changelog of sink
+     */
+    public static final String SINK_IGNORE_CHANGELOG = "sink.ignore.changelog";
+
+    /**
+     * The multiple format of sink
+     */
+    public static final String SINK_MULTIPLE_FORMAT = "sink.multiple.format";
+
+    /**
+     * The partitioner of sink
+     */
+    public static final String SINK_PARTITIONER = "sink.partitioner";
+
+    /**
+     * The topic pattern of sink
+     */
+    public static final String TOPIC_PATTERN = "topic-pattern";
+
+    /**
+     * The multiple partition pattern of sink
+     */
+    public static final String SINK_MULTIPLE_PARTITION_PATTERN = "sink.multiple.partition-pattern";
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/KafkaLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/KafkaLoadNode.java
@@ -50,6 +50,18 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.CONNECTOR;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.KAFKA;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.PROPERTIES_BOOTSTRAP_SERVERS;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.RAW_HASH;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.SINK_IGNORE_CHANGELOG;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.SINK_MULTIPLE_PARTITION_PATTERN;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.SINK_PARALLELISM;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.SINK_PARTITIONER;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.TOPIC;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.TOPIC_PATTERN;
+import static org.apache.inlong.sort.protocol.constant.KafkaConstant.UPSERT_KAFKA;
 
 /**
  * Kafka load node using kafka connectors provided by flink
@@ -130,7 +142,7 @@ public class KafkaLoadNode extends LoadNode implements InlongMetric, Metadata, S
         this.sinkMultipleFormat = sinkMultipleFormat;
         this.topicPattern = topicPattern;
         this.sinkPartitioner = sinkPartitioner;
-        if ("raw-hash".equals(sinkPartitioner)) {
+        if (RAW_HASH.equals(sinkPartitioner)) {
             this.partitionPattern = Preconditions.checkNotNull(partitionPattern,
                     "partitionPattern is null when the sinkPartitioner is 'raw-hash'");
         } else {
@@ -151,37 +163,37 @@ public class KafkaLoadNode extends LoadNode implements InlongMetric, Metadata, S
     @Override
     public Map<String, String> tableOptions() {
         Map<String, String> options = super.tableOptions();
-        options.put("topic", topic);
-        options.put("properties.bootstrap.servers", bootstrapServers);
+        options.put(TOPIC, topic);
+        options.put(PROPERTIES_BOOTSTRAP_SERVERS, bootstrapServers);
         if (getSinkParallelism() != null) {
-            options.put("sink.parallelism", getSinkParallelism().toString());
+            options.put(SINK_PARALLELISM, getSinkParallelism().toString());
         }
         if (format instanceof JsonFormat || format instanceof AvroFormat
                 || format instanceof CsvFormat || format instanceof RawFormat) {
             if (StringUtils.isEmpty(this.primaryKey)) {
-                options.put("connector", "kafka-inlong");
-                options.put("sink.ignore.changelog", "true");
+                options.put(CONNECTOR, KAFKA);
+                options.put(SINK_IGNORE_CHANGELOG, "true");
                 options.putAll(format.generateOptions(false));
             } else {
-                options.put("connector", "upsert-kafka-inlong");
+                options.put(CONNECTOR, UPSERT_KAFKA);
                 options.putAll(format.generateOptions(true));
             }
             if (format instanceof RawFormat) {
                 if (sinkMultipleFormat != null) {
-                    options.put("sink.multiple.format", sinkMultipleFormat.identifier());
+                    options.put(SINK_MULTIPLE_FORMAT, sinkMultipleFormat.identifier());
                 }
                 if (StringUtils.isNotBlank(topicPattern)) {
-                    options.put("topic-pattern", topicPattern);
+                    options.put(TOPIC_PATTERN, topicPattern);
                 }
                 if (StringUtils.isNotBlank(sinkPartitioner)) {
-                    options.put("sink.partitioner", sinkPartitioner);
+                    options.put(SINK_PARTITIONER, sinkPartitioner);
                 }
                 if (StringUtils.isNotBlank(partitionPattern)) {
-                    options.put("sink.multiple.partition-pattern", partitionPattern);
+                    options.put(SINK_MULTIPLE_PARTITION_PATTERN, partitionPattern);
                 }
             }
         } else if (format instanceof CanalJsonFormat || format instanceof DebeziumJsonFormat) {
-            options.put("connector", "kafka-inlong");
+            options.put(CONNECTOR, KAFKA);
             options.putAll(format.generateOptions(false));
         } else {
             throw new IllegalArgumentException("kafka load Node format is IllegalArgument");

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -138,7 +138,7 @@ public final class Constants {
                     .noDefaultValue()
                     .withDescription("The option 'sink.multiple.database-pattern' "
                             + "is used extract database name from the raw binary data, "
-                            + "this is only used in the multi-sink writing scenario.");
+                            + "this is only used in the multiple sink writing scenario.");
 
     public static final ConfigOption<String> SINK_MULTIPLE_TABLE_PATTERN =
             ConfigOptions.key("sink.multiple.table-pattern")

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -85,6 +85,26 @@ public final class Constants {
 
     public static final String INLONG_METRIC_STATE_NAME = "inlong-metric-states";
 
+    public static final String PK_NAMES = "pkNames";
+
+    public static final String DATA = "data";
+
+    public static final String AFTER = "after";
+
+    public static final String BEFORE = "before";
+
+    public static final String SOURCE = "source";
+
+    /**
+     * It is used for jdbc url filter for avoiding url attack
+     * see also in https://su18.org/post/jdbc-connection-url-attack/
+     */
+    public static final String AUTO_DESERIALIZE = "autoDeserialize";
+
+    public static final String AUTO_DESERIALIZE_TRUE = "autoDeserialize=true";
+
+    public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
+
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
                     .stringType()
@@ -112,14 +132,26 @@ public final class Constants {
                     .withDescription(
                             "The format of multiple sink, it represents the real format of the raw binary data");
 
-    /**
-     * It is used for jdbc url filter for avoiding url attack
-     * see also in https://su18.org/post/jdbc-connection-url-attack/
-     */
-    public static final String AUTO_DESERIALIZE = "autoDeserialize";
+    public static final ConfigOption<String> SINK_MULTIPLE_DATABASE_PATTERN =
+            ConfigOptions.key("sink.multiple.database-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The option 'sink.multiple.database-pattern' "
+                            + "is used extract database name from the raw binary data, "
+                            + "this is only used in the multi-sink writing scenario.");
 
-    public static final String AUTO_DESERIALIZE_TRUE = "autoDeserialize=true";
+    public static final ConfigOption<String> SINK_MULTIPLE_TABLE_PATTERN =
+            ConfigOptions.key("sink.multiple.table-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The option 'sink.multiple.table-pattern' "
+                            + "is used extract table name from the raw binary data, "
+                            + "this is only used in the multiple sink writing scenario.");
 
-    public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
-
+    public static final ConfigOption<Boolean> SINK_MULTIPLE_ENABLE =
+            ConfigOptions.key("sink.multiple.enable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("The option 'sink.multiple.enable' "
+                            + "is used to determine whether to support multiple sink writing, default is 'false'.");
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/AbstractDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/AbstractDynamicSchemaFormat.java
@@ -40,18 +40,31 @@ public abstract class AbstractDynamicSchemaFormat<T> {
     public static final Pattern PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
 
     /**
-     * Extract value by key from the raw data
+     * Extract values by key from the raw data
      *
      * @param message The byte array of raw data
      * @param keys The key list that will be used to extract
      * @return The value list maps the keys
      * @throws IOException The exceptions may throws when extract
      */
-    public List<String> extract(byte[] message, String... keys) throws IOException {
+    public List<String> extractValues(byte[] message, String... keys) throws IOException {
         if (keys == null || keys.length == 0) {
             return new ArrayList<>();
         }
-        final T data = deserialize(message);
+        return extractValues(deserialize(message), keys);
+    }
+
+    /**
+     * Extract values by key from the raw data
+     *
+     * @param data The raw data
+     * @param keys The key list that will be used to extract
+     * @return The value list maps the keys
+     */
+    public List<String> extractValues(T data, String... keys) {
+        if (keys == null || keys.length == 0) {
+            return new ArrayList<>();
+        }
         List<String> values = new ArrayList<>(keys.length);
         for (String key : keys) {
             values.add(extract(data, key));
@@ -67,6 +80,39 @@ public abstract class AbstractDynamicSchemaFormat<T> {
      * @return The value maps the key in the raw data
      */
     public abstract String extract(T data, String key);
+
+    /**
+     * Extract primary key names
+     *
+     * @param data The raw data
+     * @return The primary key name list
+     */
+    public abstract List<String> extractPrimaryKeyNames(T data);
+
+    /**
+     * Extract primary key values
+     *
+     * @param message The byte array of raw data
+     * @return The values of primary key
+     * @throws IOException The exception may be thrown when executing
+     */
+    public List<String> extractPrimaryKeyValues(byte[] message) throws IOException {
+        return extractPrimaryKeyValues(deserialize(message));
+    }
+
+    /**
+     * Extract primary key values
+     *
+     * @param data The raw data
+     * @return The values of primary key
+     */
+    public List<String> extractPrimaryKeyValues(T data) {
+        List<String> pkNames = extractPrimaryKeyNames(data);
+        if (pkNames == null || pkNames.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return extractValues(data, pkNames.toArray(new String[]{}));
+    }
 
     /**
      * Deserialize from byte array

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
@@ -21,6 +21,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import static org.apache.inlong.sort.base.Constants.DATA;
+import static org.apache.inlong.sort.base.Constants.PK_NAMES;
 
 /**
  * Canal json dynamic format
@@ -41,17 +43,17 @@ public class CanalJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     }
 
     @Override
-    protected JsonNode getPhysicalData(JsonNode root) {
-        JsonNode physicalData = root.get("data");
+    public JsonNode getPhysicalData(JsonNode root) {
+        JsonNode physicalData = root.get(DATA);
         if (physicalData != null) {
-            return root.get("data").get(0);
+            return root.get(DATA).get(0);
         }
         return null;
     }
 
     @Override
     public List<String> extractPrimaryKeyNames(JsonNode data) {
-        JsonNode pkNamesNode = data.get("pkNames");
+        JsonNode pkNamesNode = data.get(PK_NAMES);
         List<String> pkNames = new ArrayList<>();
         if (pkNamesNode != null && pkNamesNode.isArray()) {
             for (int i = 0; i < pkNamesNode.size(); i++) {

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
@@ -19,6 +19,9 @@ package org.apache.inlong.sort.base.format;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Canal json dynamic format
  */
@@ -44,6 +47,18 @@ public class CanalJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
             return root.get("data").get(0);
         }
         return null;
+    }
+
+    @Override
+    public List<String> extractPrimaryKeyNames(JsonNode data) {
+        JsonNode pkNamesNode = data.get("pkNames");
+        List<String> pkNames = new ArrayList<>();
+        if (pkNamesNode != null && pkNamesNode.isArray()) {
+            for (int i = 0; i < pkNamesNode.size(); i++) {
+                pkNames.add(pkNamesNode.get(i).asText());
+            }
+        }
+        return pkNames;
     }
 
     /**

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
@@ -21,6 +21,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 
 import java.util.ArrayList;
 import java.util.List;
+import static org.apache.inlong.sort.base.Constants.AFTER;
+import static org.apache.inlong.sort.base.Constants.BEFORE;
+import static org.apache.inlong.sort.base.Constants.PK_NAMES;
+import static org.apache.inlong.sort.base.Constants.SOURCE;
 
 /**
  * Debezium json dynamic format
@@ -41,10 +45,10 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     }
 
     @Override
-    protected JsonNode getPhysicalData(JsonNode root) {
-        JsonNode physicalData = root.get("after");
+    public JsonNode getPhysicalData(JsonNode root) {
+        JsonNode physicalData = root.get(AFTER);
         if (physicalData == null) {
-            physicalData = root.get("before");
+            physicalData = root.get(BEFORE);
         }
         return physicalData;
     }
@@ -52,11 +56,11 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     @Override
     public List<String> extractPrimaryKeyNames(JsonNode data) {
         List<String> pkNames = new ArrayList<>();
-        JsonNode sourceNode = data.get("source");
+        JsonNode sourceNode = data.get(SOURCE);
         if (sourceNode == null) {
             return pkNames;
         }
-        JsonNode pkNamesNode = sourceNode.get("pkNames");
+        JsonNode pkNamesNode = sourceNode.get(PK_NAMES);
         if (pkNamesNode != null && pkNamesNode.isArray()) {
             for (int i = 0; i < pkNamesNode.size(); i++) {
                 pkNames.add(pkNamesNode.get(i).asText());

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
@@ -19,6 +19,9 @@ package org.apache.inlong.sort.base.format;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Debezium json dynamic format
  */
@@ -44,6 +47,22 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
             physicalData = root.get("before");
         }
         return physicalData;
+    }
+
+    @Override
+    public List<String> extractPrimaryKeyNames(JsonNode data) {
+        List<String> pkNames = new ArrayList<>();
+        JsonNode sourceNode = data.get("source");
+        if (sourceNode == null) {
+            return pkNames;
+        }
+        JsonNode pkNamesNode = sourceNode.get("pkNames");
+        if (pkNamesNode != null && pkNamesNode.isArray()) {
+            for (int i = 0; i < pkNamesNode.size(); i++) {
+                pkNames.add(pkNamesNode.get(i).asText());
+            }
+        }
+        return pkNames;
     }
 
     /**

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
@@ -17,12 +17,15 @@
 
 package org.apache.inlong.sort.base.format;
 
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 
 /**
@@ -162,5 +165,21 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
      * @param root The json root node
      * @return The physical data node
      */
-    protected abstract JsonNode getPhysicalData(JsonNode root);
+    public abstract JsonNode getPhysicalData(JsonNode root);
+
+    /**
+     * Convert physical data to map
+     *
+     * @param root The json root node
+     * @return The map of physicalData
+     * @throws IOException The exception may be thrown when executing
+     */
+    public Map<String, String> physicalDataToMap(JsonNode root) throws IOException {
+        JsonNode physicalData = getPhysicalData(root);
+        if (physicalData == null) {
+            return new HashMap<>();
+        }
+        return objectMapper.convertValue(physicalData, new TypeReference<Map<String, String>>() {
+        });
+    }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
@@ -43,19 +43,17 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
-     * Extract value by key from the raw data
+     * Extract values by keys from the raw data
      *
-     * @param message The byte array of raw data
+     * @param root The raw data
      * @param keys The key list that will be used to extract
      * @return The value list maps the keys
-     * @throws IOException The exceptions may throws when extract
      */
     @Override
-    public List<String> extract(byte[] message, String... keys) throws IOException {
+    public List<String> extractValues(JsonNode root, String... keys) {
         if (keys == null || keys.length == 0) {
             return new ArrayList<>();
         }
-        final JsonNode root = deserialize(message);
         JsonNode physicalNode = getPhysicalData(root);
         List<String> values = new ArrayList<>(keys.length);
         if (physicalNode == null) {

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormatTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormatTest.java
@@ -18,8 +18,14 @@
 package org.apache.inlong.sort.base.format;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -78,6 +84,16 @@ public class CanalJsonDynamicSchemaFormatTest extends DynamicSchemaFormatBaseTes
         expectedValues.put("${ \t database \t }${ table }", "inventoryproducts");
         expectedValues.put("${database}_${table}_${id}_${name}", "inventory_products_111_scooter");
         return expectedValues;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testExtractPrimaryKey() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        List<String> primaryKeys = getDynamicSchemaFormat().extractPrimaryKeyNames(rootNode);
+        List<String> values = getDynamicSchemaFormat().extractValues(rootNode, primaryKeys.toArray(new String[]{}));
+        Assert.assertEquals(values, Collections.singletonList("111"));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatTest.java
@@ -18,8 +18,14 @@
 package org.apache.inlong.sort.base.format;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -43,6 +49,7 @@ public class DebeziumJsonDynamicSchemaFormatTest extends DynamicSchemaFormatBase
                 + "    \"weight\": 5.15\n"
                 + "  },\n"
                 + "  \"source\": {\"version\": \"0.9.5.Final\",\n"
+                + "\"pkNames\":[\"id\", \"name\"],"
                 + "\t\"connector\": \"mysql\",\n"
                 + "\t\"name\": \"fullfillment\",\n"
                 + "\t\"server_id\" :1,\n"
@@ -69,6 +76,16 @@ public class DebeziumJsonDynamicSchemaFormatTest extends DynamicSchemaFormatBase
         expectedValues.put("${ \t source.db \t }${ source.table }", "inventoryproducts");
         expectedValues.put("${source.db}_${source.table}_${id}_${name}", "inventory_products_111_scooter");
         return expectedValues;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testExtractPrimaryKey() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        List<String> primaryKeys = getDynamicSchemaFormat().extractPrimaryKeyNames(rootNode);
+        List<String> values = getDynamicSchemaFormat().extractValues(rootNode, primaryKeys.toArray(new String[]{}));
+        Assert.assertEquals(values, Arrays.asList("111", "scooter"));
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/RawDataHashPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/RawDataHashPartitioner.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kafka.partitioner;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.util.Preconditions;
+import org.apache.inlong.sort.base.format.AbstractDynamicSchemaFormat;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * The Raw Data Hash Partitioner is used to extract partition from raw data(bytes array):
+ * It needs a partitionPattern used to parse the pattern and a format {@link RawDataHashPartitioner#sinkMultipleFormat}
+ * to deserialization the raw data(bytes array)
+ * This partitioner will extract primary key from raw data as the partition key used hash if the 'partitionPattern'
+ * equals 'PRIMARY_KEY' else it will parse partition key from raw data.
+ *
+ * @param <T>
+ */
+public class RawDataHashPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+    /**
+     * The primary key constant, this partitioner will extract primary key from raw data if the 'partitionPattern'
+     * equals 'PRIMARY_KEY'
+     */
+    public static final String PRIMARY_KEY = "PRIMARY_KEY";
+    private static final Logger LOG = LoggerFactory.getLogger(RawDataHashPartitioner.class);
+    private static final long serialVersionUID = 1L;
+    /**
+     * The partition pattern used to extract partition
+     */
+    private String partitionPattern;
+
+    /**
+     * The format used to deserialization the raw data(bytes array)
+     */
+    private String sinkMultipleFormat;
+
+    @SuppressWarnings({"rawtypes"})
+    private AbstractDynamicSchemaFormat dynamicSchemaFormat;
+
+    @Override
+    public void open(int parallelInstanceId, int parallelInstances) {
+        super.open(parallelInstanceId, parallelInstances);
+        dynamicSchemaFormat = DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+        Preconditions.checkArgument(
+                partitions != null && partitions.length > 0,
+                "Partitions of the target topic is empty.");
+        int partition = 0;
+        try {
+            String partitionKey;
+            if (PRIMARY_KEY.equals(partitionPattern)) {
+                List<String> values = dynamicSchemaFormat.extractPrimaryKeyValues(value);
+                if (values == null || values.isEmpty()) {
+                    return partition;
+                }
+                partitionKey = StringUtils.join(values, "");
+            } else {
+                partitionKey = dynamicSchemaFormat.parse(value, partitionPattern);
+            }
+            partition = partitions[(partitionKey.hashCode() & Integer.MAX_VALUE) % partitions.length];
+        } catch (Exception e) {
+            LOG.warn("Extract partition failed", e);
+        }
+        return partition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof RawDataHashPartitioner;
+    }
+
+    @Override
+    public int hashCode() {
+        return RawDataHashPartitioner.class.hashCode();
+    }
+
+    public String getPartitionPattern() {
+        return partitionPattern;
+    }
+
+    public void setPartitionPattern(String partitionPattern) {
+        this.partitionPattern = partitionPattern;
+    }
+
+    public String getSinkMultipleFormat() {
+        return sinkMultipleFormat;
+    }
+
+    public void setSinkMultipleFormat(String sinkMultipleFormat) {
+        this.sinkMultipleFormat = sinkMultipleFormat;
+    }
+}

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.connectors.kafka.FlinkKafkaConsumerBase;
@@ -53,6 +54,7 @@ import org.apache.flink.types.RowKind;
 import org.apache.inlong.sort.base.format.AbstractDynamicSchemaFormat;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink;
+import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -89,11 +91,11 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.VAL
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.autoCompleteSchemaRegistrySubject;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createKeyFormatProjection;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.createValueFormatProjection;
-import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getFlinkKafkaPartitioner;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getKafkaProperties;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getSinkSemantic;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.getStartupOptions;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateTableSourceOptions;
+import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
 import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
@@ -110,6 +112,14 @@ import static org.apache.inlong.sort.kafka.table.KafkaOptions.KAFKA_IGNORE_ALL_C
 public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
     public static final String IDENTIFIER = "kafka-inlong";
+
+    public static final String SINK_PARTITIONER_VALUE_RAW_HASH = "raw-hash";
+
+    public static final ConfigOption<String> SINK_MULTIPLE_PARTITION_PATTERN =
+            ConfigOptions.key("sink.multiple.partition-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("option 'sink.multiple.partition-pattern' used when the partitioner is raw-hash.");
 
     private static final Set<String> SINK_SEMANTIC_ENUMS =
             new HashSet<>(
@@ -206,6 +216,18 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
                         throw new ValidationException(
                                 "Currently 'round-robin' partitioner only works "
                                         + "when option 'key.fields' is not specified.");
+                    } else if ((SINK_PARTITIONER_VALUE_RAW_HASH.equals(partitioner)
+                            || "org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner".equals(partitioner))
+                            && (!"raw".equals(tableOptions.getOptional(FORMAT).orElse(null))
+                            || !tableOptions.getOptional(SINK_MULTIPLE_FORMAT).isPresent()
+                            || !tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).isPresent()
+                            || tableOptions.getOptional(SINK_MULTIPLE_FORMAT).get().isEmpty()
+                            || tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).get().isEmpty())) {
+                        throw new ValidationException(
+                                "Currently 'raw-hash' partitioner only works "
+                                        + "when option 'format' is 'raw' and option 'sink.multiple.format' "
+                                        + "and 'sink.multiple.partition-pattern' is specified.");
+
                     } else if (partitioner.isEmpty()) {
                         throw new ValidationException(
                                 String.format(
@@ -213,6 +235,30 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
                                         SINK_PARTITIONER.key()));
                     }
                 });
+    }
+
+    private Optional<FlinkKafkaPartitioner<RowData>> getFlinkKafkaPartitioner(
+            ReadableConfig tableOptions, ClassLoader classLoader) {
+        if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
+                && SINK_PARTITIONER_VALUE_RAW_HASH.equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
+            RawDataHashPartitioner<RowData> rawHashPartitioner = new RawDataHashPartitioner<>();
+            rawHashPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT).orElse(null));
+            rawHashPartitioner.setPartitionPattern(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
+                    .orElse(null));
+            return Optional.of(rawHashPartitioner);
+        }
+        Optional<FlinkKafkaPartitioner<RowData>> partitioner = KafkaOptions
+                .getFlinkKafkaPartitioner(tableOptions, classLoader);
+        if (partitioner.isPresent()) {
+            if (partitioner.get() instanceof RawDataHashPartitioner) {
+                RawDataHashPartitioner<RowData> rawHashPartitioner =
+                        (RawDataHashPartitioner<RowData>) partitioner.get();
+                rawHashPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT).orElse(null));
+                rawHashPartitioner.setPartitionPattern(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
+                        .orElse(null));
+            }
+        }
+        return partitioner;
     }
 
     private void validateSinkSemantic(ReadableConfig tableOptions) {
@@ -263,6 +309,7 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
         options.add(INLONG_METRIC);
         options.add(INLONG_AUDIT);
         options.add(SINK_MULTIPLE_FORMAT);
+        options.add(SINK_MULTIPLE_PARTITION_PATTERN);
         return options;
     }
 

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -216,18 +216,19 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
                         throw new ValidationException(
                                 "Currently 'round-robin' partitioner only works "
                                         + "when option 'key.fields' is not specified.");
-                    } else if ((SINK_PARTITIONER_VALUE_RAW_HASH.equals(partitioner)
-                            || "org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner".equals(partitioner))
-                            && (!"raw".equals(tableOptions.getOptional(FORMAT).orElse(null))
-                            || !tableOptions.getOptional(SINK_MULTIPLE_FORMAT).isPresent()
-                            || !tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).isPresent()
-                            || tableOptions.getOptional(SINK_MULTIPLE_FORMAT).get().isEmpty()
-                            || tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).get().isEmpty())) {
-                        throw new ValidationException(
-                                "Currently 'raw-hash' partitioner only works "
-                                        + "when option 'format' is 'raw' and option 'sink.multiple.format' "
-                                        + "and 'sink.multiple.partition-pattern' is specified.");
-
+                    } else if (SINK_PARTITIONER_VALUE_RAW_HASH.equals(partitioner)
+                            || "org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner".equals(partitioner)) {
+                        boolean invalid = !"raw".equals(tableOptions.getOptional(FORMAT).orElse(null))
+                                || !tableOptions.getOptional(SINK_MULTIPLE_FORMAT).isPresent()
+                                || !tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).isPresent()
+                                || tableOptions.getOptional(SINK_MULTIPLE_FORMAT).get().isEmpty()
+                                || tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN).get().isEmpty();
+                        if (invalid) {
+                            throw new ValidationException(
+                                    "Currently 'raw-hash' partitioner only works "
+                                            + "when option 'format' is 'raw' and option 'sink.multiple.format' "
+                                            + "and 'sink.multiple.partition-pattern' is specified.");
+                        }
                     } else if (partitioner.isEmpty()) {
                         throw new ValidationException(
                                 String.format(

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/KafkaLoadSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/KafkaLoadSqlParseTest.java
@@ -109,7 +109,6 @@ public class KafkaLoadSqlParseTest extends AbstractTestBase {
                 "raw-hash", pattern);
     }
 
-
     /**
      * build node relation
      *
@@ -150,7 +149,6 @@ public class KafkaLoadSqlParseTest extends AbstractTestBase {
         ParseResult result = parser.parse();
         Assert.assertTrue(result.tryExecute());
     }
-
 
     /**
      * Test kafka to kafka with dynamic topic


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6160][Sort] Support dynamic partition for KafkaLoadNode

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6160 

### Motivation

Support dynamic partition for KafkaLoadNode when the format of kafka is raw and the 'key.fields' is not specifyed.
This is mainly for some whole database migration scenarios, we assume that the upstream input data is a mixed schema of whole database migration, we ignore the real schema for now, receive the entire record in a binary raw data format, and fetch and parse its schema and data on the kafka sink side, and according to Some data values ​​are dynamically written to related topic partitions.
Dynamic partition writing has some limitations:
1.The upstream data is raw format with a fixed inner format, only support [canal-json|debezium-json] at now
2.The 'key.fields' is not specifyed
3.It needs to specify 'sink.multiple.partition-pattern' and 'sink.multiple.format' for dynamically extracting partition from data
4.It will extract primary key from raw data as the partition key used hash if the 'sink.multiple.partition-pattern'
 equals 'PRIMARY_KEY' else it will parse partition key from raw data.

### Modifications

1.Add option of 'sink.multiple.partition-pattern'
2.Add partitioner of 'RawDataHashPartitioner'
3.Add method extractValues and extractPrimaryKeyNames and extractPrimaryKeyValues for the mode of 'DynamicSchemaFormat'

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
