### PR TITLE
[INLONG-6231][CVE] Upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <fastjson.version>1.2.83</fastjson.version>
 
         <clickhouse-jdbc.version>0.3.1</clickhouse-jdbc.version>
-        <hive.version>3.1.2</hive.version>
+        <hive.version>3.1.3</hive.version>
         <thrift.version>0.9.3</thrift.version>
         <flume.version>1.9.0</flume.version>
         <hbase.version>2.4.12</hbase.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 3.1.2
- [CVE-2021-34538](https://www.oscs1024.com/hd/CVE-2021-34538)

fix #6231

### What did I do？
Upgrade org.apache.hive:hive-exec from 3.1.2 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS