### PR TITLE
[INLONG-6507][Sort] Convert date to timestamp in oracle connector

### DIFF
--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -760,33 +760,18 @@ public final class RowDataDebeziumDeserializeSchema
      * @return the extracted data with schema
      */
     private Object getValueWithSchema(Object fieldValue, String schemaName) {
-        if (fieldValue == null) {
-            return null;
-        }
-        // Remove shaded pattern prefix of package name
-        schemaName = schemaName.replace(shadedPatternPrefix, "");
-        switch (schemaName) {
-            case MicroTime.SCHEMA_NAME:
-                Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
-                fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, serverTimeZone));
-                break;
-            case Date.SCHEMA_NAME:
-                fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));
-                break;
-            case ZonedTimestamp.SCHEMA_NAME:
-                ZonedDateTime zonedDateTime = ZonedDateTime.parse((CharSequence) fieldValue);
-                fieldValue = zonedDateTime.withZoneSameInstant(serverTimeZone).toLocalDateTime()
-                        .atZone(ZONE_UTC).format(DateTimeFormatter.ISO_INSTANT);
-                break;
-            case Timestamp.SCHEMA_NAME:
-                Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
-                fieldValue = LocalDateTime.ofInstant(instantTime, ZONE_UTC).toString();
-                break;
-            case Decimal.LOGICAL_NAME:
-                // no need to transfer decimal type since the value is already decimal
-                break;
-            default:
-                LOG.debug("schema {} is not being supported", schemaName);
+        if (MicroTime.SCHEMA_NAME.equals(schemaName)) {
+            Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
+            fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, serverTimeZone));
+        } else if (Date.SCHEMA_NAME.equals(schemaName)) {
+            fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));
+        } else if (ZonedTimestamp.SCHEMA_NAME.equals(schemaName)) {
+            ZonedDateTime zonedDateTime = ZonedDateTime.parse((CharSequence) fieldValue);
+            fieldValue = zonedDateTime.withZoneSameInstant(serverTimeZone).toLocalDateTime()
+                    .atZone(ZONE_UTC).format(DateTimeFormatter.ISO_INSTANT);
+        } else if (Timestamp.SCHEMA_NAME.equals(schemaName)) {
+            Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
+            fieldValue = LocalDateTime.ofInstant(instantTime, ZONE_UTC).toString();
         }
         return fieldValue;
     }

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -85,8 +85,6 @@ public final class RowDataDebeziumDeserializeSchema
 
     private static final ZoneId ZONE_UTC = ZoneId.of("UTC");
 
-    private static final String shadedPatternPrefix = "org.apache.inlong.sort.cdc.oracle.shaded.";
-
     /**
      * TypeInformation of the produced {@link RowData}. *
      */

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -760,7 +760,7 @@ public final class RowDataDebeziumDeserializeSchema
     private Object getValueWithSchema(Object fieldValue, String schemaName) {
         if (MicroTime.SCHEMA_NAME.equals(schemaName)) {
             Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
-            fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, serverTimeZone));
+            fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, ZONE_UTC));
         } else if (Date.SCHEMA_NAME.equals(schemaName)) {
             fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));
         } else if (ZonedTimestamp.SCHEMA_NAME.equals(schemaName)) {

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -758,6 +758,9 @@ public final class RowDataDebeziumDeserializeSchema
      * @return the extracted data with schema
      */
     private Object getValueWithSchema(Object fieldValue, String schemaName) {
+        if (fieldValue == null) {
+            return null;
+        }
         if (MicroTime.SCHEMA_NAME.equals(schemaName)) {
             Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
             fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, ZONE_UTC));

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -31,7 +31,6 @@ import io.debezium.time.MicroTimestamp;
 import io.debezium.time.NanoTime;
 import io.debezium.time.NanoTimestamp;
 import io.debezium.time.Timestamp;
-import io.debezium.time.ZonedTimestamp;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-6507][Sort] Convert date to timestamp in oracle connector

- Fixes #6507

### Motivation

In debezium, the oracle date type will be read as the int64 type, but the oracle date type mapping is the debezium timestamp type, and the debezium timestamp type is the string format of date-time. So, we need to convert the int64 to the string format of date-time.

### Modifications

When parsing field value, if the field schema is date or timestamp type, we need to convert the filed value from the number of milliseconds to the string format of date-time. The main logic is as follows:

```java
    /**
     * extract the data with the format provided by debezium
     *
     * @param fieldValue
     * @param schemaName
     * @return the extracted data with schema
     */
    private Object getValueWithSchema(Object fieldValue, String schemaName) {
        if (MicroTime.SCHEMA_NAME.equals(schemaName)) {
            Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
            fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, serverTimeZone));
        } else if (Date.SCHEMA_NAME.equals(schemaName)) {
            fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));
        } else if (ZonedTimestamp.SCHEMA_NAME.equals(schemaName)) {
            ZonedDateTime zonedDateTime = ZonedDateTime.parse((CharSequence) fieldValue);
            fieldValue = zonedDateTime.withZoneSameInstant(serverTimeZone).toLocalDateTime()
                    .atZone(ZONE_UTC).format(DateTimeFormatter.ISO_INSTANT);
        } else if (Timestamp.SCHEMA_NAME.equals(schemaName)) {
            Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
            fieldValue = LocalDateTime.ofInstant(instantTime, ZONE_UTC).toString();
        }
        return fieldValue;
    }
```
