### PR TITLE
[INLONG-6217][DataProxy] Delete the cluster.id in the common.properties file

### DIFF
--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -15,9 +15,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-# cluster id is for future use please write 1
-cluster.id=1
+
 # manager open api address and auth key
 manager.hosts=127.0.0.1:8083
 manager.auth.secretId=


### PR DESCRIPTION

- Fixes #6217
