### PR TITLE
[INLONG-6194][Agent] Support parsing metrics for different components

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentPrometheusMetricListener.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentPrometheusMetricListener.java
@@ -17,31 +17,10 @@
 
 package org.apache.inlong.agent.metrics;
 
-import io.prometheus.client.Collector;
-import io.prometheus.client.CounterMetricFamily;
-import io.prometheus.client.exporter.HTTPServer;
-import io.prometheus.client.hotspot.DefaultExports;
-import org.apache.inlong.agent.conf.AgentConfiguration;
-import org.apache.inlong.common.metric.MetricItemValue;
-import org.apache.inlong.common.metric.MetricListener;
-import org.apache.inlong.common.metric.MetricValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
-import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
-
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_PROMETHEUS_EXPORTER_PORT;
 import static org.apache.inlong.agent.constant.AgentConstants.PROMETHEUS_EXPORTER_PORT;
+import static org.apache.inlong.agent.metrics.AgentMetricItem.KEY_COMPONENT_NAME;
+import static org.apache.inlong.agent.metrics.AgentMetricItem.KEY_PLUGIN_ID;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.M_JOB_FATAL_COUNT;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.M_JOB_RUNNING_COUNT;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.M_PLUGIN_READ_COUNT;
@@ -59,6 +38,28 @@ import static org.apache.inlong.agent.metrics.AgentMetricItem.M_TASK_RETRYING_CO
 import static org.apache.inlong.agent.metrics.AgentMetricItem.M_TASK_RUNNING_COUNT;
 import static org.apache.inlong.common.metric.MetricItemMBean.DOMAIN_SEPARATOR;
 import static org.apache.inlong.common.metric.MetricRegister.JMX_DOMAIN;
+
+import io.prometheus.client.Collector;
+import io.prometheus.client.CounterMetricFamily;
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.apache.inlong.agent.conf.AgentConfiguration;
+import org.apache.inlong.common.metric.MetricItemValue;
+import org.apache.inlong.common.metric.MetricListener;
+import org.apache.inlong.common.metric.MetricValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * prometheus metric listener
@@ -142,12 +143,18 @@ public class AgentPrometheusMetricListener extends Collector implements MetricLi
         mfs.add(totalCounter);
 
         // id dimension
-        List<String> dimensionIdKeys = new ArrayList<>();
-        dimensionIdKeys.add(DEFAULT_DIMENSION_LABEL);
-        dimensionIdKeys.addAll(this.dimensionKeys);
-        CounterMetricFamily idCounter = new CounterMetricFamily("id", "metrics_of_agent_dimensions", dimensionIdKeys);
         for (Entry<String, MetricItemValue> entry : this.dimensionMetricValueMap.entrySet()) {
             MetricItemValue itemValue = entry.getValue();
+            Map<String, String> dimensionMap = itemValue.getDimensions();
+            String pluginId = dimensionMap.getOrDefault(KEY_PLUGIN_ID, "-");
+            String componentName = dimensionMap.getOrDefault(KEY_COMPONENT_NAME, "-");
+            String counterName = pluginId.equals("-") ? componentName : pluginId;
+            List<String> dimensionIdKeys = new ArrayList<>();
+            dimensionIdKeys.add(DEFAULT_DIMENSION_LABEL);
+            dimensionIdKeys.addAll(dimensionMap.keySet());
+            CounterMetricFamily idCounter = new CounterMetricFamily(counterName,
+                    "metrics_of_agent_dimensions_" + counterName,
+                    dimensionIdKeys);
 
             addCounterMetricFamily(M_JOB_RUNNING_COUNT, itemValue, idCounter);
             addCounterMetricFamily(M_JOB_FATAL_COUNT, itemValue, idCounter);
@@ -168,8 +175,8 @@ public class AgentPrometheusMetricListener extends Collector implements MetricLi
             addCounterMetricFamily(M_PLUGIN_SEND_FAIL_COUNT, itemValue, idCounter);
             addCounterMetricFamily(M_PLUGIN_READ_SUCCESS_COUNT, itemValue, idCounter);
             addCounterMetricFamily(M_PLUGIN_SEND_SUCCESS_COUNT, itemValue, idCounter);
+            mfs.add(idCounter);
         }
-        mfs.add(idCounter);
         return mfs;
     }
 
@@ -218,11 +225,11 @@ public class AgentPrometheusMetricListener extends Collector implements MetricLi
 
     private void addCounterMetricFamily(String defaultDimension, MetricItemValue itemValue,
             CounterMetricFamily idCounter) {
-        List<String> labelValues = new ArrayList<>(this.dimensionKeys.size());
+        Map<String, String> dimensionMap = itemValue.getDimensions();
+        List<String> labelValues = new ArrayList<>(dimensionMap.size() + 1);
         labelValues.add(defaultDimension);
-        Map<String, String> dimensions = itemValue.getDimensions();
-        for (String key : this.dimensionKeys) {
-            String labelValue = dimensions.getOrDefault(key, "-");
+        for (String key : dimensionMap.keySet()) {
+            String labelValue = dimensionMap.getOrDefault(key, "-");
             labelValues.add(labelValue);
         }
         long value = 0L;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentPrometheusMetricListener.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentPrometheusMetricListener.java
@@ -67,6 +67,7 @@ import org.slf4j.LoggerFactory;
 public class AgentPrometheusMetricListener extends Collector implements MetricListener {
 
     public static final String DEFAULT_DIMENSION_LABEL = "dimension";
+    public static final String HYPHEN_SYMBOL = "-";
     private static final Logger LOGGER = LoggerFactory.getLogger(AgentPrometheusMetricListener.class);
     protected HTTPServer httpServer;
     private AgentMetricItem metricItem;
@@ -146,15 +147,14 @@ public class AgentPrometheusMetricListener extends Collector implements MetricLi
         for (Entry<String, MetricItemValue> entry : this.dimensionMetricValueMap.entrySet()) {
             MetricItemValue itemValue = entry.getValue();
             Map<String, String> dimensionMap = itemValue.getDimensions();
-            String pluginId = dimensionMap.getOrDefault(KEY_PLUGIN_ID, "-");
-            String componentName = dimensionMap.getOrDefault(KEY_COMPONENT_NAME, "-");
-            String counterName = pluginId.equals("-") ? componentName : pluginId;
+            String pluginId = dimensionMap.getOrDefault(KEY_PLUGIN_ID, HYPHEN_SYMBOL);
+            String componentName = dimensionMap.getOrDefault(KEY_COMPONENT_NAME, HYPHEN_SYMBOL);
+            String counterName = pluginId.equals(HYPHEN_SYMBOL) ? componentName : pluginId;
             List<String> dimensionIdKeys = new ArrayList<>();
             dimensionIdKeys.add(DEFAULT_DIMENSION_LABEL);
             dimensionIdKeys.addAll(dimensionMap.keySet());
             CounterMetricFamily idCounter = new CounterMetricFamily(counterName,
-                    "metrics_of_agent_dimensions_" + counterName,
-                    dimensionIdKeys);
+                    "metrics_of_agent_dimensions_" + counterName, dimensionIdKeys);
 
             addCounterMetricFamily(M_JOB_RUNNING_COUNT, itemValue, idCounter);
             addCounterMetricFamily(M_JOB_FATAL_COUNT, itemValue, idCounter);
@@ -229,7 +229,7 @@ public class AgentPrometheusMetricListener extends Collector implements MetricLi
         List<String> labelValues = new ArrayList<>(dimensionMap.size() + 1);
         labelValues.add(defaultDimension);
         for (String key : dimensionMap.keySet()) {
-            String labelValue = dimensionMap.getOrDefault(key, "-");
+            String labelValue = dimensionMap.getOrDefault(key, HYPHEN_SYMBOL);
             labelValues.add(labelValue);
         }
         long value = 0L;


### PR DESCRIPTION
### Prepare a Pull Request
Support different components to parse their related metric.

- Fixes #6194 

### Motivation

Because the metrics uploaded by different agent components may be different, I split the metric item id_counter of prometheus and use KEY_PLUGIN_ID or KEY_COMPONENT_NAME as the primary key.

It is convenient for the different metric operation behind, and then there will be no common empty  data dimension in different component.
