### PR TITLE
[INLONG-6212][Sort] Support multiple sink for DorisLoadNode

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/DorisConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/DorisConstant.java
@@ -46,4 +46,23 @@ public class DorisConstant {
      * Doris password
      */
     public static final String PASSWORD = "password";
+
+    /**
+     * The multiple enable of sink
+     */
+    public static final String SINK_MULTIPLE_ENABLE = "sink.multiple.enable";
+
+    /**
+     * The multiple format of sink
+     */
+    public static final String SINK_MULTIPLE_FORMAT = "sink.multiple.format";
+
+    /**
+     * The multiple database-pattern of sink
+     */
+    public static final String SINK_MULTIPLE_DATABASE_PATTERN = "sink.multiple.database-pattern";
+    /**
+     * The multiple table-pattern of sink
+     */
+    public static final String SINK_MULTIPLE_TABLE_PATTERN = "sink.multiple.table-pattern";
 }

--- a/inlong-sort/sort-connectors/doris/pom.xml
+++ b/inlong-sort/sort-connectors/doris/pom.xml
@@ -61,11 +61,6 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.doris:*</include>
-                                </includes>
-                            </artifactSet>
                             <filters>
                                 <filter>
                                     <artifact>org.apache.inlong:sort-connector-*</artifact>

--- a/inlong-sort/sort-connectors/doris/pom.xml
+++ b/inlong-sort/sort-connectors/doris/pom.xml
@@ -16,9 +16,9 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>sort-connectors</artifactId>
         <groupId>org.apache.inlong</groupId>
@@ -36,8 +36,14 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.doris</groupId>
-            <artifactId>flink-doris-connector-${flink.minor.version}_${flink.scala.binary.version}</artifactId>
+            <artifactId>flink-doris-connector-${flink.minor.version}_${flink.scala.binary.version}
+            </artifactId>
             <version>${flink.connector.doris.version}</version>
         </dependency>
     </dependencies>
@@ -65,7 +71,9 @@
                                     <artifact>org.apache.inlong:sort-connector-*</artifact>
                                     <includes>
                                         <include>org/apache/inlong/**</include>
-                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
+                                        <include>
+                                            META-INF/services/org.apache.flink.table.factories.Factory
+                                        </include>
                                     </includes>
                                 </filter>
                             </filters>

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.doris.table;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.exception.DorisException;
+import org.apache.doris.flink.exception.StreamLoadException;
+import org.apache.doris.flink.rest.RestService;
+import org.apache.doris.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.io.RichOutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.util.ExecutorThreadFactory;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * DorisDynamicSchemaOutputFormat, copy from {@link org.apache.doris.flink.table.DorisDynamicOutputFormat}
+ * It is used in the multiple sink scenario, in this scenario, we directly convert the data format by
+ * 'sink.multiple.format' in the data stream to doris json that is used to load
+ */
+public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(DorisDynamicSchemaOutputFormat.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String COLUMNS_KEY = "columns";
+    private static final String DORIS_DELETE_SIGN = "__DORIS_DELETE_SIGN__";
+    private static final String UNIQUE_KEYS_TYPE = "UNIQUE_KEYS";
+    @SuppressWarnings({"rawtypes"})
+    private final Map<String, List> batchMap = new HashMap<>();
+    private final DorisOptions options;
+    private final DorisReadOptions readOptions;
+    private final DorisExecutionOptions executionOptions;
+    private final transient JsonDynamicSchemaFormat dynamicSchemaFormat;
+    private final String databasePattern;
+    private final String tablePattern;
+    private long batchBytes = 0L;
+    private DorisStreamLoad dorisStreamLoad;
+    private transient volatile boolean closed = false;
+    private transient ScheduledExecutorService scheduler;
+    private transient ScheduledFuture<?> scheduledFuture;
+    private transient volatile Exception flushException;
+
+    public DorisDynamicSchemaOutputFormat(DorisOptions option,
+            DorisReadOptions readOptions,
+            DorisExecutionOptions executionOptions,
+            JsonDynamicSchemaFormat dynamicSchemaFormat,
+            String databasePattern,
+            String tablePattern) {
+        this.options = option;
+        this.readOptions = readOptions;
+        this.executionOptions = executionOptions;
+        this.dynamicSchemaFormat = dynamicSchemaFormat;
+        this.databasePattern = databasePattern;
+        this.tablePattern = tablePattern;
+        handleStreamloadProp();
+    }
+
+    /**
+     * A builder used to set parameters to the output format's configuration in a fluent way.
+     *
+     * @return builder
+     */
+    public static DorisDynamicSchemaOutputFormat.Builder builder() {
+        return new DorisDynamicSchemaOutputFormat.Builder();
+    }
+
+    private void handleStreamloadProp() {
+        Properties streamLoadProp = executionOptions.getStreamLoadProp();
+        //add column key when fieldNames is not empty
+//        if (!streamLoadProp.containsKey(COLUMNS_KEY) && fieldNames != null && fieldNames.length > 0) {
+//            String columns = String.join(",", Arrays
+//                    .stream(fieldNames).map(item -> String.format("`%s`", item.trim().replace("`", ""))).collect(
+//                            Collectors.toList()));
+//            if (enableBatchDelete()) {
+//                columns = String.format("%s,%s", columns, DORIS_DELETE_SIGN);
+//            }
+//            streamLoadProp.put(COLUMNS_KEY, columns);
+//        }
+    }
+
+    private boolean enableBatchDelete() {
+        return executionOptions.getEnableDelete();
+    }
+
+    @Override
+    public void configure(Configuration configuration) {
+    }
+
+    @Override
+    public void open(int taskNumber, int numTasks) throws IOException {
+        dorisStreamLoad = new DorisStreamLoad(
+                getBackend(),
+                options.getUsername(),
+                options.getPassword(),
+                executionOptions.getStreamLoadProp());
+        if (executionOptions.getBatchIntervalMs() != 0 && executionOptions.getBatchSize() != 1) {
+            this.scheduler = Executors.newScheduledThreadPool(1,
+                    new ExecutorThreadFactory("doris-streamload-output-format"));
+            this.scheduledFuture = this.scheduler.scheduleWithFixedDelay(() -> {
+                synchronized (DorisDynamicSchemaOutputFormat.this) {
+                    if (!closed) {
+                        try {
+                            flush();
+                        } catch (Exception e) {
+                            flushException = e;
+                        }
+                    }
+                }
+            }, executionOptions.getBatchIntervalMs(), executionOptions.getBatchIntervalMs(), TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void checkFlushException() {
+        if (flushException != null) {
+            throw new RuntimeException("Writing records to streamload failed.", flushException);
+        }
+    }
+
+    @Override
+    public synchronized void writeRecord(T row) throws IOException {
+        checkFlushException();
+        addBatch(row);
+        if ((executionOptions.getBatchSize() > 0 && batchMap.size() >= executionOptions.getBatchSize())
+                || batchBytes >= executionOptions.getMaxBatchBytes()) {
+            flush();
+        }
+    }
+
+    @SuppressWarnings({"unchecked"})
+    private void addBatch(T row) throws IOException {
+        if (row instanceof RowData) {
+            RowData rowData = (RowData) row;
+            JsonNode rootNode = dynamicSchemaFormat.deserialize(rowData.getBinary(0));
+            String tableIdentifier = StringUtils.join(
+                    dynamicSchemaFormat.extractValues(rootNode, databasePattern, tablePattern), ".");
+            Map<String, String> physicalData = dynamicSchemaFormat.physicalDataToMap(rootNode);
+            batchBytes += physicalData.toString().getBytes(StandardCharsets.UTF_8).length;
+            // add doris delete sign
+            if (enableBatchDelete()) {
+                physicalData.put(DORIS_DELETE_SIGN, parseDeleteSign(rowData.getRowKind()));
+            }
+            batchMap.computeIfAbsent(tableIdentifier, k -> new ArrayList<>()).add(physicalData);
+        } else {
+            throw new RuntimeException("The type of element should be 'RowData' only.");
+        }
+    }
+
+    private String parseDeleteSign(RowKind rowKind) {
+        if (RowKind.INSERT.equals(rowKind) || RowKind.UPDATE_AFTER.equals(rowKind)) {
+            return "0";
+        } else if (RowKind.DELETE.equals(rowKind) || RowKind.UPDATE_BEFORE.equals(rowKind)) {
+            return "1";
+        } else {
+            throw new RuntimeException("Unrecognized row kind:" + rowKind.toString());
+        }
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        if (!closed) {
+            closed = true;
+
+            if (this.scheduledFuture != null) {
+                scheduledFuture.cancel(false);
+                this.scheduler.shutdown();
+            }
+
+            try {
+                flush();
+            } catch (Exception e) {
+                LOG.warn("Writing records to doris failed.", e);
+                throw new RuntimeException("Writing records to doris failed.", e);
+            } finally {
+                this.dorisStreamLoad.close();
+            }
+        }
+        checkFlushException();
+    }
+
+    @SuppressWarnings({"rawtypes"})
+    public synchronized void flush() throws IOException {
+        checkFlushException();
+        if (batchMap.isEmpty()) {
+            return;
+        }
+        for (Entry<String, List> kvs : batchMap.entrySet()) {
+            load(kvs.getKey(), OBJECT_MAPPER.writeValueAsString(kvs.getValue()));
+        }
+    }
+
+    private void load(String tableIdentifier, String result) throws IOException {
+        String[] tableWithDb = tableIdentifier.split("\\.");
+        for (int i = 0; i <= executionOptions.getMaxRetries(); i++) {
+            try {
+                dorisStreamLoad.load(tableWithDb[0], tableWithDb[1], result);
+                batchMap.remove(tableIdentifier);
+                batchBytes = 0;
+                break;
+            } catch (StreamLoadException e) {
+                LOG.error("doris sink error, retry times = {}", i, e);
+                if (i >= executionOptions.getMaxRetries()) {
+                    throw new IOException(e);
+                }
+                try {
+                    dorisStreamLoad.setHostPort(getBackend());
+                    LOG.warn("streamload error,switch be: {}",
+                            dorisStreamLoad.getLoadUrlStr(tableWithDb[0], tableWithDb[1]), e);
+                    Thread.sleep(1000 * i);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException("unable to flush; interrupted while doing another attempt", e);
+                }
+            }
+        }
+    }
+
+    private String getBackend() throws IOException {
+        try {
+            //get be url from fe
+            return RestService.randomBackend(options, readOptions, LOG);
+        } catch (IOException | DorisException e) {
+            LOG.error("get backends info fail");
+            throw new IOException(e);
+        }
+    }
+
+    /**
+     * Builder for {@link DorisDynamicSchemaOutputFormat}.
+     */
+    public static class Builder {
+
+        private final DorisOptions.Builder optionsBuilder;
+        private DorisReadOptions readOptions;
+        private DorisExecutionOptions executionOptions;
+        private JsonDynamicSchemaFormat dynamicSchemaFormat;
+        private String databasePattern;
+        private String tablePattern;
+
+        public Builder() {
+            this.optionsBuilder = DorisOptions.builder().setTableIdentifier("");
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setFenodes(String fenodes) {
+            this.optionsBuilder.setFenodes(fenodes);
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setUsername(String username) {
+            this.optionsBuilder.setUsername(username);
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setPassword(String password) {
+            this.optionsBuilder.setPassword(password);
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setReadOptions(DorisReadOptions readOptions) {
+            this.readOptions = readOptions;
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setExecutionOptions(DorisExecutionOptions executionOptions) {
+            this.executionOptions = executionOptions;
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setDynamicSchemaFormat(
+                JsonDynamicSchemaFormat dynamicSchemaFormat) {
+            this.dynamicSchemaFormat = dynamicSchemaFormat;
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setDatabasePattern(String databasePattern) {
+            this.databasePattern = databasePattern;
+            return this;
+        }
+
+        public DorisDynamicSchemaOutputFormat.Builder setTablePattern(String tablePattern) {
+            this.tablePattern = tablePattern;
+            return this;
+        }
+
+        @SuppressWarnings({"rawtypes"})
+        public DorisDynamicSchemaOutputFormat build() {
+            return new DorisDynamicSchemaOutputFormat(
+                    optionsBuilder.build(), readOptions, executionOptions,
+                    dynamicSchemaFormat, databasePattern, tablePattern);
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.util.ExecutorThreadFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,11 +67,11 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     private final DorisOptions options;
     private final DorisReadOptions readOptions;
     private final DorisExecutionOptions executionOptions;
-    private final transient JsonDynamicSchemaFormat dynamicSchemaFormat;
     private final String databasePattern;
     private final String tablePattern;
     private long batchBytes = 0L;
     private DorisStreamLoad dorisStreamLoad;
+    private String dynamicSchemaFormat;
     private transient volatile boolean closed = false;
     private transient ScheduledExecutorService scheduler;
     private transient ScheduledFuture<?> scheduledFuture;
@@ -79,7 +80,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     public DorisDynamicSchemaOutputFormat(DorisOptions option,
             DorisReadOptions readOptions,
             DorisExecutionOptions executionOptions,
-            JsonDynamicSchemaFormat dynamicSchemaFormat,
+            String dynamicSchemaFormat,
             String databasePattern,
             String tablePattern) {
         this.options = option;
@@ -166,10 +167,18 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     private void addBatch(T row) throws IOException {
         if (row instanceof RowData) {
             RowData rowData = (RowData) row;
-            JsonNode rootNode = dynamicSchemaFormat.deserialize(rowData.getBinary(0));
+            if (null == dynamicSchemaFormat) {
+                LOG.error("dynamicSchemaFormat is null");
+                throw new RuntimeException("dynamicSchemaFormat can not be null");
+            }
+            JsonDynamicSchemaFormat jsonDynamicSchemaFormat = (JsonDynamicSchemaFormat)
+                    DynamicSchemaFormatFactory.getFormat(dynamicSchemaFormat);
+            JsonNode rootNode = jsonDynamicSchemaFormat.deserialize(rowData.getBinary(0));
             String tableIdentifier = StringUtils.join(
-                    dynamicSchemaFormat.extractValues(rootNode, databasePattern, tablePattern), ".");
-            Map<String, String> physicalData = dynamicSchemaFormat.physicalDataToMap(rootNode);
+                    jsonDynamicSchemaFormat.parse(rowData.getBinary(0), databasePattern),
+                    ".",
+                    jsonDynamicSchemaFormat.parse(rowData.getBinary(0), tablePattern));
+            Map<String, String> physicalData = jsonDynamicSchemaFormat.physicalDataToMap(rootNode);
             batchBytes += physicalData.toString().getBytes(StandardCharsets.UTF_8).length;
             // add doris delete sign
             if (enableBatchDelete()) {
@@ -268,7 +277,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         private final DorisOptions.Builder optionsBuilder;
         private DorisReadOptions readOptions;
         private DorisExecutionOptions executionOptions;
-        private JsonDynamicSchemaFormat dynamicSchemaFormat;
+        private String dynamicSchemaFormat;
         private String databasePattern;
         private String tablePattern;
 
@@ -302,7 +311,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         }
 
         public DorisDynamicSchemaOutputFormat.Builder setDynamicSchemaFormat(
-                JsonDynamicSchemaFormat dynamicSchemaFormat) {
+                String dynamicSchemaFormat) {
             this.dynamicSchemaFormat = dynamicSchemaFormat;
             return this;
         }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableFactory.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.doris.table;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.table.DorisDynamicTableSource;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.inlong.sort.base.format.AbstractDynamicSchemaFormat;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_BATCH_SIZE_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_EXEC_MEM_LIMIT_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_REQUEST_RETRIES_DEFAULT;
+import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_TABLET_SIZE_DEFAULT;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_DATABASE_PATTERN;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_TABLE_PATTERN;
+
+/**
+ * This class copy from {@link org.apache.doris.flink.table.DorisDynamicTableFactory}
+ * translates the catalog table to a table source and support single table source,
+ * single table sink and multiple table sink.
+ *
+ * <p>Because the table source requires a decoding format, we are discovering the format using the
+ * provided {@link FactoryUtil} for convenience.
+ */
+public final class DorisDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    public static final ConfigOption<String> FENODES = ConfigOptions.key("fenodes").stringType().noDefaultValue()
+            .withDescription("doris fe http address.");
+    public static final ConfigOption<String> TABLE_IDENTIFIER = ConfigOptions.key("table.identifier").stringType()
+            .noDefaultValue().withDescription("the jdbc table name.");
+    public static final ConfigOption<String> USERNAME = ConfigOptions.key("username").stringType().noDefaultValue()
+            .withDescription("the jdbc user name.");
+    public static final ConfigOption<String> PASSWORD = ConfigOptions.key("password").stringType().noDefaultValue()
+            .withDescription("the jdbc password.");
+    // Prefix for Doris StreamLoad specific properties.
+    public static final String STREAM_LOAD_PROP_PREFIX = "sink.properties.";
+    // doris options
+    private static final ConfigOption<String> DORIS_READ_FIELD = ConfigOptions
+            .key("doris.read.field")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("List of column names in the Doris table, separated by commas");
+    private static final ConfigOption<String> DORIS_FILTER_QUERY = ConfigOptions
+            .key("doris.filter.query")
+            .stringType()
+            .noDefaultValue()
+            .withDescription(
+                    "Filter expression of the query, which is transparently transmitted to Doris."
+                            + " Doris uses this expression to complete source-side data filtering");
+    private static final ConfigOption<Integer> DORIS_TABLET_SIZE = ConfigOptions
+            .key("doris.request.tablet.size")
+            .intType()
+            .defaultValue(DORIS_TABLET_SIZE_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_REQUEST_CONNECT_TIMEOUT_MS = ConfigOptions
+            .key("doris.request.connect.timeout.ms")
+            .intType()
+            .defaultValue(DORIS_REQUEST_CONNECT_TIMEOUT_MS_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_REQUEST_READ_TIMEOUT_MS = ConfigOptions
+            .key("doris.request.read.timeout.ms")
+            .intType()
+            .defaultValue(DORIS_REQUEST_READ_TIMEOUT_MS_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_REQUEST_QUERY_TIMEOUT_S = ConfigOptions
+            .key("doris.request.query.timeout.s")
+            .intType()
+            .defaultValue(DORIS_REQUEST_QUERY_TIMEOUT_S_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_REQUEST_RETRIES = ConfigOptions
+            .key("doris.request.retries")
+            .intType()
+            .defaultValue(DORIS_REQUEST_RETRIES_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Boolean> DORIS_DESERIALIZE_ARROW_ASYNC = ConfigOptions
+            .key("doris.deserialize.arrow.async")
+            .booleanType()
+            .defaultValue(DORIS_DESERIALIZE_ARROW_ASYNC_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_DESERIALIZE_QUEUE_SIZE = ConfigOptions
+            .key("doris.request.retriesdoris.deserialize.queue.size")
+            .intType()
+            .defaultValue(DORIS_DESERIALIZE_QUEUE_SIZE_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Integer> DORIS_BATCH_SIZE = ConfigOptions
+            .key("doris.batch.size")
+            .intType()
+            .defaultValue(DORIS_BATCH_SIZE_DEFAULT)
+            .withDescription("");
+    private static final ConfigOption<Long> DORIS_EXEC_MEM_LIMIT = ConfigOptions
+            .key("doris.exec.mem.limit")
+            .longType()
+            .defaultValue(DORIS_EXEC_MEM_LIMIT_DEFAULT)
+            .withDescription("");
+    // flink write config options
+    private static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS = ConfigOptions
+            .key("sink.batch.size")
+            .intType()
+            .defaultValue(100)
+            .withDescription("the flush max size (includes all append, upsert and delete records), over this number"
+                    + " of records, will flush data. The default value is 100.");
+    private static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions
+            .key("sink.max-retries")
+            .intType()
+            .defaultValue(3)
+            .withDescription("the max retry times if writing records to database failed.");
+    private static final ConfigOption<Duration> SINK_BUFFER_FLUSH_INTERVAL = ConfigOptions
+            .key("sink.batch.interval")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(1))
+            .withDescription("the flush interval mills, over this time, asynchronous threads will flush data. The "
+                    + "default value is 1s.");
+    private static final ConfigOption<Boolean> SINK_ENABLE_DELETE = ConfigOptions
+            .key("sink.enable-delete")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("whether to enable the delete function");
+    private static final ConfigOption<Long> SINK_BUFFER_FLUSH_MAX_BYTES = ConfigOptions
+            .key("sink.batch.bytes")
+            .longType()
+            .defaultValue(DorisExecutionOptions.DEFAULT_MAX_BATCH_BYTES)
+            .withDescription("the flush max bytes (includes all append, upsert and delete records), over this number"
+                    + " in batch, will flush data. The default value is 10MB.");
+
+    @Override
+    public String factoryIdentifier() {
+        return "doris-inlong";
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FENODES);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FENODES);
+        options.add(TABLE_IDENTIFIER);
+        options.add(USERNAME);
+        options.add(PASSWORD);
+
+        options.add(DORIS_READ_FIELD);
+        options.add(DORIS_FILTER_QUERY);
+        options.add(DORIS_TABLET_SIZE);
+        options.add(DORIS_REQUEST_CONNECT_TIMEOUT_MS);
+        options.add(DORIS_REQUEST_READ_TIMEOUT_MS);
+        options.add(DORIS_REQUEST_QUERY_TIMEOUT_S);
+        options.add(DORIS_REQUEST_RETRIES);
+        options.add(DORIS_DESERIALIZE_ARROW_ASYNC);
+        options.add(DORIS_DESERIALIZE_QUEUE_SIZE);
+        options.add(DORIS_BATCH_SIZE);
+        options.add(DORIS_EXEC_MEM_LIMIT);
+
+        options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
+        options.add(SINK_MAX_RETRIES);
+        options.add(SINK_BUFFER_FLUSH_INTERVAL);
+        options.add(SINK_ENABLE_DELETE);
+        options.add(SINK_BUFFER_FLUSH_MAX_BYTES);
+        options.add(SINK_MULTIPLE_FORMAT);
+        options.add(SINK_MULTIPLE_DATABASE_PATTERN);
+        options.add(SINK_MULTIPLE_TABLE_PATTERN);
+        options.add(SINK_MULTIPLE_ENABLE);
+        return options;
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        // either implement your custom validation logic here ...
+        // or use the provided helper utility
+        final FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        // validate all options
+        helper.validateExcept(STREAM_LOAD_PROP_PREFIX);
+        // get the validated options
+        final ReadableConfig options = helper.getOptions();
+        // derive the produced data type (excluding computed columns) from the catalog table
+        final DataType producedDataType = context.getCatalogTable().getSchema().toPhysicalRowDataType();
+        TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+        // create and return dynamic table source
+        return new DorisDynamicTableSource(
+                getDorisOptions(helper.getOptions()),
+                getDorisReadOptions(helper.getOptions()),
+                physicalSchema);
+    }
+
+    private DorisOptions getDorisOptions(ReadableConfig readableConfig) {
+        final String fenodes = readableConfig.get(FENODES);
+        final DorisOptions.Builder builder = DorisOptions.builder()
+                .setFenodes(fenodes)
+                .setTableIdentifier(readableConfig.getOptional(TABLE_IDENTIFIER).orElse(""));
+        readableConfig.getOptional(USERNAME).ifPresent(builder::setUsername);
+        readableConfig.getOptional(PASSWORD).ifPresent(builder::setPassword);
+        return builder.build();
+    }
+
+    private DorisReadOptions getDorisReadOptions(ReadableConfig readableConfig) {
+        final DorisReadOptions.Builder builder = DorisReadOptions.builder();
+        builder.setDeserializeArrowAsync(readableConfig.get(DORIS_DESERIALIZE_ARROW_ASYNC))
+                .setDeserializeQueueSize(readableConfig.get(DORIS_DESERIALIZE_QUEUE_SIZE))
+                .setExecMemLimit(readableConfig.get(DORIS_EXEC_MEM_LIMIT))
+                .setFilterQuery(readableConfig.get(DORIS_FILTER_QUERY))
+                .setReadFields(readableConfig.get(DORIS_READ_FIELD))
+                .setRequestQueryTimeoutS(readableConfig.get(DORIS_REQUEST_QUERY_TIMEOUT_S))
+                .setRequestBatchSize(readableConfig.get(DORIS_BATCH_SIZE))
+                .setRequestConnectTimeoutMs(readableConfig.get(DORIS_REQUEST_CONNECT_TIMEOUT_MS))
+                .setRequestReadTimeoutMs(readableConfig.get(DORIS_REQUEST_READ_TIMEOUT_MS))
+                .setRequestRetries(readableConfig.get(DORIS_REQUEST_RETRIES))
+                .setRequestTabletSize(readableConfig.get(DORIS_TABLET_SIZE));
+        return builder.build();
+    }
+
+    private DorisExecutionOptions getDorisExecutionOptions(ReadableConfig readableConfig, Properties streamLoadProp) {
+        final DorisExecutionOptions.Builder builder = DorisExecutionOptions.builder();
+        builder.setBatchSize(readableConfig.get(SINK_BUFFER_FLUSH_MAX_ROWS));
+        builder.setMaxRetries(readableConfig.get(SINK_MAX_RETRIES));
+        builder.setBatchIntervalMs(readableConfig.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis());
+        builder.setStreamLoadProp(streamLoadProp);
+        builder.setEnableDelete(readableConfig.get(SINK_ENABLE_DELETE));
+        builder.setMaxBatchBytes(readableConfig.get(SINK_BUFFER_FLUSH_MAX_BYTES));
+        return builder.build();
+    }
+
+    private Properties getStreamLoadProp(Map<String, String> tableOptions) {
+        final Properties streamLoadProp = new Properties();
+
+        for (Map.Entry<String, String> entry : tableOptions.entrySet()) {
+            if (entry.getKey().startsWith(STREAM_LOAD_PROP_PREFIX)) {
+                String subKey = entry.getKey().substring(STREAM_LOAD_PROP_PREFIX.length());
+                streamLoadProp.put(subKey, entry.getValue());
+            }
+        }
+        return streamLoadProp;
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        final FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        // validate all options
+        helper.validateExcept(STREAM_LOAD_PROP_PREFIX);
+
+        Properties streamLoadProp = getStreamLoadProp(context.getCatalogTable().getOptions());
+        TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(context.getCatalogTable().getSchema());
+        String databasePattern = helper.getOptions().getOptional(SINK_MULTIPLE_DATABASE_PATTERN).orElse(null);
+        String tablePattern = helper.getOptions().getOptional(SINK_MULTIPLE_TABLE_PATTERN).orElse(null);
+        boolean multipleSink = helper.getOptions().get(SINK_MULTIPLE_ENABLE);
+        String sinkMultipleFormat = helper.getOptions().getOptional(SINK_MULTIPLE_FORMAT).orElse(null);
+        validateSinkMultiple(physicalSchema.toPhysicalRowDataType(),
+                multipleSink, sinkMultipleFormat, databasePattern, tablePattern);
+        // create and return dynamic table sink
+        return new DorisDynamicTableSink(
+                getDorisOptions(helper.getOptions()),
+                getDorisReadOptions(helper.getOptions()),
+                getDorisExecutionOptions(helper.getOptions(), streamLoadProp),
+                physicalSchema, multipleSink, sinkMultipleFormat, databasePattern, tablePattern
+        );
+    }
+
+    private void validateSinkMultiple(DataType physicalDataType, boolean multipleSink, String sinkMultipleFormat,
+            String databasePattern, String tablePattern) {
+        if (multipleSink) {
+            if (StringUtils.isBlank(databasePattern)) {
+                throw new ValidationException(
+                        "The option 'sink.multiple.database-pattern'"
+                                + " is not allowed blank when the option 'sink.multiple.enable' is 'true'");
+            }
+            if (StringUtils.isBlank(tablePattern)) {
+                throw new ValidationException(
+                        "The option 'sink.multiple.table-pattern' "
+                                + "is not allowed blank when the option 'sink.multiple.enable' is 'true'");
+            }
+            if (StringUtils.isBlank(sinkMultipleFormat)) {
+                throw new ValidationException(
+                        "The option 'sink.multiple.format' "
+                                + "is not allowed blank when the option 'sink.multiple.enable' is 'true'");
+            }
+            DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
+            List<String> supportFormats = DynamicSchemaFormatFactory.SUPPORT_FORMATS.stream().map(
+                    AbstractDynamicSchemaFormat::identifier).collect(Collectors.toList());
+            if (!supportFormats.contains(sinkMultipleFormat)) {
+                throw new ValidationException(String.format(
+                        "Unsupported value '%s' for '%s'. "
+                                + "Supported values are %s.",
+                        sinkMultipleFormat, SINK_MULTIPLE_FORMAT.key(), supportFormats));
+            }
+            if (physicalDataType.getLogicalType() instanceof VarBinaryType) {
+                throw new ValidationException(
+                        "Only supports 'BYTES' or 'VARBINARY(n)' of PhysicalDataType "
+                                + "when the option 'sink.multiple.enable' is 'true'");
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
@@ -26,8 +26,6 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.types.RowKind;
-import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
-import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 
 /**
  * DorisDynamicTableSink copy from {@link org.apache.doris.flink.table.DorisDynamicTableSink}
@@ -94,8 +92,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
                 .setExecutionOptions(executionOptions)
                 .setDatabasePattern(databasePattern)
                 .setTablePattern(tablePattern)
-                .setDynamicSchemaFormat(
-                        (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat));
+                .setDynamicSchemaFormat(sinkMultipleFormat);
         return OutputFormatProvider.of(builder.build());
     }
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.doris.table;
+
+import org.apache.doris.flink.cfg.DorisExecutionOptions;
+import org.apache.doris.flink.cfg.DorisOptions;
+import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.table.DorisDynamicOutputFormat;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.OutputFormatProvider;
+import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
+import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
+
+/**
+ * DorisDynamicTableSink copy from {@link org.apache.doris.flink.table.DorisDynamicTableSink}
+ * It supports both single table sink and multiple table sink
+ **/
+public class DorisDynamicTableSink implements DynamicTableSink {
+
+    private final DorisOptions options;
+    private final DorisReadOptions readOptions;
+    private final DorisExecutionOptions executionOptions;
+    private final TableSchema tableSchema;
+    private final boolean multipleSink;
+    private final String sinkMultipleFormat;
+    private final String databasePattern;
+    private final String tablePattern;
+
+    public DorisDynamicTableSink(DorisOptions options,
+            DorisReadOptions readOptions,
+            DorisExecutionOptions executionOptions,
+            TableSchema tableSchema,
+            boolean multipleSink,
+            String sinkMultipleFormat,
+            String databasePattern,
+            String tablePattern) {
+        this.options = options;
+        this.readOptions = readOptions;
+        this.executionOptions = executionOptions;
+        this.tableSchema = tableSchema;
+        this.multipleSink = multipleSink;
+        this.sinkMultipleFormat = sinkMultipleFormat;
+        this.databasePattern = databasePattern;
+        this.tablePattern = tablePattern;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode changelogMode) {
+        return ChangelogMode.newBuilder()
+                .addContainedKind(RowKind.INSERT)
+                .addContainedKind(RowKind.DELETE)
+                .addContainedKind(RowKind.UPDATE_AFTER)
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked"})
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        if (!multipleSink) {
+            DorisDynamicOutputFormat.Builder builder = DorisDynamicOutputFormat.builder()
+                    .setFenodes(options.getFenodes())
+                    .setUsername(options.getUsername())
+                    .setPassword(options.getPassword())
+                    .setTableIdentifier(options.getTableIdentifier())
+                    .setReadOptions(readOptions)
+                    .setExecutionOptions(executionOptions)
+                    .setFieldDataTypes(tableSchema.getFieldDataTypes())
+                    .setFieldNames(tableSchema.getFieldNames());
+            return OutputFormatProvider.of(builder.build());
+        }
+        DorisDynamicSchemaOutputFormat.Builder builder = DorisDynamicSchemaOutputFormat.builder()
+                .setFenodes(options.getFenodes())
+                .setUsername(options.getUsername())
+                .setPassword(options.getPassword())
+                .setReadOptions(readOptions)
+                .setExecutionOptions(executionOptions)
+                .setDatabasePattern(databasePattern)
+                .setTablePattern(tablePattern)
+                .setDynamicSchemaFormat(
+                        (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat));
+        return OutputFormatProvider.of(builder.build());
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new DorisDynamicTableSink(options, readOptions, executionOptions,
+                tableSchema, multipleSink, sinkMultipleFormat, databasePattern, tablePattern);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Doris Table Sink Of InLong";
+    }
+}
+

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisStreamLoad.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisStreamLoad.java
@@ -58,7 +58,7 @@ public class DorisStreamLoad implements Serializable {
 
     private static final List<String> DORIS_SUCCESS_STATUS = new ArrayList<>(
             Arrays.asList("Success", "Publish Timeout"));
-    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load?";
+    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load";
     private final String authEncoding;
     private final Properties streamLoadProp;
     private final CloseableHttpClient httpClient;
@@ -125,6 +125,8 @@ public class DorisStreamLoad implements Serializable {
             for (Map.Entry<Object, Object> entry : streamLoadProp.entrySet()) {
                 put.setHeader(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
             }
+            put.setHeader("format", "json");
+            put.setHeader("strip_outer_array", "true");
             StringEntity entity = new StringEntity(value, "UTF-8");
             put.setEntity(entity);
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisStreamLoad.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisStreamLoad.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.doris.table;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.doris.flink.exception.StreamLoadException;
+import org.apache.doris.flink.rest.models.RespContent;
+import org.apache.doris.shaded.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.doris.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.doris.shaded.org.apache.commons.codec.binary.Base64;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+/**
+ * DorisStreamLoad copy from {@link org.apache.doris.flink.table.DorisStreamLoad}
+ **/
+public class DorisStreamLoad implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(org.apache.doris.flink.table.DorisStreamLoad.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final List<String> DORIS_SUCCESS_STATUS = new ArrayList<>(
+            Arrays.asList("Success", "Publish Timeout"));
+    private static final String LOAD_URL_PATTERN = "http://%s/api/%s/%s/_stream_load?";
+    private final String authEncoding;
+    private final Properties streamLoadProp;
+    private final CloseableHttpClient httpClient;
+    private String hostPort;
+
+    public DorisStreamLoad(String hostPort, String user, String passwd,
+            Properties streamLoadProp) {
+        this.hostPort = hostPort;
+        this.authEncoding = basicAuthHeader(user, passwd);
+        this.streamLoadProp = streamLoadProp;
+        HttpClientBuilder httpClientBuilder = HttpClients
+                .custom()
+                .setRedirectStrategy(new DefaultRedirectStrategy() {
+                    @Override
+                    protected boolean isRedirectable(String method) {
+                        return true;
+                    }
+                });
+        this.httpClient = httpClientBuilder.build();
+    }
+
+    public void load(String db, String tbl, String value) throws StreamLoadException {
+        LoadResponse loadResponse = loadBatch(db, tbl, value);
+        LOG.info("Streamload Response:{}", loadResponse);
+        if (loadResponse.status != 200) {
+            throw new StreamLoadException("stream load error: " + loadResponse.respContent);
+        } else {
+            try {
+                RespContent respContent = OBJECT_MAPPER.readValue(loadResponse.respContent, RespContent.class);
+                if (!DORIS_SUCCESS_STATUS.contains(respContent.getStatus())) {
+                    String errMsg = String.format("stream load error: %s, see more in %s", respContent.getMessage(),
+                            respContent.getErrorURL());
+                    throw new StreamLoadException(errMsg);
+                }
+            } catch (IOException e) {
+                throw new StreamLoadException(e);
+            }
+        }
+    }
+
+    public String getLoadUrlStr(String db, String tbl) {
+        return String.format(LOAD_URL_PATTERN, hostPort, db, tbl);
+    }
+
+    public void setHostPort(String hostPort) {
+        this.hostPort = hostPort;
+    }
+
+    private LoadResponse loadBatch(String db, String tbl, String value) {
+        String label = streamLoadProp.getProperty("label");
+        if (StringUtils.isBlank(label)) {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+            String formatDate = sdf.format(new Date());
+            label = String.format("flink_connector_%s_%s", formatDate,
+                    UUID.randomUUID().toString().replaceAll("-", ""));
+        }
+
+        try {
+            final String loadUrlStr = String.format(LOAD_URL_PATTERN, hostPort, db, tbl);
+            HttpPut put = new HttpPut(loadUrlStr);
+            put.setHeader(HttpHeaders.EXPECT, "100-continue");
+            put.setHeader(HttpHeaders.AUTHORIZATION, this.authEncoding);
+            put.setHeader("label", label);
+            for (Map.Entry<Object, Object> entry : streamLoadProp.entrySet()) {
+                put.setHeader(String.valueOf(entry.getKey()), String.valueOf(entry.getValue()));
+            }
+            StringEntity entity = new StringEntity(value, "UTF-8");
+            put.setEntity(entity);
+
+            try (CloseableHttpResponse response = httpClient.execute(put)) {
+                final int statusCode = response.getStatusLine().getStatusCode();
+                final String reasonPhrase = response.getStatusLine().getReasonPhrase();
+                String loadResult = "";
+                if (response.getEntity() != null) {
+                    loadResult = EntityUtils.toString(response.getEntity());
+                }
+                return new LoadResponse(statusCode, reasonPhrase, loadResult);
+            }
+        } catch (Exception e) {
+            String err = "failed to stream load data with label: " + label;
+            LOG.warn(err, e);
+            return new LoadResponse(-1, e.getMessage(), err);
+        }
+    }
+
+    private String basicAuthHeader(String username, String password) {
+        final String tobeEncode = username + ":" + password;
+        byte[] encoded = Base64.encodeBase64(tobeEncode.getBytes(StandardCharsets.UTF_8));
+        return "Basic " + new String(encoded);
+    }
+
+    public void close() throws IOException {
+        if (null != httpClient) {
+            try {
+                httpClient.close();
+            } catch (IOException e) {
+                LOG.error("Closing httpClient failed.", e);
+                throw new RuntimeException("Closing httpClient failed.", e);
+            }
+        }
+    }
+
+    public static class LoadResponse {
+
+        public int status;
+        public String respMsg;
+        public String respContent;
+
+        public LoadResponse(int status, String respMsg, String respContent) {
+            this.status = status;
+            this.respMsg = respMsg;
+            this.respContent = respContent;
+        }
+
+        @Override
+        public String toString() {
+            try {
+                return OBJECT_MAPPER.writeValueAsString(this);
+            } catch (JsonProcessingException e) {
+                return "";
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/doris/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/inlong-sort/sort-connectors/doris/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.inlong.sort.doris.table.DorisDynamicTableFactory

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisMultipleSinkTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisMultipleSinkTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.inlong.sort.formats.common.VarBinaryFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.enums.KafkaScanStartupMode;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.KafkaExtractNode;
+import org.apache.inlong.sort.protocol.node.format.CanalJsonFormat;
+import org.apache.inlong.sort.protocol.node.format.RawFormat;
+import org.apache.inlong.sort.protocol.node.load.DorisLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Test for {@link org.apache.inlong.sort.protocol.node.load.DorisLoadNode}
+ */
+public class DorisMultipleSinkTest {
+
+    private KafkaExtractNode buildKafkaExtractNode() {
+        List<FieldInfo> fields = Collections.singletonList(new FieldInfo("raw", new VarBinaryFormatInfo()));
+        return new KafkaExtractNode("1", "kafka_input", fields,
+                null, null, "kafka_raw", "localhost:9092",
+                new RawFormat(), KafkaScanStartupMode.EARLIEST_OFFSET, null,
+                "test_group", null, null);
+    }
+
+    /**
+     * Build node relation
+     *
+     * @param inputs extract node
+     * @param outputs load node
+     * @return node relation
+     */
+    private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    private DorisLoadNode buildDorisLoadNodeWithMultipleSink(String databasePattern, String tablePattern) {
+        List<FieldInfo> fields = Collections.singletonList(new FieldInfo("raw", new VarBinaryFormatInfo()));
+        List<FieldRelation> relations = Collections
+                .singletonList(new FieldRelation(new FieldInfo("raw", new VarBinaryFormatInfo()),
+                        new FieldInfo("raw", new VarBinaryFormatInfo())));
+        return new DorisLoadNode("2", "doris_output", fields, relations,
+                null, null, 1, null,
+                "localhost:8030", "root", "000000", null,
+                null, true, new CanalJsonFormat(), databasePattern, tablePattern);
+    }
+
+    /**
+     * Test kafka to doris with multiple sink enable
+     *
+     * @throws Exception The exception may be thrown when executing
+     */
+    @Test
+    public void testDorisMultipleSinkParse() throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        env.disableOperatorChaining();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode = buildKafkaExtractNode();
+        Node outputNode = buildDorisLoadNodeWithMultipleSink("${database}", "${table}");
+        StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, outputNode),
+                Collections.singletonList(buildNodeRelation(Collections.singletonList(inputNode),
+                        Collections.singletonList(outputNode))));
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+}


### PR DESCRIPTION
Prepare a Pull Request
(Change the title refer to the following example)

Title: [INLONG-6212][Sort] Support multiple sink for DorisLoadNode

(The following XYZ should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)

Fixes https://github.com/apache/inlong/issues/6212

Motivation
Support multiple sink for DorisLoadNode.In this scenario, we agree that the upstream data stream is binary data in a certain format such as 'canal-json' or 'debezium', and the main processing steps as follows:

Deserialize the binary data by the format specified with 'sink.multiple.format'
Dynamic extract the database and table from it used with 'sink.multiple.database-pattern' and 'sink.multiple.table-pattern'
Convert the deserialized data to the json data that is used for Doris StreamLoad
Use StreamLoad load data to Doris used with the database and table that is extracted earlier.
Modifications
1.Add DorisDynamicSchemaOutputFormat
2.Update DorisStreamLoad,DorisDynamicTableSink,DorisDynamicTableFactory
3.Update DorisLoadNode

Verifying this change
(Please pick either of the following options)

 This change is a trivial rework/code cleanup without any test coverage.

 This change is already covered by existing tests, such as:
(please describe tests)

 This change added tests and can be verified as follows:

(example:)

Added integration tests for end-to-end deployment with large payloads (10MB)
Extended integration test for recovery after broker failure
Documentation
Does this pull request introduce a new feature? (yes / no)
If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
If a feature is not applicable for documentation, explain why?
If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation