### PR TITLE
[INLONG-6171][Manager] Fix the lightweight group union nodes relation error

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -123,18 +123,22 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             List<StreamSource> sources = sourceMap.get(streamId);
             List<StreamSink> sinks = sinkMap.get(streamId);
             List<NodeRelation> relations;
-            if (CollectionUtils.isEmpty(transformResponses)) {
-                relations = NodeRelationUtils.createNodeRelations(sources, sinks);
-            } else {
-                relations = NodeRelationUtils.createNodeRelations(inlongStream);
-                // in standard mode, replace upstream source node and transform input fields node to mq node
-                if (InlongConstants.STANDARD_MODE.equals(groupInfo.getLightweight())) {
+
+            if (InlongConstants.STANDARD_MODE.equals(groupInfo.getLightweight())) {
+                if (CollectionUtils.isNotEmpty(transformResponses)) {
+                    relations = NodeRelationUtils.createNodeRelations(inlongStream);
+
+                    // in standard mode, replace upstream source node and transform input fields node to mq node
                     // mq node name, which is inlong stream id
                     String mqNodeName = sources.get(0).getSourceName();
                     Set<String> nodeNameSet = getInputNodeNames(sources, transformResponses);
                     adjustTransformField(transformResponses, nodeNameSet, mqNodeName);
                     adjustNodeRelations(relations, nodeNameSet, mqNodeName);
+                } else {
+                    relations = NodeRelationUtils.createNodeRelations(sources, sinks);
                 }
+            } else {
+                relations = NodeRelationUtils.createNodeRelations(inlongStream);
             }
 
             // create extract-transform-load nodes


### PR DESCRIPTION
- Fixes #6171

### Motivation

Lightweight group may contain multiple union nodes rather than transform nodes which leads to the wrong branch when generating node relations. Fix it.

- lightweight group goes to the branch using user specified relation and union mutiple input nodes as before.
- standard group with transform nodes do the same as above, but redirects the input node to the MQ node.
- standard group without transform node use the source and sink nodes directly.