### PR TITLE
[INLONG-6675][Sort] Add metrics.audit.proxy.hosts option to support report metrics

### DIFF
--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -32,7 +32,6 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
-import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkConfig;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkInfo;
 import org.apache.inlong.manager.plugin.flink.dto.StopWithSavepointRequest;
@@ -196,7 +195,7 @@ public class FlinkService {
     private String submitJobBySavepoint(FlinkInfo flinkInfo, SavepointRestoreSettings settings) throws Exception {
         String localJarPath = flinkInfo.getLocalJarPath();
         final File jarFile = new File(localJarPath);
-        final String[] programArgs = genProgramArgsV2(flinkInfo, flinkConfig);
+        final String[] programArgs = genProgramArgs(flinkInfo, flinkConfig);
 
         List<URL> connectorJars = flinkInfo.getConnectorJarPaths().stream().map(p -> {
             try {
@@ -254,30 +253,7 @@ public class FlinkService {
     /**
      * Build the program of the Flink job.
      */
-    @Deprecated
     private String[] genProgramArgs(FlinkInfo flinkInfo, FlinkConfig flinkConfig) {
-        List<String> list = new ArrayList<>();
-        list.add("-cluster-id");
-        list.add(flinkInfo.getJobName());
-        list.add("-dataflow.info.file");
-        list.add(flinkInfo.getLocalConfPath());
-        list.add("-source.type");
-        list.add(flinkInfo.getSourceType());
-        list.add("-sink.type");
-        list.add(flinkInfo.getSinkType());
-        list.add("-metrics.audit.proxy.hosts");
-        list.add(flinkConfig.getAuditProxyHosts());
-        // TODO Support more than one stream with one group
-        if (flinkInfo.getInlongStreamInfoList() != null
-                && !flinkInfo.getInlongStreamInfoList().isEmpty()) {
-            InlongStreamInfo inlongStreamInfo = flinkInfo.getInlongStreamInfoList().get(0);
-            list.add("-job.orderly.output");
-            list.add(String.valueOf(inlongStreamInfo.getSyncSend()));
-        }
-        return list.toArray(new String[0]);
-    }
-
-    private String[] genProgramArgsV2(FlinkInfo flinkInfo, FlinkConfig flinkConfig) {
         List<String> list = new ArrayList<>();
         list.add("-cluster-id");
         list.add(flinkInfo.getJobName());

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -285,6 +285,8 @@ public class FlinkService {
         list.add(flinkInfo.getLocalConfPath());
         list.add("-checkpoint.interval");
         list.add("60000");
+        list.add("-metrics.audit.proxy.hosts");
+        list.add(flinkConfig.getAuditProxyHosts());
         return list.toArray(new String[0]);
     }
 

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -58,12 +58,9 @@ public class Entrance {
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {
             final GroupInfo groupInfo = getGroupInfoFromFile(config.getString(Constants.GROUP_INFO_FILE));
-            boolean hasAuditProxyHosts =
-                    StringUtils.isNotEmpty(groupInfo.getProperties().get(Constants.METRICS_AUDIT_PROXY_HOSTS.key()));
-            if (!hasAuditProxyHosts) {
-                groupInfo.getProperties().put(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
-                        config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS));
-            }
+            groupInfo.getProperties().putIfAbsent(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
+                    config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS));
+
             parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
         } else {
             String statements = getStatementSetFromFile(sqlFile);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -58,6 +58,12 @@ public class Entrance {
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {
             final GroupInfo groupInfo = getGroupInfoFromFile(config.getString(Constants.GROUP_INFO_FILE));
+            boolean hasAuditProxyHosts =
+                    StringUtils.isNotEmpty(groupInfo.getProperties().get(Constants.METRICS_AUDIT_PROXY_HOSTS.key()));
+            if (!hasAuditProxyHosts) {
+                groupInfo.getProperties().put(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
+                        config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS));
+            }
             parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
         } else {
             String statements = getStatementSetFromFile(sqlFile);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/Entrance.java
@@ -58,9 +58,10 @@ public class Entrance {
         Parser parser;
         if (StringUtils.isEmpty(sqlFile)) {
             final GroupInfo groupInfo = getGroupInfoFromFile(config.getString(Constants.GROUP_INFO_FILE));
-            groupInfo.getProperties().putIfAbsent(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
-                    config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS));
-
+            if (StringUtils.isNotEmpty(config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS))) {
+                groupInfo.getProperties().putIfAbsent(Constants.METRICS_AUDIT_PROXY_HOSTS.key(),
+                        config.getString(Constants.METRICS_AUDIT_PROXY_HOSTS));
+            }
             parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
         } else {
             String statements = getStatementSetFromFile(sqlFile);
@@ -72,7 +73,7 @@ public class Entrance {
     }
 
     private static String getStatementSetFromFile(String fileName) throws IOException {
-        return Files.toString(new File(fileName), StandardCharsets.UTF_8);
+        return Files.asCharSource(new File(fileName), StandardCharsets.UTF_8).read();
     }
 
     private static GroupInfo getGroupInfoFromFile(String fileName) throws IOException {


### PR DESCRIPTION
### Prepare a Pull Request
- Title: [INLONG-6675][Sort] Sort does not report metrics because Flink Sql missing the `metrics.audit.proxy.hosts` parameter

- Fixes #6675 

### Motivation

Fix `metrics.audit.proxy.hosts` parameter missing problem.

### Modifications

Pass the `metrics.audit.proxy.hosts` parameter to `org.apache.inlong.sort.Entrance`