### PR TITLE
[INLONG-6322][Sort] Fix write data incorrect for doris connector with sink multiple scenario

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -295,7 +295,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             }
         }
         if (!errorTables.isEmpty()) {
-            // Clean the key that has erros
+            // Clean the key that has errors
             errorTables.forEach(batchMap::remove);
         }
         batchBytes = 0;

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -137,10 +137,8 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             this.scheduler = new ScheduledThreadPoolExecutor(1,
                     new ExecutorThreadFactory("doris-streamload-output-format"));
             this.scheduledFuture = this.scheduler.scheduleWithFixedDelay(() -> {
-                synchronized (DorisDynamicSchemaOutputFormat.this) {
-                    if (!closed && !flushing) {
-                        flush();
-                    }
+                if (!closed && !flushing) {
+                    flush();
                 }
             }, executionOptions.getBatchIntervalMs(), executionOptions.getBatchIntervalMs(), TimeUnit.MILLISECONDS);
         }
@@ -267,6 +265,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     public synchronized void flush() {
         flushing = true;
         if (batchMap.isEmpty()) {
+            flushing = false;
             return;
         }
         List<String> errorTables = new ArrayList<>();

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -264,7 +264,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     @SuppressWarnings({"rawtypes"})
     public synchronized void flush() {
         flushing = true;
-        if (batchMap.isEmpty()) {
+        if (!hasRecords()) {
             flushing = false;
             return;
         }
@@ -303,6 +303,21 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         LOG.info("Doris sink statistics: readInNum: {}, writeOutNum: {}, errorNum: {}, ddlNum: {}",
                 readInNum.get(), writeOutNum.get(), errorNum.get(), ddlNum.get());
         flushing = false;
+    }
+
+    @SuppressWarnings("rawtypes")
+    private boolean hasRecords() {
+        if (batchMap.isEmpty()) {
+            return false;
+        }
+        boolean hasRecords = false;
+        for (List value : batchMap.values()) {
+            if (!value.isEmpty()) {
+                hasRecords = true;
+                break;
+            }
+        }
+        return hasRecords;
     }
 
     private void load(String tableIdentifier, String result) throws IOException {


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

Title: [INLONG-6322][Sort] Fix write data incorrect for doris connector with sink multiple scenario

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

Fixes #6322 

### Motivation

Fix write data incorrect for doris connector with sink multiple scenario

### Modifications

Update DorisDynamicSchemaOutputFormat to fix it.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
