### PR TITLE
[INLONG-6702][DataProxy] Modify DataProxy to obtain the default network card name of the local ip

### DIFF
--- a/inlong-dataproxy/dataproxy-docker/Dockerfile
+++ b/inlong-dataproxy/dataproxy-docker/Dockerfile
@@ -27,7 +27,7 @@ EXPOSE 46801 46802
 ENV MANAGER_OPENAPI_IP=127.0.0.1
 ENV MANAGER_OPENAPI_PORT=8083
 # specify the name of the network card in the container to obtain the local IP
-ENV ETH_NAME=eth1
+ENV ETH_NAME=eth0
 # enable audit, true or false
 ENV AUDIT_ENABLE=true
 ENV AUDIT_PROXY_URL=127.0.0.1:10081


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

[INLONG-6702][DataProxy] Modify DataProxy to obtain the default network card name of the local ip

- Fixes #6702

### Motivation

In most cases, the container network card will use eth0, but the current default is eth1, which leads to certain thresholds and doubts for users who are not deep in use, so change the default network card name to eth0 in most cases.

### Modifications

Changing the default network card name to eth0.