### PR TITLE
[INLONG-6604][DataProxy] Fix can not get the local IP in the docker container

### DIFF
--- a/inlong-dataproxy/dataproxy-docker/Dockerfile
+++ b/inlong-dataproxy/dataproxy-docker/Dockerfile
@@ -26,6 +26,8 @@ ADD ${DATAPROXY_TARBALL} /opt/inlong-dataproxy
 EXPOSE 46801 46802
 ENV MANAGER_OPENAPI_IP=127.0.0.1
 ENV MANAGER_OPENAPI_PORT=8083
+# specify the name of the network card in the container to obtain the local IP
+ENV ETH_NAME=eth1
 # enable audit, true or false
 ENV AUDIT_ENABLE=true
 ENV AUDIT_PROXY_URL=127.0.0.1:10081

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -17,9 +17,8 @@
 #
 
 file_path=$(cd "$(dirname "$0")"/../;pwd)
-# You need to pay attention to obtaining the local IP. The int6 network segment starting with 30 is excluded here.
-# When your business needs a network segment starting with 30, you need to modify this to avoid not getting it.
-local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}' | grep -v "^30.*")
+# Obtain the local ip by specifying the network card name according to the environment variable
+local_ip=$(ifconfig $ETH_NAME | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}')
 # config
 cd "${file_path}/"
 common_conf_file=./conf/common.properties

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -17,7 +17,7 @@
 #
 
 file_path=$(cd "$(dirname "$0")"/../;pwd)
-local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}' | grep -v "30.*")
+local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}' | grep -v "^30.*")
 # config
 cd "${file_path}/"
 common_conf_file=./conf/common.properties

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -17,7 +17,8 @@
 #
 
 file_path=$(cd "$(dirname "$0")"/../;pwd)
-# Obtain the local ip by specifying the network card name according to the environment variable
+# Obtain the local ip by specifying the network card name according to the environment variable and
+# it should be noted that this is a single network card IP acquisition method.
 local_ip=$(ifconfig $ETH_NAME | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}')
 # config
 cd "${file_path}/"

--- a/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
+++ b/inlong-dataproxy/dataproxy-docker/dataproxy-docker.sh
@@ -17,6 +17,8 @@
 #
 
 file_path=$(cd "$(dirname "$0")"/../;pwd)
+# You need to pay attention to obtaining the local IP. The int6 network segment starting with 30 is excluded here.
+# When your business needs a network segment starting with 30, you need to modify this to avoid not getting it.
 local_ip=$(ifconfig | grep inet | grep -v inet6 | grep -v "127.0.0.1" | awk '{print $2}' | grep -v "^30.*")
 # config
 cd "${file_path}/"


### PR DESCRIPTION
### Prepare a Pull Request

- Title Example: [INLONG-6604][Component] Title of the pull request

[INLONG-6604][DataProxy] Fix can not get the local IP in the docker container

- Fixes #6604

### Motivation

Fix can not get the local IP in the docker container

### Modifications

get the local IP in the docker container excluding the ip of the network segment starting with 30.

### Verifying this change

get the local IP in the docker container excluding the ip of the network segment starting with 30.

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
