### PR TITLE
[INLONG-6552][Sort] Fix MicroTimestamp error in oracle connector

### DIFF
--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -773,6 +773,9 @@ public final class RowDataDebeziumDeserializeSchema
         } else if (Timestamp.SCHEMA_NAME.equals(schemaName)) {
             Instant instantTime = Instant.ofEpochMilli((Long) fieldValue);
             fieldValue = LocalDateTime.ofInstant(instantTime, ZONE_UTC).toString();
+        } else if (MicroTimestamp.SCHEMA_NAME.equals(schemaName)) {
+            Instant instantTime = Instant.ofEpochMilli((Long) fieldValue / 1000);
+            fieldValue = LocalDateTime.ofInstant(instantTime, ZONE_UTC).toString();
         }
         return fieldValue;
     }


### PR DESCRIPTION
###  Fix MicroTimestamp error in mysql connector

- Fixes #6552

### Motivation

The debezium read oracle's timestamp type as a number of microseconds, we should convert it to a  string format of date-time.

### Modifications

If field schema is timestamp type, we need convert to  a string format of date-time from a number of microseconds.