### PR TITLE
[INLONG-6578][Sort] Fix the problem of write failure after Doris sets the 'sink. properties. columns' parameter

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
@@ -17,9 +17,13 @@
 
 package org.apache.inlong.sort.doris.table;
 
+import java.util.Properties;
 import org.apache.doris.flink.cfg.DorisExecutionOptions;
 import org.apache.doris.flink.cfg.DorisOptions;
 import org.apache.doris.flink.cfg.DorisReadOptions;
+import org.apache.doris.flink.exception.DorisException;
+import org.apache.doris.flink.rest.RestService;
+import org.apache.doris.flink.rest.models.Schema;
 import org.apache.doris.flink.table.DorisDynamicOutputFormat;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -28,12 +32,16 @@ import org.apache.flink.table.connector.sink.OutputFormatProvider;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.types.RowKind;
 import org.apache.inlong.sort.doris.internal.GenericDorisSinkFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * DorisDynamicTableSink copy from {@link org.apache.doris.flink.table.DorisDynamicTableSink}
  * It supports both single table sink and multiple table sink
  **/
 public class DorisDynamicTableSink implements DynamicTableSink {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DorisDynamicTableSink.class);
 
     private final DorisOptions options;
     private final DorisReadOptions readOptions;
@@ -47,6 +55,9 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     private final String inlongMetric;
     private final String auditHostAndPorts;
     private final Integer parallelism;
+    private static final String UNIQUE_KEYS_TYPE = "UNIQUE_KEYS";
+    public static final String COLUMNS_KEY = "columns";
+    public static final String DORIS_DELETE_SIGN = "__DORIS_DELETE_SIGN__";
 
     public DorisDynamicTableSink(DorisOptions options,
             DorisReadOptions readOptions,
@@ -87,6 +98,13 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         if (!multipleSink) {
+            Properties loadProperties = executionOptions.getStreamLoadProp();
+            // if enable batch delete, the columns must add tag '__DORIS_DELETE_SIGN__'
+            String columns = (String) loadProperties.get(COLUMNS_KEY);
+            if (loadProperties.containsKey(COLUMNS_KEY) && !columns.contains(DORIS_DELETE_SIGN)
+                    && enableBatchDelete()) {
+                loadProperties.put(COLUMNS_KEY, String.format("%s,%s", columns, DORIS_DELETE_SIGN));
+            }
             DorisDynamicOutputFormat.Builder builder = DorisDynamicOutputFormat.builder()
                     .setFenodes(options.getFenodes())
                     .setUsername(options.getUsername())
@@ -124,6 +142,15 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     @Override
     public String asSummaryString() {
         return "Doris Table Sink Of InLong";
+    }
+
+    private boolean enableBatchDelete() {
+        try {
+            Schema schema = RestService.getSchema(options, readOptions, LOG);
+            return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
+        } catch (DorisException e) {
+            throw new RuntimeException("Failed fetch doris table schema: " + options.getTableIdentifier());
+        }
     }
 }
 


### PR DESCRIPTION
### Fix the problem of write failure after Doris sets the 'sink. properties. columns' parameter

- Fixes #6578

### Motivation

To write bitmap data to doris, we need to set the `sink.properties.columns` option.

```sql
CREATE TABLE `table_2`(
    `dt` INT,
    `page` STRING,
    `user_id` INT)
    WITH (
    'inlong.metric.labels' = 'groupId=1&streamId=1&nodeId=2',
    'sink.properties.columns' = 'dt,page,user_id,user_id=to_bitmap(user_id)',
    'connector' = 'doris-inlong',
    'fenodes' = 'xxxx:8030',
    'username' = 'root',
    'password' = 'xxx',
    'sink.multiple.enable' = 'false',
    'table.identifier' = 'db.table'
)
```

But, when writing data to doris, it will add a hidden column called `__ DORIS_ DELETE_ SIGN__`. More details refers [batch-delete-manual](https://doris.apache.org/docs/data-operate/update-delete/batch-delete-manual/). The source code is as follows:

```java
// add doris delete sign
if (enableBatchDelete()) {
    if (jsonFormat) {
        valueMap.put(DORIS_DELETE_SIGN, parseDeleteSign(rowData.getRowKind()));
    } else {
        value.add(parseDeleteSign(rowData.getRowKind()));
    }
}
```

So, we need to add a column called `__ DORIS_ DELETE_ SIGN__` at the end of parameter, it identifies that the newly added column is a`__ DORIS_ DELETE_ SIGN__` field. such as: 

```sql
'sink.properties.columns' = 'dt,page,user_id,user_id=to_bitmap(user_id), __ DORIS_ DELETE_ SIGN__'
```

### Modifications

如果用户设置了`sink.properties.columns`参数,判断是否批量删除，如果可以，就在column参数中增加一个隐藏列`__ DORIS_ DELETE_ SIGN__`。代码如下：

If the user has set `sink.properties.columns` option. We should determine whether to enable batch delete. If it enable batch delete, add a hidden column called `__ DORIS_ DELETE_ SIGN__` to the column parameter.  The code is as follows:

```java
Properties loadProperties = executionOptions.getStreamLoadProp();
// if enable batch delete, the columns must add tag '__DORIS_DELETE_SIGN__'
String columns = (String) loadProperties.get(COLUMNS_KEY);
if (loadProperties.containsKey(COLUMNS_KEY) && !columns.contains(DORIS_DELETE_SIGN)
        && enableBatchDelete()) {
    loadProperties.put(COLUMNS_KEY, String.format("%s,%s", columns, DORIS_DELETE_SIGN));
}

private boolean enableBatchDelete() {
    try {
        Schema schema = RestService.getSchema(options, readOptions, LOG);
        return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
    } catch (DorisException e) {
        throw new RuntimeException("Failed fetch doris table schema: " + options.getTableIdentifier());
    }
}
```