### PR TITLE
[INLONG-6307][Sort] Add whether to ignore single-table error policy processing for multiple sink of DorisLoadNode

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -157,4 +157,10 @@ public final class Constants {
                     .enumType(SchemaUpdateExceptionPolicy.class)
                     .defaultValue(SchemaUpdateExceptionPolicy.TRY_IT_BEST)
                     .withDescription("The action to deal with schema update in multiple sink.");
+
+    public static final ConfigOption<Boolean> SINK_MULTIPLE_IGNORE_SINGLE_TABLE_ERRORS =
+            ConfigOptions.key("sink.multiple.ignore-single-table-errors")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether ignore the single table erros when multiple sink writing scenario.");
 }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableFactory.java
@@ -57,6 +57,7 @@ import static org.apache.doris.flink.cfg.ConfigurationOptions.DORIS_TABLET_SIZE_
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_DATABASE_PATTERN;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_IGNORE_SINGLE_TABLE_ERRORS;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_TABLE_PATTERN;
 
 /**
@@ -208,6 +209,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         options.add(SINK_MULTIPLE_DATABASE_PATTERN);
         options.add(SINK_MULTIPLE_TABLE_PATTERN);
         options.add(SINK_MULTIPLE_ENABLE);
+        options.add(SINK_MULTIPLE_IGNORE_SINGLE_TABLE_ERRORS);
         return options;
     }
 
@@ -290,6 +292,7 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
         String databasePattern = helper.getOptions().getOptional(SINK_MULTIPLE_DATABASE_PATTERN).orElse(null);
         String tablePattern = helper.getOptions().getOptional(SINK_MULTIPLE_TABLE_PATTERN).orElse(null);
         boolean multipleSink = helper.getOptions().get(SINK_MULTIPLE_ENABLE);
+        boolean ignoreSingleTableErrors = helper.getOptions().get(SINK_MULTIPLE_IGNORE_SINGLE_TABLE_ERRORS);
         String sinkMultipleFormat = helper.getOptions().getOptional(SINK_MULTIPLE_FORMAT).orElse(null);
         validateSinkMultiple(physicalSchema.toPhysicalRowDataType(),
                 multipleSink, sinkMultipleFormat, databasePattern, tablePattern);
@@ -298,8 +301,8 @@ public final class DorisDynamicTableFactory implements DynamicTableSourceFactory
                 getDorisOptions(helper.getOptions()),
                 getDorisReadOptions(helper.getOptions()),
                 getDorisExecutionOptions(helper.getOptions(), streamLoadProp),
-                physicalSchema, multipleSink, sinkMultipleFormat, databasePattern, tablePattern
-        );
+                physicalSchema, multipleSink, sinkMultipleFormat, databasePattern,
+                tablePattern, ignoreSingleTableErrors);
     }
 
     private void validateSinkMultiple(DataType physicalDataType, boolean multipleSink, String sinkMultipleFormat,

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
@@ -41,6 +41,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     private final String sinkMultipleFormat;
     private final String databasePattern;
     private final String tablePattern;
+    private final boolean ignoreSingleTableErrors;
 
     public DorisDynamicTableSink(DorisOptions options,
             DorisReadOptions readOptions,
@@ -49,7 +50,8 @@ public class DorisDynamicTableSink implements DynamicTableSink {
             boolean multipleSink,
             String sinkMultipleFormat,
             String databasePattern,
-            String tablePattern) {
+            String tablePattern,
+            boolean ignoreSingleTableErrors) {
         this.options = options;
         this.readOptions = readOptions;
         this.executionOptions = executionOptions;
@@ -58,6 +60,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
         this.sinkMultipleFormat = sinkMultipleFormat;
         this.databasePattern = databasePattern;
         this.tablePattern = tablePattern;
+        this.ignoreSingleTableErrors = ignoreSingleTableErrors;
     }
 
     @Override
@@ -92,14 +95,15 @@ public class DorisDynamicTableSink implements DynamicTableSink {
                 .setExecutionOptions(executionOptions)
                 .setDatabasePattern(databasePattern)
                 .setTablePattern(tablePattern)
-                .setDynamicSchemaFormat(sinkMultipleFormat);
+                .setDynamicSchemaFormat(sinkMultipleFormat)
+                .setIgnoreSingleTableErrors(ignoreSingleTableErrors);
         return OutputFormatProvider.of(builder.build());
     }
 
     @Override
     public DynamicTableSink copy() {
-        return new DorisDynamicTableSink(options, readOptions, executionOptions,
-                tableSchema, multipleSink, sinkMultipleFormat, databasePattern, tablePattern);
+        return new DorisDynamicTableSink(options, readOptions, executionOptions, tableSchema,
+                multipleSink, sinkMultipleFormat, databasePattern, tablePattern, ignoreSingleTableErrors);
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6307][Sort] Add whether to ignore single-table error policy processing for multiple sink of DorisLoadNode

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6307

### Motivation

Add whether to ignore single-table error policy processing for multiple sink of DorisLoadNode
In multiple sink writing scenario, a table may have an error during the writing process. At this time, we can either ignore this error or throw this error to ensure data consistency, so i add the option 'sink.multiple.ignore-single-table-errors' to support this strategy choice.

### Modifications

1.Add a option 'sink.multiple.ignore-single-table-errors' for org.apache.inlong.sort.base.Constants
2.Update DorisDynamicSchemaOutputFormat,DorisDynamicTableFactory,DorisDynamicTableSink to support this feature

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
