### PR TITLE
[INLONG-6283][Sort] Fix the JAR conflict between sort-dist and sort-connector

### DIFF
--- a/inlong-sort/sort-formats/format-json/pom.xml
+++ b/inlong-sort/sort-formats/format-json/pom.xml
@@ -78,6 +78,7 @@
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
- Fixes #6283 

### Motivation

sort jar conflict between sort-dist and connector

### Modifications

make debezium-core in sort-format-json provided since the dependency can be found in connector jar 

### Verifying this change
