### PR TITLE
[INLONG-6222][Manager] Fix parse source status failure in Command tools

### DIFF
--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/GroupInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/GroupInfo.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.client.cli.pojo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 import org.apache.inlong.manager.client.cli.util.ParseStatus;
+import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
 
 import java.util.Date;
 
@@ -33,7 +34,7 @@ public class GroupInfo {
     private String inlongGroupId;
     private String name;
 
-    @ParseStatus
+    @ParseStatus(clazz = SimpleGroupStatus.class)
     private String status;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date modifyTime;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/SinkInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/SinkInfo.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.client.cli.pojo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 import org.apache.inlong.manager.client.cli.util.ParseStatus;
+import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
 
 import java.util.Date;
 
@@ -35,7 +36,7 @@ public class SinkInfo {
     private String sinkType;
     private String sinkName;
 
-    @ParseStatus
+    @ParseStatus(clazz = SimpleGroupStatus.class)
     private String status;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date modifyTime;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/SourceInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/SourceInfo.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.client.cli.pojo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 import org.apache.inlong.manager.client.cli.util.ParseStatus;
+import org.apache.inlong.manager.common.enums.SimpleSourceStatus;
 
 import java.util.Date;
 
@@ -36,7 +37,7 @@ public class SourceInfo {
     private String sourceName;
     private String serializationType;
 
-    @ParseStatus
+    @ParseStatus(clazz = SimpleSourceStatus.class)
     private String status;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date modifyTime;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/StreamInfo.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/pojo/StreamInfo.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.client.cli.pojo;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Data;
 import org.apache.inlong.manager.client.cli.util.ParseStatus;
+import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
 
 import java.util.Date;
 
@@ -36,7 +37,7 @@ public class StreamInfo {
     private String dataEncoding;
     private String dataSeparator;
 
-    @ParseStatus
+    @ParseStatus(clazz = SimpleGroupStatus.class)
     private String status;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private Date modifyTime;

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/ParseStatus.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/ParseStatus.java
@@ -29,5 +29,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ParseStatus {
-
+    Class<?> clazz();
 }

--- a/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/PrintUtils.java
+++ b/inlong-manager/manager-client-tools/src/main/java/org/apache/inlong/manager/client/cli/util/PrintUtils.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.client.cli.util;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.SimpleGroupStatus;
+import org.apache.inlong.manager.common.enums.SimpleSourceStatus;
 import org.apache.inlong.manager.common.util.JsonUtils;
 
 import java.lang.reflect.Field;
@@ -178,9 +179,15 @@ public class PrintUtils {
             field.setAccessible(true);
             if (field.isAnnotationPresent(ParseStatus.class)) {
                 try {
-                    int status = Integer.parseInt(field.get(target).toString());
-                    SimpleGroupStatus groupStatus = SimpleGroupStatus.parseStatusByCode(status);
-                    field.set(target, String.format("%s (%d)", groupStatus, status));
+                    int code = Integer.parseInt(field.get(target).toString());
+                    String name = "";
+                    Class<?> clazz = field.getAnnotation(ParseStatus.class).clazz();
+                    if (SimpleGroupStatus.class.equals(clazz)) {
+                        name = SimpleGroupStatus.parseStatusByCode(code).toString();
+                    } else if (SimpleSourceStatus.class.equals(clazz)) {
+                        name = SimpleSourceStatus.parseByStatus(code).toString();
+                    }
+                    field.set(target, String.format("%s (%d)", name, code));
                 } catch (IllegalAccessException e) {
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6222 

### Motivation

![image](https://user-images.githubusercontent.com/58519431/196638722-dca9b9dd-f6ac-4728-b163-9dcdf2c3f595.png)

### Modifications

1.Add a parameter to `ParseStatus` to differentiate between different state types.

### Verifying this change

Run `managerctl list source -g xxx -s xxx`

![企业微信截图_16661616145771](https://user-images.githubusercontent.com/58519431/196639819-39f208b8-7797-48ef-aaf1-66218854be9c.png)
