### PR TITLE
[INLONG-6537][Sort] Fix the decimal type loss of precision during DDL synchronization

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
@@ -75,6 +75,9 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
      */
     private static final Integer FIRST = 0;
 
+    private static final int DEFAULT_DECIMAL_PRECISION = 15;
+    private static final int DEFAULT_DECIMAL_SCALE = 5;
+
     private static final Map<Integer, LogicalType> SQL_TYPE_2_FLINK_TYPE_MAPPING =
             ImmutableMap.<Integer, LogicalType>builder()
                     .put(java.sql.Types.CHAR, new CharType())
@@ -85,8 +88,8 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
                     .put(java.sql.Types.REAL, new FloatType())
                     .put(java.sql.Types.DOUBLE, new DoubleType())
                     .put(java.sql.Types.FLOAT, new FloatType())
-                    .put(java.sql.Types.DECIMAL, new DecimalType())
-                    .put(java.sql.Types.NUMERIC, new DecimalType())
+                    .put(java.sql.Types.DECIMAL, new DecimalType(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE))
+                    .put(java.sql.Types.NUMERIC, new DecimalType(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE))
                     .put(java.sql.Types.BIT, new BooleanType())
                     .put(java.sql.Types.TIME, new TimeType())
                     .put(java.sql.Types.TIMESTAMP_WITH_TIMEZONE, new LocalZonedTimestampType())
@@ -109,8 +112,8 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
                     .put(java.sql.Types.REAL, new FloatType())
                     .put(java.sql.Types.DOUBLE, new DoubleType())
                     .put(java.sql.Types.FLOAT, new FloatType())
-                    .put(java.sql.Types.DECIMAL, new DecimalType())
-                    .put(java.sql.Types.NUMERIC, new DecimalType())
+                    .put(java.sql.Types.DECIMAL, new DecimalType(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE))
+                    .put(java.sql.Types.NUMERIC, new DecimalType(DEFAULT_DECIMAL_PRECISION, DEFAULT_DECIMAL_SCALE))
                     .put(java.sql.Types.BIT, new BooleanType())
                     .put(java.sql.Types.TIME, new VarCharType())
                     .put(java.sql.Types.TIMESTAMP_WITH_TIMEZONE, new LocalZonedTimestampType())


### PR DESCRIPTION
[INLONG-6537][Sort] Fix During DDL synchronization 'decimal' type loss of precision

### Prepare a Pull Request
- Title Example: [INLONG-6537][Sort] Fix During DDL synchronization 'decimal' type loss of precision
- Fixes #6537 

### Motivation

*Fix During DDL synchronization 'decimal' type loss of precision*

### Modifications

*Define a larger range 'decimal(15, 5)'.*
