### PR TITLE
[INLONG-6724][Sort] Supports dirty data side-output for doris sink

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
@@ -23,6 +23,10 @@ package org.apache.inlong.sort.base.dirty;
 public enum DirtyType {
 
     /**
+     * Undefined dirty type
+     */
+    UNDEFINED("Undefined"),
+    /**
      * Field mapping error, it refers to the field mapping error between source
      * and sink or between the flink system and the external system.
      * For example, the number of fields contained in the flink system
@@ -61,9 +65,18 @@ public enum DirtyType {
      */
     VALUE_SERIALIZE_ERROR("ValueSerializeError"),
     /**
-     * Undefined dirty type
+     * Batch load error
      */
-    UNDEFINED("Undefined");
+    BATCH_LOAD_ERROR("BatchLoadError"),
+    /**
+     * Unsupported data type
+     */
+    UNSUPPORTED_DATA_TYPE("UnsupportedDataType"),
+    /**
+     * Json process error
+     */
+    JSON_PROCESS_ERROR("JsonProcessError"),
+    ;
 
     private final String format;
 

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisExtractNodeToDorisLoadNodeTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisExtractNodeToDorisLoadNodeTest.java
@@ -42,9 +42,9 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
@@ -75,7 +75,6 @@ public class DorisExtractNodeToDorisLoadNodeTest extends AbstractTestBase {
                 new FieldInfo("age", new IntFormatInfo()),
                 new FieldInfo("price", new DecimalFormatInfo()),
                 new FieldInfo("sale", new DoubleFormatInfo()));
-
         List<FieldRelation> fieldRelations = Arrays
                 .asList(new FieldRelation(new FieldInfo("dt", new StringFormatInfo()),
                         new FieldInfo("dt", new StringFormatInfo())),
@@ -91,9 +90,15 @@ public class DorisExtractNodeToDorisLoadNodeTest extends AbstractTestBase {
                                 new FieldInfo("sale", new DoubleFormatInfo())));
 
         List<FilterFunction> filters = new ArrayList<>();
-        Map<String, String> map = new HashMap<>();
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=test&table=test2");
         return new DorisLoadNode("2", "doris_output", fields, fieldRelations,
-                filters, null, 1, map,
+                filters, null, 1, properties,
                 "localhost:8030", "root",
                 "000000", "test.test2", null);
     }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisMultipleSinkTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/DorisMultipleSinkTest.java
@@ -39,7 +39,9 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -73,8 +75,22 @@ public class DorisMultipleSinkTest {
         List<FieldRelation> relations = Collections
                 .singletonList(new FieldRelation(new FieldInfo("raw", new VarBinaryFormatInfo()),
                         new FieldInfo("raw", new VarBinaryFormatInfo())));
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=${database}&table=${table}");
+        properties.put("dirty.identifier", "${database}-${table}-${SYSTEM_TIME}");
+        properties.put("dirty.side-output.s3.bucket", "s3-test-bucket");
+        properties.put("dirty.side-output.s3.endpoint", "s3.test.endpoint");
+        properties.put("dirty.side-output.s3.key", "dirty/test");
+        properties.put("dirty.side-output.s3.region", "region");
+        properties.put("dirty.side-output.s3.access-key-id", "access_key_id");
+        properties.put("dirty.side-output.s3.secret-key-id", "secret_key_id");
         return new DorisLoadNode("2", "doris_output", fields, relations,
-                null, null, 1, null,
+                null, null, 1, properties,
                 "localhost:8030", "root", "000000", null,
                 null, true, new CanalJsonFormat(), databasePattern, tablePattern);
     }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6724

### Motivation

Supports dirty data side-output for Doris sink.

In this part:
1. Load 'DirtySinkFactory' and create 'DirtySink' by the config
2. It needs to determine whether it is dirty data in the connector.
3. Side output dirty data by the 'DirtySink' dependents on the configured, the built-in side-out of dirty data has 'LogDirtySink'(#6618) and 'S3DirtySink'(#6655).

### Modifications

1. Create a dirty sink and inject it into Doris sink
2. Add dirty handle for 'DorisDynamicSchemaOutputFormat'
3. Add a unit test for this

### Verifying this change

- [x] This change is already covered by existing tests, such as:

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
