### PR TITLE
[INLONG-6387][Manager] Adapt auto-push source status and fix source field update

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
@@ -80,11 +80,6 @@ public class StreamSinkServiceImpl implements StreamSinkService {
     private StreamSinkEntityMapper sinkMapper;
     @Autowired
     private StreamSinkFieldEntityMapper sinkFieldMapper;
-    @Autowired
-    private AutowireCapableBeanFactory autowireCapableBeanFactory;
-
-    // To avoid circular dependencies, you cannot use @Autowired, it will be injected by AutowireCapableBeanFactory
-    private InlongStreamProcessService streamProcessOperation;
 
     @Override
     @Transactional(rollbackFor = Throwable.class)
@@ -244,7 +239,7 @@ public class StreamSinkServiceImpl implements StreamSinkService {
         }
         StreamSinkOperator sinkOperator = operatorFactory.getInstance(request.getSinkType());
         sinkOperator.updateOpt(request, nextStatus, operator);
-        
+
         LOGGER.info("success to update sink by id: {}", request);
         return true;
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
@@ -47,11 +47,9 @@ import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.service.group.GroupCheckService;
-import org.apache.inlong.manager.service.stream.InlongStreamProcessService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/StreamSinkServiceImpl.java
@@ -125,15 +125,6 @@ public class StreamSinkServiceImpl implements StreamSinkService {
             sinkEntity.setStatus(nextStatus.getCode());
             sinkMapper.updateStatus(sinkEntity);
         }
-        // If the stream is [CONFIG_SUCCESSFUL], then asynchronously start the [CREATE_STREAM_RESOURCE] process
-        if (streamSuccess) {
-            // To work around the circular reference check we manually instantiate and wire
-            if (streamProcessOperation == null) {
-                streamProcessOperation = new InlongStreamProcessService();
-                autowireCapableBeanFactory.autowireBean(streamProcessOperation);
-            }
-            streamProcessOperation.startProcess(groupId, streamId, operator, false);
-        }
         LOGGER.info("success to save sink info: {}", request);
         return id;
     }
@@ -253,16 +244,7 @@ public class StreamSinkServiceImpl implements StreamSinkService {
         }
         StreamSinkOperator sinkOperator = operatorFactory.getInstance(request.getSinkType());
         sinkOperator.updateOpt(request, nextStatus, operator);
-
-        // If the stream is [CONFIG_SUCCESSFUL], then asynchronously start the [CREATE_STREAM_RESOURCE] process
-        if (streamSuccess) {
-            // To work around the circular reference check we manually instantiate and wire
-            if (streamProcessOperation == null) {
-                streamProcessOperation = new InlongStreamProcessService();
-                autowireCapableBeanFactory.autowireBean(streamProcessOperation);
-            }
-            streamProcessOperation.startProcess(groupId, streamId, operator, false);
-        }
+        
         LOGGER.info("success to update sink by id: {}", request);
         return true;
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
@@ -28,8 +28,10 @@ import org.apache.inlong.manager.common.enums.SourceStatus;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.InlongStreamFieldEntity;
 import org.apache.inlong.manager.dao.entity.StreamSourceEntity;
 import org.apache.inlong.manager.dao.entity.StreamSourceFieldEntity;
+import org.apache.inlong.manager.dao.mapper.InlongStreamFieldEntityMapper;
 import org.apache.inlong.manager.dao.mapper.StreamSourceEntityMapper;
 import org.apache.inlong.manager.dao.mapper.StreamSourceFieldEntityMapper;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -58,6 +60,8 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
     protected StreamSourceEntityMapper sourceMapper;
     @Autowired
     protected StreamSourceFieldEntityMapper sourceFieldMapper;
+    @Autowired
+    protected InlongStreamFieldEntityMapper streamFieldMapper;
 
     /**
      * Getting the source type.
@@ -121,7 +125,7 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
         Preconditions.checkNotNull(entity, ErrorCodeEnum.SOURCE_INFO_NOT_FOUND.getMessage());
 
         if (SourceType.AUTO_PUSH.equals(entity.getSourceType())) {
-            LOGGER.warn("auto push source {} can not be updated", entity.getSourceName());
+            updateFieldOpt(entity, request.getFieldList());
             return;
         }
 
@@ -238,12 +242,32 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
             return;
         }
 
-        // First physically delete the existing fields
+        // Stream source fields
         sourceFieldMapper.deleteAll(sourceId);
-        // Then batch save the source fields
         this.saveFieldOpt(entity, fieldInfos);
 
+        // InLong stream fields
+        String groupId = entity.getInlongGroupId();
+        String streamId = entity.getInlongStreamId();
+        streamFieldMapper.deleteAllByIdentifier(groupId, streamId);
+        saveStreamField(groupId, streamId, fieldInfos);
+
         LOGGER.info("success to update source fields");
+    }
+
+    void saveStreamField(String groupId, String streamId, List<StreamField> infoList) {
+        if (CollectionUtils.isEmpty(infoList)) {
+            return;
+        }
+        infoList.forEach(streamField -> streamField.setId(null));
+        List<InlongStreamFieldEntity> list = CommonBeanUtils.copyListProperties(infoList,
+                InlongStreamFieldEntity::new);
+        for (InlongStreamFieldEntity entity : list) {
+            entity.setInlongGroupId(groupId);
+            entity.setInlongStreamId(streamId);
+            entity.setIsDeleted(InlongConstants.UN_DELETED);
+        }
+        streamFieldMapper.insertAll(list);
     }
 
     private void saveFieldOpt(StreamSourceEntity entity, List<StreamField> fieldInfos) {


### PR DESCRIPTION
- Fixes #6387 

### Motivation
- The auto push source type can be in status that does not make sense, for example, TO_BE_ISSUED_FROZEN.
- The auto push source fields are not correctly updated.
- Other adaptation issue.

### Modification
- Replace all temporary status with end status for auto push source type.
- Correctly update stream source fields and inlong stream fields.
- Remove stream operation on sink update (**open for discussion**)
     _So what's the appropriate time to restart after config updates ? Perhaps it's better be launched by end user in a separate call. According to the Single Responsibility Principle the service update handler should only perform no other than config updating._
