### PR TITLE
[INLONG-6181][Agent][DataProxy][Manager] Support node protocol reporting and query

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -186,7 +186,7 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
 
         HeartbeatMsg heartbeatMsg = new HeartbeatMsg();
         heartbeatMsg.setIp(agentIp);
-        heartbeatMsg.setPort(agentPort);
+        heartbeatMsg.setPort(String.valueOf(agentPort));
         heartbeatMsg.setComponentType(ComponentTypeEnum.Agent.getName());
         heartbeatMsg.setReportTime(System.currentTimeMillis());
         if (StringUtils.isNotBlank(clusterName)) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -27,6 +27,7 @@ import org.apache.inlong.agent.metrics.AgentMetricItemSet;
 import org.apache.inlong.agent.metrics.audit.AuditUtils;
 import org.apache.inlong.agent.plugin.message.SequentialID;
 import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.common.constant.ProtocolType;
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sdk.dataproxy.DefaultMessageSender;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
@@ -62,7 +63,6 @@ public class SenderManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(SenderManager.class);
     private static final SequentialID SEQUENTIAL_ID = SequentialID.getInstance();
     private static final AtomicInteger SENDER_INDEX = new AtomicInteger(0);
-    private static final String DEFAULT_PROTOCOL_TYPE = "TCP";
     // cache for group and sender list, share the map cross agent lifecycle.
     private static final ConcurrentHashMap<String, List<DefaultMessageSender>> SENDER_MAP =
             new ConcurrentHashMap<>();
@@ -88,7 +88,8 @@ public class SenderManager {
     private final String inlongGroupId;
     private final int maxSenderPerGroup;
     private final String sourcePath;
-    //metric
+
+    // metric
     private AgentMetricItemSet metricItemSet;
     private Map<String, String> dimensions;
     private TaskPositionManager taskPositionManager;
@@ -189,7 +190,7 @@ public class SenderManager {
 
         proxyClientConfig.setIoThreadNum(ioThreadNum);
         proxyClientConfig.setEnableBusyWait(enableBusyWait);
-        proxyClientConfig.setProtocolType(DEFAULT_PROTOCOL_TYPE);
+        proxyClientConfig.setProtocolType(ProtocolType.TCP);
 
         DefaultMessageSender sender = new DefaultMessageSender(proxyClientConfig, SHARED_FACTORY);
         sender.setMsgtype(msgType);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -62,6 +62,7 @@ public class SenderManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(SenderManager.class);
     private static final SequentialID SEQUENTIAL_ID = SequentialID.getInstance();
     private static final AtomicInteger SENDER_INDEX = new AtomicInteger(0);
+    private static final String DEFAULT_PROTOCOL_TYPE = "TCP";
     // cache for group and sender list, share the map cross agent lifecycle.
     private static final ConcurrentHashMap<String, List<DefaultMessageSender>> SENDER_MAP =
             new ConcurrentHashMap<>();
@@ -188,6 +189,7 @@ public class SenderManager {
 
         proxyClientConfig.setIoThreadNum(ioThreadNum);
         proxyClientConfig.setEnableBusyWait(enableBusyWait);
+        proxyClientConfig.setProtocolType(DEFAULT_PROTOCOL_TYPE);
 
         DefaultMessageSender sender = new DefaultMessageSender(proxyClientConfig, SHARED_FACTORY);
         sender.setMsgtype(msgType);

--- a/inlong-common/src/main/java/org/apache/inlong/common/constant/ProtocolType.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/constant/ProtocolType.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.common.consts;
+package org.apache.inlong.common.constant;
 
 /**
  * Constants of protocol type.

--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/ComponentHeartbeat.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/ComponentHeartbeat.java
@@ -33,7 +33,7 @@ public class ComponentHeartbeat {
 
     private String ip;
 
-    private int port;
+    private String port;
 
     private String protocolType;
 
@@ -42,7 +42,7 @@ public class ComponentHeartbeat {
     public ComponentHeartbeat() {
     }
 
-    public ComponentHeartbeat(String clusterTag, String clusterName, String componentType, String ip, int port,
+    public ComponentHeartbeat(String clusterTag, String clusterName, String componentType, String ip, String port,
             String inCharges, String protocolType) {
         this.clusterTag = clusterTag;
         this.clusterName = clusterName;

--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
@@ -41,7 +41,7 @@ public class HeartbeatMsg {
     /**
      * Port of component
      */
-    private int port;
+    private String port;
 
     /**
      * ProtocolType of component

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -24,9 +24,9 @@ manager.auth.secretId=
 manager.auth.secretKey=
 proxy.report.ip=127.0.0.1
 # support TCP: 46801/HTTP: 46802/TCP,HTTP: 46801,46802
-proxy.report.port=46801
+proxy.report.port=46801,46802
 # support TCP/HTTP/TCP,HTTP
-proxy.report.protocol.type=TCP
+proxy.report.protocol.type=TCP,HTTP
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 proxy.cluster.tag=default_cluster

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -16,27 +16,33 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# cluter id is for future use please write 1
+# cluster id is for future use please write 1
 cluster.id=1
 # manager open api address and auth key
 manager.hosts=127.0.0.1:8083
 manager.auth.secretId=
 manager.auth.secretKey=
+
+# proxy report config
 proxy.report.ip=127.0.0.1
-# support TCP: 46801/HTTP: 46802/TCP,HTTP: 46801,46802
+# support TCP:46801 / HTTP:46802 / TCP,HTTP:46801,46802
 proxy.report.port=46801,46802
 # support TCP/HTTP/TCP,HTTP
-proxy.report.protocol.type=TCP,HTTP
+proxy.report.protocolType=TCP,HTTP
+
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 proxy.cluster.tag=default_cluster
 proxy.cluster.inCharges=admin
 # check interval of local config (millisecond)
 configCheckInterval=10000
+
+# metric config
 metricDomains=DataProxy
 metricDomains.DataProxy.domainListeners=org.apache.inlong.dataproxy.metrics.prometheus.PrometheusMetricListener
 metricDomains.DataProxy.snapshotInterval=60000
 prometheusHttpPort=9081
+
 # whether to enable audit
 audit.enable=true
 # audit proxy address

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -23,14 +23,16 @@ manager.hosts=127.0.0.1:8083
 manager.auth.secretId=
 manager.auth.secretKey=
 proxy.report.ip=127.0.0.1
+#support TCP: 46801/HTTP: 46802/TCP,HTTP: 46801,46802
 proxy.report.port=46801
+#support TCP/HTTP/TCP,HTTP
+proxy.report.protocol.type=TCP
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 proxy.cluster.tag=default_cluster
 proxy.cluster.inCharges=admin
 # check interval of local config (millisecond)
 configCheckInterval=10000
-
 metricDomains=DataProxy
 metricDomains.DataProxy.domainListeners=org.apache.inlong.dataproxy.metrics.prometheus.PrometheusMetricListener
 metricDomains.DataProxy.snapshotInterval=60000

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -23,9 +23,9 @@ manager.hosts=127.0.0.1:8083
 manager.auth.secretId=
 manager.auth.secretKey=
 proxy.report.ip=127.0.0.1
-#support TCP: 46801/HTTP: 46802/TCP,HTTP: 46801,46802
+# support TCP: 46801/HTTP: 46802/TCP,HTTP: 46801,46802
 proxy.report.port=46801
-#support TCP/HTTP/TCP,HTTP
+# support TCP/HTTP/TCP,HTTP
 proxy.report.protocol.type=TCP
 # proxy cluster name
 proxy.cluster.name=default_dataproxy

--- a/inlong-dataproxy/conf/dataproxy-pulsar.conf
+++ b/inlong-dataproxy/conf/dataproxy-pulsar.conf
@@ -26,7 +26,7 @@
 # and config order property in source module in dataproxy.
 #
 
-agent1.sources = tcp-source
+agent1.sources = tcp-source http-source
 agent1.channels = ch-msg1 ch-msg2 ch-msg3 ch-msg5 ch-msg6
 agent1.sinks = pulsar-sink-msg1 pulsar-sink-msg2 pulsar-sink-msg3 pulsar-sink-msg5 pulsar-sink-msg6
 
@@ -35,7 +35,7 @@ agent1.sinks = pulsar-sink-msg1 pulsar-sink-msg2 pulsar-sink-msg3 pulsar-sink-ms
 # agent1.channels = ch-msg1 ch-msg2 ch-msg3 ch-msg5 ch-msg6
 # agent1.sinks = pulsar-sink-msg1 pulsar-sink-msg2 pulsar-sink-msg3 pulsar-sink-msg5 pulsar-sink-msg6
 
-
+# tcp-source
 agent1.sources.tcp-source.channels = ch-msg1 ch-msg2 ch-msg3 ch-msg5 ch-msg6
 agent1.sources.tcp-source.type = org.apache.inlong.dataproxy.source.SimpleTcpSource
 agent1.sources.tcp-source.msg-factory-name = org.apache.inlong.dataproxy.source.ServerMessageFactory
@@ -57,6 +57,27 @@ agent1.sources.tcp-source.metric-recovery-path = ./data/file/recovery
 agent1.sources.tcp-source.metric-agent-port = 8003
 agent1.sources.tcp-source.metric-cache-size = 1000000
 agent1.sources.tcp-source.set = 10
+
+# http-source
+agent1.sources.http-source.channels = ch-msg1 ch-msg2 ch-msg5 ch-msg6
+agent1.sources.http-source.type = org.apache.inlong.dataproxy.http.SimpleHttpSource
+agent1.sources.http-source.message-handler-name = org.apache.inlong.dataproxy.http.SimpleMessageHandler
+agent1.sources.http-source.host = 0.0.0.0
+agent1.sources.http-source.port = 46802
+agent1.sources.http-source.max-msg-length = 524288
+#agent1.sources.http-source.topic = persistent://public/default/dataproxy-default-topic
+agent1.sources.http-source.attr = m=9
+agent1.sources.http-source.connections = 30000
+agent1.sources.http-source.max-threads = 64
+agent1.sources.http-source.receiveBufferSize = 1048576
+agent1.sources.http-source.sendBufferSize = 1048576
+agent1.sources.http-source.custom-cp = true
+agent1.sources.http-source.selector.type = org.apache.inlong.dataproxy.channel.FailoverChannelSelector
+agent1.sources.http-source.selector.master = ch-msg1 ch-msg2
+agent1.sources.http-source.metric-recovery-path = ./data/file/recovery
+agent1.sources.http-source.metric-agent-port=8003
+agent1.sources.http-source.metric-cache-size=1000000
+agent1.sources.http-source.set=10
 
 agent1.channels.ch-msg1.type = memory
 agent1.channels.ch-msg1.capacity = 50000

--- a/inlong-dataproxy/conf/dataproxy-tube.conf
+++ b/inlong-dataproxy/conf/dataproxy-tube.conf
@@ -17,6 +17,10 @@
 # under the License.
 #
 
+agent1.sources = tcp-source http-source
+agent1.channels = ch-back ch-msg1 ch-msg2 ch-msg3 ch-msg5 ch-msg6 ch-msg7 ch-msg8 ch-msg9 ch-msg10
+agent1.sinks = meta-sink-msg1 meta-sink-msg2 meta-sink-msg3 meta-sink-msg5 meta-sink-msg6 meta-sink-msg7 meta-sink-msg8 meta-sink-transfer
+
 #6-segment protocol TCP source
 agent1.sources.tcp-source.channels = ch-msg1 ch-msg2 ch-msg3 ch-more1 ch-more2 ch-more3 ch-msg5 ch-msg6 ch-msg7 ch-msg8 ch-msg9 ch-msg10 ch-back
 agent1.sources.tcp-source.type = org.apache.inlong.dataproxy.source.SimpleTcpSource
@@ -46,6 +50,30 @@ agent1.sources.tcp-source.set=10
 agent1.sources.tcp-source.old-metric-on=true
 agent1.sources.tcp-source.new-metric-on=true
 agent1.sources.tcp-source.metric_topic_prefix=manager_tmertic
+
+# http-source
+agent1.sources.http-source.channels = ch-msg1 ch-msg2 ch-msg3 ch-more1 ch-more2 ch-more3 ch-msg5 ch-msg6 ch-msg7 ch-msg8 ch-msg9 ch-msg10 ch-back
+agent1.sources.http-source.type = org.apache.inlong.dataproxy.http.SimpleHttpSource
+agent1.sources.http-source.message-handler-name = org.apache.inlong.dataproxy.http.SimpleMessageHandler
+agent1.sources.http-source.host = 0.0.0.0
+agent1.sources.http-source.port = 46802
+agent1.sources.http-source.max-msg-length = 524288
+#agent1.sources.http-source.topic = persistent://public/default/dataproxy-default-topic
+agent1.sources.http-source.attr = m=9
+agent1.sources.http-source.connections = 50000
+agent1.sources.http-source.max-threads = 64
+agent1.sources.http-source.receiveBufferSize = 1048576
+agent1.sources.http-source.sendBufferSize = 1048576
+agent1.sources.http-source.custom-cp = true
+agent1.sources.http-source.selector.type = org.apache.inlong.dataproxy.channel.FailoverChannelSelector
+agent1.sources.http-source.selector.master = ch-msg1 ch-msg2
+agent1.sources.http-source.metric-recovery-path = ./data/file/recovery
+agent1.sources.http-source.metric-agent-port=8003
+agent1.sources.http-source.metric-cache-size=1000000
+agent1.sources.http-source.set=10
+agent1.sources.http-source.old-metric-on=true
+agent1.sources.http-source.new-metric-on=true
+agent1.sources.http-source.metric_topic_prefix=manager_tmertic
 
 agent1.channels.ch-back.type = memory
 agent1.channels.ch-back.capacity = 10000000
@@ -153,8 +181,3 @@ agent1.sinks.meta-sink-msg8.type =org.apache.inlong.dataproxy.sink.TubeSink
 
 agent1.sinks.meta-sink-msg8.channel = ch-back
 agent1.sinks.meta-sink-msg8.type =org.apache.inlong.dataproxy.sink.TubeSink
-
-agent1.sources = tcp-source
-agent1.channels = ch-back ch-msg1 ch-msg2 ch-msg3 ch-msg5 ch-msg6 ch-msg7 ch-msg8 ch-msg9 ch-msg10
-agent1.sinks = meta-sink-msg1 meta-sink-msg2 meta-sink-msg3 meta-sink-msg5 meta-sink-msg6 meta-sink-msg7 meta-sink-msg8 meta-sink-transfer
-

--- a/inlong-dataproxy/dataproxy-docker/Dockerfile
+++ b/inlong-dataproxy/dataproxy-docker/Dockerfile
@@ -33,6 +33,7 @@ ENV AUDIT_PROXY_URL=127.0.0.1:10081
 ENV MQ_TYPE=pulsar
 ENV CLUSTER_TAG=default_cluster
 ENV CLUSTER_NAME=default_dataproxy
+ENV PROTOCOL_TYPE=TCP
 ENV CLUSTER_IN_CHARGES=admin
 ENV DATAPROXY_JVM_HEAP_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 -XX:-UseAdaptiveSizePolicy"
 WORKDIR /opt/inlong-dataproxy

--- a/inlong-dataproxy/dataproxy-docker/Dockerfile
+++ b/inlong-dataproxy/dataproxy-docker/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
 # add tarball from target output
 ARG DATAPROXY_TARBALL
 ADD ${DATAPROXY_TARBALL} /opt/inlong-dataproxy
-EXPOSE 46801
+EXPOSE 46801 46802
 ENV MANAGER_OPENAPI_IP=127.0.0.1
 ENV MANAGER_OPENAPI_PORT=8083
 # enable audit, true or false
@@ -33,7 +33,6 @@ ENV AUDIT_PROXY_URL=127.0.0.1:10081
 ENV MQ_TYPE=pulsar
 ENV CLUSTER_TAG=default_cluster
 ENV CLUSTER_NAME=default_dataproxy
-ENV PROTOCOL_TYPE=TCP
 ENV CLUSTER_IN_CHARGES=admin
 ENV DATAPROXY_JVM_HEAP_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 -XX:-UseAdaptiveSizePolicy"
 WORKDIR /opt/inlong-dataproxy

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -21,9 +21,7 @@ local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{pr
 # config
 cd "${file_path}/"
 common_conf_file=./conf/common.properties
-mq_conf_file=./conf/dataproxy-${MQ_TYPE}.conf
 
-http_conf_file=./conf/dataproxy-mulit-pulsar-http-example.conf
 sed -i "s/manager.hosts=.*$/manager.hosts=${MANAGER_OPENAPI_IP}:${MANAGER_OPENAPI_PORT}/g" "${common_conf_file}"
 sed -i "s/audit.enable=.*$/audit.enable=${AUDIT_ENABLE}/g" "${common_conf_file}"
 sed -i "s/audit.proxys=.*$/audit.proxys=${AUDIT_PROXY_URL}/g" "${common_conf_file}"
@@ -31,15 +29,6 @@ sed -i "s/proxy.report.ip=.*$/proxy.report.ip=${local_ip}/g" "${common_conf_file
 sed -i "s/proxy.cluster.tag=.*$/proxy.cluster.tag=${CLUSTER_TAG}/g" "${common_conf_file}"
 sed -i "s/proxy.cluster.name=.*$/proxy.cluster.name=${CLUSTER_NAME}/g" "${common_conf_file}"
 sed -i "s/proxy.cluster.inCharges=.*$/proxy.cluster.inCharges=${CLUSTER_IN_CHARGES}/g" "${common_conf_file}"
-sed -i "s/proxy.report.protocol.type=.*$/proxy.report.protocol.type=${PROTOCOL_TYPE}/g" "${common_conf_file}"
-
-if [ "${PROTOCOL_TYPE}" = "HTTP" ]; then
-  sed -i "s/agent1.sources=.*$/agent1.sources=http-source/g" "${mq_conf_file}"
-  sed -n '29~49p' ${http_conf_file} >> ${mq_conf_file}
-elif [ "${PROTOCOL_TYPE}" = "HTTP,TCP" ] || [ "${PROTOCOL_TYPE}" = "TCP,HTTP" ]; then
-  sed -i "s/agent1.sources=.*$/agent1.sources=http-source tcp-source/g" "${mq_conf_file}"
-  sed -n '29~49p' ${http_conf_file} >> ${mq_conf_file}   
-fi
 
 # start
 if [ "${MQ_TYPE}" = "pulsar" ]; then

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -21,6 +21,9 @@ local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{pr
 # config
 cd "${file_path}/"
 common_conf_file=./conf/common.properties
+mq_conf_file=./conf/dataproxy-${MQ_TYPE}.conf
+
+http_conf_file=./conf/dataproxy-mulit-pulsar-http-example.conf
 sed -i "s/manager.hosts=.*$/manager.hosts=${MANAGER_OPENAPI_IP}:${MANAGER_OPENAPI_PORT}/g" "${common_conf_file}"
 sed -i "s/audit.enable=.*$/audit.enable=${AUDIT_ENABLE}/g" "${common_conf_file}"
 sed -i "s/audit.proxys=.*$/audit.proxys=${AUDIT_PROXY_URL}/g" "${common_conf_file}"
@@ -28,6 +31,15 @@ sed -i "s/proxy.report.ip=.*$/proxy.report.ip=${local_ip}/g" "${common_conf_file
 sed -i "s/proxy.cluster.tag=.*$/proxy.cluster.tag=${CLUSTER_TAG}/g" "${common_conf_file}"
 sed -i "s/proxy.cluster.name=.*$/proxy.cluster.name=${CLUSTER_NAME}/g" "${common_conf_file}"
 sed -i "s/proxy.cluster.inCharges=.*$/proxy.cluster.inCharges=${CLUSTER_IN_CHARGES}/g" "${common_conf_file}"
+sed -i "s/proxy.report.protocol.type=.*$/proxy.report.protocol.type=${PROTOCOL_TYPE}/g" "${common_conf_file}"
+
+if [ "${PROTOCOL_TYPE}" = "HTTP" ]; then
+  sed -i "s/agent1.sources=.*$/agent1.sources=http-source/g" "${mq_conf_file}"
+  sed -n '29~49p' ${http_conf_file} >> ${mq_conf_file}
+elif [ "${PROTOCOL_TYPE}" = "HTTP,TCP" ] || [ "${PROTOCOL_TYPE}" = "TCP,HTTP" ]; then
+  sed -i "s/agent1.sources=.*$/agent1.sources=http-source tcp-source/g" "${mq_conf_file}"
+  sed -n '29~49p' ${http_conf_file} >> ${mq_conf_file}   
+fi
 
 # start
 if [ "${MQ_TYPE}" = "pulsar" ]; then

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -101,6 +101,7 @@ public class ConfigConstants {
     public static final String PROXY_CLUSTER_INCHARGES = "proxy.cluster.inCharges";
     public static final String PROXY_REPORT_IP = "proxy.report.ip";
     public static final String PROXY_REPORT_PORT = "proxy.report.port";
+    public static final String PROXY_REPORT_PROTOCOL_TYPE = "proxy.report.protocol.type";
     public static final String CONFIG_CHECK_INTERVAL = "configCheckInterval";
 
     public static final String DECODER_BODY = "body";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -101,7 +101,7 @@ public class ConfigConstants {
     public static final String PROXY_CLUSTER_INCHARGES = "proxy.cluster.inCharges";
     public static final String PROXY_REPORT_IP = "proxy.report.ip";
     public static final String PROXY_REPORT_PORT = "proxy.report.port";
-    public static final String PROXY_REPORT_PROTOCOL_TYPE = "proxy.report.protocol.type";
+    public static final String PROXY_REPORT_PROTOCOL_TYPE = "proxy.report.protocolType";
     public static final String CONFIG_CHECK_INTERVAL = "configCheckInterval";
 
     public static final String DECODER_BODY = "body";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
@@ -43,6 +43,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.PROXY_REPORT_PROTOCOL_TYPE;
 
 /**
  * Heartbeat management logic.
@@ -51,6 +52,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class HeartbeatManager implements AbstractHeartbeatManager {
 
     public static final String DEFAULT_REPORT_PORT = "46801";
+    public static final String DEFAULT_REPORT_PROTOCOL_TYPE = "TCP";
     public static final String DEFAULT_CLUSTER_TAG = "default_cluster";
     public static final String DEFAULT_CLUSTER_NAME = "default_dataproxy";
     public static final String DEFAULT_CLUSTER_INCHARGES = "admin";
@@ -118,8 +120,8 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         HeartbeatMsg heartbeatMsg = new HeartbeatMsg();
         Map<String, String> commonProperties = configManager.getCommonProperties();
         heartbeatMsg.setIp(commonProperties.get(ConfigConstants.PROXY_REPORT_IP));
-        heartbeatMsg.setPort(Integer.parseInt(commonProperties.getOrDefault(
-                ConfigConstants.PROXY_REPORT_PORT, DEFAULT_REPORT_PORT)));
+        heartbeatMsg.setPort(commonProperties.getOrDefault(
+                ConfigConstants.PROXY_REPORT_PORT, DEFAULT_REPORT_PORT));
         heartbeatMsg.setComponentType(ComponentTypeEnum.DataProxy.getName());
         heartbeatMsg.setReportTime(System.currentTimeMillis());
         heartbeatMsg.setClusterTag(commonProperties.getOrDefault(
@@ -128,6 +130,8 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
                 ConfigConstants.PROXY_CLUSTER_NAME, DEFAULT_CLUSTER_NAME));
         heartbeatMsg.setInCharges(commonProperties.getOrDefault(
                 ConfigConstants.PROXY_CLUSTER_INCHARGES, DEFAULT_CLUSTER_INCHARGES));
+        heartbeatMsg.setProtocolType(
+                commonProperties.getOrDefault(PROXY_REPORT_PROTOCOL_TYPE, DEFAULT_REPORT_PROTOCOL_TYPE));
 
         Map<String, String> groupIdMappings = configManager.getGroupIdMappingProperties();
         Map<String, Map<String, String>> streamIdMappings = configManager.getStreamIdMappingProperties();

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongClusterNodeEntityMapper.xml
@@ -86,7 +86,9 @@
         and type = #{type, jdbcType=VARCHAR}
         and ip = #{ip, jdbcType=VARCHAR}
         and port = #{port, jdbcType=INTEGER}
-        and protocol_type = #{protocolType, jdbcType=VARCHAR}
+        <if test="protocolType != null and protocolType != ''">
+            and protocol_type = #{protocolType, jdbcType=VARCHAR}
+        </if>
     </select>
     <select id="selectByCondition"
             parameterType="org.apache.inlong.manager.pojo.cluster.ClusterPageRequest"
@@ -101,6 +103,9 @@
             </if>
             <if test="parentId != null and parentId != ''">
                 and parent_id = #{parentId, jdbcType=INTEGER}
+            </if>
+            <if test="protocolType != null and protocolType != ''">
+                and protocol_type = #{protocolType, jdbcType=VARCHAR}
             </if>
             <if test="keyword != null and keyword != ''">
                 and (

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterPageRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterPageRequest.java
@@ -60,6 +60,9 @@ public class ClusterPageRequest extends PageRequest {
     @ApiModelProperty(value = "Extend tag")
     private String extTag;
 
+    @ApiModelProperty(value = "Protocol type for DATAPROXY, for example: http,tcp")
+    private String protocolType;
+
     @ApiModelProperty(value = "The inlong cluster tag list")
     private List<String> clusterTagList;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterPageRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterPageRequest.java
@@ -60,7 +60,7 @@ public class ClusterPageRequest extends PageRequest {
     @ApiModelProperty(value = "Extend tag")
     private String extTag;
 
-    @ApiModelProperty(value = "Protocol type for DATAPROXY, for example: http,tcp")
+    @ApiModelProperty(value = "Protocol type, such as: TCP, HTTP")
     private String protocolType;
 
     @ApiModelProperty(value = "The inlong cluster tag list")

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManager.java
@@ -103,6 +103,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         String protocolType = heartbeat.getProtocolType();
         String[] protocolTypes = StringUtils.isNoneBlank(protocolType) && ports.length > 1
                 ? heartbeat.getProtocolType().split(InlongConstants.COMMA) : null;
+        int handlerNum = 0;
         for (int i = 0; i < ports.length; i++) {
             HeartbeatMsg heartbeatMsg = OBJECT_MAPPER.readValue(
                     OBJECT_MAPPER.writeValueAsBytes(heartbeat), HeartbeatMsg.class);
@@ -114,15 +115,15 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
             if (lastHeartbeat == null) {
                 InlongClusterNodeEntity clusterNode = getClusterNode(clusterInfo, heartbeatMsg);
                 if (clusterNode == null) {
-                    insertClusterNode(clusterInfo, heartbeatMsg, clusterInfo.getCreator());
+                    handlerNum += insertClusterNode(clusterInfo, heartbeatMsg, clusterInfo.getCreator());
                 } else {
-                    updateClusterNode(clusterNode);
+                    handlerNum += updateClusterNode(clusterNode);
                 }
             }
         }
 
         // if the heartbeat already exists, or does not exist but insert/update success, then put it into the cache
-        if (lastHeartbeat == null) {
+        if (lastHeartbeat == null && handlerNum == ports.length) {
             heartbeatCache.put(componentHeartbeat, heartbeat);
         }
     }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
@@ -176,7 +176,7 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
         return clusterService.updateNode(request, GLOBAL_OPERATOR);
     }
 
-    private HeartbeatMsg createHeartbeatMsg(String clusterName, String ip, int port, String type) {
+    private HeartbeatMsg createHeartbeatMsg(String clusterName, String ip, String port, String type) {
         HeartbeatMsg heartbeatMsg = new HeartbeatMsg();
         heartbeatMsg.setIp(ip);
         heartbeatMsg.setPort(port);
@@ -327,9 +327,11 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
         Assertions.assertNotNull(nodeId2);
 
         // report heartbeat
-        HeartbeatMsg msg1 = createHeartbeatMsg(clusterName, ip, port1, ComponentTypeEnum.DataProxy.getName());
+        HeartbeatMsg msg1 = createHeartbeatMsg(clusterName, ip, String.valueOf(port1),
+                ComponentTypeEnum.DataProxy.getName());
         heartbeatManager.reportHeartbeat(msg1);
-        HeartbeatMsg msg2 = createHeartbeatMsg(clusterName, ip, port2, ComponentTypeEnum.DataProxy.getName());
+        HeartbeatMsg msg2 = createHeartbeatMsg(clusterName, ip, String.valueOf(port2),
+                ComponentTypeEnum.DataProxy.getName());
         heartbeatManager.reportHeartbeat(msg2);
 
         // create an inlong group which use the clusterTag

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
@@ -22,7 +22,7 @@ import org.apache.inlong.common.heartbeat.HeartbeatMsg;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeInfo;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeResponse;
 import org.apache.inlong.manager.common.consts.MQType;
-import org.apache.inlong.manager.common.consts.ProtocolType;
+import org.apache.inlong.common.constant.ProtocolType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManagerTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManagerTest.java
@@ -63,7 +63,7 @@ public class HeartbeatManagerTest extends ServiceBaseTest {
         nodeRequest.setParentId(clusterId);
         nodeRequest.setType(msg.getComponentType());
         nodeRequest.setIp(msg.getIp());
-        nodeRequest.setPort(msg.getPort());
+        nodeRequest.setPort(Integer.valueOf(msg.getPort()));
         nodeRequest.setProtocolType(ProtocolType.HTTP);
         InlongClusterNodeEntity clusterNode = clusterNodeMapper.selectByUniqueKey(nodeRequest);
         Assertions.assertNotNull(clusterNode);
@@ -84,9 +84,9 @@ public class HeartbeatManagerTest extends ServiceBaseTest {
     private HeartbeatMsg createHeartbeatMsg() {
         HeartbeatMsg heartbeatMsg = new HeartbeatMsg();
         heartbeatMsg.setIp("127.0.0.1");
-        heartbeatMsg.setPort(8008);
+        heartbeatMsg.setPort("46802");
         heartbeatMsg.setProtocolType(ProtocolType.HTTP);
-        heartbeatMsg.setComponentType(ComponentTypeEnum.Agent.getName());
+        heartbeatMsg.setComponentType(ComponentTypeEnum.DataProxy.getName());
         heartbeatMsg.setReportTime(System.currentTimeMillis());
         return heartbeatMsg;
     }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManagerTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/heartbeat/HeartbeatManagerTest.java
@@ -20,7 +20,7 @@ package org.apache.inlong.manager.service.core.heartbeat;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.inlong.common.enums.ComponentTypeEnum;
 import org.apache.inlong.common.heartbeat.HeartbeatMsg;
-import org.apache.inlong.manager.common.consts.ProtocolType;
+import org.apache.inlong.common.constant.ProtocolType;
 import org.apache.inlong.manager.common.enums.NodeStatus;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.dao.entity.InlongClusterEntity;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/HeartbeatServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/HeartbeatServiceTest.java
@@ -51,8 +51,9 @@ public class HeartbeatServiceTest extends ServiceBaseTest {
     @Test
     public void testReportHeartbeat() {
         HeartbeatReportRequest request = new HeartbeatReportRequest();
-        request.setComponentType(ComponentTypeEnum.Agent.getName());
+        request.setComponentType(ComponentTypeEnum.DataProxy.getName());
         request.setIp("127.0.0.1");
+        request.setPort("56802");
         request.setReportTime(Instant.now().toEpochMilli());
         request.setProtocolType(ProtocolType.HTTP);
 
@@ -78,7 +79,7 @@ public class HeartbeatServiceTest extends ServiceBaseTest {
     @Test
     public void testGetStreamHeartbeat() {
         HeartbeatQueryRequest request = new HeartbeatQueryRequest();
-        request.setComponent(ComponentTypeEnum.Agent.getName());
+        request.setComponent(ComponentTypeEnum.DataProxy.getName());
         request.setInstance("127.0.0.1");
         request.setInlongGroupId("group1");
         request.setInlongStreamId("stream1");

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/HeartbeatServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/HeartbeatServiceTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Maps;
 import org.apache.inlong.common.enums.ComponentTypeEnum;
 import org.apache.inlong.common.heartbeat.GroupHeartbeat;
 import org.apache.inlong.common.heartbeat.StreamHeartbeat;
-import org.apache.inlong.manager.common.consts.ProtocolType;
+import org.apache.inlong.common.constant.ProtocolType;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.pojo.heartbeat.HeartbeatQueryRequest;
 import org.apache.inlong.manager.pojo.heartbeat.HeartbeatReportRequest;

--- a/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
@@ -127,7 +127,7 @@ CREATE TABLE IF NOT EXISTS `inlong_cluster_node`
     `type`          varchar(20)  NOT NULL COMMENT 'Cluster type, such as: AGENT, DATAPROXY, etc',
     `ip`            varchar(512) NOT NULL COMMENT 'Cluster IP, separated by commas, such as: 127.0.0.1:8080,host2:8081',
     `port`          int(6)       NULL COMMENT 'Cluster port',
-    `protocol_type` varchar(20)  NOT NULL COMMENT 'DATAPROXY Source listen protocol type, such as: TCP/HTTP',
+    `protocol_type` varchar(20)  DEFAULT NULL COMMENT 'DATAPROXY Source listen protocol type, such as: TCP/HTTP',
     `ext_params`    mediumtext            DEFAULT NULL COMMENT 'Another fields will be saved as JSON string',
     `description`   varchar(256)          DEFAULT '' COMMENT 'Description of cluster node',
     `status`        int(4)                DEFAULT '0' COMMENT 'Cluster status',

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -137,7 +137,7 @@ CREATE TABLE IF NOT EXISTS `inlong_cluster_node`
     `type`          varchar(20)  NOT NULL COMMENT 'Cluster type, such as: AGENT, DATAPROXY, etc',
     `ip`            varchar(512) NOT NULL COMMENT 'Cluster IP, separated by commas, such as: 127.0.0.1:8080,host2:8081',
     `port`          int(6)       NULL COMMENT 'Cluster port',
-    `protocol_type` varchar(20)  NOT NULL COMMENT 'DATAPROXY Source listen protocol type, such as: TCP/HTTP',
+    `protocol_type` varchar(20)  DEFAULT NULL COMMENT 'DATAPROXY Source listen protocol type, such as: TCP/HTTP',
     `ext_params`    mediumtext            DEFAULT NULL COMMENT 'Another fields will be saved as JSON string',
     `description`   varchar(256)          DEFAULT '' COMMENT 'Description of cluster node',
     `status`        int(4)                DEFAULT '0' COMMENT 'Cluster status',


### PR DESCRIPTION
Support node protocol reporting and query.

1.DataProxy supports http and tcp protocol reporting.
2.Agent supports to query dp node by protocol.
3.Manager client supports to query dp node by protocol and groupId.

- Fixes #6181 

### Motivation

1.This PR supports node of dp protocol, for example: tcp, http.
2.Agent queries node of dp by dp SDK.
3.Maneger client  queries node of cluster by protocol 

### Modifications

Agent send manager.
Dataproxy Multi-protocol reporting.
Update SDK param of dp-config.

### Verifying this change


- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
