### PR TITLE
[INLONG-6263][CVE] Upgrade com.google.guava to 30.0-jre

### DIFF
--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -30,7 +30,7 @@
     <name>Apache InLong - TubeMQ Manager</name>
 
     <properties>
-        <guava.version>21.0</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <docker.image.prefix>springboot-docker</docker.image.prefix>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerability found in com.google.guava:guava 21.0
- [CVE-2018-10237](https://www.oscs1024.com/hd/CVE-2018-10237)

Fixes: #6263

### What did I do？
Upgrade com.google.guava:guava from 21.0 to 30.0-jre for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS