### PR TITLE
fix(sec): upgrade org.apache.hive:hive-exec to 3.1.3

### DIFF
--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -48,7 +48,7 @@
         <rat.basedir>${basedir}</rat.basedir>
         <hbase.version>2.2.3</hbase.version>
         <dlc.hive.version>2.3.7</dlc.hive.version>
-        <iceberg.hive.version>2.3.7</iceberg.hive.version>
+        <iceberg.hive.version>3.1.3</iceberg.hive.version>
     </properties>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hive:hive-exec 2.3.7
- [CVE-2021-34538](https://www.oscs1024.com/hd/CVE-2021-34538)


### What did I do？
Upgrade org.apache.hive:hive-exec from 2.3.7 to 3.1.3 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS