### PR TITLE
[INLONG-6463][Manager] Support create subscription and topic of multiple pulsar cluster

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarResourceOperator.java
@@ -88,7 +88,7 @@ public class PulsarResourceOperator implements QueueResourceOperator {
                 clusterService.listByTagAndType(clusterTag, ClusterType.PULSAR).stream()
                         .map(clusterInfo -> (PulsarClusterInfo) clusterInfo)
                         .collect(Collectors.toList());
-        for(PulsarClusterInfo pulsarCluster : pulsarClusters) {
+        for (PulsarClusterInfo pulsarCluster : pulsarClusters) {
             try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
                 String clusterName = pulsarCluster.getName();
                 // create pulsar tenant and namespace
@@ -118,7 +118,8 @@ public class PulsarResourceOperator implements QueueResourceOperator {
                 // create pulsar topic and subscription
                 for (InlongStreamBriefInfo stream : streamInfoList) {
                     this.createTopic(pulsarInfo, pulsarCluster, stream.getMqResource());
-                    this.createSubscription(pulsarInfo, pulsarCluster, stream.getMqResource(), stream.getInlongStreamId());
+                    this.createSubscription(pulsarInfo, pulsarCluster, stream.getMqResource(),
+                            stream.getInlongStreamId());
                 }
             } catch (Exception e) {
                 String msg = String.format("failed to create pulsar resource for groupId=%s, cluster=%s", groupId,


### PR DESCRIPTION

### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6463 

### Motivation

Manager only create subscription and topic of one related cluster, which will result in consume faliure of sort-flink

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
