### PR TITLE
[INLONG-6621][Manager] Fixed the problem of source tasks are issued repeatedly

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -380,6 +380,7 @@
         status = #{nextStatus, jdbcType=INTEGER}
         <where>
             is_deleted = 0
+            and status != 101
             and inlong_group_id = #{groupId, jdbcType=VARCHAR}
             <if test="streamId != null">
                 and inlong_stream_id = #{streamId, jdbcType=VARCHAR}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
@@ -169,11 +169,11 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
         // re-issue task if necessary
         if (InlongConstants.STANDARD_MODE.equals(groupMode)) {
             if (GroupStatus.forCode(groupStatus).equals(GroupStatus.CONFIG_SUCCESSFUL)) {
-                entity.setStatus(SourceStatus.TO_BE_ISSUED_ADD.getCode());
+                entity.setStatus(SourceStatus.TO_BE_ISSUED_RETRY.getCode());
             } else {
                 switch (SourceStatus.forCode(entity.getStatus())) {
                     case SOURCE_NORMAL:
-                        entity.setStatus(SourceStatus.TO_BE_ISSUED_ADD.getCode());
+                        entity.setStatus(SourceStatus.TO_BE_ISSUED_RETRY.getCode());
                         break;
                     case SOURCE_FAILED:
                         entity.setStatus(SourceStatus.SOURCE_NEW.getCode());


### PR DESCRIPTION

### Prepare a Pull Request
- Fixes #6621 
- 
### Motivation
Fixed the problem of source tasks are issued repeatedly

### Modifications
1.The workflow is executed without updating the data source in a SOURCE_NORMAL state.
2.When updating the data source, the data source state changes from SOURCE_NORMAL to TO_BE_ISSUED_RETRY.
