### PR TITLE
[INLONG-6570][Manager] Ignore the length of the field when building sort config

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -35,6 +35,8 @@ public class InlongConstants {
      */
     public static final String COMMA = ",";
 
+    public static final String LEFT_BRACKET = "(";
+
     public static final String ADMIN_USER = "admin";
 
     public static final Integer AFFECTED_ONE_ROW = 1;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
@@ -34,6 +34,7 @@ public enum FieldType {
     FIXED,
     BYTE,
     BINARY,
+    VARCHAR,
     VARBINARY,
     BOOLEAN,
     DATE,

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
@@ -55,6 +55,8 @@ import org.apache.inlong.sort.protocol.MetaFieldInfo;
 
 import java.util.List;
 
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
 /**
  * Util for sort field info.
  */
@@ -172,7 +174,7 @@ public class FieldInfoUtils {
      */
     public static FormatInfo convertFieldFormat(String type, String format) {
         FormatInfo formatInfo;
-        FieldType fieldType = FieldType.forName(type);
+        FieldType fieldType = FieldType.forName(StringUtils.substringBefore(type, LEFT_BRACKET));
         switch (fieldType) {
             case BOOLEAN:
                 formatInfo = new BooleanFormatInfo();
@@ -267,6 +269,7 @@ public class FieldInfoUtils {
             case STRUCT:
                 formatInfo = createRowFormatInfo(format);
                 break;
+            case VARCHAR:
             default: // default is string
                 formatInfo = new StringFormatInfo();
         }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6570 

### Motivation

![image](https://user-images.githubusercontent.com/58519431/202382982-597641d5-91f5-47c2-bf2a-0fc577d237d9.png)

### Modifications

Gets the string before the first occurrence of a `(`.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
