### PR TITLE
[INLONG-5024][Manager] Improve the delete operation of InlongGroup

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -41,7 +41,8 @@ public enum ErrorCodeEnum {
     GROUP_INFO_INCORRECT(1003, "Group info was incorrect"),
     GROUP_SAVE_FAILED(1003, "Failed to save/update inlong group"),
     GROUP_PERMISSION_DENIED(1004, "No permission to access this inlong group"),
-    GROUP_HAS_STREAM(1005, "There are some valid inlong stream for this inlong group"),
+    GROUP_DELETE_HAS_STREAM(1005, "The inlong group contains inlong streams and is not allowed to be deleted"),
+
     GROUP_UPDATE_NOT_ALLOWED(1006, "The current inlong group status does not support modification"),
     GROUP_DELETE_NOT_ALLOWED(1007, "The current inlong group status does not support deletion"),
     GROUP_ID_UPDATE_NOT_ALLOWED(1008, "The current inlong group status does not support modifying the group id"),
@@ -74,7 +75,7 @@ public enum ErrorCodeEnum {
     STREAM_EXT_SAVE_FAILED(1207, "Failed to save/update inlong stream extension information"),
     STREAM_FIELD_SAVE_FAILED(1208, "Failed to save/update inlong stream field"),
     STREAM_DELETE_HAS_SOURCE(1209, "The inlong stream contains source info and is not allowed to be deleted"),
-    STREAM_DELETE_HAS_SINK(1210, "The inlong stream contains data sink info and is not allowed to be deleted"),
+    STREAM_DELETE_HAS_SINK(1210, "The inlong stream contains sink info and is not allowed to be deleted"),
 
     SOURCE_TYPE_IS_NULL(1300, "Source type is null"),
     SOURCE_TYPE_NOT_SUPPORT(1301, "Source type '%s' not support"),

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -39,18 +39,17 @@ public enum ErrorCodeEnum {
     GROUP_NOT_FOUND(1001, "Inlong group does not exist/no operation authority"),
     GROUP_DUPLICATE(1002, "Inlong group already exists"),
     GROUP_INFO_INCORRECT(1003, "Group info was incorrect"),
-    GROUP_SAVE_FAILED(1003, "Failed to save/update inlong group"),
-    GROUP_PERMISSION_DENIED(1004, "No permission to access this inlong group"),
-    GROUP_DELETE_HAS_STREAM(1005, "The inlong group contains inlong streams and is not allowed to be deleted"),
-
+    GROUP_SAVE_FAILED(1004, "Failed to save/update inlong group"),
+    GROUP_PERMISSION_DENIED(1005, "No permission to access this inlong group"),
     GROUP_UPDATE_NOT_ALLOWED(1006, "The current inlong group status does not support modification"),
     GROUP_DELETE_NOT_ALLOWED(1007, "The current inlong group status does not support deletion"),
-    GROUP_ID_UPDATE_NOT_ALLOWED(1008, "The current inlong group status does not support modifying the group id"),
-    GROUP_MIDDLEWARE_UPDATE_NOT_ALLOWED(1011,
-            "The current inlong group status does not support modifying the MQ type"),
+    GROUP_DELETE_HAS_STREAM(1008, "The inlong group contains inlong streams and is not allowed to be deleted"),
+
+    GROUP_ID_UPDATE_NOT_ALLOWED(1010, "The current status does not support modifying the inlong group id"),
+    GROUP_MIDDLEWARE_UPDATE_NOT_ALLOWED(1011, "The current status does not support modifying the MQ type"),
     GROUP_NAME_UPDATE_NOT_ALLOWED(1012, "The current inlong group status does not support modifying the name"),
     GROUP_INFO_INCONSISTENT(1013, "The inlong group info is inconsistent, please contact the administrator"),
-    GROUP_MODE_UNSUPPORTED(1014, "The current inlong group mode only support lightweight, standard"),
+    GROUP_MODE_UNSUPPORTED(1014, "The current inlong group mode only support lightweight or standard"),
 
     OPT_NOT_ALLOWED_BY_STATUS(1021, "InlongGroup status %s was not allowed to add/update/delete related info"),
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
@@ -46,12 +46,45 @@ public interface InlongGroupService {
     String save(InlongGroupRequest groupInfo, String operator);
 
     /**
+     * Query whether the specified group id exists
+     *
+     * @param groupId the group id to be queried
+     * @return does it exist
+     */
+    Boolean exist(String groupId);
+
+    /**
      * Get inlong group info based on inlong group id
      *
      * @param groupId inlong group id
      * @return detail of inlong group
      */
     InlongGroupInfo get(String groupId);
+
+    /**
+     * Query the group information of each status of the current user
+     *
+     * @param operator name of operator
+     * @return inlong group status statistics
+     */
+    InlongGroupCountResponse countGroupByUser(String operator);
+
+    /**
+     * According to the group id, query the topic to which it belongs
+     *
+     * @param groupId Inlong group id
+     * @return Topic information
+     * @apiNote TubeMQ corresponds to the group, only 1 topic
+     */
+    InlongGroupTopicInfo getTopic(String groupId);
+
+    /**
+     * According to the group id, query the backup topic to which it belongs
+     *
+     * @param groupId inlong group id
+     * @return backup topic info
+     */
+    InlongGroupTopicInfo getBackupTopic(String groupId);
 
     /**
      * Paging query inlong group brief info list
@@ -79,7 +112,16 @@ public interface InlongGroupService {
      * @param operator name of operator
      * @return whether succeed
      */
-    boolean updateStatus(String groupId, Integer status, String operator);
+    Boolean updateStatus(String groupId, Integer status, String operator);
+
+    /**
+     * Check whether deletion is supported for the specified group.
+     *
+     * @param groupId inlong group id
+     * @param operator name of operator
+     * @return inlong group info
+     */
+    InlongGroupInfo doDeleteCheck(String groupId, String operator);
 
     /**
      * Delete the group information of the specified group id
@@ -87,40 +129,9 @@ public interface InlongGroupService {
      * @param groupId The group id that needs to be deleted
      * @param operator name of operator
      * @return whether succeed
+     * @apiNote Before invoking this delete method, you must
      */
-    boolean delete(String groupId, String operator);
-
-    /**
-     * Query whether the specified group id exists
-     *
-     * @param groupId the group id to be queried
-     * @return does it exist
-     */
-    Boolean exist(String groupId);
-
-    /**
-     * Query the group information of each status of the current user
-     *
-     * @param operator name of operator
-     * @return inlong group status statistics
-     */
-    InlongGroupCountResponse countGroupByUser(String operator);
-
-    /**
-     * According to the group id, query the topic to which it belongs
-     *
-     * @param groupId inlong group id
-     * @return topic info
-     */
-    InlongGroupTopicInfo getTopic(String groupId);
-
-    /**
-     * According to the group id, query the backup topic to which it belongs
-     *
-     * @param groupId inlong group id
-     * @return backup topic info
-     */
-    InlongGroupTopicInfo getBackupTopic(String groupId);
+    Boolean delete(String groupId, String operator);
 
     /**
      * Save the group modified when the approval is passed

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupFailedListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupFailedListener.java
@@ -51,6 +51,7 @@ public class UpdateGroupFailedListener implements ProcessEventListener {
 
         // update inlong group status and other info
         String operator = context.getOperator();
+        // delete process failed, then change the group status to [CONFIG_FAILED]
         groupService.updateStatus(groupId, GroupStatus.CONFIG_FAILED.getCode(), operator);
         groupService.update(form.getGroupInfo().genRequest(), operator);
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamService.java
@@ -44,6 +44,15 @@ public interface InlongStreamService {
     Integer save(InlongStreamRequest request, String operator);
 
     /**
+     * Query whether the inlong stream ID exists
+     *
+     * @param groupId inlong group id
+     * @param streamId inlong stream id
+     * @return true: exists, false: does not exist
+     */
+    Boolean exist(String groupId, String streamId);
+
+    /**
      * Query the details of the specified inlong stream
      *
      * @param groupId Inlong group id
@@ -59,15 +68,6 @@ public interface InlongStreamService {
      * @return Inlong stream info list
      */
     List<InlongStreamInfo> list(String groupId);
-
-    /**
-     * Query whether the inlong stream ID exists
-     *
-     * @param groupId inlong group id
-     * @param streamId inlong stream id
-     * @return true: exists, false: does not exist
-     */
-    Boolean exist(String groupId, String streamId);
 
     /**
      * Paging query inlong stream brief info list
@@ -103,7 +103,10 @@ public interface InlongStreamService {
     Boolean update(InlongStreamRequest request, String operator);
 
     /**
-     * Delete the specified inlong stream
+     * Delete the specified inlong stream.
+     * <p/>
+     * When deleting an inlong stream, you need to check whether there are some related
+     * stream_sources or stream_sinks
      *
      * @param groupId Inlong group id
      * @param streamId Inlong stream id

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
@@ -127,6 +127,14 @@ public class InlongStreamServiceImpl implements InlongStreamService {
     }
 
     @Override
+    public Boolean exist(String groupId, String streamId) {
+        Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
+        Preconditions.checkNotNull(groupId, ErrorCodeEnum.STREAM_ID_IS_EMPTY.getMessage());
+        InlongStreamEntity streamEntity = streamMapper.selectByIdentifier(groupId, streamId);
+        return streamEntity != null;
+    }
+
+    @Override
     public InlongStreamInfo get(String groupId, String streamId) {
         LOGGER.debug("begin to get inlong stream by groupId={}, streamId={}", groupId, streamId);
         Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
@@ -181,14 +189,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
             streamInfo.setSourceList(sourceList);
         });
         return streamList;
-    }
-
-    @Override
-    public Boolean exist(String groupId, String streamId) {
-        Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
-        Preconditions.checkNotNull(groupId, ErrorCodeEnum.STREAM_ID_IS_EMPTY.getMessage());
-        InlongStreamEntity streamEntity = streamMapper.selectByIdentifier(groupId, streamId);
-        return streamEntity != null;
     }
 
     /**
@@ -307,7 +307,7 @@ public class InlongStreamServiceImpl implements InlongStreamService {
             throw new BusinessException(ErrorCodeEnum.CONFIG_EXPIRED);
         }
         // Check whether the current inlong group status supports modification
-        this.checkCanUpdate(inlongGroupEntity.getStatus(), streamEntity, request);
+        this.doUpdateCheck(inlongGroupEntity.getStatus(), streamEntity, request);
 
         CommonBeanUtils.copyProperties(request, streamEntity, true);
         streamEntity.setModifier(operator);
@@ -326,8 +326,8 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         return true;
     }
 
-    @Transactional(rollbackFor = Throwable.class)
     @Override
+    @Transactional(rollbackFor = Throwable.class)
     public Boolean delete(String groupId, String streamId, String operator) {
         LOGGER.debug("begin to delete inlong stream, groupId={}, streamId={}", groupId, streamId);
         Preconditions.checkNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
@@ -580,7 +580,7 @@ public class InlongStreamServiceImpl implements InlongStreamService {
      * @param streamEntity Original inlong stream entity
      * @param request New inlong stream information
      */
-    private void checkCanUpdate(Integer groupStatus, InlongStreamEntity streamEntity, InlongStreamRequest request) {
+    private void doUpdateCheck(Integer groupStatus, InlongStreamEntity streamEntity, InlongStreamRequest request) {
         if (streamEntity == null || request == null) {
             return;
         }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -68,34 +68,18 @@ public class InlongGroupController {
         return Response.success(groupService.save(groupRequest, operator));
     }
 
-    @RequestMapping(value = "/group/get/{groupId}", method = RequestMethod.GET)
-    @ApiOperation(value = "Get inlong group")
-    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
-    public Response<InlongGroupInfo> get(@PathVariable String groupId) {
-        return Response.success(groupService.get(groupId));
-    }
-
-    @RequestMapping(value = "/group/list", method = RequestMethod.POST)
-    @ApiOperation(value = "List inlong groups by paginating")
-    public Response<PageResult<InlongGroupBriefInfo>> listBrief(@RequestBody InlongGroupPageRequest request) {
-        request.setCurrentUser(LoginUserUtils.getLoginUser().getName());
-        request.setIsAdminRole(LoginUserUtils.getLoginUser().getRoles().contains(UserTypeEnum.ADMIN.name()));
-        return Response.success(groupService.listBrief(request));
-    }
-
-    @RequestMapping(value = "/group/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
-    @ApiOperation(value = "Update inlong group")
-    public Response<String> update(@Validated(UpdateValidation.class) @RequestBody InlongGroupRequest groupRequest) {
-        String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(groupService.update(groupRequest, operator));
-    }
-
     @RequestMapping(value = "/group/exist/{groupId}", method = RequestMethod.GET)
     @ApiOperation(value = "Is the inlong group id exists")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
     public Response<Boolean> exist(@PathVariable String groupId) {
         return Response.success(groupService.exist(groupId));
+    }
+
+    @RequestMapping(value = "/group/get/{groupId}", method = RequestMethod.GET)
+    @ApiOperation(value = "Get inlong group")
+    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
+    public Response<InlongGroupInfo> get(@PathVariable String groupId) {
+        return Response.success(groupService.get(groupId));
     }
 
     @RequestMapping(value = "/group/countByStatus", method = RequestMethod.GET)
@@ -115,6 +99,40 @@ public class InlongGroupController {
     @ApiOperation(value = "Get backup topic info")
     public Response<InlongGroupTopicInfo> getBackupTopic(@PathVariable String groupId) {
         return Response.success(groupService.getBackupTopic(groupId));
+    }
+
+    @RequestMapping(value = "/group/list", method = RequestMethod.POST)
+    @ApiOperation(value = "List inlong groups by paginating")
+    public Response<PageResult<InlongGroupBriefInfo>> listBrief(@RequestBody InlongGroupPageRequest request) {
+        request.setCurrentUser(LoginUserUtils.getLoginUser().getName());
+        request.setIsAdminRole(LoginUserUtils.getLoginUser().getRoles().contains(UserTypeEnum.ADMIN.name()));
+        return Response.success(groupService.listBrief(request));
+    }
+
+    @RequestMapping(value = "/group/update", method = RequestMethod.POST)
+    @OperationLog(operation = OperationType.UPDATE)
+    @ApiOperation(value = "Update inlong group")
+    public Response<String> update(@Validated(UpdateValidation.class) @RequestBody InlongGroupRequest groupRequest) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(groupService.update(groupRequest, operator));
+    }
+
+    @RequestMapping(value = "/group/delete/{groupId}", method = RequestMethod.DELETE)
+    @ApiOperation(value = "Delete inlong group info")
+    @OperationLog(operation = OperationType.DELETE)
+    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
+    public Response<Boolean> delete(@PathVariable String groupId) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(groupProcessOperation.deleteProcess(groupId, operator));
+    }
+
+    @RequestMapping(value = "/group/deleteAsync/{groupId}", method = RequestMethod.DELETE)
+    @ApiOperation(value = "Delete inlong group info")
+    @OperationLog(operation = OperationType.DELETE)
+    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
+    public Response<String> deleteAsync(@PathVariable String groupId) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(groupProcessOperation.deleteProcessAsync(groupId, operator));
     }
 
     @RequestMapping(value = "/group/startProcess/{groupId}", method = RequestMethod.POST)
@@ -141,15 +159,6 @@ public class InlongGroupController {
         return Response.success(groupProcessOperation.restartProcess(groupId, operator));
     }
 
-    @RequestMapping(value = "/group/delete/{groupId}", method = RequestMethod.DELETE)
-    @ApiOperation(value = "Delete inlong group info")
-    @OperationLog(operation = OperationType.DELETE)
-    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
-    public Response<Boolean> delete(@PathVariable String groupId) {
-        String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(groupProcessOperation.deleteProcess(groupId, operator));
-    }
-
     @RequestMapping(value = "/group/suspendProcessAsync/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Suspend inlong group process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
@@ -164,15 +173,6 @@ public class InlongGroupController {
     public Response<String> restartProcessAsync(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.restartProcessAsync(groupId, operator));
-    }
-
-    @RequestMapping(value = "/group/deleteAsync/{groupId}", method = RequestMethod.DELETE)
-    @ApiOperation(value = "Delete inlong group info")
-    @OperationLog(operation = OperationType.DELETE)
-    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
-    public Response<String> deleteAsync(@PathVariable String groupId) {
-        String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(groupProcessOperation.deleteProcessAsync(groupId, operator));
     }
 
     @PostMapping(value = "/group/reset")


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5024

### Motivation

Improve the delete operation of InlongGroup.

### Modifications

1. Before starting the delete process, check whether the group can be updated.
2. At the end of the delete process, call the delete method to delete the inlong group. 

1. Before starting the delete process (`InlongGroupProcessOperation#deleteProcess`), first call the `InlongGroupServiceImpl#doDeleteCheck` method to check, and then start the process after the check is passed;

2. After the process succeeds, `UpdateGroupCompleteListener` calls the deletion method (`groupService.delete(groupId, operator)`.

### Verifying this change

- [X] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)