### PR TITLE
[INLONG-6430][Release] Add the 1.4.0 version option for the bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -76,10 +76,10 @@ body:
       multiple: false
       options:
         - 'master'
+        - '1.4.0'
         - '1.3.0'
         - '1.2.0'
         - '1.1.0'
-        - '1.0.0'
     validations:
       required: true
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6430

### Motivation

1.0.0 is not maintained, so remove it, and add the forward 1.4.0.

