### PR TITLE
[INLONG-6675][Sort] Sort does not report metrics because Flink Sql missing the metrics.audit.proxy.hosts parameter

### DIFF
--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -285,6 +285,8 @@ public class FlinkService {
         list.add(flinkInfo.getLocalConfPath());
         list.add("-checkpoint.interval");
         list.add("60000");
+        list.add("-metrics.audit.proxy.hosts");
+        list.add(flinkConfig.getAuditProxyHosts());
         return list.toArray(new String[0]);
     }
 

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -58,7 +58,8 @@ public class Entrance {
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {
             final GroupInfo groupInfo = getGroupInfoFromFile(config.getString(Constants.GROUP_INFO_FILE));
-            parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+            String auditProxyHosts = config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS);
+            parser = FlinkSqlParser.getInstance(tableEnv, groupInfo, auditProxyHosts);
         } else {
             String statements = getStatementSetFromFile(sqlFile);
             parser = NativeFlinkSqlParser.getInstance(tableEnv, statements);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -18,6 +18,8 @@
 package org.apache.inlong.sort.parser.impl;
 
 import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.inlong.sort.configuration.Constants;
@@ -83,6 +85,10 @@ public class FlinkSqlParser implements Parser {
     private final List<String> loadTableSqls = new ArrayList<>();
     private final List<String> insertSqls = new ArrayList<>();
 
+    @Getter
+    @Setter
+    private String auditProxyHosts;
+
     /**
      * Flink sql parse constructor
      *
@@ -104,6 +110,20 @@ public class FlinkSqlParser implements Parser {
      */
     public static FlinkSqlParser getInstance(TableEnvironment tableEnv, GroupInfo groupInfo) {
         return new FlinkSqlParser(tableEnv, groupInfo);
+    }
+
+    /**
+     * Get an instance of FlinkSqlParser
+     *
+     * @param tableEnv The tableEnv, it is the execution environment of flink sql
+     * @param groupInfo The groupInfo, it is the data model abstraction of task execution
+     * @param auditProxyHosts The auditProxyHosts, it is used to report audit metrics
+     * @return FlinkSqlParser The flink sql parse handler
+     */
+    public static FlinkSqlParser getInstance(TableEnvironment tableEnv, GroupInfo groupInfo, String auditProxyHosts) {
+        FlinkSqlParser flinkSqlParser = new FlinkSqlParser(tableEnv, groupInfo);
+        flinkSqlParser.setAuditProxyHosts(auditProxyHosts);
+        return flinkSqlParser;
     }
 
     /**
@@ -194,10 +214,10 @@ public class FlinkSqlParser implements Parser {
                             Constants.STREAM_ID + "=" + streamInfo.getStreamId(),
                             Constants.NODE_ID + "=" + node.getId())
                             .collect(Collectors.joining("&")));
-            // METRICS_AUDIT_PROXY_HOSTS depends on INLONG_GROUP_STREAM_NODE
-            if (StringUtils.isNotEmpty(groupInfo.getProperties().get(Constants.METRICS_AUDIT_PROXY_HOSTS.key()))) {
+
+            if (StringUtils.isNotEmpty(auditProxyHosts)) {
                 properties.put(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
-                        groupInfo.getProperties().get(Constants.METRICS_AUDIT_PROXY_HOSTS.key()));
+                        auditProxyHosts);
             }
         });
     }


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-6675][Sort] Sort does not report metrics because Flink Sql missing the metrics.audit.proxy.hosts parameter

- Fixes #6675 

### Motivation

Fix `metrics.audit.proxy.hosts` parameter missing problem.

### Modifications

Pass the `metrics.audit.proxy.hosts` parameter to `org.apache.inlong.sort.Entrance`.
