### PR TITLE
[INLONG-6440][Manager] Fix heart beat information error for ip

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
@@ -153,6 +153,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
 
         // protocolType may be null, and the protocolTypes' length may be less than ports' length
         String[] ports = heartbeat.getPort().split(InlongConstants.COMMA);
+        String[] ips = heartbeat.getIp().split(InlongConstants.COMMA);
         String protocolType = heartbeat.getProtocolType();
         String[] protocolTypes = null;
         if (StringUtils.isNotBlank(protocolType) && ports.length > 1) {
@@ -167,6 +168,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
             HeartbeatMsg heartbeatMsg = JsonUtils.parseObject(JsonUtils.toJsonByte(heartbeat), HeartbeatMsg.class);
             assert heartbeatMsg != null;
             heartbeatMsg.setPort(ports[i].trim());
+            heartbeatMsg.setIp(ips[i].trim());
             if (protocolTypes != null) {
                 heartbeatMsg.setProtocolType(protocolTypes[i]);
             } else {


### PR DESCRIPTION
Manager splits ips is error.
Fix heart beat information error for ip.

- Fixes #6440 

### Motivation

Heartbeat information is error.

### Modifications

Add ips information.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
