### PR TITLE
[INLONG-6250][Sort] Return ZonedTimestamp when mysql data schema is timestamp or dataTime

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -81,9 +81,6 @@ public final class RowDataDebeziumDeserializeSchema
 
     private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ISO_TIME;
 
-    private static final DateTimeFormatter timestampFormatter = DateTimeFormatter.ofPattern(
-            "yyyy-MM-dd HH:mm:ss");
-
     /**
      * TypeInformation of the produced {@link RowData}. *
      */
@@ -637,7 +634,9 @@ public final class RowDataDebeziumDeserializeSchema
                 // by default the field value is zoned timestamp, no need to convert
                 break;
             case Timestamp.SCHEMA_NAME:
-                fieldValue = Instant.ofEpochMilli((Long) fieldValue).toString();
+                Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
+                fieldValue = DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(LocalDateTime.ofInstant(instantTime,
+                        serverTimeZone));
                 break;
             default:
                 LOG.error("parse schema {} error", schemaName);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -58,7 +58,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
@@ -635,14 +634,10 @@ public final class RowDataDebeziumDeserializeSchema
                 fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));
                 break;
             case ZonedTimestamp.SCHEMA_NAME:
-                ZonedDateTime zonedDateTime = ZonedDateTime.parse((CharSequence) fieldValue);
-                fieldValue = timestampFormatter.format(zonedDateTime
-                        .withZoneSameInstant(serverTimeZone).toLocalDateTime());
+                // by default the field value is zoned timestamp, no need to convert
                 break;
             case Timestamp.SCHEMA_NAME:
-                Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
-                fieldValue = timestampFormatter.format(LocalDateTime.ofInstant(instantTime,
-                        serverTimeZone));
+                fieldValue = Instant.ofEpochMilli((Long) fieldValue).toString();
                 break;
             default:
                 LOG.error("parse schema {} error", schemaName);


### PR DESCRIPTION
- Fixes #6250 

### Motivation

[INLONG-6250][Sort] Return ZonedTimestamp when mysql data schema is timestamp or dataTime

### Modifications

[INLONG-6250][Sort] Return ZonedTimestamp when mysql data schema is timestamp or dataTime

### Verifying this change

run AllmigrateTest