### PR TITLE
[INLONG-5049][Manager] Command tools add CRUD for user

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/CreateCommand.java
@@ -24,12 +24,16 @@ import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.InlongStreamBuilder;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
+import org.apache.inlong.manager.client.api.inner.client.UserClient;
 import org.apache.inlong.manager.client.cli.pojo.CreateGroupConf;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.client.cli.validator.UserTypeValidator;
+import org.apache.inlong.manager.common.enums.UserTypeEnum;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
+import org.apache.inlong.manager.pojo.user.UserRequest;
 
 import java.io.File;
 import java.util.List;
@@ -49,6 +53,7 @@ public class CreateCommand extends AbstractCommand {
         jcommander.addCommand("cluster", new CreateCluster());
         jcommander.addCommand("cluster-tag", new CreateClusterTag());
         jcommander.addCommand("cluster-node", new CreateClusterNode());
+        jcommander.addCommand("user", new CreateUser());
     }
 
     @Parameters(commandDescription = "Create group by json file")
@@ -168,6 +173,44 @@ public class CreateCommand extends AbstractCommand {
                 Integer nodeId = clusterClient.saveNode(request);
                 if (nodeId != null) {
                     System.out.println("Create cluster node success! ID: " + nodeId);
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Create user")
+    private static class CreateUser extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-u", "--username"}, description = "username")
+        private String username;
+
+        @Parameter(names = {"-p", "--password"}, description = "password")
+        private String password;
+
+        @Parameter(names = {"-t", "--type"}, description = "account type", validateWith = UserTypeValidator.class)
+        private String type;
+
+        @Parameter(names = {"-d", "--days"}, description = "valid days")
+        private Integer validDays;
+
+        @Override
+        void run() {
+            try {
+                UserRequest request = new UserRequest();
+                request.setName(username);
+                request.setPassword(password);
+                request.setAccountType(UserTypeEnum.parseName(type));
+                request.setValidDays(validDays);
+                ClientUtils.initClientFactory();
+                UserClient userClient = ClientUtils.clientFactory.getUserClient();
+                Integer userId = userClient.register(request);
+                if (userId != null) {
+                    System.out.println("Create user success! ID: " + userId);
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DeleteCommand.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.Parameters;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
+import org.apache.inlong.manager.client.api.inner.client.UserClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 
 import java.util.List;
@@ -42,6 +43,7 @@ public class DeleteCommand extends AbstractCommand {
         jcommander.addCommand("cluster", new DeleteCluster());
         jcommander.addCommand("cluster-tag", new DeleteClusterTag());
         jcommander.addCommand("cluster-node", new DeleteClusterNode());
+        jcommander.addCommand("user", new DeleteUser());
     }
 
     @Parameters(commandDescription = "Delete group by group id")
@@ -130,6 +132,29 @@ public class DeleteCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.deleteNode(nodeId)) {
                     System.out.println("Delete cluster node success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Delete user by user id")
+    private static class DeleteUser extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "user id")
+        private int userId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                UserClient userClient = ClientUtils.clientFactory.getUserClient();
+                if (userClient.delete(userId)) {
+                    System.out.println("Delete user success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/DescribeCommand.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
+import org.apache.inlong.manager.client.api.inner.client.UserClient;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
@@ -36,6 +37,7 @@ import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+import org.apache.inlong.manager.pojo.user.UserInfo;
 
 import java.util.List;
 
@@ -58,6 +60,7 @@ public class DescribeCommand extends AbstractCommand {
         jcommander.addCommand("cluster", new DescribeCluster());
         jcommander.addCommand("cluster-tag", new DescribeClusterTag());
         jcommander.addCommand("cluster-node", new DescribeClusterNode());
+        jcommander.addCommand("user", new DescribeUser());
     }
 
     @Parameters(commandDescription = "Get stream details")
@@ -226,6 +229,28 @@ public class DescribeCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 ClusterNodeResponse nodeInfo = clusterClient.getNode(nodeId);
                 PrintUtils.printJson(nodeInfo);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get user details")
+    private static class DescribeUser extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-id", "--id"}, required = true, description = "user id")
+        private int userId;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                UserClient userClient = ClientUtils.clientFactory.getUserClient();
+                UserInfo userInfo = userClient.getById(userId);
+                PrintUtils.printJson(userInfo);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
@@ -278,7 +278,7 @@ public class ListCommand extends AbstractCommand {
         @Parameter()
         private List<String> params;
 
-        @Parameter(names = {"-u","--username"}, description = "username")
+        @Parameter(names = {"-u", "--username"}, description = "username")
         private String username;
 
         @Parameter(names = {"--type"}, description = "user type", validateWith = UserTypeValidator.class)

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/ListCommand.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.client.api.inner.client.InlongGroupClient;
 import org.apache.inlong.manager.client.api.inner.client.InlongStreamClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSinkClient;
 import org.apache.inlong.manager.client.api.inner.client.StreamSourceClient;
+import org.apache.inlong.manager.client.api.inner.client.UserClient;
 import org.apache.inlong.manager.client.cli.pojo.ClusterNodeInfo;
 import org.apache.inlong.manager.client.cli.pojo.ClusterTagInfo;
 import org.apache.inlong.manager.client.cli.pojo.GroupInfo;
@@ -33,7 +34,9 @@ import org.apache.inlong.manager.client.cli.pojo.StreamInfo;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
 import org.apache.inlong.manager.client.cli.util.PrintUtils;
 import org.apache.inlong.manager.client.cli.validator.ClusterTypeValidator;
+import org.apache.inlong.manager.client.cli.validator.UserTypeValidator;
 import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
+import org.apache.inlong.manager.common.enums.UserTypeEnum;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.ClusterNodeResponse;
 import org.apache.inlong.manager.pojo.cluster.ClusterPageRequest;
@@ -45,6 +48,8 @@ import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+import org.apache.inlong.manager.pojo.user.UserInfo;
+import org.apache.inlong.manager.pojo.user.UserRequest;
 
 import java.util.List;
 
@@ -67,6 +72,7 @@ public class ListCommand extends AbstractCommand {
         jcommander.addCommand("cluster", new ListCluster());
         jcommander.addCommand("cluster-tag", new ListClusterTag());
         jcommander.addCommand("cluster-node", new ListClusterNode());
+        jcommander.addCommand("user", new ListUser());
     }
 
     @Parameters(commandDescription = "Get stream summary information")
@@ -260,6 +266,35 @@ public class ListCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 PageResult<ClusterNodeResponse> nodeInfo = clusterClient.listNode(request);
                 PrintUtils.print(nodeInfo.getList(), ClusterNodeInfo.class);
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Get user summary information")
+    private static class ListUser extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-u","--username"}, description = "username")
+        private String username;
+
+        @Parameter(names = {"--type"}, description = "user type", validateWith = UserTypeValidator.class)
+        private String type;
+
+        @Override
+        void run() {
+            try {
+                ClientUtils.initClientFactory();
+                UserRequest request = new UserRequest();
+                Integer integer = UserTypeEnum.parseName(type);
+                request.setAccountType(integer);
+                request.setKeyword(username);
+                UserClient userClient = ClientUtils.clientFactory.getUserClient();
+                PageResult<UserInfo> userInfo = userClient.list(request);
+                PrintUtils.print(userInfo.getList(), org.apache.inlong.manager.client.cli.pojo.UserInfo.class);
             } catch (Exception e) {
                 System.out.println(e.getMessage());
             }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -175,6 +175,9 @@ public class UpdateCommand extends AbstractCommand {
         @Parameter(names = {"-u", "--username"}, description = "username to be modify")
         private String username;
 
+        @Parameter(names = {"-p", "--password"}, description = "new password")
+        private String password;
+
         @Parameter(names = {"-d", "--days"}, description = "new valid days")
         private Integer validDays;
 
@@ -185,14 +188,15 @@ public class UpdateCommand extends AbstractCommand {
                 request.setName(username);
                 ClientUtils.initClientFactory();
                 UserClient userClient = ClientUtils.clientFactory.getUserClient();
-                List<UserInfo> userInfo = userClient.list(request).getList();
+                UserInfo userInfo = userClient.getByName(username);
                 if (userInfo == null) {
                     throw new BusinessException(username + " not exist, please check.");
                 }
-                request.setId(userInfo.get(0).getId());
-                request.setAccountType(userInfo.get(0).getAccountType());
+                request.setId(userInfo.getId());
+                request.setNewPassword(password);
+                request.setAccountType(userInfo.getAccountType());
                 request.setValidDays(validDays);
-                request.setVersion(userInfo.get(0).getVersion());
+                request.setVersion(userInfo.getVersion());
                 if (userClient.update(request) != null) {
                     System.out.println("Update user success!");
                 }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/UpdateCommand.java
@@ -24,12 +24,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.client.api.InlongClient;
 import org.apache.inlong.manager.client.api.InlongGroup;
 import org.apache.inlong.manager.client.api.inner.client.InlongClusterClient;
+import org.apache.inlong.manager.client.api.inner.client.UserClient;
 import org.apache.inlong.manager.client.cli.util.ClientUtils;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 import org.apache.inlong.manager.pojo.cluster.ClusterTagRequest;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
+import org.apache.inlong.manager.pojo.user.UserInfo;
+import org.apache.inlong.manager.pojo.user.UserRequest;
 
 import java.io.File;
 import java.util.List;
@@ -50,6 +54,7 @@ public class UpdateCommand extends AbstractCommand {
         jcommander.addCommand("cluster", new UpdateCommand.UpdateCluster());
         jcommander.addCommand("cluster-tag", new UpdateCommand.UpdateClusterTag());
         jcommander.addCommand("cluster-node", new UpdateCommand.UpdateClusterNode());
+        jcommander.addCommand("user", new UpdateCommand.UpdateUser());
     }
 
     @Parameters(commandDescription = "Update group by json file")
@@ -154,6 +159,42 @@ public class UpdateCommand extends AbstractCommand {
                 InlongClusterClient clusterClient = ClientUtils.clientFactory.getClusterClient();
                 if (clusterClient.updateNode(request)) {
                     System.out.println("Update cluster node success!");
+                }
+            } catch (Exception e) {
+                System.out.println(e.getMessage());
+            }
+        }
+    }
+
+    @Parameters(commandDescription = "Update User")
+    private static class UpdateUser extends AbstractCommandRunner {
+
+        @Parameter()
+        private List<String> params;
+
+        @Parameter(names = {"-u", "--username"}, description = "username to be modify")
+        private String username;
+
+        @Parameter(names = {"-d", "--days"}, description = "new valid days")
+        private Integer validDays;
+
+        @Override
+        void run() {
+            try {
+                UserRequest request = new UserRequest();
+                request.setName(username);
+                ClientUtils.initClientFactory();
+                UserClient userClient = ClientUtils.clientFactory.getUserClient();
+                List<UserInfo> userInfo = userClient.list(request).getList();
+                if (userInfo == null) {
+                    throw new BusinessException(username + " not exist, please check.");
+                }
+                request.setId(userInfo.get(0).getId());
+                request.setAccountType(userInfo.get(0).getAccountType());
+                request.setValidDays(validDays);
+                request.setVersion(userInfo.get(0).getVersion());
+                if (userClient.update(request) != null) {
+                    System.out.println("Update user success!");
                 }
             } catch (Exception e) {
                 System.out.println(e.getMessage());

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/UserInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/UserInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.cli.pojo;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * User info, including user id, username, etc.
+ */
+@Data
+public class UserInfo {
+
+    private Integer id;
+    private String name;
+    private Integer accountType;
+    private String status;
+    private String creator;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private Date createTime;
+}

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/UserTypeValidator.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/validator/UserTypeValidator.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.cli.validator;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+import org.apache.inlong.manager.common.enums.UserTypeEnum;
+
+public class UserTypeValidator implements IParameterValidator {
+
+    @Override
+    public void validate(String name, String value) throws ParameterException {
+        try {
+            UserTypeEnum.parseName(value);
+        } catch (Exception e) {
+            throw new ParameterException(e.getMessage());
+        }
+    }
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/User.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/User.java
@@ -47,6 +47,14 @@ public interface User {
     UserInfo getById(Integer id);
 
     /**
+     * Get user info by username
+     *
+     * @param name username
+     * @return user info
+     */
+    UserInfo getByName(String name);
+
+    /**
      * List all users basic info by request condition
      *
      * @param request request

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/UserImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/UserImpl.java
@@ -55,6 +55,12 @@ public class UserImpl implements User {
     }
 
     @Override
+    public UserInfo getByName(String name) {
+        Preconditions.checkNotNull(name, "username cannot be null");
+        return userClient.getByName(name);
+    }
+
+    @Override
     public PageResult<UserInfo> list(UserRequest request) {
         Preconditions.checkNotNull(request, "request cannot be null");
         return userClient.list(request);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/UserClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/UserClient.java
@@ -78,6 +78,20 @@ public class UserClient {
     }
 
     /**
+     * Get user info by username
+     *
+     * @param name username
+     * @return user info
+     */
+    public UserInfo getByName(String name) {
+        Preconditions.checkNotNull(name, "username cannot be null");
+
+        Response<UserInfo> response = ClientUtils.executeHttpCall(userApi.getByName(name));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
      * List all users basic info by request condition
      *
      * @param request request

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/UserApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/UserApi.java
@@ -40,6 +40,9 @@ public interface UserApi {
     @GET("user/get/{id}")
     Call<Response<UserInfo>> getById(@Path("id") Integer id);
 
+    @GET("user/getByName/{name}")
+    Call<Response<UserInfo>> getByName(@Path("name") String name);
+
     @POST("user/listAll")
     Call<Response<PageResult<UserInfo>>> list(@Body UserRequest request);
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/UserTypeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/UserTypeEnum.java
@@ -51,15 +51,25 @@ public enum UserTypeEnum implements IntListValuable {
             .map(UserTypeEnum::getCode)
             .collect(Collectors.toList());
 
-    public static UserTypeEnum parse(Integer value) {
+    public static UserTypeEnum parseCode(Integer value) {
         return Arrays.stream(UserTypeEnum.class.getEnumConstants())
                 .filter(x -> x.getCode().equals(value))
                 .findAny()
                 .orElse(null);
     }
 
+    public static Integer parseName(String value) {
+        for (UserTypeEnum type : UserTypeEnum.values()) {
+            if (type.name().equals(value)) {
+                return type.code;
+            }
+        }
+
+        return null;
+    }
+
     public static String name(Integer value) {
-        return parse(value).name();
+        return parseCode(value).name();
     }
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
@@ -65,10 +65,16 @@ public class UserController {
     }
 
     @GetMapping("/user/get/{id}")
-    @ApiOperation(value = "Get user info")
+    @ApiOperation(value = "Get user info by user id")
     public Response<UserInfo> getById(@PathVariable Integer id) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(userService.getById(id, currentUser));
+    }
+
+    @GetMapping("/user/getByName/{name}")
+    @ApiOperation(value = "Get user info by username")
+    public Response<UserInfo> getByName(@PathVariable String name) {
+        return Response.success(userService.getByName(name));
     }
 
     @PostMapping("/user/listAll")


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5049 

### Motivation

Command tools add CRUD for user.

### Modifications

1. Support get `UserTypeEnum.code` by `UserTypeEnum.name` in `UserTypeEnum`
2. Add CRUD for user.
3. Add `getUserByName` for manager-client

### Verifying this change

1.managerctl list user
```
user      Get user summary information
      Usage: user [options]
        Options:
          --type
            user type
          -u, --username
            username
```

2.managerctl describe user
```
user      Get user details
      Usage: user [options]
        Options:
        * -id, --id
            user id
```
4.managerctl create user
```
user      Create user
      Usage: user [options]
        Options:
          -d, --days
            valid days
          -p, --password
            password
          -t, --type
            account type
          -u, --username
            username
```
5.managerctl update user
```
user      Update User
      Usage: user [options]
        Options:
          -d, --days
            new valid days
          -u, --username
            username to be modify
```
6.managerctl delete user
```
user      Delete user by user id
      Usage: user [options]
        Options:
        * -id, --id
            user id
```
