### PR TITLE
[INLONG-6555][CI] Update for set-output command is deprecated (addendum)

### DIFF
--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           changed=$(ct list-changed --config ${{ env.CT_CONFIG_PATH }} --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "name=changed::true" >> $GITHUB_OUTPUT
             echo "Changed charts: $changed"
           else
             echo "Charts are not changed, they will not be linted, validated, installed and tested."


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6555

### Motivation

there is missed a place that needs to fix.
