### PR TITLE
[INLONG-6639][Sort] Fix DynamicPulsarDeserializationSchema deserialize NPE problem when sourceMetricData is not initialized

### DIFF
--- a/inlong-sort/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/DynamicPulsarDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/DynamicPulsarDeserializationSchema.java
@@ -126,7 +126,9 @@ public class DynamicPulsarDeserializationSchema implements PulsarDeserialization
         // also not for a cartesian product with the keys
         if (keyDeserialization == null && !hasMetadata) {
             valueDeserialization.deserialize(message.getData(), new CallbackCollector<>(inputRow -> {
-                sourceMetricData.outputMetricsWithEstimate(inputRow);
+                if (sourceMetricData != null) {
+                    sourceMetricData.outputMetricsWithEstimate(inputRow);
+                }
                 collector.collect(inputRow);
             }));
             return;


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-6639][Sort] Fix DynamicPulsarDeserializationSchema deserialize NPE problem when sourceMetricData is not initialized.

- Fixes #6639 

### Motivation

Fix DynamicPulsarDeserializationSchema deserialize NPE problem when sourceMetricData is not initialized.

### Modifications

Do not report metrics when sourceMetricData is not initialized.
