### PR TITLE
[INLONG-6220][Manager] Support query cluster nodes by the manager client

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyNodeResponse.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyNodeResponse.java
@@ -28,6 +28,12 @@ import java.util.List;
 public class DataProxyNodeResponse {
 
     /**
+     * DataProxy cluster id
+     */
+    @Deprecated
+    private Integer clusterId;
+
+    /**
      * Is the DataProxy cluster an intranet? 0: no, 1: yes
      */
     private Integer isIntranet;

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyNodeResponse.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyNodeResponse.java
@@ -28,11 +28,6 @@ import java.util.List;
 public class DataProxyNodeResponse {
 
     /**
-     * DataProxy cluster id
-     */
-    private Integer clusterId;
-
-    /**
      * Is the DataProxy cluster an intranet? 0: no, 1: yes
      */
     private Integer isIntranet;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -225,6 +225,15 @@ public interface InlongClient {
     PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request);
 
     /**
+     * Get DP node info by groupId and protocol
+     *
+     * @param groupId inlong group id
+     * @param protocolType protocol type, such as: TCP,HTTP
+     * @return DP list
+     */
+    List<ClusterNodeResponse> listDPNode(String groupId, String protocolType);
+
+    /**
      * Update cluster node.
      *
      * @param request cluster node to be modified

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -229,7 +229,7 @@ public interface InlongClient {
      *
      * @param groupId inlong group id
      * @param protocolType protocol type, such as: TCP,HTTP
-     * @return DP list
+     * @return DataProxy list
      */
     List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType);
 

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -31,6 +31,7 @@ import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupStatusInfo;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -225,13 +226,14 @@ public interface InlongClient {
     PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request);
 
     /**
-     * Get DataProxy node info by groupId and protocol
+     * List cluster nodes
      *
-     * @param groupId inlong group id
-     * @param protocolType protocol type, such as: TCP,HTTP
-     * @return DataProxy list
+     * @param inlongGroupId inlong group id
+     * @param clusterType cluster type
+     * @param protocolType protocol type, such as: TCP, HTTP
+     * @return cluster node list
      */
-    List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType);
+    List<ClusterNodeResponse> listNode(String inlongGroupId, String clusterType, @Nullable String protocolType);
 
     /**
      * Update cluster node.

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/InlongClient.java
@@ -225,13 +225,13 @@ public interface InlongClient {
     PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request);
 
     /**
-     * Get DP node info by groupId and protocol
+     * Get DataProxy node info by groupId and protocol
      *
      * @param groupId inlong group id
      * @param protocolType protocol type, such as: TCP,HTTP
      * @return DP list
      */
-    List<ClusterNodeResponse> listDPNode(String groupId, String protocolType);
+    List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType);
 
     /**
      * Update cluster node.

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -245,8 +245,8 @@ public class InlongClientImpl implements InlongClient {
 
     @Override
     public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
-        Preconditions.checkNotNull(groupId, "DP group id cannot be empty");
-        Preconditions.checkNotNull(protocolType, "DP protocol type cannot be empty");
+        Preconditions.checkNotNull(groupId, "DataProxy group id cannot be empty");
+        Preconditions.checkNotNull(protocolType, "DataProxy protocol type cannot be empty");
         return clusterClient.listDataProxyNode(groupId, protocolType);
     }
 

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -239,15 +239,15 @@ public class InlongClientImpl implements InlongClient {
 
     @Override
     public PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request) {
-        Preconditions.checkNotNull(request.getParentId(), "Cluster id cannot be empty");
+        Preconditions.checkNotNull(request.getParentId(), "parentId cannot be empty");
         return clusterClient.listNode(request);
     }
 
     @Override
-    public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
-        Preconditions.checkNotNull(groupId, "DataProxy group id cannot be empty");
-        Preconditions.checkNotNull(protocolType, "DataProxy protocol type cannot be empty");
-        return clusterClient.listDataProxyNode(groupId, protocolType);
+    public List<ClusterNodeResponse> listNode(String inlongGroupId, String clusterType, String protocolType) {
+        Preconditions.checkNotNull(inlongGroupId, "inlongGroupId cannot be empty");
+        Preconditions.checkNotNull(clusterType, "clusterType cannot be empty");
+        return clusterClient.listNode(inlongGroupId, clusterType, protocolType);
     }
 
     @Override

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -244,6 +244,13 @@ public class InlongClientImpl implements InlongClient {
     }
 
     @Override
+    public List<ClusterNodeResponse> listDPNode(String groupId, String protocolType) {
+        Preconditions.checkNotNull(groupId, "DP group id cannot be empty");
+        Preconditions.checkNotNull(protocolType, "DP protocol type cannot be empty");
+        return clusterClient.listDPNode(groupId, protocolType);
+    }
+
+    @Override
     public Boolean updateNode(ClusterNodeRequest request) {
         Preconditions.checkNotNull(request, "inlong cluster node cannot be empty");
         Preconditions.checkNotNull(request.getId(), "cluster node id cannot be empty");

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongClientImpl.java
@@ -244,10 +244,10 @@ public class InlongClientImpl implements InlongClient {
     }
 
     @Override
-    public List<ClusterNodeResponse> listDPNode(String groupId, String protocolType) {
+    public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
         Preconditions.checkNotNull(groupId, "DP group id cannot be empty");
         Preconditions.checkNotNull(protocolType, "DP protocol type cannot be empty");
-        return clusterClient.listDPNode(groupId, protocolType);
+        return clusterClient.listDataProxyNode(groupId, protocolType);
     }
 
     @Override

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -34,6 +34,8 @@ import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.common.UpdateResult;
 
+import java.util.List;
+
 /**
  * Client for {@link InlongClusterApi}.
  */
@@ -251,6 +253,20 @@ public class InlongClusterClient {
     public PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request) {
         Response<PageResult<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(
                 inlongClusterApi.listNode(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
+     * Get DP node info by groupId and protocol
+     *
+     * @param groupId inlong group id
+     * @param protocolType protocol type, such as: TCP,HTTP
+     * @return DP list
+     */
+    public List<ClusterNodeResponse> listDPNode(String groupId, String protocolType) {
+        Response<List<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(
+                inlongClusterApi.listDPNode(groupId, protocolType));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -258,15 +258,16 @@ public class InlongClusterClient {
     }
 
     /**
-     * Get DataProxy node info by groupId and protocol
+     * List cluster nodes
      *
-     * @param groupId inlong group id
-     * @param protocolType protocol type, such as: TCP,HTTP
-     * @return DataProxy list
+     * @param inlongGroupId inlong group id
+     * @param clusterType cluster type
+     * @param protocolType protocol type, such as: TCP, HTTP
+     * @return cluster node list
      */
-    public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
+    public List<ClusterNodeResponse> listNode(String inlongGroupId, String clusterType, String protocolType) {
         Response<List<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(
-                inlongClusterApi.listDataProxyNode(groupId, protocolType));
+                inlongClusterApi.listNodeByGroupId(inlongGroupId, clusterType, protocolType));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -258,15 +258,15 @@ public class InlongClusterClient {
     }
 
     /**
-     * Get DP node info by groupId and protocol
+     * Get DataProxy node info by groupId and protocol
      *
      * @param groupId inlong group id
      * @param protocolType protocol type, such as: TCP,HTTP
      * @return DP list
      */
-    public List<ClusterNodeResponse> listDPNode(String groupId, String protocolType) {
+    public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
         Response<List<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(
-                inlongClusterApi.listDPNode(groupId, protocolType));
+                inlongClusterApi.listDataProxyNode(groupId, protocolType));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -262,7 +262,7 @@ public class InlongClusterClient {
      *
      * @param groupId inlong group id
      * @param protocolType protocol type, such as: TCP,HTTP
-     * @return DP list
+     * @return DataProxy list
      */
     public List<ClusterNodeResponse> listDataProxyNode(String groupId, String protocolType) {
         Response<List<ClusterNodeResponse>> response = ClientUtils.executeHttpCall(

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -89,9 +89,9 @@ public interface InlongClusterApi {
     @POST("cluster/node/list")
     Call<Response<PageResult<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
 
-    @GET("cluster/node/list/dataproxy/{groupId}")
-    Call<Response<List<ClusterNodeResponse>>> listDataProxyNode(@Path("groupId") String groupId,
-            @Query("protocolType") String protocolType);
+    @GET("cluster/node/listByGroupId")
+    Call<Response<List<ClusterNodeResponse>>> listNodeByGroupId(@Query("inlongGroupId") String inlongGroupId,
+            @Query("clusterType") String clusterType, @Query("protocolType") String protocolType);
 
     @POST("cluster/node/update")
     Call<Response<Boolean>> updateNode(@Body ClusterNodeRequest request);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -89,7 +89,7 @@ public interface InlongClusterApi {
     @POST("cluster/node/list")
     Call<Response<PageResult<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
 
-    @GET("cluster/node/list/dp/{groupId}")
+    @GET("cluster/node/list/dataproxy/{groupId}")
     Call<Response<List<ClusterNodeResponse>>> listDataProxyNode(@Path("groupId") String groupId,
             @Query("protocolType") String protocolType);
 

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -90,7 +90,7 @@ public interface InlongClusterApi {
     Call<Response<PageResult<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
 
     @GET("cluster/node/list/dp/{groupId}")
-    Call<Response<List<ClusterNodeResponse>>> listDPNode(@Path("groupId") String groupId,
+    Call<Response<List<ClusterNodeResponse>>> listDataProxyNode(@Path("groupId") String groupId,
             @Query("protocolType") String protocolType);
 
     @POST("cluster/node/update")

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -37,6 +37,8 @@ import retrofit2.http.POST;
 import retrofit2.http.Path;
 import retrofit2.http.Query;
 
+import java.util.List;
+
 public interface InlongClusterApi {
 
     @POST("cluster/tag/save")
@@ -86,6 +88,10 @@ public interface InlongClusterApi {
 
     @POST("cluster/node/list")
     Call<Response<PageResult<ClusterNodeResponse>>> listNode(@Body ClusterPageRequest request);
+
+    @GET("cluster/node/list/dp/{groupId}")
+    Call<Response<List<ClusterNodeResponse>>> listDPNode(@Path("groupId") String groupId,
+            @Query("protocolType") String protocolType);
 
     @POST("cluster/node/update")
     Call<Response<Boolean>> updateNode(@Body ClusterNodeRequest request);

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -953,7 +953,8 @@ class ClientFactoryTest {
                                         Response.success(responses))
                                 ))
         );
-        List<ClusterNodeResponse> clusterNode = clusterClient.listDataProxyNode("1", ProtocolType.HTTP);
+        List<ClusterNodeResponse> clusterNode = clusterClient.listNode(
+                "1", ClusterType.DATAPROXY, ProtocolType.HTTP);
         Assertions.assertEquals(1, clusterNode.size());
     }
 

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -915,7 +915,7 @@ class ClientFactoryTest {
     }
 
     @Test
-    void testGetNode() {
+    void testGetClusterNode() {
         ClusterNodeResponse response = ClusterNodeResponse.builder()
                 .id(1)
                 .type(ClusterType.DATAPROXY)
@@ -935,7 +935,7 @@ class ClientFactoryTest {
     }
 
     @Test
-    void testListDPNode() {
+    void testListClusterNode() {
         ClusterNodeResponse response = ClusterNodeResponse.builder()
                 .id(5)
                 .type(ClusterType.DATAPROXY)
@@ -947,7 +947,7 @@ class ClientFactoryTest {
         List<ClusterNodeResponse> responses = new ArrayList<>();
         responses.add(response);
         stubFor(
-                get(urlMatching("/inlong/manager/api/cluster/node/list/dataproxy/1.*"))
+                get(urlMatching("/inlong/manager/api/cluster/node/listByGroupId.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(responses))

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -947,7 +947,7 @@ class ClientFactoryTest {
         List<ClusterNodeResponse> responses = new ArrayList<>();
         responses.add(response);
         stubFor(
-                get(urlMatching("/inlong/manager/api/cluster/node/list/dp/1.*"))
+                get(urlMatching("/inlong/manager/api/cluster/node/list/dataproxy/1.*"))
                         .willReturn(
                                 okJson(JsonUtils.toJsonString(
                                         Response.success(responses))

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.inlong.common.constant.ProtocolType;
 import org.apache.inlong.manager.client.api.ClientConfiguration;
 import org.apache.inlong.manager.client.api.impl.InlongClientImpl;
 import org.apache.inlong.manager.client.api.inner.client.ClientFactory;
@@ -931,6 +932,29 @@ class ClientFactoryTest {
         );
         ClusterNodeResponse clientNode = clusterClient.getNode(1);
         Assertions.assertEquals(1, clientNode.getId());
+    }
+
+    @Test
+    void testListDPNode() {
+        ClusterNodeResponse response = ClusterNodeResponse.builder()
+                .id(5)
+                .type(ClusterType.DATAPROXY)
+                .parentId(1)
+                .ip("127.0.0.1")
+                .port(46801)
+                .protocolType(ProtocolType.HTTP)
+                .build();
+        List<ClusterNodeResponse> responses = new ArrayList<>();
+        responses.add(response);
+        stubFor(
+                get(urlMatching("/inlong/manager/api/cluster/node/list/dp/1.*"))
+                        .willReturn(
+                                okJson(JsonUtils.toJsonString(
+                                        Response.success(responses))
+                                ))
+        );
+        List<ClusterNodeResponse> clusterNode = clusterClient.listDPNode("1", ProtocolType.HTTP);
+        Assertions.assertEquals(1, clusterNode.size());
     }
 
     @Test

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -953,7 +953,7 @@ class ClientFactoryTest {
                                         Response.success(responses))
                                 ))
         );
-        List<ClusterNodeResponse> clusterNode = clusterClient.listDPNode("1", ProtocolType.HTTP);
+        List<ClusterNodeResponse> clusterNode = clusterClient.listDataProxyNode("1", ProtocolType.HTTP);
         Assertions.assertEquals(1, clusterNode.size());
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -193,6 +193,16 @@ public interface InlongClusterService {
     PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request, String currentUser);
 
     /**
+     * Get DataProxy node info by groupId and protocol
+     *
+     * @param groupId group id
+     * @param protocolType protocol type
+     * @param currentUser current operator
+     * @return cluster node list
+     */
+    List<ClusterNodeResponse> getDPByGroupId(String groupId, String protocolType, String currentUser);
+
+    /**
      * Query node IP list by cluster type
      *
      * @param type cluster type

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -193,14 +193,14 @@ public interface InlongClusterService {
     PageResult<ClusterNodeResponse> listNode(ClusterPageRequest request, String currentUser);
 
     /**
-     * Get DataProxy node info by groupId and protocol
+     * List cluster nodes
      *
-     * @param groupId group id
-     * @param protocolType protocol type
-     * @param currentUser current operator
+     * @param inlongGroupId inlong group id
+     * @param clusterType cluster type
+     * @param protocolType protocol type, such as: TCP, HTTP
      * @return cluster node list
      */
-    List<ClusterNodeResponse> getDataProxyByGroupId(String groupId, String protocolType, String currentUser);
+    List<ClusterNodeResponse> listNodeByGroupId(String inlongGroupId, String clusterType, String protocolType);
 
     /**
      * Query node IP list by cluster type

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -200,7 +200,7 @@ public interface InlongClusterService {
      * @param currentUser current operator
      * @return cluster node list
      */
-    List<ClusterNodeResponse> getDPByGroupId(String groupId, String protocolType, String currentUser);
+    List<ClusterNodeResponse> getDataProxyByGroupId(String groupId, String protocolType, String currentUser);
 
     /**
      * Query node IP list by cluster type

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -581,7 +581,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     }
 
     @Override
-    public List<ClusterNodeResponse> getDPByGroupId(String groupId, String protocolType, String currentUser) {
+    public List<ClusterNodeResponse> getDataProxyByGroupId(String groupId, String protocolType, String currentUser) {
         Map<Integer, List<InlongClusterNodeEntity>> clusterDP = getDPClusterNodes(groupId, protocolType);
         if (clusterDP.isEmpty()) {
             return new ArrayList<>();
@@ -683,7 +683,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         InlongClusterEntity cluster = clusterMapper.selectById(entity.getParentId());
         String message = "Current user does not have permission to delete cluster node";
         checkUser(cluster, operator, message);
-        
+
         entity.setIsDeleted(entity.getId());
         entity.setModifier(operator);
         if (InlongConstants.AFFECTED_ONE_ROW != clusterNodeMapper.updateById(entity)) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -703,6 +703,9 @@ public class InlongClusterServiceImpl implements InlongClusterService {
             return response;
         }
 
+        // all cluster nodes belong to the same clusterId
+        response.setClusterId(nodeEntities.get(0).getParentId());
+
         // TODO consider the data proxy load and re-balance
         List<DataProxyNodeInfo> nodeList = new ArrayList<>();
         for (InlongClusterNodeEntity nodeEntity : nodeEntities) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -582,16 +582,16 @@ public class InlongClusterServiceImpl implements InlongClusterService {
 
     @Override
     public List<ClusterNodeResponse> getDataProxyByGroupId(String groupId, String protocolType, String currentUser) {
-        Map<Integer, List<InlongClusterNodeEntity>> clusterDP = getDPClusterNodes(groupId, protocolType);
-        if (clusterDP.isEmpty()) {
+        Map<Integer, List<InlongClusterNodeEntity>> clusterDataProxy = getDataProxyClusterNodes(groupId, protocolType);
+        if (clusterDataProxy.isEmpty()) {
             return new ArrayList<>();
         }
-        Integer clusterId = clusterDP.keySet().iterator().next();
+        Integer clusterId = clusterDataProxy.keySet().iterator().next();
         InlongClusterEntity cluster = clusterMapper.selectById(clusterId);
         String message = "Current user does not have permission to get cluster node list";
         checkUser(cluster, currentUser, message);
         return CommonBeanUtils
-                .copyListProperties(clusterDP.get(clusterId), ClusterNodeResponse::new);
+                .copyListProperties(clusterDataProxy.get(clusterId), ClusterNodeResponse::new);
     }
 
     private void checkUser(InlongClusterEntity cluster, String currentUser, String errMsg) {
@@ -697,17 +697,18 @@ public class InlongClusterServiceImpl implements InlongClusterService {
 
     @Override
     public DataProxyNodeResponse getDataProxyNodes(String inlongGroupId, String protocolType) {
-        Map<Integer, List<InlongClusterNodeEntity>> clusterDP = getDPClusterNodes(inlongGroupId, protocolType);
+        Map<Integer, List<InlongClusterNodeEntity>> clusterDataProxy = getDataProxyClusterNodes(inlongGroupId,
+                protocolType);
         DataProxyNodeResponse response = new DataProxyNodeResponse();
-        if (clusterDP.isEmpty()) {
+        if (clusterDataProxy.isEmpty()) {
             return response;
         }
-        Integer clusterId = clusterDP.keySet().iterator().next();
+        Integer clusterId = clusterDataProxy.keySet().iterator().next();
         response.setClusterId(clusterId);
         // if more than one data proxy cluster, currently takes first
         // TODO consider the data proxy load and re-balance
         List<DataProxyNodeInfo> nodeInfos = new ArrayList<>();
-        for (InlongClusterNodeEntity nodeEntity : clusterDP.get(clusterId)) {
+        for (InlongClusterNodeEntity nodeEntity : clusterDataProxy.get(clusterId)) {
             DataProxyNodeInfo nodeInfo = new DataProxyNodeInfo();
             nodeInfo.setId(nodeEntity.getId());
             nodeInfo.setIp(nodeEntity.getIp());
@@ -723,7 +724,8 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         return response;
     }
 
-    private Map<Integer, List<InlongClusterNodeEntity>> getDPClusterNodes(String inlongGroupId, String protocolType) {
+    private Map<Integer, List<InlongClusterNodeEntity>> getDataProxyClusterNodes(String inlongGroupId,
+            String protocolType) {
         LOGGER.debug("begin to get data proxy nodes for groupId={}, protocol={}", inlongGroupId, protocolType);
         InlongGroupEntity groupEntity = groupMapper.selectByGroupId(inlongGroupId);
         if (groupEntity == null) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -199,17 +199,17 @@ public class InlongClusterController {
     }
 
     @GetMapping(value = "/cluster/node/list/dp/{groupId}")
-    @ApiOperation(value = "DP nodes by group id and protocol type")
+    @ApiOperation(value = "DataProxy nodes by group id and protocol type")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "groupId", value = "group id", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "protocolType", value = "protocol type",
                     dataTypeClass = String.class, required = true),
     })
     @OperationLog(operation = OperationType.GET)
-    public Response<List<ClusterNodeResponse>> listDPByGroupId(@PathVariable String groupId,
+    public Response<List<ClusterNodeResponse>> listDataProxyByGroupId(@PathVariable String groupId,
             @RequestParam String protocolType) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
-        return Response.success(clusterService.getDPByGroupId(groupId, protocolType, currentUser));
+        return Response.success(clusterService.getDataProxyByGroupId(groupId, protocolType, currentUser));
     }
 
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -198,7 +198,7 @@ public class InlongClusterController {
         return Response.success(clusterService.listNode(request, currentUser));
     }
 
-    @GetMapping(value = "/cluster/node/list/dp/{groupId}")
+    @GetMapping(value = "/cluster/node/list/dataproxy/{groupId}")
     @ApiOperation(value = "DataProxy nodes by group id and protocol type")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "groupId", value = "group id", dataTypeClass = String.class, required = true),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -52,6 +52,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 /**
  * Inlong cluster controller
  */
@@ -194,6 +196,20 @@ public class InlongClusterController {
     public Response<PageResult<ClusterNodeResponse>> listNode(@RequestBody ClusterPageRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.listNode(request, currentUser));
+    }
+
+    @GetMapping(value = "/cluster/node/list/dp/{groupId}")
+    @ApiOperation(value = "DP nodes by group id and protocol type")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", value = "group id", dataTypeClass = String.class, required = true),
+            @ApiImplicitParam(name = "protocolType", value = "protocol type",
+                    dataTypeClass = String.class, required = true),
+    })
+    @OperationLog(operation = OperationType.GET)
+    public Response<List<ClusterNodeResponse>> listDPByGroupId(@PathVariable String groupId,
+            @RequestParam String protocolType) {
+        String currentUser = LoginUserUtils.getLoginUser().getName();
+        return Response.success(clusterService.getDPByGroupId(groupId, protocolType, currentUser));
     }
 
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -192,24 +192,23 @@ public class InlongClusterController {
     }
 
     @PostMapping(value = "/cluster/node/list")
-    @ApiOperation(value = "List cluster nodes")
+    @ApiOperation(value = "List cluster nodes by pagination")
     public Response<PageResult<ClusterNodeResponse>> listNode(@RequestBody ClusterPageRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.listNode(request, currentUser));
     }
 
-    @GetMapping(value = "/cluster/node/list/dataproxy/{groupId}")
-    @ApiOperation(value = "DataProxy nodes by group id and protocol type")
+    @GetMapping(value = "/cluster/node/listByGroupId")
+    @ApiOperation(value = "List cluster nodes by groupId, clusterType and protocolType")
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "groupId", value = "group id", dataTypeClass = String.class, required = true),
-            @ApiImplicitParam(name = "protocolType", value = "protocol type",
-                    dataTypeClass = String.class, required = true),
+            @ApiImplicitParam(name = "inlongGroupId", dataTypeClass = String.class, required = true),
+            @ApiImplicitParam(name = "clusterType", dataTypeClass = String.class, required = true),
+            @ApiImplicitParam(name = "protocolType", dataTypeClass = String.class, required = false)
     })
     @OperationLog(operation = OperationType.GET)
-    public Response<List<ClusterNodeResponse>> listDataProxyByGroupId(@PathVariable String groupId,
-            @RequestParam String protocolType) {
-        String currentUser = LoginUserUtils.getLoginUser().getName();
-        return Response.success(clusterService.getDataProxyByGroupId(groupId, protocolType, currentUser));
+    public Response<List<ClusterNodeResponse>> listByGroupId(@RequestParam String inlongGroupId,
+            @RequestParam String clusterType, @RequestParam(required = false) String protocolType) {
+        return Response.success(clusterService.listNodeByGroupId(inlongGroupId, clusterType, protocolType));
     }
 
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)


### PR DESCRIPTION
1. Support query of DataProxy cluster based on inlongGroupId and protocolType.
2. The common code to extract the cluster query.

- Fixes #6220 

### Motivation

Update Manager client, add query DataProxy nodes by group id and protocol type.

### Modifications

InlongClusterController.listNodeByGroupId

### Verifying this change

- [x] This change added tests and can be verified as follows:

```
@test
ClientFactoryTest.testListClusterNode()
```