### PR TITLE
[INLONG-6256][Sort] Support debezium-json format with schema parse for DebeziumJsonDynamicSchemaFormat

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,10 +40,23 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     private static final String SOURCE = "source";
     private static final String PK_NAMES = "pkNames";
     private static final String OP_TYPE = "op";
-    private static final String OP_READ = "r"; // snapshot read
-    private static final String OP_CREATE = "c"; // insert
-    private static final String OP_UPDATE = "u"; // update
-    private static final String OP_DELETE = "d"; // delete
+    private static final String PAYLOAD = "payload";
+    /**
+     * Snapshot read
+     */
+    private static final String OP_READ = "r";
+    /**
+     * Insert
+     */
+    private static final String OP_CREATE = "c";
+    /**
+     * Update
+     */
+    private static final String OP_UPDATE = "u";
+    /**
+     * Delete
+     */
+    private static final String OP_DELETE = "d";
 
 
     private static final DebeziumJsonDynamicSchemaFormat FORMAT = new DebeziumJsonDynamicSchemaFormat();
@@ -58,32 +72,53 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
 
     @Override
     public JsonNode getPhysicalData(JsonNode root) {
-        JsonNode physicalData = root.get(AFTER);
-        if (physicalData == null) {
-            physicalData = root.get(BEFORE);
+        JsonNode payload = root.get(PAYLOAD);
+        if (payload == null) {
+            JsonNode physicalData = root.get(AFTER);
+            if (physicalData == null) {
+                physicalData = root.get(BEFORE);
+            }
+            return physicalData;
         }
-        return physicalData;
+        return getPhysicalData(payload);
     }
 
     @Override
     public List<String> extractPrimaryKeyNames(JsonNode data) {
         List<String> pkNames = new ArrayList<>();
-        JsonNode sourceNode = data.get(SOURCE);
-        if (sourceNode == null) {
+        JsonNode payload = data.get(PAYLOAD);
+        if (payload == null) {
+            JsonNode sourceNode = data.get(SOURCE);
+            if (sourceNode == null) {
+                return pkNames;
+            }
+            JsonNode pkNamesNode = sourceNode.get(PK_NAMES);
+            if (pkNamesNode != null && pkNamesNode.isArray()) {
+                for (int i = 0; i < pkNamesNode.size(); i++) {
+                    pkNames.add(pkNamesNode.get(i).asText());
+                }
+            }
             return pkNames;
         }
-        JsonNode pkNamesNode = sourceNode.get(PK_NAMES);
-        if (pkNamesNode != null && pkNamesNode.isArray()) {
-            for (int i = 0; i < pkNamesNode.size(); i++) {
-                pkNames.add(pkNamesNode.get(i).asText());
-            }
+        return extractPrimaryKeyNames(payload);
+    }
+
+    @Override
+    public String parse(JsonNode rootNode, String pattern) throws IOException {
+        JsonNode payload = rootNode.get(PAYLOAD);
+        if (payload == null) {
+            return super.parse(rootNode, pattern);
         }
-        return pkNames;
+        return super.parse(payload, pattern);
     }
 
     @Override
     public boolean extractDDLFlag(JsonNode data) {
-        return data.has(DDL_FLAG) ? data.get(DDL_FLAG).asBoolean(false) : false;
+        JsonNode payload = data.get(PAYLOAD);
+        if (payload == null) {
+            return data.has(DDL_FLAG) && data.get(DDL_FLAG).asBoolean(false);
+        }
+        return extractDDLFlag(payload);
     }
 
     @Override
@@ -94,34 +129,41 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
 
     @Override
     public List<RowData> extractRowData(JsonNode data, RowType rowType) {
-        JsonNode opNode = data.get(OP_TYPE);
-        JsonNode dataBeforeNode = data.get(BEFORE);
-        JsonNode dataAfterNode = data.get(AFTER);
-        if (opNode == null || (dataBeforeNode == null && dataAfterNode == null)) {
-            throw new IllegalArgumentException(
-                    String.format("Error opNode: %s, or dataBeforeNode: %s, dataAfterNode",
-                            opNode, dataBeforeNode, dataAfterNode));
-        }
-        List<RowData> rowDataList = new ArrayList<>();
-        JsonToRowDataConverter rowDataConverter = rowDataConverters.createConverter(rowType);
+        JsonNode payload = data.get(PAYLOAD);
+        if (payload == null) {
+            JsonNode opNode = data.get(OP_TYPE);
+            JsonNode dataBeforeNode = data.get(BEFORE);
+            JsonNode dataAfterNode = data.get(AFTER);
+            if (opNode == null || (dataBeforeNode == null && dataAfterNode == null)) {
+                throw new IllegalArgumentException(
+                        String.format("Error opNode: %s, or dataBeforeNode: %s, dataAfterNode: %s",
+                                opNode, dataBeforeNode, dataAfterNode));
+            }
+            List<RowData> rowDataList = new ArrayList<>();
+            JsonToRowDataConverter rowDataConverter = rowDataConverters.createConverter(rowType);
 
-        String op = data.get(OP_TYPE).asText();
-        if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
-            RowData rowData = (RowData) rowDataConverter.convert(dataAfterNode);
-            rowData.setRowKind(RowKind.INSERT);
-            rowDataList.add(rowData);
-        } else if (OP_UPDATE.equals(op)) {
-            RowData rowData = (RowData) rowDataConverter.convert(dataAfterNode);
-            rowData.setRowKind(RowKind.UPDATE_AFTER);
-            rowDataList.add(rowData);
-        } else if (OP_DELETE.equals(op)) {
-            RowData rowData = (RowData) rowDataConverter.convert(dataBeforeNode);
-            rowData.setRowKind(RowKind.DELETE);
-            rowDataList.add(rowData);
-        } else {
-            throw new IllegalArgumentException("Unsupported op_type: " + op);
+            String op = data.get(OP_TYPE).asText();
+            if (OP_CREATE.equals(op) || OP_READ.equals(op)) {
+                RowData rowData = (RowData) rowDataConverter.convert(dataAfterNode);
+                rowData.setRowKind(RowKind.INSERT);
+                rowDataList.add(rowData);
+            } else if (OP_UPDATE.equals(op)) {
+                RowData rowData = (RowData) rowDataConverter.convert(dataBeforeNode);
+                rowData.setRowKind(RowKind.UPDATE_BEFORE);
+                rowDataList.add(rowData);
+                rowData = (RowData) rowDataConverter.convert(dataAfterNode);
+                rowData.setRowKind(RowKind.UPDATE_AFTER);
+                rowDataList.add(rowData);
+            } else if (OP_DELETE.equals(op)) {
+                RowData rowData = (RowData) rowDataConverter.convert(dataBeforeNode);
+                rowData.setRowKind(RowKind.DELETE);
+                rowDataList.add(rowData);
+            } else {
+                throw new IllegalArgumentException("Unsupported op_type: " + op);
+            }
+            return rowDataList;
         }
-        return rowDataList;
+        return extractRowData(payload, rowType);
     }
 
     /**

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatTest.java
@@ -88,6 +88,13 @@ public class DebeziumJsonDynamicSchemaFormatTest extends DynamicSchemaFormatBase
         Assert.assertEquals(values, Arrays.asList("111", "scooter"));
     }
 
+    @Test
+    public void testExtractPhysicalData() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        Assert.assertNotNull(((JsonDynamicSchemaFormat) getDynamicSchemaFormat()).getPhysicalData(rootNode));
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
     protected AbstractDynamicSchemaFormat getDynamicSchemaFormat() {

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
@@ -213,7 +213,8 @@ public class DebeziumJsonDynamicSchemaFormatWithSchemaTest extends DynamicSchema
                 + "      \"pos\": 154,\n"
                 + "      \"row\": 0,\n"
                 + "      \"thread\": 7,\n"
-                + "      \"query\": \"INSERT INTO customers (first_name, last_name, email) VALUES ('Anne', 'Kretchmar', 'annek@noanswer.org')\"\n"
+                + "      \"query\": \"INSERT INTO customers (first_name, last_name, email)"
+                + " VALUES ('Anne', 'Kretchmar', 'annek@noanswer.org')\"\n"
                 + "    }\n"
                 + "  }\n"
                 + "}";

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
@@ -18,6 +18,10 @@
 package org.apache.inlong.sort.base.format;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -246,6 +250,21 @@ public class DebeziumJsonDynamicSchemaFormatWithSchemaTest extends DynamicSchema
         JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
                 .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
         Assert.assertNotNull(((JsonDynamicSchemaFormat) getDynamicSchemaFormat()).getPhysicalData(rootNode));
+    }
+
+    @Test
+    public void testExtractRowType() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        String[] names = new String[]{"id", "first_name", "last_name", "email"};
+        LogicalType[] types = new LogicalType[]{
+                new IntType(false),
+                new VarCharType(false, 1),
+                new VarCharType(),
+                new VarCharType()
+        };
+        RowType rowType = RowType.of(true, types, names);
+        Assert.assertEquals(getDynamicSchemaFormat().extractSchema(rootNode), rowType);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormatWithSchemaTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.format;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test for {@link DebeziumJsonDynamicSchemaFormat}
+ */
+public class DebeziumJsonDynamicSchemaFormatWithSchemaTest extends DynamicSchemaFormatBaseTest<JsonNode> {
+
+    @Override
+    protected String getSource() {
+        return "{\n"
+                + "  \"schema\": { \n"
+                + "    \"type\": \"struct\",\n"
+                + "    \"fields\": [\n"
+                + "      {\n"
+                + "        \"type\": \"struct\",\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"type\": \"int32\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"id\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"first_name\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"last_name\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"email\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"optional\": true,\n"
+                + "        \"name\": \"mysql-server-1.inventory.customers.Value\", \n"
+                + "        \"field\": \"before\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"type\": \"struct\",\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"type\": \"int32\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"id\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"first_name\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"last_name\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"email\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"optional\": true,\n"
+                + "        \"name\": \"mysql-server-1.inventory.customers.Value\",\n"
+                + "        \"field\": \"after\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"type\": \"struct\",\n"
+                + "        \"fields\": [\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"version\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"connector\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"name\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"int64\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"ts_ms\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"boolean\",\n"
+                + "            \"optional\": true,\n"
+                + "            \"default\": false,\n"
+                + "            \"field\": \"snapshot\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"db\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": true,\n"
+                + "            \"field\": \"table\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"int64\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"server_id\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": true,\n"
+                + "            \"field\": \"gtid\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"file\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"int64\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"pos\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"int32\",\n"
+                + "            \"optional\": false,\n"
+                + "            \"field\": \"row\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"int64\",\n"
+                + "            \"optional\": true,\n"
+                + "            \"field\": \"thread\"\n"
+                + "          },\n"
+                + "          {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"optional\": true,\n"
+                + "            \"field\": \"query\"\n"
+                + "          }\n"
+                + "        ],\n"
+                + "        \"optional\": false,\n"
+                + "        \"name\": \"io.debezium.connector.mysql.Source\", \n"
+                + "        \"field\": \"source\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"type\": \"string\",\n"
+                + "        \"optional\": false,\n"
+                + "        \"field\": \"op\"\n"
+                + "      },\n"
+                + "      {\n"
+                + "        \"type\": \"int64\",\n"
+                + "        \"optional\": true,\n"
+                + "        \"field\": \"ts_ms\"\n"
+                + "      }\n"
+                + "    ],\n"
+                + "    \"optional\": false,\n"
+                + "    \"name\": \"mysql-server-1.inventory.customers.Envelope\" \n"
+                + "  },\n"
+                + "  \"payload\": { \n"
+                + "    \"op\": \"c\", \n"
+                + "    \"ts_ms\": 1465491411815, \n"
+                + "    \"before\": null, \n"
+                + "    \"after\": { \n"
+                + "      \"id\": 1004,\n"
+                + "      \"first_name\": \"Anne\",\n"
+                + "      \"last_name\": \"Kretchmar\",\n"
+                + "      \"email\": \"annek@noanswer.org\"\n"
+                + "    },\n"
+                + "    \"source\": { \n"
+                + "      \"version\": \"1.9.6.Final\",\n"
+                + "      \"connector\": \"mysql\",\n"
+                + "      \"name\": \"mysql-server-1\",\n"
+                + "      \"ts_ms\": 0,\n"
+                + "      \"pkNames\":[\"id\", \"first_name\"],"
+                + "      \"snapshot\": false,\n"
+                + "      \"db\": \"inventory\",\n"
+                + "      \"table\": \"customers\",\n"
+                + "      \"server_id\": 0,\n"
+                + "      \"gtid\": null,\n"
+                + "      \"file\": \"mysql-bin.000003\",\n"
+                + "      \"pos\": 154,\n"
+                + "      \"row\": 0,\n"
+                + "      \"thread\": 7,\n"
+                + "      \"query\": \"INSERT INTO customers (first_name, last_name, email) VALUES ('Anne', 'Kretchmar', 'annek@noanswer.org')\"\n"
+                + "    }\n"
+                + "  }\n"
+                + "}";
+    }
+
+    @Override
+    protected Map<String, String> getExpectedValues() {
+        Map<String, String> expectedValues = new HashMap<>();
+        expectedValues.put("${source.db}${source.table}", "inventorycustomers");
+        expectedValues.put("${source.db}_${source.table}", "inventory_customers");
+        expectedValues.put("prefix_${source.db}_${source.table}_suffix", "prefix_inventory_customers_suffix");
+        expectedValues.put("${ \t source.db \t }${ source.table }", "inventorycustomers");
+        expectedValues.put("${source.db}_${source.table}_${id}_${first_name}", "inventory_customers_1004_Anne");
+        return expectedValues;
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testExtractPrimaryKey() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        List<String> primaryKeys = getDynamicSchemaFormat().extractPrimaryKeyNames(rootNode);
+        List<String> values = getDynamicSchemaFormat().extractValues(rootNode, primaryKeys.toArray(new String[]{}));
+        Assert.assertEquals(values, Arrays.asList("1004", "Anne"));
+    }
+
+    @Test
+    public void testExtractPhysicalData() throws IOException {
+        JsonNode rootNode = (JsonNode) getDynamicSchemaFormat()
+                .deserialize(getSource().getBytes(StandardCharsets.UTF_8));
+        Assert.assertNotNull(((JsonDynamicSchemaFormat) getDynamicSchemaFormat()).getPhysicalData(rootNode));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    protected AbstractDynamicSchemaFormat getDynamicSchemaFormat() {
+        return DebeziumJsonDynamicSchemaFormat.getInstance();
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6256][Sort] Support debezium-json format with schema parse for DebeziumJsonDynamicSchemaFormat

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6256 

### Motivation

Support debezium-json format with schema parse for DebeziumJsonDynamicSchemaFormat.
A complete debezium format with schema will put metadata, physical fields, etc. in the payload, we also need to support parsing of this format and extract physical data, metadata, ddl, and etc. The data example as follows:
```{
  "schema": { 
    "type": "struct",
    "fields": [
      {
        "type": "struct",
        "fields": [
          {
            "type": "int32",
            "optional": false,
            "field": "id"
          },
          {
            "type": "string",
            "optional": false,
            "field": "first_name"
          },
          {
            "type": "string",
            "optional": false,
            "field": "last_name"
          },
          {
            "type": "string",
            "optional": false,
            "field": "email"
          }
        ],
        "optional": true,
        "name": "mysql-server-1.inventory.customers.Value", 
        "field": "before"
      },
      {
        "type": "struct",
        "fields": [
          {
            "type": "int32",
            "optional": false,
            "field": "id"
          },
          {
            "type": "string",
            "optional": false,
            "field": "first_name"
          },
          {
            "type": "string",
            "optional": false,
            "field": "last_name"
          },
          {
            "type": "string",
            "optional": false,
            "field": "email"
          }
        ],
        "optional": true,
        "name": "mysql-server-1.inventory.customers.Value",
        "field": "after"
      },
      {
        "type": "struct",
        "fields": [
          {
            "type": "string",
            "optional": false,
            "field": "version"
          },
          {
            "type": "string",
            "optional": false,
            "field": "connector"
          },
          {
            "type": "string",
            "optional": false,
            "field": "name"
          },
          {
            "type": "int64",
            "optional": false,
            "field": "ts_ms"
          },
          {
            "type": "boolean",
            "optional": true,
            "default": false,
            "field": "snapshot"
          },
          {
            "type": "string",
            "optional": false,
            "field": "db"
          },
          {
            "type": "string",
            "optional": true,
            "field": "table"
          },
          {
            "type": "int64",
            "optional": false,
            "field": "server_id"
          },
          {
            "type": "string",
            "optional": true,
            "field": "gtid"
          },
          {
            "type": "string",
            "optional": false,
            "field": "file"
          },
          {
            "type": "int64",
            "optional": false,
            "field": "pos"
          },
          {
            "type": "int32",
            "optional": false,
            "field": "row"
          },
          {
            "type": "int64",
            "optional": true,
            "field": "thread"
          },
          {
            "type": "string",
            "optional": true,
            "field": "query"
          }
        ],
        "optional": false,
        "name": "io.debezium.connector.mysql.Source", 
        "field": "source"
      },
      {
        "type": "string",
        "optional": false,
        "field": "op"
      },
      {
        "type": "int64",
        "optional": true,
        "field": "ts_ms"
      }
    ],
    "optional": false,
    "name": "mysql-server-1.inventory.customers.Envelope" 
  },
  "payload": { 
    "op": "c", 
    "ts_ms": 1465491411815, 
    "before": null, 
    "after": { 
      "id": 1004,
      "first_name": "Anne",
      "last_name": "Kretchmar",
      "email": "annek@noanswer.org"
    },
    "source": { 
      "version": "1.9.6.Final",
      "connector": "mysql",
      "name": "mysql-server-1",
      "ts_ms": 0,
      "snapshot": false,
      "db": "inventory",
      "table": "customers",
      "server_id": 0,
      "gtid": null,
      "file": "mysql-bin.000003",
      "pos": 154,
      "row": 0,
      "thread": 7,
      "query": "INSERT INTO customers (first_name, last_name, email) VALUES ('Anne', 'Kretchmar', 'annek@noanswer.org')"
    }
  }
}
```
### Modifications

1. Update DebeziumJsonDynamicSchemaFormat and DebeziumJsonDynamicSchemaFormatTest
2. Add DebeziumJsonDynamicSchemaFormatWithSchemaTest
3. 
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
