### PR TITLE
[INLONG-6318][Sort] MySQL connector supports snapshots and restores the metric state

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSource.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSource.java
@@ -167,7 +167,7 @@ public class MySqlSource<T>
                         sourceConfig.isIncludeSchemaChanges()),
                 readerContext.getConfiguration(),
                 mySqlSourceReaderContext,
-                sourceConfig);
+                sourceConfig, sourceReaderMetrics);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -98,4 +98,15 @@ public class MySqlSourceReaderMetrics {
             sourceMetricData.outputMetrics(rowCountSize, rowDataSize);
         }
     }
+
+    public void initMetrics(long rowCountSize, long rowDataSize) {
+        if (sourceMetricData != null) {
+            sourceMetricData.getNumBytesIn().inc(rowDataSize);
+            sourceMetricData.getNumRecordsIn().inc(rowCountSize);
+        }
+    }
+
+    public SourceMetricData getSourceMetricData() {
+        return sourceMetricData;
+    }
 }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -145,8 +145,8 @@ public final class MySqlRecordEmitter<T>
                     new Collector<T>() {
                         @Override
                         public void collect(final T t) {
-                            sourceReaderMetrics.outputMetrics(1L,
-                                    t.toString().getBytes(StandardCharsets.UTF_8).length);
+                            long byteNum = t.toString().getBytes(StandardCharsets.UTF_8).length;
+                            sourceReaderMetrics.outputMetrics(1L, byteNum);
                             output.collect(t);
                         }
 

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
@@ -29,6 +29,7 @@ import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSource
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.cdc.mysql.debezium.DebeziumUtils;
 import org.apache.inlong.sort.cdc.mysql.source.config.MySqlSourceConfig;
 import org.apache.inlong.sort.cdc.mysql.source.events.BinlogSplitMetaEvent;
@@ -41,6 +42,7 @@ import org.apache.inlong.sort.cdc.mysql.source.events.LatestFinishedSplitsSizeRe
 import org.apache.inlong.sort.cdc.mysql.source.events.SuspendBinlogReaderAckEvent;
 import org.apache.inlong.sort.cdc.mysql.source.events.SuspendBinlogReaderEvent;
 import org.apache.inlong.sort.cdc.mysql.source.events.WakeupReaderEvent;
+import org.apache.inlong.sort.cdc.mysql.source.metrics.MySqlSourceReaderMetrics;
 import org.apache.inlong.sort.cdc.mysql.source.offset.BinlogOffset;
 import org.apache.inlong.sort.cdc.mysql.source.split.FinishedSnapshotSplitInfo;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlBinlogSplit;
@@ -49,6 +51,7 @@ import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSnapshotSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSnapshotSplitState;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplitState;
+import org.apache.inlong.sort.cdc.mysql.source.split.MysqlMetricSplit;
 import org.apache.inlong.sort.cdc.mysql.source.utils.TableDiscoveryUtils;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -84,6 +87,7 @@ public class MySqlSourceReader<T>
     private final int subtaskId;
     private final MySqlSourceReaderContext mySqlSourceReaderContext;
     private MySqlBinlogSplit suspendedBinlogSplit;
+    private MySqlSourceReaderMetrics sourceReaderMetrics;
 
     public MySqlSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecord>> elementQueue,
@@ -91,7 +95,8 @@ public class MySqlSourceReader<T>
             RecordEmitter<SourceRecord, T, MySqlSplitState> recordEmitter,
             Configuration config,
             MySqlSourceReaderContext context,
-            MySqlSourceConfig sourceConfig) {
+            MySqlSourceConfig sourceConfig,
+            MySqlSourceReaderMetrics sourceReaderMetrics) {
         super(
                 elementQueue,
                 new SingleThreadFetcherManager<>(elementQueue, splitReaderSupplier::get),
@@ -104,6 +109,7 @@ public class MySqlSourceReader<T>
         this.subtaskId = context.getSourceReaderContext().getIndexOfSubtask();
         this.mySqlSourceReaderContext = context;
         this.suspendedBinlogSplit = null;
+        this.sourceReaderMetrics = sourceReaderMetrics;
     }
 
     @Override
@@ -142,6 +148,13 @@ public class MySqlSourceReader<T>
         if (suspendedBinlogSplit != null) {
             unfinishedSplits.add(suspendedBinlogSplit);
         }
+        SourceMetricData sourceMetricData = sourceReaderMetrics.getSourceMetricData();
+        LOG.info("inlong-metric-states snapshot sourceMetricData:{}", sourceMetricData);
+        if (sourceMetricData != null) {
+            unfinishedSplits.add(
+                    new MysqlMetricSplit(sourceMetricData.getNumBytesIn().getCount(),
+                            sourceMetricData.getNumRecordsIn().getCount()));
+        }
         return unfinishedSplits;
     }
 
@@ -171,6 +184,15 @@ public class MySqlSourceReader<T>
         List<MySqlSplit> unfinishedSplits = new ArrayList<>();
         for (MySqlSplit split : splits) {
             LOG.info("Add Split: " + split);
+            if (split.isMetricSplit()) {
+                MysqlMetricSplit mysqlMetricSplit = (MysqlMetricSplit) split;
+                LOG.info("inlong-metric-states restore metricSplit:{}", mysqlMetricSplit);
+                sourceReaderMetrics.initMetrics(mysqlMetricSplit.getNumRecordsIn(),
+                        mysqlMetricSplit.getNumBytesIn());
+                LOG.info("inlong-metric-states restore sourceReaderMetrics:{}",
+                        sourceReaderMetrics.getSourceMetricData());
+                continue;
+            }
             if (split.isSnapshotSplit()) {
                 MySqlSnapshotSplit snapshotSplit = split.asSnapshotSplit();
                 if (snapshotSplit.isSnapshotReadFinished()) {
@@ -206,7 +228,7 @@ public class MySqlSourceReader<T>
         final String splitId = split.splitId();
         if (split.getTableSchemas().isEmpty()) {
             try (MySqlConnection jdbc =
-                         DebeziumUtils.createMySqlConnection(sourceConfig.getDbzConfiguration())) {
+                    DebeziumUtils.createMySqlConnection(sourceConfig.getDbzConfiguration())) {
                 Map<TableId, TableChanges.TableChange> tableSchemas =
                         TableDiscoveryUtils.discoverCapturedTableSchemas(sourceConfig, jdbc);
                 LOG.info("The table schema discovery for binlog split {} success", splitId);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
@@ -47,11 +47,11 @@ import org.apache.inlong.sort.cdc.mysql.source.offset.BinlogOffset;
 import org.apache.inlong.sort.cdc.mysql.source.split.FinishedSnapshotSplitInfo;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlBinlogSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlBinlogSplitState;
+import org.apache.inlong.sort.cdc.mysql.source.split.MySqlMetricSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSnapshotSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSnapshotSplitState;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplit;
 import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplitState;
-import org.apache.inlong.sort.cdc.mysql.source.split.MysqlMetricSplit;
 import org.apache.inlong.sort.cdc.mysql.source.utils.TableDiscoveryUtils;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
@@ -152,7 +152,7 @@ public class MySqlSourceReader<T>
         LOG.info("inlong-metric-states snapshot sourceMetricData:{}", sourceMetricData);
         if (sourceMetricData != null) {
             unfinishedSplits.add(
-                    new MysqlMetricSplit(sourceMetricData.getNumBytesIn().getCount(),
+                    new MySqlMetricSplit(sourceMetricData.getNumBytesIn().getCount(),
                             sourceMetricData.getNumRecordsIn().getCount()));
         }
         return unfinishedSplits;
@@ -185,7 +185,7 @@ public class MySqlSourceReader<T>
         for (MySqlSplit split : splits) {
             LOG.info("Add Split: " + split);
             if (split.isMetricSplit()) {
-                MysqlMetricSplit mysqlMetricSplit = (MysqlMetricSplit) split;
+                MySqlMetricSplit mysqlMetricSplit = (MySqlMetricSplit) split;
                 LOG.info("inlong-metric-states restore metricSplit:{}", mysqlMetricSplit);
                 sourceReaderMetrics.initMetrics(mysqlMetricSplit.getNumRecordsIn(),
                         mysqlMetricSplit.getNumBytesIn());

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlMetricSplit.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlMetricSplit.java
@@ -23,7 +23,10 @@ import io.debezium.relational.history.TableChanges.TableChange;
 
 import java.util.Map;
 
-public class MysqlMetricSplit extends MySqlSplit {
+/**
+ * The split to describe a split of MySql metric.
+ */
+public class MySqlMetricSplit extends MySqlSplit {
 
     private Long numRecordsIn = 0L;
 
@@ -45,11 +48,11 @@ public class MysqlMetricSplit extends MySqlSplit {
         this.numBytesIn = numBytesIn;
     }
 
-    public MysqlMetricSplit(String splitId) {
+    public MySqlMetricSplit(String splitId) {
         super(splitId);
     }
 
-    public MysqlMetricSplit(Long numBytesIn, Long numRecordsIn) {
+    public MySqlMetricSplit(Long numBytesIn, Long numRecordsIn) {
         this("");
         this.numBytesIn = numBytesIn;
         this.numRecordsIn = numRecordsIn;

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplit.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplit.java
@@ -34,6 +34,14 @@ public abstract class MySqlSplit implements SourceSplit {
         this.splitId = splitId;
     }
 
+    public final boolean isMetricSplit() {
+        return getClass() == MysqlMetricSplit.class;
+    }
+
+    public final MysqlMetricSplit asMetricSplit() {
+        return (MysqlMetricSplit) this;
+    }
+
     /** Checks whether this split is a snapshot split. */
     public final boolean isSnapshotSplit() {
         return getClass() == MySqlSnapshotSplit.class;

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplit.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplit.java
@@ -35,11 +35,11 @@ public abstract class MySqlSplit implements SourceSplit {
     }
 
     public final boolean isMetricSplit() {
-        return getClass() == MysqlMetricSplit.class;
+        return getClass() == MySqlMetricSplit.class;
     }
 
-    public final MysqlMetricSplit asMetricSplit() {
-        return (MysqlMetricSplit) this;
+    public final MySqlMetricSplit asMetricSplit() {
+        return (MySqlMetricSplit) this;
     }
 
     /** Checks whether this split is a snapshot split. */

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplitSerializer.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplitSerializer.java
@@ -56,6 +56,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
 
     private static final int SNAPSHOT_SPLIT_FLAG = 1;
     private static final int BINLOG_SPLIT_FLAG = 2;
+    private static final int METRIC_SPLIT_FLAG = 3;
 
     private static void writeTableSchemas(
             Map<TableId, TableChange> tableSchemas, DataOutputSerializer out) throws IOException {
@@ -167,7 +168,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
             // serialization
             snapshotSplit.serializedFormCache = result;
             return result;
-        } else {
+        } else if (split.isBinlogSplit()) {
             final MySqlBinlogSplit binlogSplit = split.asBinlogSplit();
             // optimization: the splits lazily cache their own serialized form
             if (binlogSplit.serializedFormCache != null) {
@@ -188,6 +189,15 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
             // optimization: cache the serialized from, so we avoid the byte work during repeated
             // serialization
             binlogSplit.serializedFormCache = result;
+            return result;
+        } else {
+            final MysqlMetricSplit mysqlMetricSplit = split.asMetricSplit();
+            final DataOutputSerializer out = SERIALIZER_CACHE.get();
+            out.writeInt(METRIC_SPLIT_FLAG);
+            out.writeLong(mysqlMetricSplit.getNumBytesIn());
+            out.writeLong(mysqlMetricSplit.getNumRecordsIn());
+            final byte[] result = out.getCopyOfBuffer();
+            out.clear();
             return result;
         }
     }
@@ -255,6 +265,10 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
                     tableChangeMap,
                     totalFinishedSplitSize,
                     isSuspended);
+        } else if (splitKind == METRIC_SPLIT_FLAG) {
+            long numBytesIn = in.readLong();
+            long numRecordsIn = in.readLong();
+            return new MysqlMetricSplit(numBytesIn, numRecordsIn);
         } else {
             throw new IOException("Unknown split kind: " + splitKind);
         }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplitSerializer.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSplitSerializer.java
@@ -191,7 +191,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
             binlogSplit.serializedFormCache = result;
             return result;
         } else {
-            final MysqlMetricSplit mysqlMetricSplit = split.asMetricSplit();
+            final MySqlMetricSplit mysqlMetricSplit = split.asMetricSplit();
             final DataOutputSerializer out = SERIALIZER_CACHE.get();
             out.writeInt(METRIC_SPLIT_FLAG);
             out.writeLong(mysqlMetricSplit.getNumBytesIn());
@@ -268,7 +268,7 @@ public final class MySqlSplitSerializer implements SimpleVersionedSerializer<MyS
         } else if (splitKind == METRIC_SPLIT_FLAG) {
             long numBytesIn = in.readLong();
             long numRecordsIn = in.readLong();
-            return new MysqlMetricSplit(numBytesIn, numRecordsIn);
+            return new MySqlMetricSplit(numBytesIn, numRecordsIn);
         } else {
             throw new IOException("Unknown split kind: " + splitKind);
         }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MysqlMetricSplit.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MysqlMetricSplit.java
@@ -1,0 +1,75 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mysql.source.split;
+
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges.TableChange;
+
+import java.util.Map;
+
+public class MysqlMetricSplit extends MySqlSplit {
+
+    private Long numRecordsIn = 0L;
+
+    private Long numBytesIn = 0L;
+
+    public Long getNumRecordsIn() {
+        return numRecordsIn;
+    }
+
+    public void setNumRecordsIn(Long numRecordsIn) {
+        this.numRecordsIn = numRecordsIn;
+    }
+
+    public Long getNumBytesIn() {
+        return numBytesIn;
+    }
+
+    public void setNumBytesIn(Long numBytesIn) {
+        this.numBytesIn = numBytesIn;
+    }
+
+    public MysqlMetricSplit(String splitId) {
+        super(splitId);
+    }
+
+    public MysqlMetricSplit(Long numBytesIn, Long numRecordsIn) {
+        this("");
+        this.numBytesIn = numBytesIn;
+        this.numRecordsIn = numRecordsIn;
+    }
+
+    public void setMetricData(long count, long byteNum) {
+        numRecordsIn = numRecordsIn + count;
+        numBytesIn = numBytesIn + byteNum;
+    }
+
+    @Override
+    public Map<TableId, TableChange> getTableSchemas() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "MysqlMetricSplit{"
+                + "numRecordsIn=" + numRecordsIn
+                + ", numBytesIn=" + numBytesIn
+                + '}';
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-6318][Sort] Mysql connector support metric state snapshot and restore

- Fixes #6318 

### Motivation

* Mysql connector support metric state snapshot and restore

Mysql connector use the `SourceFunction` and the new [Source](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface) to read data.

We can use `CheckpointedFunction` to support metric state snapshot and restore when we use `SourceFunction`.

But We can't use `CheckpointedFunction` when use the new [Source](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface). 

So we address this problem by adding a `MySqlMetricSplit` to support metric state snapshot and restore.

### Modifications

* Add `MysqlMetricSplit` to support metric state snapshot and restore
* Modify `DebeziumSourceFunction` to support metric state snapshot and restore
