### PR TITLE
[INLONG-6401][Sort] Schema update stuck in dead loop cause stackoverflow in multiple sink scences

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -229,10 +229,12 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         Transaction transaction = table.newTransaction();
         if (table.schema().sameSchema(oldSchema)) {
             List<TableChange> tableChanges = SchemaChangeUtils.diffSchema(oldSchema, newSchema);
-            if (canHandleWithSchemaUpdatePolicy(tableId, tableChanges)) {
-                SchemaChangeUtils.applySchemaChanges(transaction.updateSchema(), tableChanges);
-                LOG.info("Schema evolution in table({}) for table change: {}", tableId, tableChanges);
+            if (!canHandleWithSchemaUpdatePolicy(tableId, tableChanges)) {
+                // If can not handle this schema update, should not push data into next operator
+                return;
             }
+            SchemaChangeUtils.applySchemaChanges(transaction.updateSchema(), tableChanges);
+            LOG.info("Schema evolution in table({}) for table change: {}", tableId, tableChanges);
         }
         transaction.commitTransaction();
         handleSchemaInfoEvent(tableId, table.schema());
@@ -270,22 +272,20 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
     private boolean canHandleWithSchemaUpdatePolicy(TableIdentifier tableId, List<TableChange> tableChanges) {
         boolean canHandle = true;
         for (TableChange tableChange : tableChanges) {
-            if (tableChange instanceof AddColumn) {
-                canHandle &= MultipleSinkOption.canHandleWithSchemaUpdate(tableId.toString(), tableChange,
-                        multipleSinkOption.getSchemaUpdatePolicy());
-            } else {
-                if (MultipleSinkOption.canHandleWithSchemaUpdate(tableId.toString(), tableChange,
-                        multipleSinkOption.getSchemaUpdatePolicy())) {
-                    LOG.info("Ignore table {} schema change: {} because iceberg can't handle it.",
-                            tableId, tableChange);
-                }
+            canHandle &= MultipleSinkOption.canHandleWithSchemaUpdate(tableId.toString(), tableChange,
+                    multipleSinkOption.getSchemaUpdatePolicy());
+            if (!(tableChange instanceof AddColumn)) {
                 // todo:currently iceberg can only handle addColumn, so always return false
+                LOG.info("Ignore table {} schema change: {} because iceberg can't handle it.",
+                        tableId, tableChange);
                 canHandle = false;
             }
+            if (!canHandle) {
+                blacklist.add(tableId);
+                break;
+            }
         }
-        if (!canHandle) {
-            blacklist.add(tableId);
-        }
+
         return canHandle;
     }
 }


### PR DESCRIPTION
[INLONG-6401][Sort] Bugfix:Schema update stuck in dead loop cause stackoverflow in multiple sink scences

### Prepare a Pull Request
- [INLONG-6401][Sort] Bugfix:Schema update stuck in dead loop cause stackoverflow in multiple sink scences
- Fixes #6401

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve*

### Modifications

*If can not handle this schema update, should not push data into next operator, just break the dead loop*

