### PR TITLE
[INLONG-6166][Sort] Fix can not get pkNames metadata for MySqlExtractNode

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/MetadataConverter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/MetadataConverter.java
@@ -40,6 +40,6 @@ public interface MetadataConverter extends Serializable {
     }
 
     default Object read(SourceRecord record, @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-        return read(record);
+        return read(record, tableSchema);
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6166][Sort] Fix can not get pkNames metadata for MySqlExtractNode

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6166 

### Motivation

Fix can not get pkNames metadata for MySqlExtractNode

### Modifications

Update the default action of method 'read' in class 'MetadataConverter'

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
