### PR TITLE
[INLONG-6681][Agent] Handle different sink type configurations

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/JobProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/JobProfile.java
@@ -18,14 +18,23 @@
 package org.apache.inlong.agent.conf;
 
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.agent.constant.JobConstants;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyTopicInfo;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
+
+import java.util.List;
+
+import static org.apache.inlong.agent.constant.JobConstants.JOB_MQ_ClUSTERS;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_MQ_TOPIC;
 
 /**
  * job profile which contains details describing properties of one job.
  */
 public class JobProfile extends AbstractConfiguration {
 
-    private final Gson gson = new Gson();
+    private static final Gson GSON = new Gson();
 
     /**
      * parse json string to configuration instance.
@@ -75,10 +84,35 @@ public class JobProfile extends AbstractConfiguration {
     }
 
     public String toJsonStr() {
-        return gson.toJson(getConfigStorage());
+        return GSON.toJson(getConfigStorage());
     }
 
     public String getInstanceId() {
         return get(JobConstants.JOB_INSTANCE_ID);
+    }
+
+    /**
+     * get MQClusterInfo list from config
+     */
+    public List<MQClusterInfo> getMqClusters() {
+        List<MQClusterInfo> result = null;
+        String mqClusterStr = get(JOB_MQ_ClUSTERS);
+        if (StringUtils.isNotBlank(mqClusterStr)) {
+            result = GSON.fromJson(mqClusterStr, new TypeToken<List<MQClusterInfo>>() {
+            }.getType());
+        }
+        return result;
+    }
+
+    /**
+     * get mqTopic from config
+     */
+    public DataProxyTopicInfo getMqTopic() {
+        DataProxyTopicInfo result = null;
+        String topicStr = get(JOB_MQ_TOPIC);
+        if (StringUtils.isNotBlank(topicStr)) {
+            result = GSON.fromJson(topicStr, DataProxyTopicInfo.class);
+        }
+        return result;
     }
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
@@ -34,7 +34,6 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_SOURCE_CLASS = "job.source";
     public static final String JOB_SOURCE_TYPE = "job.sourceType";
 
-    public static final String JOB_SINK = "job.sink";
     public static final String JOB_CHANNEL = "job.channel";
     public static final String JOB_NAME = "job.name";
     public static final String JOB_LINE_FILTER_PATTERN = "job.pattern";
@@ -43,6 +42,13 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_DESCRIPTION = "job.description";
     public static final String DEFAULT_JOB_DESCRIPTION = "default job description";
     public static final String DEFAULT_JOB_LINE_FILTER = "";
+
+    // sink config
+    public static final String JOB_SINK = "job.sink";
+    public static final String JOB_PROXY_SEND = "job.proxySend";
+    public static final boolean DEFAULT_JOB_PROXY_SEND = false;
+    public static final String JOB_MQ_ClUSTERS = "job.mqClusters";
+    public static final String JOB_MQ_TOPIC = "job.topicInfo";
 
     // File job
     public static final String JOB_TRIGGER = "job.fileJob.trigger";

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/conf/TestConfiguration.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/conf/TestConfiguration.java
@@ -17,12 +17,26 @@
 
 package org.apache.inlong.agent.conf;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.inlong.agent.constant.JobConstants;
+import org.apache.inlong.agent.pojo.JobProfileDto;
+import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.common.pojo.agent.DataConfig;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyTopicInfo;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.inlong.agent.constant.JobConstants.JOB_PROXY_SEND;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_SINK;
+import static org.apache.inlong.agent.pojo.JobProfileDto.DEFAULT_DATAPROXY_SINK;
+import static org.apache.inlong.agent.pojo.JobProfileDto.PULSAR_SINK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TestConfiguration {
 
@@ -68,6 +82,44 @@ public class TestConfiguration {
         Assert.assertTrue(jobJsonConf.allRequiredKeyExist());
         assertEquals("1", jobJsonConf.get(JobConstants.JOB_ID));
         assertEquals("test", jobJsonConf.get(JobConstants.JOB_NAME));
+    }
+
+    @Test
+    public void testJobSinkConf() {
+        DataConfig dataConfig = new DataConfig();
+        dataConfig.setTaskType(101);
+        dataConfig.setDataReportType(1);
+        JobProfile profile = JobProfileDto.convertToTriggerProfile(dataConfig);
+        assertEquals(profile.get(JOB_SINK), DEFAULT_DATAPROXY_SINK);
+        assertTrue(profile.getBoolean(JOB_PROXY_SEND, false));
+
+        dataConfig.setDataReportType(0);
+        profile = JobProfileDto.convertToTriggerProfile(dataConfig);
+        assertEquals(profile.get(JOB_SINK), DEFAULT_DATAPROXY_SINK);
+        assertFalse(profile.getBoolean(JOB_PROXY_SEND, true));
+
+        List<MQClusterInfo> mqClusterInfos = new ArrayList<>();
+        MQClusterInfo mqCluster = new MQClusterInfo();
+        mqCluster.setMqType(MQType.PULSAR);
+        mqCluster.setToken("token");
+        mqCluster.setUrl("mqurl");
+        assertTrue(mqCluster.isValid());
+
+        mqClusterInfos.add(mqCluster);
+        dataConfig.setDataReportType(2);
+        dataConfig.setMqClusters(mqClusterInfos);
+        dataConfig.setTopicInfo(new DataProxyTopicInfo("topic", "groupId"));
+        profile = JobProfileDto.convertToTriggerProfile(dataConfig);
+        List<MQClusterInfo> mqClusterResult = profile.getMqClusters();
+
+        assertEquals(profile.get(JOB_SINK), PULSAR_SINK);
+        assertEquals(mqClusterResult.size(), 1);
+        assertEquals(mqClusterResult.get(0).getToken(), "token");
+        assertEquals(mqClusterResult.get(0).getUrl(), "mqurl");
+
+        DataProxyTopicInfo topicResult = profile.getMqTopic();
+        assertEquals(topicResult.getTopic(), "topic");
+        assertEquals(topicResult.getInlongGroupId(), "groupId");
     }
 
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/job/Job.java
@@ -38,14 +38,15 @@ import java.util.List;
 public class Job {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Job.class);
-    private static int COUNTER = 1;
-    private final JobProfile jobConf;
+    protected static int COUNTER = 1;
+    protected final JobProfile jobConf;
     // job name
     private String name;
     // job description
     private String description;
-    private String jobInstanceId;
-    private ThreadLocal<Integer> threadNum = new ThreadLocal<Integer>() {
+    protected String jobInstanceId;
+    protected List<Task> taskList = new ArrayList<>();
+    protected ThreadLocal<Integer> threadNum = new ThreadLocal<Integer>() {
 
         protected Integer initialValue() {
             return 0;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/SenderManager.java
@@ -52,6 +52,8 @@ import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AU
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_HOST;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_PORT;
+import static org.apache.inlong.agent.constant.JobConstants.DEFAULT_JOB_PROXY_SEND;
+import static org.apache.inlong.agent.constant.JobConstants.JOB_PROXY_SEND;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.KEY_INLONG_GROUP_ID;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.KEY_INLONG_STREAM_ID;
 import static org.apache.inlong.agent.metrics.AgentMetricItem.KEY_PLUGIN_ID;
@@ -89,6 +91,7 @@ public class SenderManager {
     private final String inlongGroupId;
     private final int maxSenderPerGroup;
     private final String sourcePath;
+    private final boolean proxySend;
 
     // metric
     private AgentMetricItemSet metricItemSet;
@@ -104,6 +107,7 @@ public class SenderManager {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
         managerHost = conf.get(AGENT_MANAGER_VIP_HTTP_HOST);
         managerPort = conf.getInt(AGENT_MANAGER_VIP_HTTP_PORT);
+        proxySend = jobConf.getBoolean(JOB_PROXY_SEND, DEFAULT_JOB_PROXY_SEND);
         localhost = jobConf.get(CommonConstants.PROXY_LOCAL_HOST, CommonConstants.DEFAULT_PROXY_LOCALHOST);
         netTag = jobConf.get(CommonConstants.PROXY_NET_TAG, CommonConstants.DEFAULT_PROXY_NET_TAG);
         isLocalVisit = jobConf.getBoolean(
@@ -240,10 +244,10 @@ public class SenderManager {
             AgentUtils.silenceSleepInMs(retrySleepTime);
         }
         try {
-            selectSender(batchMessage.getGroupId()).asyncSendMessage(
-                    new AgentSenderCallback(batchMessage, retry), batchMessage.getDataList(),
-                    batchMessage.getGroupId(), batchMessage.getStreamId(), batchMessage.getDataTime(),
-                    SEQUENTIAL_ID.getNextUuid(), maxSenderTimeout, TimeUnit.SECONDS, batchMessage.getExtraMap());
+            selectSender(batchMessage.getGroupId()).asyncSendMessage(new AgentSenderCallback(batchMessage, retry),
+                    batchMessage.getDataList(), batchMessage.getGroupId(), batchMessage.getStreamId(),
+                    batchMessage.getDataTime(), SEQUENTIAL_ID.getNextUuid(), maxSenderTimeout, TimeUnit.SECONDS,
+                    batchMessage.getExtraMap(), proxySend);
             int msgCnt = batchMessage.getDataList().size();
             getMetricItem(batchMessage.getGroupId(), batchMessage.getStreamId()).pluginSendCount.addAndGet(msgCnt);
 
@@ -275,7 +279,7 @@ public class SenderManager {
 
         try {
             SendResult result = selectSender(groupId).sendMessage(batchMessage.getDataList(), groupId, streamId,
-                    dataTime, "", maxSenderTimeout, TimeUnit.SECONDS, batchMessage.getExtraMap());
+                    dataTime, "", maxSenderTimeout, TimeUnit.SECONDS, batchMessage.getExtraMap(), proxySend);
             metricItem.pluginSendCount.addAndGet(msgCnt);
 
             if (result == SendResult.OK) {

--- a/inlong-common/pom.xml
+++ b/inlong-common/pom.xml
@@ -80,6 +80,10 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/DataReportTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/DataReportTypeEnum.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.enums;
+
+/**
+ * Enum of data report type
+ */
+public enum DataReportTypeEnum {
+
+    NORMAL_SEND_TO_DATAPROXY(0),
+    PROXY_SEND_TO_DATAPROXY(1),
+    DIRECT_SEND_TO_MQ(2);
+
+    private final int type;
+
+    DataReportTypeEnum(int type) {
+        this.type = type;
+    }
+
+    public static DataReportTypeEnum getReportType(int type) {
+        switch (type) {
+            case 0:
+                return NORMAL_SEND_TO_DATAPROXY;
+            case 1:
+                return PROXY_SEND_TO_DATAPROXY;
+            case 2:
+                return DIRECT_SEND_TO_MQ;
+            default:
+                throw new RuntimeException("Unsupported data report type " + type);
+        }
+    }
+
+    public int getType() {
+        return type;
+    }
+}

--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
@@ -36,6 +36,9 @@ public enum TaskTypeEnum {
     REDIS(11),
     MQTT(12),
 
+    // only used for unit test
+    MOCK(101)
+
     ;
 
     private final int type;
@@ -70,6 +73,8 @@ public enum TaskTypeEnum {
                 return TUBEMQ;
             case 12:
                 return MQTT;
+            case 101:
+                return MOCK;
             default:
                 throw new RuntimeException("Unsupported task type " + taskType);
         }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/DataConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/DataConfig.java
@@ -19,10 +19,15 @@ package org.apache.inlong.common.pojo.agent;
 
 import lombok.Data;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.inlong.common.enums.DataReportTypeEnum;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyTopicInfo;
 import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 
 import java.util.List;
+
+import static org.apache.inlong.common.enums.DataReportTypeEnum.DIRECT_SEND_TO_MQ;
+import static org.apache.inlong.common.enums.DataReportTypeEnum.NORMAL_SEND_TO_DATAPROXY;
+import static org.apache.inlong.common.enums.DataReportTypeEnum.PROXY_SEND_TO_DATAPROXY;
 
 /**
  * The task config for agent.
@@ -75,10 +80,11 @@ public class DataConfig {
     private DataProxyTopicInfo topicInfo;
 
     public boolean isValid() {
-        if (dataReportType == 0 || dataReportType == 1) {
+        DataReportTypeEnum reportType = DataReportTypeEnum.getReportType(dataReportType);
+        if (reportType == NORMAL_SEND_TO_DATAPROXY || reportType == PROXY_SEND_TO_DATAPROXY) {
             return true;
         }
-        if (dataReportType == 2 && CollectionUtils.isNotEmpty(mqClusters) && mqClusters.stream()
+        if (reportType == DIRECT_SEND_TO_MQ && CollectionUtils.isNotEmpty(mqClusters) && mqClusters.stream()
                 .allMatch(MQClusterInfo::isValid) && topicInfo.isValid()) {
             return true;
         }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/DataConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/DataConfig.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.common.pojo.agent;
 
 import lombok.Data;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyTopicInfo;
 import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 
@@ -74,6 +75,13 @@ public class DataConfig {
     private DataProxyTopicInfo topicInfo;
 
     public boolean isValid() {
-        return true;
+        if (dataReportType == 0 || dataReportType == 1) {
+            return true;
+        }
+        if (dataReportType == 2 && CollectionUtils.isNotEmpty(mqClusters) && mqClusters.stream()
+                .allMatch(MQClusterInfo::isValid) && topicInfo.isValid()) {
+            return true;
+        }
+        return false;
     }
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyTopicInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/DataProxyTopicInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.common.pojo.dataproxy;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Topic info for DataProxy, includes the topic name and the inlongGroupId to which it belongs.
  */
@@ -81,6 +83,10 @@ public class DataProxyTopicInfo {
 
     public void setM(String m) {
         this.m = m;
+    }
+
+    public boolean isValid() {
+        return StringUtils.isNoneBlank(inlongGroupId) && StringUtils.isNotBlank(topic);
     }
 
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/MQClusterInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/dataproxy/MQClusterInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.common.pojo.dataproxy;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +29,9 @@ public class MQClusterInfo {
 
     private String url;
     private String token;
+    /**
+     * MQType.PULSAR, MQType.TUBEMQ  or MQType.PULSAR
+     */
     private String mqType;
     private Map<String, String> params = new HashMap<>();
 
@@ -60,5 +65,12 @@ public class MQClusterInfo {
 
     public void setParams(Map<String, String> params) {
         this.params = params;
+    }
+
+    public boolean isValid() {
+        if (StringUtils.isBlank(mqType) || StringUtils.isBlank(url)) {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-6681][Agent] Handle different sink type configurations

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6681 

### Motivation
- Let `Agent` support different sink type, such as `DataProxy` and Pulsar etc.

### Modifications
- Parse and handle sink configuration of agent job
- Based sink configuration, choose proxySend or not

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
