### PR TITLE
[INLONG-6584][Sort] Add read phase metric and table level metric for MySQL

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -58,7 +58,7 @@ public final class Constants {
 
     public static final String NUM_RECORDS_IN_PER_SECOND = "numRecordsInPerSecond";
     /**
-     * Timestamp when phase change was read
+     * Timestamp when the read phase changed
      */
     public static final String READ_PHASE_TIMESTAMP = "readPhaseTimestamp";
     /**

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -58,6 +58,10 @@ public final class Constants {
 
     public static final String NUM_RECORDS_IN_PER_SECOND = "numRecordsInPerSecond";
     /**
+     * Timestamp when phase change was read
+     */
+    public static final String READ_PHASE_TIMESTAMP = "readPhaseTimestamp";
+    /**
      * Time span in seconds
      */
     public static final Integer TIME_SPAN_IN_SECONDS = 60;
@@ -74,9 +78,37 @@ public final class Constants {
      */
     public static final String NODE_ID = "nodeId";
     /**
+     * Database Name used in inlong metric
+     */
+    public static final String DATABASE_NAME = "database";
+    /**
+     * Table Name used in inlong metric
+     */
+    public static final String TABLE_NAME = "table";
+    /**
+     * Read Phase used in inlong metric
+     */
+    public static final String READ_PHASE = "readPhase";
+    /**
+     * Schema Name used in inlong metric
+     */
+    public static final String SCHEMA_NAME = "schema";
+    /**
+     * Topic Name used in inlong metric
+     */
+    public static final String TOPIC_NAME = "topic";
+    /**
      * It is used for 'inlong.metric.labels' or 'sink.dirty.labels'
      */
     public static final String DELIMITER = "&";
+    /**
+     * It is used for metric data to build schema identify
+     */
+    public static final String SEMICOLON = ".";
+    /**
+     * It is used for metric data to spilt schema identify
+     */
+    public static final String SPILT_SEMICOLON = "\\.";
     /**
      * The delimiter of key and value, it is used for 'inlong.metric.labels' or 'sink.dirty.labels'
      */

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/enums/ReadPhase.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/enums/ReadPhase.java
@@ -26,25 +26,20 @@ import java.util.stream.Stream;
 public enum ReadPhase {
 
     /**
-     * This indicator represents the prepare phase during the read phase
+     * This indicator type represents the snapshot phase when the entire database is migrated reading the snapshot data.
      */
-    PREPARE_PHASE("prepare_phase", 0L),
-
+    SNAPSHOT_PHASE("snapshot_phase", 1),
     /**
-     * This indicator represents the snapshot phase during the read phase
+     * This indicator type represents the incremental phase when the entire database is migrated reading the incremental data.
      */
-    SNAPSHOT_PHASE("snapshot_phase", 1L),
-    /**
-     * This indicator represents the incremental phase during the read phase
-     */
-    INCREASE_PHASE("incremental_phase", 2L);
+    INCREASE_PHASE("incremental_phase", 2);
 
     private String phase;
-    private Long value;
+    private int code;
 
-    ReadPhase(String phase, Long value) {
+    ReadPhase(String phase, int code) {
         this.phase = phase;
-        this.value = value;
+        this.code = code;
     }
 
     public String getPhase() {
@@ -55,22 +50,22 @@ public enum ReadPhase {
         this.phase = phase;
     }
 
-    public Long getValue() {
-        return value;
+    public int getCode() {
+        return code;
     }
 
-    public void setValue(Long value) {
-        this.value = value;
+    public void setCode(int code) {
+        this.code = code;
     }
 
     /**
-     * get the read phase enum by value
+     * get the read phase enum by code
      *
-     * @param value the value
+     * @param code the code
      * @return the read phase enum
      */
-    public static ReadPhase getReadPhaseByValue(long value) {
-        return Stream.of(ReadPhase.values()).filter(v -> v.getValue() == value).findFirst().orElse(null);
+    public static ReadPhase getReadPhaseByCode(int code) {
+        return Stream.of(ReadPhase.values()).filter(v -> v.getCode() == code).findFirst().orElse(null);
     }
 
     /**

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/enums/ReadPhase.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/enums/ReadPhase.java
@@ -1,0 +1,85 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.enums;
+
+import java.util.stream.Stream;
+
+/**
+ * A enum class for metrics read phase
+ */
+public enum ReadPhase {
+
+    /**
+     * This indicator represents the prepare phase during the read phase
+     */
+    PREPARE_PHASE("prepare_phase", 0L),
+
+    /**
+     * This indicator represents the snapshot phase during the read phase
+     */
+    SNAPSHOT_PHASE("snapshot_phase", 1L),
+    /**
+     * This indicator represents the incremental phase during the read phase
+     */
+    INCREASE_PHASE("incremental_phase", 2L);
+
+    private String phase;
+    private Long value;
+
+    ReadPhase(String phase, Long value) {
+        this.phase = phase;
+        this.value = value;
+    }
+
+    public String getPhase() {
+        return phase;
+    }
+
+    public void setPhase(String phase) {
+        this.phase = phase;
+    }
+
+    public Long getValue() {
+        return value;
+    }
+
+    public void setValue(Long value) {
+        this.value = value;
+    }
+
+    /**
+     * get the read phase enum by value
+     *
+     * @param value the value
+     * @return the read phase enum
+     */
+    public static ReadPhase getReadPhaseByValue(long value) {
+        return Stream.of(ReadPhase.values()).filter(v -> v.getValue() == value).findFirst().orElse(null);
+    }
+
+    /**
+     * get the read phase enum by phase
+     *
+     * @param phase the phase name
+     * @return the read phase enum
+     */
+    public static ReadPhase getReadPhaseByPhase(String phase) {
+        return Stream.of(ReadPhase.values()).filter(v -> v.getPhase().equals(phase)).findFirst().orElse(null);
+    }
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -52,6 +52,7 @@ public class MetricOption implements Serializable {
     private long initBytes;
     private long initDirtyRecords;
     private long initDirtyBytes;
+    private long readPhase;
 
     private MetricOption(
             String inlongLabels,
@@ -60,7 +61,8 @@ public class MetricOption implements Serializable {
             long initRecords,
             long initBytes,
             Long initDirtyRecords,
-            Long initDirtyBytes) {
+            Long initDirtyBytes,
+            Long readPhase) {
         Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(inlongLabels),
                 "Inlong labels must be set for register metric.");
 
@@ -68,6 +70,7 @@ public class MetricOption implements Serializable {
         this.initBytes = initBytes;
         this.initDirtyRecords = initDirtyRecords;
         this.initDirtyBytes = initDirtyBytes;
+        this.readPhase = readPhase;
         this.labels = new LinkedHashMap<>();
         String[] inLongLabelArray = inlongLabels.split(DELIMITER);
         Preconditions.checkArgument(Stream.of(inLongLabelArray).allMatch(label -> label.contains("=")),
@@ -144,6 +147,14 @@ public class MetricOption implements Serializable {
         this.initDirtyBytes = initDirtyBytes;
     }
 
+    public long getReadPhase() {
+        return readPhase;
+    }
+
+    public void setReadPhase(long readPhase) {
+        this.readPhase = readPhase;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -163,6 +174,7 @@ public class MetricOption implements Serializable {
         private long initBytes = 0L;
         private Long initDirtyRecords = 0L;
         private Long initDirtyBytes = 0L;
+        private long initReadPhase = 0L;
 
         private Builder() {
         }
@@ -202,12 +214,17 @@ public class MetricOption implements Serializable {
             return this;
         }
 
+        public MetricOption.Builder withInitReadPhase(Long initReadPhase) {
+            this.initReadPhase = initReadPhase;
+            return this;
+        }
+
         public MetricOption build() {
             if (inlongLabels == null && inlongAudit == null) {
                 return null;
             }
             return new MetricOption(inlongLabels, inlongAudit, registeredMetric, initRecords, initBytes,
-                    initDirtyRecords, initDirtyBytes);
+                    initDirtyRecords, initDirtyBytes, initReadPhase);
         }
     }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricState.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/MetricState.java
@@ -32,6 +32,8 @@ public class MetricState implements Serializable {
 
     private Map<String, Long> metrics;
 
+    private Map<String, MetricState> subMetricStateMap;
+
     public MetricState() {
     }
 
@@ -54,6 +56,15 @@ public class MetricState implements Serializable {
 
     public void setMetrics(Map<String, Long> metrics) {
         this.metrics = metrics;
+    }
+
+    public Map<String, MetricState> getSubMetricStateMap() {
+        return subMetricStateMap;
+    }
+
+    public void setSubMetricStateMap(
+            Map<String, MetricState> subMetricStateMap) {
+        this.subMetricStateMap = subMetricStateMap;
     }
 
     public Long getMetricValue(String metricName) {

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -189,8 +189,8 @@ public class SourceMetricData implements MetricData {
         return labels;
     }
 
-    public void outputMetricsWithEstimate(Object o) {
-        long size = o.toString().getBytes(StandardCharsets.UTF_8).length;
+    public void outputMetricsWithEstimate(Object data) {
+        long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
         outputMetrics(1, size);
     }
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
@@ -28,7 +28,7 @@ import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.ThreadSafeCounter;
 
 /**
- * A collection class for handling read phase metric
+ * A collection class for handling read phase metric data
  */
 public class ReadPhaseMetricData implements MetricData {
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
@@ -1,0 +1,105 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.metric.phase;
+
+import static org.apache.inlong.sort.base.Constants.READ_PHASE_TIMESTAMP;
+
+import java.util.Map;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.inlong.sort.base.metric.MetricData;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.ThreadSafeCounter;
+
+/**
+ * A collection class for handling read phase metric
+ */
+public class ReadPhaseMetricData implements MetricData {
+
+    private final MetricGroup metricGroup;
+    private Counter readPhase;
+    private final Map<String, String> labels;
+
+    public ReadPhaseMetricData(MetricOption option, MetricGroup metricGroup) {
+        this.metricGroup = metricGroup;
+        this.labels = option.getLabels();
+        ThreadSafeCounter readPhaseCounter = new ThreadSafeCounter();
+        readPhaseCounter.inc(option.getReadPhase());
+        registerMetricsForReadPhase(readPhaseCounter);
+    }
+
+    /**
+     * User can use custom counter that extends from {@link Counter}
+     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
+     * prometheus
+     */
+    private void registerMetricsForReadPhase(Counter counter) {
+        readPhase = registerCounter(READ_PHASE_TIMESTAMP, counter);
+    }
+
+    /**
+     * Get metric group
+     *
+     * @return The MetricGroup
+     */
+    @Override
+    public MetricGroup getMetricGroup() {
+        return metricGroup;
+    }
+
+    /**
+     * Get labels
+     *
+     * @return The labels defined in inlong
+     */
+    @Override
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    /**
+     * get read phase counter
+     *
+     * @return the read phase counter
+     */
+    public Counter getReadPhase() {
+        return readPhase;
+    }
+
+    /**
+     * output read phase metric,just keep the time to change that moment
+     */
+    public void outputMetrics() {
+        if (readPhase != null) {
+            long count = readPhase.getCount();
+            if (count == 0) {
+                readPhase.inc(System.currentTimeMillis());
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "ReadPhaseMetricData{"
+                + "metricGroup=" + metricGroup
+                + ", labels=" + labels
+                + ", readPhase=" + readPhase.getCount()
+                + '}';
+    }
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/phase/ReadPhaseMetricData.java
@@ -33,7 +33,7 @@ import org.apache.inlong.sort.base.metric.ThreadSafeCounter;
 public class ReadPhaseMetricData implements MetricData {
 
     private final MetricGroup metricGroup;
-    private Counter readPhase;
+    private Counter readPhaseTimestamp;
     private final Map<String, String> labels;
 
     public ReadPhaseMetricData(MetricOption option, MetricGroup metricGroup) {
@@ -45,12 +45,13 @@ public class ReadPhaseMetricData implements MetricData {
     }
 
     /**
-     * User can use custom counter that extends from {@link Counter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
+     * Register read phase time metrics and user can use custom counter that extends from {@link Counter}, and note that
+     * we just keep the time to change that moment
+     * groupId and streamId and nodeId and readPhase are label value, user can use it filter metric data when use metric reporter
      * prometheus
      */
     private void registerMetricsForReadPhase(Counter counter) {
-        readPhase = registerCounter(READ_PHASE_TIMESTAMP, counter);
+        readPhaseTimestamp = registerCounter(READ_PHASE_TIMESTAMP, counter);
     }
 
     /**
@@ -79,17 +80,17 @@ public class ReadPhaseMetricData implements MetricData {
      * @return the read phase counter
      */
     public Counter getReadPhase() {
-        return readPhase;
+        return readPhaseTimestamp;
     }
 
     /**
      * output read phase metric,just keep the time to change that moment
      */
     public void outputMetrics() {
-        if (readPhase != null) {
-            long count = readPhase.getCount();
+        if (readPhaseTimestamp != null) {
+            long count = readPhaseTimestamp.getCount();
             if (count == 0) {
-                readPhase.inc(System.currentTimeMillis());
+                readPhaseTimestamp.inc(System.currentTimeMillis());
             }
         }
     }
@@ -99,7 +100,7 @@ public class ReadPhaseMetricData implements MetricData {
         return "ReadPhaseMetricData{"
                 + "metricGroup=" + metricGroup
                 + ", labels=" + labels
-                + ", readPhase=" + readPhase.getCount()
+                + ", readPhaseTimestamp=" + readPhaseTimestamp.getCount()
                 + '}';
     }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceSubMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceSubMetricData.java
@@ -1,0 +1,44 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.metric.sub;
+
+import java.util.Map;
+import org.apache.inlong.sort.base.enums.ReadPhase;
+import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
+
+/**
+ * A collection class for handling sub metrics
+ */
+public interface SourceSubMetricData {
+
+    /**
+     * Get read phase metric map
+     *
+     * @return The read phase metric map
+     */
+    Map<ReadPhase, ReadPhaseMetricData> getReadPhaseMetricMap();
+
+    /**
+     * Get sub source metric map
+     *
+     * @return The sub source metric map
+     */
+    Map<String, SourceMetricData> getSubSourceMetricMap();
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -107,7 +107,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
     /**
      * build sub source metric data
      *
-     * @param schemaInfoArray source record schema info array
+     * @param schemaInfoArray the schema info array of record
      * @param subMetricState sub metric state
      * @param sourceMetricData source metric data
      * @return sub source metric data
@@ -160,8 +160,8 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
      *
      * @param database the database name of record
      * @param table the table name of record
-     * @param isSnapshotRecord is it snapshotRecord record
-     * @param data the record data
+     * @param isSnapshotRecord is it snapshot record
+     * @param data the data of record
      */
     public void outputMetricsWithEstimate(String database, String table, boolean isSnapshotRecord, Object data) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
@@ -211,7 +211,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
 
             MetricOption metricOption = MetricOption.builder()
                     .withInitReadPhase(metricState != null ? metricState.getMetricValue(readPhase.getPhase()) : 0L)
-                    .withInlongLabels(metricGroupLabels + DELIMITER + READ_PHASE + "=" + readPhase.getValue())
+                    .withInlongLabels(metricGroupLabels + DELIMITER + READ_PHASE + "=" + readPhase.getCode())
                     .withRegisterMetric(RegisteredMetric.ALL)
                     .build();
             readPhaseMetricData = new ReadPhaseMetricData(metricOption, getMetricGroup());

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -62,7 +62,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
     }
 
     /**
-     * register sub metrics group from sub metric state
+     * register sub source metrics group from metric state
      *
      * @param metricState MetricState
      */
@@ -70,7 +70,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
         if (metricState == null) {
             return;
         }
-        // register source read phase metric from metric state
+        // register source read phase metric
         Stream.of(ReadPhase.values()).forEach(readPhase -> {
             Long readPhaseMetricValue = metricState.getMetricValue(readPhase.getPhase());
             if (readPhaseMetricValue > 0) {
@@ -78,7 +78,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
             }
         });
 
-        // register sub source metric data from sub metric state
+        // register sub source metric data
         if (metricState.getSubMetricStateMap() == null) {
             return;
         }
@@ -117,7 +117,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
         if (sourceMetricData == null || schemaInfoArray == null) {
             return null;
         }
-        // build sub metric data
+        // build sub source metric data
         Map<String, String> labels = sourceMetricData.getLabels();
         String metricGroupLabels = labels.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
                 .collect(Collectors.joining(DELIMITER));
@@ -135,7 +135,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
     }
 
     /**
-     * build record schema identify
+     * build record schema identify,in the form of database.table
      *
      * @param database the database name of record
      * @param table the table name of record
@@ -149,7 +149,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
      * parse record schema identify
      *
      * @param schemaIdentify the schema identify of record
-     * @return the record schema identify array
+     * @return the record schema identify array,String[]{database,table}
      */
     public String[] parseSchemaIdentify(String schemaIdentify) {
         return schemaIdentify.split(Constants.SPILT_SEMICOLON);
@@ -176,7 +176,7 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
             subSourceMetricData = buildSubSourceMetricData(new String[]{database, table}, this);
             subSourceMetricMap.put(identify, subSourceMetricData);
         }
-        // sourceMetric and subSourceMetric output metrics
+        // source metric and sub source metric output metrics
         long rowCountSize = 1L;
         long rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
         this.outputMetrics(rowCountSize, rowDataSize);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -1,0 +1,240 @@
+/*
+ *   Licensed to the Apache Software Foundation (ASF) under one
+ *   or more contributor license agreements.  See the NOTICE file
+ *   distributed with this work for additional information
+ *   regarding copyright ownership.  The ASF licenses this file
+ *   to you under the Apache License, Version 2.0 (the
+ *   "License"); you may not use this file except in compliance
+ *   with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.metric.sub;
+
+import static org.apache.inlong.sort.base.Constants.DELIMITER;
+import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
+import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN;
+import static org.apache.inlong.sort.base.Constants.READ_PHASE;
+
+import com.google.common.collect.Maps;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.inlong.sort.base.Constants;
+import org.apache.inlong.sort.base.enums.ReadPhase;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A collection class for handling sub metrics of table schema type
+ */
+public class SourceTableMetricData extends SourceMetricData implements SourceSubMetricData {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(SourceTableMetricData.class);
+
+    /**
+     * The read phase metric container of source metric data
+     */
+    private final Map<ReadPhase, ReadPhaseMetricData> readPhaseMetricDataMap = Maps.newHashMap();
+    /**
+     * The sub source metric data container of source metric data
+     */
+    private final Map<String, SourceMetricData> subSourceMetricMap = Maps.newHashMap();
+
+    public SourceTableMetricData(MetricOption option, MetricGroup metricGroup) {
+        super(option, metricGroup);
+    }
+
+    /**
+     * register sub metrics group from sub metric state
+     *
+     * @param metricState MetricState
+     */
+    public void registerSubMetricsGroup(MetricState metricState) {
+        if (metricState == null) {
+            return;
+        }
+        // register source read phase metric from metric state
+        Stream.of(ReadPhase.values()).forEach(readPhase -> {
+            Long readPhaseMetricValue = metricState.getMetricValue(readPhase.getPhase());
+            if (readPhaseMetricValue > 0) {
+                outputReadPhaseMetrics(metricState, readPhase);
+            }
+        });
+
+        // register sub source metric data from sub metric state
+        if (metricState.getSubMetricStateMap() == null) {
+            return;
+        }
+        Map<String, MetricState> subMetricStateMap = metricState.getSubMetricStateMap();
+        for (Entry<String, MetricState> subMetricStateEntry : subMetricStateMap.entrySet()) {
+            String[] schemaInfoArray = parseSchemaIdentify(subMetricStateEntry.getKey());
+            final MetricState subMetricState = subMetricStateEntry.getValue();
+            SourceMetricData subSourceMetricData = buildSubSourceMetricData(schemaInfoArray,
+                    subMetricState, this);
+            subSourceMetricMap.put(subMetricStateEntry.getKey(), subSourceMetricData);
+        }
+        LOGGER.info("register subMetricsGroup from metricState,sub metric map size:{}", subSourceMetricMap.size());
+    }
+
+    /**
+     * build sub source metric data
+     *
+     * @param schemaInfoArray source record schema info
+     * @param sourceMetricData source metric data
+     * @return sub source metric data
+     */
+    private SourceMetricData buildSubSourceMetricData(String[] schemaInfoArray, SourceMetricData sourceMetricData) {
+        return buildSubSourceMetricData(schemaInfoArray, null, sourceMetricData);
+    }
+
+    /**
+     * build sub source metric data
+     *
+     * @param schemaInfoArray source record schema info array
+     * @param subMetricState sub metric state
+     * @param sourceMetricData source metric data
+     * @return sub source metric data
+     */
+    private SourceMetricData buildSubSourceMetricData(String[] schemaInfoArray, MetricState subMetricState,
+            SourceMetricData sourceMetricData) {
+        if (sourceMetricData == null || schemaInfoArray == null) {
+            return null;
+        }
+        // build sub metric data
+        Map<String, String> labels = sourceMetricData.getLabels();
+        String metricGroupLabels = labels.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining(DELIMITER));
+        StringBuilder labelBuilder = new StringBuilder(metricGroupLabels);
+        labelBuilder.append(DELIMITER).append(Constants.DATABASE_NAME).append("=").append(schemaInfoArray[0])
+                .append(DELIMITER).append(Constants.TABLE_NAME).append("=").append(schemaInfoArray[1]);
+
+        MetricOption metricOption = MetricOption.builder()
+                .withInitRecords(subMetricState != null ? subMetricState.getMetricValue(NUM_RECORDS_IN) : 0L)
+                .withInitBytes(subMetricState != null ? subMetricState.getMetricValue(NUM_BYTES_IN) : 0L)
+                .withInlongLabels(labelBuilder.toString())
+                .withRegisterMetric(RegisteredMetric.ALL)
+                .build();
+        return new SourceTableMetricData(metricOption, sourceMetricData.getMetricGroup());
+    }
+
+    /**
+     * build record schema identify
+     *
+     * @param database the database name of record
+     * @param table the table name of record
+     * @return the record schema identify
+     */
+    public String buildSchemaIdentify(String database, String table) {
+        return database + Constants.SEMICOLON + table;
+    }
+
+    /**
+     * parse record schema identify
+     *
+     * @param schemaIdentify the schema identify of record
+     * @return the record schema identify array
+     */
+    public String[] parseSchemaIdentify(String schemaIdentify) {
+        return schemaIdentify.split(Constants.SPILT_SEMICOLON);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param database the database name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshotRecord record
+     * @param data the record data
+     */
+    public void outputMetricsWithEstimate(String database, String table, boolean isSnapshotRecord, Object data) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            outputMetricsWithEstimate(data);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, table);
+        SourceMetricData subSourceMetricData;
+        if (subSourceMetricMap.containsKey(identify)) {
+            subSourceMetricData = subSourceMetricMap.get(identify);
+        } else {
+            subSourceMetricData = buildSubSourceMetricData(new String[]{database, table}, this);
+            subSourceMetricMap.put(identify, subSourceMetricData);
+        }
+        // sourceMetric and subSourceMetric output metrics
+        long rowCountSize = 1L;
+        long rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
+        this.outputMetrics(rowCountSize, rowDataSize);
+        subSourceMetricData.outputMetrics(rowCountSize, rowDataSize);
+
+        // output read phase metric
+        outputReadPhaseMetrics((isSnapshotRecord) ? ReadPhase.SNAPSHOT_PHASE : ReadPhase.INCREASE_PHASE);
+    }
+
+    /**
+     * output read phase metric
+     *
+     * @param readPhase the readPhase of record
+     */
+    public void outputReadPhaseMetrics(ReadPhase readPhase) {
+        outputReadPhaseMetrics(null, readPhase);
+    }
+
+    /**
+     * output read phase metric
+     *
+     * @param metricState the metric state of record
+     * @param readPhase the readPhase of record
+     */
+    public void outputReadPhaseMetrics(MetricState metricState, ReadPhase readPhase) {
+        ReadPhaseMetricData readPhaseMetricData = readPhaseMetricDataMap.get(readPhase);
+        if (readPhaseMetricData == null) {
+            // build read phase metric data
+            String metricGroupLabels = getLabels().entrySet().stream()
+                    .map(entry -> entry.getKey() + "=" + entry.getValue())
+                    .collect(Collectors.joining(DELIMITER));
+
+            MetricOption metricOption = MetricOption.builder()
+                    .withInitReadPhase(metricState != null ? metricState.getMetricValue(readPhase.getPhase()) : 0L)
+                    .withInlongLabels(metricGroupLabels + DELIMITER + READ_PHASE + "=" + readPhase.getValue())
+                    .withRegisterMetric(RegisteredMetric.ALL)
+                    .build();
+            readPhaseMetricData = new ReadPhaseMetricData(metricOption, getMetricGroup());
+            readPhaseMetricDataMap.put(readPhase, readPhaseMetricData);
+        }
+        readPhaseMetricData.outputMetrics();
+    }
+
+    @Override
+    public Map<ReadPhase, ReadPhaseMetricData> getReadPhaseMetricMap() {
+        return readPhaseMetricDataMap;
+    }
+
+    @Override
+    public Map<String, SourceMetricData> getSubSourceMetricMap() {
+        return this.subSourceMetricMap;
+    }
+
+    @Override
+    public String toString() {
+        return "SourceTableMetricData{"
+                + "readPhaseMetricDataMap=" + readPhaseMetricDataMap
+                + ", subSourceMetricMap=" + subSourceMetricMap
+                + '}';
+    }
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
@@ -89,7 +89,7 @@ public class MetricStateUtils {
                         metrics.put(entry.getKey(), entry.getValue());
                     }
                 }
-                // restore sub source metric state
+                // restore sub source metric data state
                 Map<String, MetricState> subIndexMetricStateMap = metricState.getSubMetricStateMap();
                 if (subIndexMetricStateMap != null && !subIndexMetricStateMap.isEmpty()) {
                     for (Entry<String, MetricState> entry : subIndexMetricStateMap.entrySet()) {
@@ -162,7 +162,7 @@ public class MetricStateUtils {
         metricDataMap.put(NUM_BYTES_IN, sourceMetricData.getNumBytesIn().getCount());
         MetricState metricState = new MetricState(subtaskIndex, metricDataMap);
 
-        // snapshot metric state data for SourceSubMetricData
+        // snapshot sub metric data state
         snapshotMetricStateForSourceSubMetricData(sourceMetricData, subtaskIndex, metricState);
         metricStateListState.add(metricState);
     }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
@@ -18,10 +18,16 @@
 
 package org.apache.inlong.sort.base.util;
 
+import java.util.Map.Entry;
+import java.util.Set;
 import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.metrics.Counter;
+import org.apache.inlong.sort.base.enums.ReadPhase;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
+import org.apache.inlong.sort.base.metric.sub.SourceSubMetricData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +75,10 @@ public class MetricStateUtils {
         if (currentSubtaskNum >= previousSubtaskNum) {
             currentMetricState = map.get(subtaskIndex);
         } else {
+            Map<String, MetricState> subMetricStateMap = new HashMap<>();
             Map<String, Long> metrics = new HashMap<>(16);
             currentMetricState = new MetricState(subtaskIndex, metrics);
+            currentMetricState.setSubMetricStateMap(subMetricStateMap);
             List<Integer> indexList = computeIndexList(subtaskIndex, currentSubtaskNum, previousSubtaskNum);
             for (Integer index : indexList) {
                 MetricState metricState = map.get(index);
@@ -79,6 +87,30 @@ public class MetricStateUtils {
                         metrics.put(entry.getKey(), metrics.get(entry.getKey()) + entry.getValue());
                     } else {
                         metrics.put(entry.getKey(), entry.getValue());
+                    }
+                }
+                // restore sub source metric state
+                Map<String, MetricState> subIndexMetricStateMap = metricState.getSubMetricStateMap();
+                if (subIndexMetricStateMap != null && !subIndexMetricStateMap.isEmpty()) {
+                    for (Entry<String, MetricState> entry : subIndexMetricStateMap.entrySet()) {
+                        MetricState subMetricState;
+                        if (subMetricStateMap.containsKey(entry.getKey())) {
+                            subMetricState = subMetricStateMap.get(entry.getKey());
+                            Map<String, Long> subMetrics = subMetricState.getMetrics();
+                            Map<String, Long> currentSubMetrics = entry.getValue().getMetrics();
+                            for (Entry<String, Long> currentSubEntry : currentSubMetrics.entrySet()) {
+                                if (subMetrics.containsKey(currentSubEntry.getKey())) {
+                                    subMetrics.put(currentSubEntry.getKey(),
+                                            subMetrics.get(currentSubEntry.getKey()) + currentSubEntry.getValue());
+                                } else {
+                                    subMetrics.put(currentSubEntry.getKey(), currentSubEntry.getValue());
+                                }
+                            }
+                        } else {
+                            subMetricState = entry.getValue();
+                            subMetricState.setSubtaskIndex(subtaskIndex);
+                        }
+                        subMetricStateMap.put(entry.getKey(), subMetricState);
                     }
                 }
             }
@@ -129,11 +161,52 @@ public class MetricStateUtils {
         metricDataMap.put(NUM_RECORDS_IN, sourceMetricData.getNumRecordsIn().getCount());
         metricDataMap.put(NUM_BYTES_IN, sourceMetricData.getNumBytesIn().getCount());
         MetricState metricState = new MetricState(subtaskIndex, metricDataMap);
+
+        // snapshot metric state data for SourceSubMetricData
+        snapshotMetricStateForSourceSubMetricData(sourceMetricData, subtaskIndex, metricState);
         metricStateListState.add(metricState);
     }
 
     /**
      *
+     * Snapshot sub metric state data for {@link SourceSubMetricData}
+     * @param sourceMetricData {@link SourceMetricData} A collection class for handling metrics
+     * @param subtaskIndex subtask index
+     * @param metricState state of source metric data
+     * @throws Exception throw exception when add sub metric state
+     */
+    private static void snapshotMetricStateForSourceSubMetricData(SourceMetricData sourceMetricData,
+            Integer subtaskIndex, MetricState metricState) {
+        if (!(sourceMetricData instanceof SourceSubMetricData)) {
+            return;
+        }
+        SourceSubMetricData sourcesubMetricData = (SourceSubMetricData) sourceMetricData;
+        // snapshot read phase metric
+        Map<String, Long> metricDataMap = metricState.getMetrics();
+        Map<ReadPhase, ReadPhaseMetricData> readPhaseMetricMap = sourcesubMetricData.getReadPhaseMetricMap();
+        if (readPhaseMetricMap != null && !readPhaseMetricMap.isEmpty()) {
+            Set<Entry<ReadPhase, ReadPhaseMetricData>> entries = readPhaseMetricMap.entrySet();
+            for (Entry<ReadPhase, ReadPhaseMetricData> entry : entries) {
+                Counter readPhase = entry.getValue().getReadPhase();
+                metricDataMap.put(entry.getKey().getPhase(), (readPhase != null) ? readPhase.getCount() : 0L);
+            }
+        }
+        // snapshot sub source metric
+        Map<String, SourceMetricData> subSourceMetricMap = sourcesubMetricData.getSubSourceMetricMap();
+        if (subSourceMetricMap != null && !subSourceMetricMap.isEmpty()) {
+            Map<String, MetricState> subMetricStateMap = new HashMap<>();
+            Set<Entry<String, SourceMetricData>> entries = subSourceMetricMap.entrySet();
+            for (Entry<String, SourceMetricData> entry : entries) {
+                Map<String, Long> subMetricDataMap = new HashMap<>(4);
+                subMetricDataMap.put(NUM_RECORDS_IN, entry.getValue().getNumRecordsIn().getCount());
+                subMetricDataMap.put(NUM_BYTES_IN, entry.getValue().getNumBytesIn().getCount());
+                subMetricStateMap.put(entry.getKey(), new MetricState(subtaskIndex, subMetricDataMap));
+            }
+            metricState.setSubMetricStateMap(subMetricStateMap);
+        }
+    }
+
+    /**
      * Snapshot metric state data for {@link SinkMetricData}
      * @param metricStateListState state data list
      * @param sinkMetricData {@link SinkMetricData} A collection class for handling metrics

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
@@ -18,6 +18,9 @@
 
 package org.apache.inlong.sort.cdc.debezium;
 
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.connector.SnapshotRecord;
+import io.debezium.data.Envelope;
 import io.debezium.document.DocumentReader;
 import io.debezium.document.DocumentWriter;
 import io.debezium.embedded.Connect;
@@ -51,7 +54,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
-import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.sub.SourceTableMetricData;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.cdc.debezium.internal.DebeziumChangeConsumer;
 import org.apache.inlong.sort.cdc.debezium.internal.DebeziumChangeFetcher;
@@ -63,6 +66,7 @@ import org.apache.inlong.sort.cdc.debezium.internal.FlinkOffsetBackingStore;
 import org.apache.inlong.sort.cdc.debezium.internal.Handover;
 import org.apache.inlong.sort.cdc.debezium.internal.SchemaRecord;
 import org.apache.inlong.sort.cdc.debezium.utils.CallbackCollector;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,7 +237,9 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     private String inlongAudit;
 
-    private SourceMetricData sourceMetricData;
+    private boolean migrateAll;
+
+    private SourceTableMetricData sourceMetricData;
 
     private transient ListState<MetricState> metricStateListState;
 
@@ -247,13 +253,15 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             @Nullable DebeziumOffset specificOffset,
             Validator validator,
             String inlongMetric,
-            String inlongAudit) {
+            String inlongAudit,
+            boolean migrateAll) {
         this.deserializer = deserializer;
         this.properties = properties;
         this.specificOffset = specificOffset;
         this.validator = validator;
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
+        this.migrateAll = migrateAll;
     }
 
     @Override
@@ -447,7 +455,11 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 .withRegisterMetric(RegisteredMetric.ALL)
                 .build();
         if (metricOption != null) {
-            sourceMetricData = new SourceMetricData(metricOption, metricGroup);
+            sourceMetricData = new SourceTableMetricData(metricOption, metricGroup);
+            if (migrateAll) {
+                // register sub source metric data from metric state
+                sourceMetricData.registerSubMetricsGroup(metricState);
+            }
         }
 
         properties.setProperty("name", "engine");
@@ -500,7 +512,16 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                             public void deserialize(SourceRecord record, Collector<T> out,
                                     TableChange tableSchema) throws Exception {
                                 deserializer.deserialize(record, new CallbackCollector<>(inputRow -> {
-                                    if (sourceMetricData != null) {
+                                    if (sourceMetricData != null && record != null && migrateAll) {
+                                        Struct value = (Struct) record.value();
+                                        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                                        String dbName = source.getString(AbstractSourceInfo.DATABASE_NAME_KEY);
+                                        String tableName = source.getString(AbstractSourceInfo.TABLE_NAME_KEY);
+                                        SnapshotRecord snapshotRecord = SnapshotRecord.fromSource(source);
+                                        boolean isSnapshotRecord = (SnapshotRecord.TRUE == snapshotRecord);
+                                        sourceMetricData
+                                                .outputMetricsWithEstimate(dbName, tableName, isSnapshotRecord, value);
+                                    } else if (sourceMetricData != null && record != null) {
                                         sourceMetricData.outputMetricsWithEstimate(record.value());
                                     }
                                     out.collect(inputRow);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
@@ -72,6 +72,7 @@ public class MySqlSource {
         private DebeziumDeserializationSchema<T> deserializer;
         private String inlongMetric;
         private String inlongAudit;
+        private boolean migrateAll;
 
         public Builder<T> hostname(String hostname) {
             this.hostname = hostname;
@@ -179,6 +180,11 @@ public class MySqlSource {
             return this;
         }
 
+        public Builder<T> migrateAll(boolean migrateAll) {
+            this.migrateAll = migrateAll;
+            return this;
+        }
+
         /**
          * builder
          */
@@ -273,7 +279,8 @@ public class MySqlSource {
             }
 
             return new DebeziumSourceFunction<>(
-                    deserializer, props, specificOffset, new MySqlValidator(props), inlongMetric, inlongAudit);
+                    deserializer, props, specificOffset, new MySqlValidator(props), inlongMetric, inlongAudit,
+                    migrateAll);
         }
     }
 }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
@@ -300,6 +300,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .startupOptions(startupOptions)
                             .inlongMetric(inlongMetric)
                             .inlongAudit(inlongAudit)
+                            .migrateAll(migrateAll)
                             .deserializer(deserializer);
             Optional.ofNullable(serverId)
                     .ifPresent(serverId -> builder.serverId(Integer.parseInt(serverId)));


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-6584][Sort] Add read phase metric and table level metric for MYSQL

- Fixes #6584

### Motivation

   The background is that when the entire database is migrated, the business needs to count the indicators of table granularity. Dynamically generate table granularity MetricGroup according to the schema of data records; internally maintain MetricGroup container to realize table granularity reporting indicators.

### Modifications

  Inherit the original node-level indicators. Connectors with different table-level indicators use different table-level indicator entities, which are determined by the connector itself
