### PR TITLE
[INLONG-6529][Sort] Fix microtime time zone error in mysql connector

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -630,7 +630,7 @@ public final class RowDataDebeziumDeserializeSchema
         switch (schemaName) {
             case MicroTime.SCHEMA_NAME:
                 Instant instant = Instant.ofEpochMilli((Long) fieldValue / 1000);
-                fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, serverTimeZone));
+                fieldValue = timeFormatter.format(LocalDateTime.ofInstant(instant, ZONE_UTC));
                 break;
             case Date.SCHEMA_NAME:
                 fieldValue = dateFormatter.format(LocalDate.ofEpochDay((Integer) fieldValue));


### PR DESCRIPTION
- Fixes #6529 

### Motivation

Fix microtime time zone error in mysql connector

### Modifications

The debezium convert micro time to utc, so we need to convert it back using utc time zone 

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
