### PR TITLE
[INLONG-6574][Sort] Add dirty data metric for HBase

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -30,9 +30,9 @@ public final class Constants {
     /**
      * constants for metrics
      */
-    public static final String DIRTY_BYTES = "dirtyBytes";
+    public static final String DIRTY_BYTES_OUT = "dirtyBytesOut";
 
-    public static final String DIRTY_RECORDS = "dirtyRecords";
+    public static final String DIRTY_RECORDS_OUT = "dirtyRecordsOut";
 
     public static final String NUM_BYTES_OUT = "numBytesOut";
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -49,18 +49,24 @@ public class MetricOption implements Serializable {
     private RegisteredMetric registeredMetric;
     private long initRecords;
     private long initBytes;
+    private long initDirtyRecords;
+    private long initDirtyBytes;
 
     private MetricOption(
             String inlongLabels,
             @Nullable String inlongAudit,
             RegisteredMetric registeredMetric,
             long initRecords,
-            long initBytes) {
+            long initBytes,
+            Long initDirtyRecords,
+            Long initDirtyBytes) {
         Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(inlongLabels),
                 "Inlong labels must be set for register metric.");
 
         this.initRecords = initRecords;
         this.initBytes = initBytes;
+        this.initDirtyRecords = initDirtyRecords;
+        this.initDirtyBytes = initDirtyBytes;
         this.labels = new LinkedHashMap<>();
         String[] inLongLabelArray = inlongLabels.split(DELIMITER);
         Preconditions.checkArgument(Stream.of(inLongLabelArray).allMatch(label -> label.contains("=")),
@@ -121,6 +127,22 @@ public class MetricOption implements Serializable {
         this.initBytes = initBytes;
     }
 
+    public long getInitDirtyRecords() {
+        return initDirtyRecords;
+    }
+
+    public void setInitDirtyRecords(long initDirtyRecords) {
+        this.initDirtyRecords = initDirtyRecords;
+    }
+
+    public long getInitDirtyBytes() {
+        return initDirtyBytes;
+    }
+
+    public void setInitDirtyBytes(long initDirtyBytes) {
+        this.initDirtyBytes = initDirtyBytes;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -137,6 +159,8 @@ public class MetricOption implements Serializable {
         private RegisteredMetric registeredMetric = RegisteredMetric.ALL;
         private long initRecords = 0L;
         private long initBytes = 0L;
+        private Long initDirtyRecords = 0L;
+        private Long initDirtyBytes = 0L;
 
         private Builder() {
         }
@@ -166,11 +190,22 @@ public class MetricOption implements Serializable {
             return this;
         }
 
+        public MetricOption.Builder withInitDirtyRecords(Long initDirtyRecords) {
+            this.initDirtyRecords = initDirtyRecords;
+            return this;
+        }
+
+        public MetricOption.Builder withInitDirtyBytes(Long initDirtyBytes) {
+            this.initDirtyBytes = initDirtyBytes;
+            return this;
+        }
+
         public MetricOption build() {
             if (inlongLabels == null && inlongAudit == null) {
                 return null;
             }
-            return new MetricOption(inlongLabels, inlongAudit, registeredMetric, initRecords, initBytes);
+            return new MetricOption(inlongLabels, inlongAudit, registeredMetric, initRecords, initBytes,
+                    initDirtyRecords, initDirtyBytes);
         }
     }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -29,8 +29,8 @@ import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES;
-import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS;
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT_FOR_METER;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT_PER_SECOND;
@@ -51,8 +51,8 @@ public class SinkMetricData implements MetricData {
     private Counter numBytesOut;
     private Counter numRecordsOutForMeter;
     private Counter numBytesOutForMeter;
-    private Counter dirtyRecords;
-    private Counter dirtyBytes;
+    private Counter dirtyRecordsOut;
+    private Counter dirtyBytesOut;
     private Meter numRecordsOutPerSecond;
     private Meter numBytesOutPerSecond;
 
@@ -63,10 +63,12 @@ public class SinkMetricData implements MetricData {
 
         ThreadSafeCounter recordsOutCounter = new ThreadSafeCounter();
         ThreadSafeCounter bytesOutCounter = new ThreadSafeCounter();
+        ThreadSafeCounter dirtyRecordsOutCounter = new ThreadSafeCounter();
+        ThreadSafeCounter dirtyBytesOutCounter = new ThreadSafeCounter();
         switch (registeredMetric) {
             case DIRTY:
-                registerMetricsForDirtyBytes(new ThreadSafeCounter());
-                registerMetricsForDirtyRecords(new ThreadSafeCounter());
+                registerMetricsForDirtyBytesOut(new ThreadSafeCounter());
+                registerMetricsForDirtyRecordsOut(new ThreadSafeCounter());
                 break;
             case NORMAL:
                 recordsOutCounter.inc(option.getInitRecords());
@@ -79,12 +81,14 @@ public class SinkMetricData implements MetricData {
                 registerMetricsForNumRecordsOutPerSecond();
                 break;
             default:
-                registerMetricsForDirtyBytes(new ThreadSafeCounter());
-                registerMetricsForDirtyRecords(new ThreadSafeCounter());
                 recordsOutCounter.inc(option.getInitRecords());
                 bytesOutCounter.inc(option.getInitBytes());
+                dirtyRecordsOutCounter.inc(option.getInitDirtyRecords());
+                dirtyBytesOutCounter.inc(option.getInitDirtyBytes());
                 registerMetricsForNumBytesOut(bytesOutCounter);
                 registerMetricsForNumRecordsOut(recordsOutCounter);
+                registerMetricsForDirtyRecordsOut(dirtyRecordsOutCounter);
+                registerMetricsForDirtyBytesOut(dirtyBytesOutCounter);
                 registerMetricsForNumBytesOutForMeter(new ThreadSafeCounter());
                 registerMetricsForNumRecordsOutForMeter(new ThreadSafeCounter());
                 registerMetricsForNumBytesOutPerSecond();
@@ -181,12 +185,12 @@ public class SinkMetricData implements MetricData {
         numBytesOutPerSecond = registerMeter(NUM_BYTES_OUT_PER_SECOND, this.numBytesOutForMeter);
     }
 
-    public void registerMetricsForDirtyRecords() {
-        registerMetricsForDirtyRecords(new SimpleCounter());
+    public void registerMetricsForDirtyRecordsOut() {
+        registerMetricsForDirtyRecordsOut(new SimpleCounter());
     }
 
-    public void registerMetricsForDirtyRecords(Counter counter) {
-        dirtyRecords = registerCounter(DIRTY_RECORDS, counter);
+    public void registerMetricsForDirtyRecordsOut(Counter counter) {
+        dirtyRecordsOut = registerCounter(DIRTY_RECORDS_OUT, counter);
     }
 
     /**
@@ -194,8 +198,8 @@ public class SinkMetricData implements MetricData {
      * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
      * prometheus
      */
-    public void registerMetricsForDirtyBytes() {
-        registerMetricsForDirtyBytes(new SimpleCounter());
+    public void registerMetricsForDirtyBytesOut() {
+        registerMetricsForDirtyBytesOut(new SimpleCounter());
     }
 
     /**
@@ -203,8 +207,8 @@ public class SinkMetricData implements MetricData {
      * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
      * prometheus
      */
-    public void registerMetricsForDirtyBytes(Counter counter) {
-        dirtyBytes = registerCounter(DIRTY_BYTES, counter);
+    public void registerMetricsForDirtyBytesOut(Counter counter) {
+        dirtyBytesOut = registerCounter(DIRTY_BYTES_OUT, counter);
     }
 
     public Counter getNumRecordsOut() {
@@ -215,12 +219,12 @@ public class SinkMetricData implements MetricData {
         return numBytesOut;
     }
 
-    public Counter getDirtyRecords() {
-        return dirtyRecords;
+    public Counter getDirtyRecordsOut() {
+        return dirtyRecordsOut;
     }
 
-    public Counter getDirtyBytes() {
-        return dirtyBytes;
+    public Counter getDirtyBytesOut() {
+        return dirtyBytesOut;
     }
 
     public Meter getNumRecordsOutPerSecond() {
@@ -283,12 +287,12 @@ public class SinkMetricData implements MetricData {
     }
 
     public void invokeDirty(long rowCount, long rowSize) {
-        if (dirtyRecords != null) {
-            dirtyRecords.inc(rowCount);
+        if (dirtyRecordsOut != null) {
+            dirtyRecordsOut.inc(rowCount);
         }
 
-        if (dirtyBytes != null) {
-            dirtyBytes.inc(rowSize);
+        if (dirtyBytesOut != null) {
+            dirtyBytesOut.inc(rowSize);
         }
     }
 
@@ -300,8 +304,8 @@ public class SinkMetricData implements MetricData {
                         + "metricGroup=" + metricGroup
                         + ", labels=" + labels
                         + ", auditOperator=" + auditOperator
-                        + ", dirtyRecords=" + dirtyRecords.getCount()
-                        + ", dirtyBytes=" + dirtyBytes.getCount()
+                        + ", dirtyRecords=" + dirtyRecordsOut.getCount()
+                        + ", dirtyBytes=" + dirtyBytesOut.getCount()
                         + '}';
             case NORMAL:
                 return "SinkMetricData{"
@@ -324,8 +328,8 @@ public class SinkMetricData implements MetricData {
                         + ", numBytesOut=" + numBytesOut.getCount()
                         + ", numRecordsOutForMeter=" + numRecordsOutForMeter.getCount()
                         + ", numBytesOutForMeter=" + numBytesOutForMeter.getCount()
-                        + ", dirtyRecords=" + dirtyRecords.getCount()
-                        + ", dirtyBytes=" + dirtyBytes.getCount()
+                        + ", dirtyRecordsOut=" + dirtyRecordsOut.getCount()
+                        + ", dirtyBytesOut=" + dirtyBytesOut.getCount()
                         + ", numRecordsOutPerSecond=" + numRecordsOutPerSecond.getRate()
                         + ", numBytesOutPerSecond=" + numBytesOutPerSecond.getRate()
                         + '}';

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
@@ -22,14 +22,16 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN;
@@ -67,7 +69,7 @@ public class MetricStateUtils {
         if (currentSubtaskNum >= previousSubtaskNum) {
             currentMetricState = map.get(subtaskIndex);
         } else {
-            Map<String, Long> metrics = new HashMap<>(4);
+            Map<String, Long> metrics = new HashMap<>(16);
             currentMetricState = new MetricState(subtaskIndex, metrics);
             List<Integer> indexList = computeIndexList(subtaskIndex, currentSubtaskNum, previousSubtaskNum);
             for (Integer index : indexList) {
@@ -147,6 +149,8 @@ public class MetricStateUtils {
         Map<String, Long> metricDataMap = new HashMap<>();
         metricDataMap.put(NUM_RECORDS_OUT, sinkMetricData.getNumRecordsOut().getCount());
         metricDataMap.put(NUM_BYTES_OUT, sinkMetricData.getNumBytesOut().getCount());
+        metricDataMap.put(DIRTY_RECORDS_OUT, sinkMetricData.getDirtyRecordsOut().getCount());
+        metricDataMap.put(DIRTY_BYTES_OUT, sinkMetricData.getDirtyBytesOut().getCount());
         MetricState metricState = new MetricState(subtaskIndex, metricDataMap);
         metricStateListState.add(metricState);
     }


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-6574][Sort] Add dirty data metric for HBase

- Fixes #6574 

### Motivation

* Add dirty data metric for HBase

### Modifications

* Modify base of sort-connector module, add `dirtyRecordsOut` `dirtyBytesOut`.
* Modify HBase connector for metric computing, exception just print and count dirtyData. 

