### PR TITLE
[INLONG-6395][Manager] Fix wrong annotation in InlongStreamApi delete method

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
@@ -64,5 +64,5 @@ public interface InlongStreamApi {
     Call<Response<Boolean>> deleteProcess(@Path("groupId") String groupId, @Path("streamId") String streamId);
 
     @DELETE("stream/delete")
-    Call<Response<Boolean>> delete(@Path("groupId") String groupId, @Path("streamId") String streamId);
+    Call<Response<Boolean>> delete(@Query("groupId") String groupId, @Query("streamId") String streamId);
 }


### PR DESCRIPTION


### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6395 

### Motivation

Before `Call<Response<Boolean>> delete(@Path("groupId") String groupId, @Path("streamId") String streamId);`

Should be `Call<Response<Boolean>> delete(@Query("groupId") String groupId, @Query("streamId") String streamId);
`
### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
