### PR TITLE
[INLONG-6555][CI] Update for set-output command is deprecated

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -94,9 +94,9 @@ jobs:
           && github.repository_owner == 'apache'
         run: |
           if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-            echo "::set-output name=match_master::true"
+            echo "name=match_master::true" >> $GITHUB_OUTPUT
           elif [[ ${{ github.ref_name }} =~ ^branch-[0-9]+\.[0-9]+$ ]]; then
-            echo "::set-output name=match_release::true"
+            echo "name=match_release::true" >> $GITHUB_OUTPUT
           fi
 
       # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'branch-1.4'.


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6555

### Motivation
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
<img width="755" alt="image" src="https://user-images.githubusercontent.com/18047329/201955916-968e9d8f-e931-4505-b6c3-afd04ba3b190.png">

