### PR TITLE
[INLONG-6243][Sort] Support custom name for Sort job

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
@@ -18,7 +18,6 @@
 package org.apache.inlong.sort.configuration;
 
 import java.time.Duration;
-
 import static org.apache.inlong.sort.configuration.ConfigOptions.key;
 
 /**
@@ -95,6 +94,12 @@ public class Constants {
      */
     public static final ConfigOption<String> CLUSTER_ID = key("cluster-id").noDefaultValue()
             .withDescription("The ID of the cluster, used to separate multiple clusters.");
+
+    /**
+     * The job name of this job, default is 'InLong-Sort-Job'
+     */
+    public static final ConfigOption<String> JOB_NAME = key("job.name").defaultValue("InLong-Sort-Job")
+            .withDescription("The job name of this job");
 
     /**
      * The ZooKeeper quorum to use.

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/configuration/Constants.java
@@ -90,6 +90,12 @@ public class Constants {
     //  Common configs
     // ------------------------------------------------------------------------
     /**
+     * The pipeline name is the key of configuration
+     * that represents the configuration of {@link this#JOB_NAME} in Flink Table API
+     */
+    public static final String PIPELINE_NAME = "pipeline.name";
+
+    /**
      * The ID of the cluster, used to separate multiple clusters.
      */
     public static final ConfigOption<String> CLUSTER_ID = key("cluster-id").noDefaultValue()

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -52,7 +52,8 @@ public class Entrance {
         EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()
                 .inStreamingMode().build();
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
-        tableEnv.getConfig().getConfiguration().setString("pipeline.name", config.getString(Constants.JOB_NAME));
+        tableEnv.getConfig().getConfiguration().setString(Constants.PIPELINE_NAME,
+                config.getString(Constants.JOB_NAME));
         String sqlFile = config.getString(Constants.SQL_SCRIPT_FILE);
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -52,6 +52,7 @@ public class Entrance {
         EnvironmentSettings settings = EnvironmentSettings.newInstance().useBlinkPlanner()
                 .inStreamingMode().build();
         StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        tableEnv.getConfig().getConfiguration().setString("pipeline.name", config.getString(Constants.JOB_NAME));
         String sqlFile = config.getString(Constants.SQL_SCRIPT_FILE);
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6243][Sort] Add custom name for sort job

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6243 

### Motivation

Add custom name for sort job, if it is not specified, it will be 'InLong-Sort-Job'.

### Modifications

1. Add job name setting with 'org.apache.inlong.sort.Entrance'
2. Add  JOB_NAME constant  for 'org.apache.inlong.sort.configuration.Constants'

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
