### PR TITLE
[INLONG-6732][Manager] Fix wrong SortSDK topic properties

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -383,7 +383,7 @@ public class SortSourceServiceImpl implements SortSourceService {
                     String fullTopic = tenant.concat("/").concat(namespace).concat("/").concat(topic);
                     return Topic.builder()
                             .topic(fullTopic)
-                            .topicProperties(streamInfo.getExtParamsMap())
+                            .topicProperties(sink.getExtParamsMap())
                             .build();
                 })
                 .collect(Collectors.toList());


### PR DESCRIPTION

- Fixes #6732 

### Motivation

SortSdk topic properties should get from stream_sink instead of inlong_stream.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
