### PR TITLE
[INLONG-6689][Docker]  Support running docker-compose on Arm Chip

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: '2.3'
+version: '2.4'
 
 services:
   mysql:
     image: mysql:8.0.28
     container_name: mysql
-    platform: linux/x86_64
+    platform: "linux/x86_64"
     ports:
       - "3306:3306"
     environment:

--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   mysql:
     image: mysql:8.0.28
     container_name: mysql
+    platform: linux/x86_64
     ports:
       - "3306:3306"
     environment:


### PR DESCRIPTION
### Support running docker-compose on Arm Chip

Fixes #6689 

### Motivation

Specify the `--platform` parameter of the `MySQL` image.

### Modifications

By modifying the `--platform` parameter of the `MySQL` image, it can simulate `x86` instructions to build a docker image under different system architectures, and only need the same `docker-compose` script

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
