### PR TITLE
[INLONG-6239][Manager] Add inlongctl in the root directory

### DIFF
--- a/bin/inlongctl
+++ b/bin/inlongctl
@@ -1,0 +1,25 @@
+#! /bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+INLONG_HOME=$(
+  cd $(dirname $0)
+  cd ..
+  pwd
+)
+
+bash +x $INLONG_HOME/inlong-manager/bin/managerctl $*


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6239 

### Modifications

Add `bin/inlongctl` in the root directory to execute `inlong-manager/bin/managerctl`
