### PR TITLE
[INLONG-6657][Sort] Add dirty data metric for Hive

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -258,6 +258,11 @@ public class SinkMetricData implements MetricData {
         invoke(1, size);
     }
 
+    public void invokeDirtyWithEstimate(Object o) {
+        long size = o.toString().getBytes(StandardCharsets.UTF_8).length;
+        invokeDirty(1, size);
+    }
+
     public void invoke(long rowCount, long rowSize) {
         if (numRecordsOut != null) {
             numRecordsOut.inc(rowCount);

--- a/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
@@ -213,6 +213,8 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             if (metricData != null) {
                 metricData.invokeDirtyWithEstimate(element.getValue());
             }
+            // TODO: to support dirty data side-output
+            throw new RuntimeException(e);
         }
     }
 

--- a/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
@@ -56,8 +56,8 @@ import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
  */
 public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOperator<OUT>
         implements
-        OneInputStreamOperator<IN, OUT>,
-        BoundedOneInput {
+            OneInputStreamOperator<IN, OUT>,
+            BoundedOneInput {
 
     private static final long serialVersionUID = 1L;
 
@@ -178,7 +178,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             this.metricStateListState = context.getOperatorStateStore().getUnionListState(
                     new ListStateDescriptor<>(
                             INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
-                    })));
+                            })));
         }
         if (context.isRestored()) {
             metricState = MetricStateUtils.restoreMetricState(metricStateListState,

--- a/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
@@ -213,7 +213,6 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             if (metricData != null) {
                 metricData.invokeDirtyWithEstimate(element.getValue());
             }
-            throw new RuntimeException(e);
         }
     }
 

--- a/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
@@ -199,7 +199,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
     }
 
     @Override
-    public void processElement(StreamRecord<IN> element) {
+    public void processElement(StreamRecord<IN> element) throws Exception{
         try {
             helper.onElement(
                     element.getValue(),

--- a/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/hive/src/main/java/org/apache/inlong/sort/hive/filesystem/AbstractStreamingWriter.java
@@ -56,8 +56,8 @@ import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
  */
 public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOperator<OUT>
         implements
-            OneInputStreamOperator<IN, OUT>,
-            BoundedOneInput {
+        OneInputStreamOperator<IN, OUT>,
+        BoundedOneInput {
 
     private static final long serialVersionUID = 1L;
 
@@ -98,7 +98,9 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
         setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
-    /** Notifies a partition created. */
+    /**
+     * Notifies a partition created.
+     */
     protected abstract void partitionCreated(String partition);
 
     /**
@@ -115,7 +117,9 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
      */
     protected abstract void onPartFileOpened(String partition, Path newPath);
 
-    /** Commit up to this checkpoint id. */
+    /**
+     * Commit up to this checkpoint id.
+     */
     protected void commitUpToCheckpoint(long checkpointId) throws Exception {
         helper.commitUpToCheckpoint(checkpointId);
     }
@@ -174,7 +178,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             this.metricStateListState = context.getOperatorStateStore().getUnionListState(
                     new ListStateDescriptor<>(
                             INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
-                            })));
+                    })));
         }
         if (context.isRestored()) {
             metricState = MetricStateUtils.restoreMetricState(metricStateListState,
@@ -199,7 +203,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
     }
 
     @Override
-    public void processElement(StreamRecord<IN> element) throws Exception{
+    public void processElement(StreamRecord<IN> element) throws Exception {
         try {
             helper.onElement(
                     element.getValue(),


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6657 

### Motivation

Add dirty data metric for Hive.

### Modifications

1. Add `DirtyRecords` and `DirtyBytes` when init `MetricOption`.
2. Calculate dirty data when an exception is caught.
