### PR TITLE
[INLONG-6690][Sort] Fix the multiple migrations of Doris when batch delete was enabled

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -234,7 +234,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             Schema schema = RestService.getSchema(options, readOptions, LOG);
             return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
         } catch (DorisException e) {
-            throw new RuntimeException("Failed fetch doris table schema: " + options.getTableIdentifier(), e);
+            return executionOptions.getEnableDelete();
         }
     }
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -230,11 +230,14 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     }
 
     private boolean enableBatchDelete() {
+        if (multipleSink) {
+            return executionOptions.getEnableDelete();
+        }
         try {
             Schema schema = RestService.getSchema(options, readOptions, LOG);
             return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
         } catch (DorisException e) {
-            return executionOptions.getEnableDelete();
+            throw new RuntimeException("Failed fetch doris single table schema: " + options.getTableIdentifier(), e);
         }
     }
 


### PR DESCRIPTION
[ [INLONG-6690] doris multiple sink migration throws exception at enable batch delete](https://github.com/apache/inlong/issues/6690) 

A one liner bugfix which fixes the issue of some problems encountered when doing multiple sink migration