### PR TITLE
[INLONG-6600][Sort] Fix dead lock when one stream is removed from or migrated to one sink

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsOutputChannel.java
@@ -206,6 +206,13 @@ public class EsOutputChannel extends Thread {
                 Thread.sleep(context.getProcessInterval());
                 return;
             }
+            // get id config
+            String uid = indexRequest.getEvent().getUid();
+            if (context.getIdConfig(uid) == null) {
+                context.addSendResultMetric(indexRequest.getEvent(), context.getTaskName(), false,
+                        indexRequest.getSendTime());
+                return;
+            }
             // send
             bulkProcessor.add(indexRequest);
             context.addSendMetric(indexRequest.getEvent(), context.getTaskName());


### PR DESCRIPTION

- Fixes #6600 

### Motivation

When one stream is removed from or migrated to one sink, the unsent ES request will be retried and failed forever.

### Modifications

Check if the EsIdConfig is still exist before each send. If no, discard this request.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.
### Documentation

  - Does this pull request introduce a new feature? / no
