### PR TITLE
[INLONG-6510][Docker] Exclude ClickHouse SQL file in audit for docker mode

### DIFF
--- a/inlong-distribution/src/main/assemblies/release.xml
+++ b/inlong-distribution/src/main/assemblies/release.xml
@@ -174,6 +174,9 @@
         <fileSet>
             <directory>../inlong-audit/audit-release/target/apache-inlong-audit-${project.version}-bin/sql</directory>
             <outputDirectory>../docker/docker-compose/sql</outputDirectory>
+            <excludes>
+                <exclude>apache_inlong_audit_clickhouse.sql</exclude>
+            </excludes>
         </fileSet>
         <!-- package sql file for docker compose-->
         <fileSet>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6510

### Motivation
CK sql file do not need Initialize when using docker-compose.
