### PR TITLE
[INLONG-6568][Manager] Not modify the status of the deleted source

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -379,7 +379,8 @@
         set previous_status = status,
         status = #{nextStatus, jdbcType=INTEGER}
         <where>
-            inlong_group_id = #{groupId, jdbcType=VARCHAR}
+            is_deleted = 0
+            and inlong_group_id = #{groupId, jdbcType=VARCHAR}
             <if test="streamId != null">
                 and inlong_stream_id = #{streamId, jdbcType=VARCHAR}
             </if>


### PR DESCRIPTION

### Prepare a Pull Request
- Fixes #6568 
### Motivation

Fix the problem that the status of the deleted source was incorrectly modified

### Modifications

After the group and stream workflows are configured, only update the status of data sources that have not been deleted.
