### PR TITLE
[INLONG-5628][Sort] Add buffer limit for dispatch queue of the sink

### DIFF
--- a/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
+++ b/inlong-sort-standalone/sort-standalone-common/src/main/java/org/apache/inlong/sort/standalone/utils/FlumeConfigGenerator.java
@@ -34,6 +34,8 @@ public class FlumeConfigGenerator {
     public static final String KEY_SORT_SINK_TYPE = "sortSink.type";
     public static final String KEY_SORT_SOURCE_TYPE = "sortSource.type";
     public static final String KEY_SORT_INTERCEPTOR_TYPE = "interceptor.type";
+    public static final String DEFAULT_SORT_INTERCEPTOR_TYPE 
+        = "org.apache.inlong.sort.standalone.rollback.TimeBasedFilterInterceptor$Builder";
     public static final String KEY_ROLLBACK_START_TIME = "rollback.startTime";
     public static final String KEY_ROLLBACK_STOP_TIME = "rollback.stopTime";
 
@@ -138,8 +140,7 @@ public class FlumeConfigGenerator {
      */
     private static void appendSources(
             Map<String, String> flumeConf,
-            String name, Map<String,
-            String> sinkParams) {
+            String name, Map<String, String> sinkParams) {
         // sources
         String sourceName = name + "Source";
         flumeConf.put(name + ".sources", sourceName);
@@ -169,8 +170,8 @@ public class FlumeConfigGenerator {
         builder.setLength(0);
         String interceptorType = builder.append(prefix).append("interceptors.").append(interceptorName)
                 .append(".type").toString();
-        Optional.ofNullable(CommonPropertiesHolder.getString(KEY_SORT_INTERCEPTOR_TYPE))
-                .map(type -> flumeConf.put(interceptorType, type));
+        flumeConf.put(interceptorType,
+                CommonPropertiesHolder.getString(KEY_SORT_INTERCEPTOR_TYPE, DEFAULT_SORT_INTERCEPTOR_TYPE));
         builder.setLength(0);
         String startTimeKey = builder.append(prefix).append("interceptors.").append(interceptorName).append(".")
                 .append(KEY_ROLLBACK_START_TIME).toString();

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/SinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/SinkContext.java
@@ -17,11 +17,6 @@
 
 package org.apache.inlong.sort.standalone.sink;
 
-import java.util.Date;
-import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
@@ -32,8 +27,14 @@ import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItemSet;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 import org.slf4j.Logger;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * 
@@ -47,6 +48,8 @@ public class SinkContext {
     public static final String KEY_PROCESSINTERVAL = "processInterval";
     public static final String KEY_RELOADINTERVAL = "reloadInterval";
     public static final String KEY_TASK_NAME = "taskName";
+    public static final String KEY_MAX_BUFFERQUEUE_SIZE_KB = "maxBufferQueueSizeKb";
+    public static final int DEFAULT_MAX_BUFFERQUEUE_SIZE_KB = 128 * 1024;
 
     protected final String clusterId;
     protected final String taskName;
@@ -236,5 +239,16 @@ public class SinkContext {
         inlongStreamId = (StringUtils.isBlank(inlongStreamId)) ? "-" : inlongStreamId;
         dimensions.put(SortMetricItem.KEY_INLONG_GROUP_ID, inlongGroupId);
         dimensions.put(SortMetricItem.KEY_INLONG_STREAM_ID, inlongStreamId);
+    }
+
+    /**
+     * createBufferQueue
+     * @return
+     */
+    public static <U> BufferQueue<U> createBufferQueue() {
+        int maxBufferQueueSizeKb = CommonPropertiesHolder.getInteger(KEY_MAX_BUFFERQUEUE_SIZE_KB,
+                DEFAULT_MAX_BUFFERQUEUE_SIZE_KB);
+        BufferQueue<U> dispatchQueue = new BufferQueue<>(maxBufferQueueSizeKb);
+        return dispatchQueue;
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsCallbackListener.java
@@ -87,6 +87,7 @@ public class EsCallbackListener implements BulkProcessor.Listener {
                 context.backDispatchQueue(requestItem);
             } else {
                 context.addSendResultMetric(event, context.getTaskName(), true, sendTime);
+                context.releaseDispatchQueue(requestItem);
                 event.ack();
             }
         }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
@@ -201,7 +201,7 @@ public class EsOutputChannel extends Thread {
                 return;
             }
             // get indexRequest
-            indexRequest = context.taskDispatchQueue();
+            indexRequest = context.takeDispatchQueue();
             if (indexRequest == null) {
                 Thread.sleep(context.getProcessInterval());
                 return;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSink.java
@@ -17,16 +17,17 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.flume.Context;
 import org.apache.flume.EventDeliveryException;
 import org.apache.flume.conf.Configurable;
 import org.apache.flume.sink.AbstractSink;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * EsSink
@@ -36,7 +37,7 @@ public class EsSink extends AbstractSink implements Configurable {
     public static final Logger LOG = LoggerFactory.getLogger(EsSink.class);
 
     private Context parentContext;
-    private final LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+    private BufferQueue<EsIndexRequest> dispatchQueue;
     private EsSinkContext context;
     // workers
     private List<EsChannelWorker> workers = new ArrayList<>();
@@ -50,6 +51,7 @@ public class EsSink extends AbstractSink implements Configurable {
     public void start() {
         super.start();
         try {
+            this.dispatchQueue = SinkContext.createBufferQueue();
             this.context = new EsSinkContext(getName(), parentContext, getChannel(), dispatchQueue);
             this.context.start();
             for (int i = 0; i < context.getMaxThreads(); i++) {

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/SortSdkSource.java
@@ -238,8 +238,9 @@ public final class SortSdkSource extends AbstractSource
      * @return Map
      */
     private Map<String, String> getSortClientConfigParameters() {
+        Map<String, String> sortSdkParams = new HashMap<>();
         Map<String, String> commonParams = CommonPropertiesHolder.getContext().getSubProperties(SORT_SDK_PREFIX);
-        Map<String, String> sortSdkParams = new HashMap<>(commonParams);
+        sortSdkParams.putAll(commonParams);
         SortTaskConfig taskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
         if (taskConfig != null) {
             Map<String, String> sinkParams = taskConfig.getSinkParams();

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestDefaultEvent2IndexRequestHandler.java
@@ -17,17 +17,17 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * 
@@ -45,7 +45,7 @@ public class TestDefaultEvent2IndexRequestHandler {
      */
     @Test
     public void test() throws Exception {
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
         ProfileEvent event = TestEsSinkContext.mockProfileEvent();
         String uid = event.getUid();

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsCallbackListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsCallbackListener.java
@@ -17,10 +17,10 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -46,7 +46,7 @@ public class TestEsCallbackListener {
 
     @Before
     public void before() throws Exception {
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         this.context = TestEsSinkContext.mock(dispatchQueue);
     }
 
@@ -74,7 +74,7 @@ public class TestEsCallbackListener {
     @Test
     public void testAfterSuccessBulk() throws Exception {
         // prepare
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
         ProfileEvent event = TestEsSinkContext.mockProfileEvent();
         EsIndexRequest indexRequest = context.createIndexRequestHandler().parse(context, event);

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsChannelWorker.java
@@ -17,11 +17,11 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.flume.Transaction;
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,7 +47,7 @@ public class TestEsChannelWorker {
      */
     @Before
     public void before() throws Exception {
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         this.context = TestEsSinkContext.mock(dispatchQueue);
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsOutputChannel.java
@@ -17,12 +17,10 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import static org.mockito.ArgumentMatchers.any;
-
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
@@ -41,6 +39,8 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * 
@@ -109,12 +109,12 @@ public class TestEsOutputChannel {
      */
     @Test
     public void test() throws Exception {
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         EsSinkContext context = TestEsSinkContext.mock(dispatchQueue);
         EsOutputChannel output = new EsOutputChannel(context);
         ProfileEvent event = TestEsSinkContext.mockProfileEvent();
         EsIndexRequest indexRequest = context.createIndexRequestHandler().parse(context, event);
-        dispatchQueue.add(indexRequest);
+        dispatchQueue.offer(indexRequest);
         output.init();
         output.send();
         output.close();

--- a/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/test/java/org/apache/inlong/sort/standalone/sink/elasticsearch/TestEsSinkContext.java
@@ -17,20 +17,14 @@
 
 package org.apache.inlong.sort.standalone.sink.elasticsearch;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-
-import java.nio.charset.Charset;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.LinkedBlockingQueue;
-
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.inlong.common.metric.MetricRegister;
 import org.apache.inlong.sort.standalone.channel.BufferQueueChannel;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
 import org.apache.inlong.sort.standalone.utils.Constants;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,6 +32,13 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 
 /**
  * 
@@ -59,7 +60,7 @@ public class TestEsSinkContext {
      * @return EsSinkContext
      * @throws Exception exception
      */
-    public static EsSinkContext mock(LinkedBlockingQueue<EsIndexRequest> dispatchQueue) throws Exception {
+    public static EsSinkContext mock(BufferQueue<EsIndexRequest> dispatchQueue) throws Exception {
         PowerMockito.mockStatic(MetricRegister.class);
         PowerMockito.doNothing().when(MetricRegister.class, "register", any());
         Context context = CommonPropertiesHolder.getContext();
@@ -105,7 +106,7 @@ public class TestEsSinkContext {
      */
     @Test
     public void test() throws Exception {
-        LinkedBlockingQueue<EsIndexRequest> dispatchQueue = new LinkedBlockingQueue<>();
+        BufferQueue<EsIndexRequest> dispatchQueue = SinkContext.createBufferQueue();
         EsSinkContext context = mock(dispatchQueue);
         assertEquals(10, context.getBulkSizeMb());
     }


### PR DESCRIPTION
- Title: [INLONG-5628][SortStandalone] Add buffer limit of sink dispatch queue
- Fixes #5628 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
