### PR TITLE
[INLONG-6335][Sort] Support the blob and binary data of MySql all migrate

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -51,9 +51,9 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.nio.ByteBuffer;
 
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -599,6 +599,11 @@ public final class RowDataDebeziumDeserializeSchema
                         // normal type doesn't have schema name
                         // schema names are time schemas
                         fieldValue = getTimeValue(fieldValue, schemaName);
+                    }
+                    if (fieldValue instanceof ByteBuffer) {
+                        // binary data (blob or varbinary in mysql) are stored in bytebuffer
+                        // use utf-8 to decode as a string by default
+                        fieldValue = new String(((ByteBuffer) fieldValue).array());
                     }
                     data.put(fieldName, fieldValue);
                 }


### PR DESCRIPTION
- Fixes #6335 

### Motivation

support blob and binary data from mysql
binary data are supported using nio bytebuffer, we use utf-8 to decode as string

### Modifications

binary data are supported using nio bytebuffer, we use utf-8 to decode as string

### Verifying this change

run allmigratetest