### PR TITLE
[INLONG-6426][Manager] SortSourceService support multi stream under one group

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
@@ -289,7 +289,8 @@
         select
                inlong_group_id,
                inlong_stream_id,
-               mq_resource
+               mq_resource,
+               ext_params
         from inlong_stream
         where is_deleted = 0
     </select>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSinkEntityMapper.xml
@@ -372,6 +372,7 @@
         select inlong_cluster_name as sortClusterName,
                sort_task_name,
                inlong_group_id     as groupId,
+               inlong_stream_id    as streamId,
                ext_params
         from stream_sink
         where is_deleted = 0

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/standalone/SortSourceStreamInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/standalone/SortSourceStreamInfo.java
@@ -17,11 +17,34 @@
 
 package org.apache.inlong.manager.pojo.sort.standalone;
 
+import com.google.gson.Gson;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Data
 public class SortSourceStreamInfo {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SortSourceStreamInfo.class);
+    private static final Gson GSON = new Gson();
+
     private String inlongGroupId;
     private String inlongStreamId;
     private String mqResource;
+    String extParams;
+    Map<String, String> extParamsMap = new ConcurrentHashMap<>();
+
+    public Map<String, String> getExtParamsMap() {
+        if (extParamsMap.isEmpty() && StringUtils.isNotBlank(extParams)) {
+            try {
+                extParamsMap = GSON.fromJson(extParams, Map.class);
+            } catch (Throwable t) {
+                LOGGER.error("fail to parse group ext params", t);
+            }
+        }
+        return extParamsMap;
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/standalone/SortSourceStreamSinkInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/standalone/SortSourceStreamSinkInfo.java
@@ -35,6 +35,7 @@ public class SortSourceStreamSinkInfo {
     String sortClusterName;
     String sortTaskName;
     String groupId;
+    String streamId;
     String extParams;
     Map<String, String> extParamsMap;
 

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
@@ -69,10 +69,12 @@ public class SortServiceImplTest extends ServiceBaseTest {
     private static final String TEST_CLUSTER = "testCluster";
     private static final String TEST_TASK = "testTask";
     private static final String TEST_GROUP = "testGroup";
-    private static final String TEST_STREAM = "1";
+    private static final String TEST_STREAM_1 = "1";
+    private static final String TEST_STREAM_2 = "2";
     private static final String TEST_TAG = "testTag";
     private static final String BACK_UP_TAG = "testBackupTag";
-    private static final String TEST_TOPIC = "testTopic";
+    private static final String TEST_TOPIC_1 = "testTopic";
+    private static final String TEST_TOPIC_2 = "testTopic2";
     private static final String TEST_SINK_TYPE = "testSinkType";
     private static final String TEST_CREATOR = "testUser";
 
@@ -204,11 +206,13 @@ public class SortServiceImplTest extends ServiceBaseTest {
     private void prepareAll() {
         this.prepareCluster(TEST_CLUSTER);
         this.preparePulsar("testPulsar", true, TEST_TAG);
-        this.preparePulsar("testPulsar2", true, BACK_UP_TAG);
+        this.preparePulsar("backupPulsar", true, BACK_UP_TAG);
         this.prepareDataNode(TEST_TASK);
         this.prepareGroupId(TEST_GROUP);
-        this.prepareStreamId(TEST_GROUP, TEST_STREAM);
-        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER);
+        this.prepareStreamId(TEST_GROUP, TEST_STREAM_1, TEST_TOPIC_1);
+        this.prepareStreamId(TEST_GROUP, TEST_STREAM_2, TEST_TOPIC_2);
+        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER, TEST_STREAM_1);
+        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER, TEST_STREAM_2);
     }
 
     private void prepareDataNode(String taskName) {
@@ -255,12 +259,12 @@ public class SortServiceImplTest extends ServiceBaseTest {
         groupService.save(request, "test operator");
     }
 
-    private void prepareStreamId(String groupId, String streamId) {
+    private void prepareStreamId(String groupId, String streamId, String topic) {
         InlongStreamRequest request = new InlongStreamRequest();
         request.setInlongGroupId(groupId);
         request.setInlongStreamId(streamId);
         request.setName("test_stream_name");
-        request.setMqResource(TEST_TOPIC);
+        request.setMqResource(topic);
         request.setVersion(InlongConstants.INITIAL_VERSION);
         List<InlongStreamExtInfo> extInfos = new ArrayList<>();
         InlongStreamExtInfo ext = new InlongStreamExtInfo();
@@ -268,7 +272,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
         ext.setInlongStreamId(streamId);
         ext.setInlongGroupId(groupId);
         ext.setKeyName(ClusterSwitch.BACKUP_MQ_RESOURCE);
-        ext.setKeyValue("backup_topic");
+        ext.setKeyValue("backup_" + topic);
         request.setExtList(extInfos);
         streamService.save(request, "test_operator");
     }
@@ -305,7 +309,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
         clusterService.save(request, "test operator");
     }
 
-    private void prepareTask(String taskName, String groupId, String clusterName) {
+    private void prepareTask(String taskName, String groupId, String clusterName, String streamId) {
         SinkRequest request = new HiveSinkRequest();
         request.setDataNodeName(taskName);
         request.setSinkType(SinkType.HIVE);
@@ -313,7 +317,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
         request.setSinkName(taskName);
         request.setSortTaskName(taskName);
         request.setInlongGroupId(groupId);
-        request.setInlongStreamId("1");
+        request.setInlongStreamId(streamId);
         Map<String, Object> properties = new HashMap<>();
         properties.put("delimiter", "|");
         properties.put("dataType", "text");


### PR DESCRIPTION
- Fixes #6426

### Motivation

The old version of **_SortSourceService_**  only support one stream under one group.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*
- [ ] This change is already covered by existing tests, such as:
SortServiceImplTest


### Documentation

  - Does this pull request introduce a new feature? yes 
  - If yes, how is the feature documented? JavaDocs
