### PR TITLE
[INLONG-6738][DataProxy] New sink architecture integration

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/ComponentHeartbeat.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/ComponentHeartbeat.java
@@ -31,6 +31,8 @@ public class ComponentHeartbeat {
 
     private String clusterTag;
 
+    private String extTag;
+
     private String clusterName;
 
     private String componentType;
@@ -49,11 +51,12 @@ public class ComponentHeartbeat {
     public ComponentHeartbeat() {
     }
 
-    public ComponentHeartbeat(String clusterTag, String clusterName,
-            String componentType, String ip, String port,
-            String inCharges, String protocolType) {
+    public ComponentHeartbeat(String clusterTag, String extTag,
+            String clusterName, String componentType, String ip,
+            String port, String inCharges, String protocolType) {
         this.nodeSrvStatus = NodeSrvStatus.OK;
         this.clusterTag = clusterTag;
+        this.extTag = extTag;
         this.clusterName = clusterName;
         this.componentType = componentType;
         this.ip = ip;
@@ -64,11 +67,12 @@ public class ComponentHeartbeat {
     }
 
     public ComponentHeartbeat(NodeSrvStatus nodeSrvStatus,
-            String clusterTag, String clusterName,
+            String clusterTag, String extTag, String clusterName,
             String componentType, String ip, String port,
             String inCharges, String protocolType, int loadValue) {
         this.nodeSrvStatus = nodeSrvStatus;
         this.clusterTag = clusterTag;
+        this.extTag = extTag;
         this.clusterName = clusterName;
         this.componentType = componentType;
         this.ip = ip;

--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
@@ -78,7 +78,7 @@ public class HeartbeatMsg {
     /**
      * Ext tag of cluster, key=value pairs seperated by &
      */
-    private String clusterExtTag;
+    private String extTag;
 
     /**
      * Name of responsible person, separated by commas(,)
@@ -101,7 +101,7 @@ public class HeartbeatMsg {
     private Integer load = 0xffff;
 
     public ComponentHeartbeat componentHeartbeat() {
-        return new ComponentHeartbeat(nodeSrvStatus, clusterTag, clusterExtTag, clusterName,
+        return new ComponentHeartbeat(nodeSrvStatus, clusterTag, extTag, clusterName,
                 componentType, ip, port, inCharges, protocolType, load);
     }
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
@@ -76,6 +76,11 @@ public class HeartbeatMsg {
     private String clusterTag;
 
     /**
+     * Ext tag of cluster, key=value pairs seperated by &
+     */
+    private String clusterExtTag;
+
+    /**
      * Name of responsible person, separated by commas(,)
      */
     private String inCharges = "admin";
@@ -96,7 +101,7 @@ public class HeartbeatMsg {
     private Integer load = 0xffff;
 
     public ComponentHeartbeat componentHeartbeat() {
-        return new ComponentHeartbeat(nodeSrvStatus, clusterTag, clusterName,
+        return new ComponentHeartbeat(nodeSrvStatus, clusterTag, clusterExtTag, clusterName,
                 componentType, ip, port, inCharges, protocolType, load);
     }
 }

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -24,6 +24,7 @@ manager.auth.secretKey=
 # proxy cluster name
 proxy.cluster.name=default_dataproxy
 proxy.cluster.tag=default_cluster
+proxy.cluster.extTag=default=true
 proxy.cluster.inCharges=admin
 # check interval of local config (millisecond)
 configCheckInterval=10000

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -38,3 +38,7 @@ prometheusHttpPort=9081
 audit.enable=true
 # audit proxy address
 audit.proxys=127.0.0.1:10081
+
+# remote config loader
+idTopicConfig.type=org.apache.inlong.dataproxy.config.loader.ManagerIdTopicConfigLoader
+cacheClusterConfig.type=org.apache.inlong.dataproxy.config.loader.ManagerCacheClusterConfigLoader

--- a/inlong-dataproxy/conf/dataproxy-pulsar.conf
+++ b/inlong-dataproxy/conf/dataproxy-pulsar.conf
@@ -116,17 +116,22 @@ agent1.channels.ch-msg6.fsyncPerTransaction = false
 agent1.channels.ch-msg6.fsyncInterval = 10
 
 agent1.sinks.pulsar-sink-msg1.channel = ch-msg1
-agent1.sinks.pulsar-sink-msg1.type = org.apache.inlong.dataproxy.sink.PulsarSink
+agent1.sinks.pulsar-sink-msg1.type = org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSink
+agent1.sinks.pulsar-sink-msg1.maxThreads=1
 
 agent1.sinks.pulsar-sink-msg2.channel = ch-msg2
-agent1.sinks.pulsar-sink-msg2.type = org.apache.inlong.dataproxy.sink.PulsarSink
+agent1.sinks.pulsar-sink-msg2.type = org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSink
+agent1.sinks.pulsar-sink-msg1.maxThreads=1
 
 # For order message
 agent1.sinks.pulsar-sink-msg3.channel = ch-msg3
-agent1.sinks.pulsar-sink-msg3.type = org.apache.inlong.dataproxy.sink.PulsarSink
+agent1.sinks.pulsar-sink-msg3.type = org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSink
+agent1.sinks.pulsar-sink-msg1.maxThreads=1
 
 agent1.sinks.pulsar-sink-msg5.channel = ch-msg5
-agent1.sinks.pulsar-sink-msg5.type = org.apache.inlong.dataproxy.sink.PulsarSink
+agent1.sinks.pulsar-sink-msg5.type = org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSink
+agent1.sinks.pulsar-sink-msg1.maxThreads=1
 
 agent1.sinks.pulsar-sink-msg6.channel = ch-msg6
-agent1.sinks.pulsar-sink-msg6.type = org.apache.inlong.dataproxy.sink.PulsarSink
+agent1.sinks.pulsar-sink-msg6.type = org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSink
+agent1.sinks.pulsar-sink-msg1.maxThreads=1

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/RemoteConfigManager.java
@@ -108,18 +108,19 @@ public class RemoteConfigManager implements IRepository {
                 try {
                     String strReloadInterval = CommonPropertiesHolder.getString(KEY_CONFIG_CHECK_INTERVAL);
                     instance.reloadInterval = NumberUtils.toLong(strReloadInterval, DEFAULT_HEARTBEAT_INTERVAL_MS);
-                    //
-                    String ipListParserType = CommonPropertiesHolder.getString(IManagerIpListParser.KEY_MANAGER_TYPE);
+
+                    String ipListParserType = CommonPropertiesHolder.getString(IManagerIpListParser.KEY_MANAGER_TYPE,
+                            DefaultManagerIpListParser.class.getName());
                     Class<? extends IManagerIpListParser> ipListParserClass;
                     ipListParserClass = (Class<? extends IManagerIpListParser>) Class
                             .forName(ipListParserType);
                     instance.ipListParser = ipListParserClass.getDeclaredConstructor().newInstance();
-                    //
+
                     SecureRandom random = new SecureRandom(String.valueOf(System.currentTimeMillis()).getBytes());
                     instance.managerIpListIndex.set(random.nextInt());
-                    //
+
                     instance.httpClient = constructHttpClient();
-                    //
+
                     instance.reload();
                     instance.setReloadTimer();
                     isInit = true;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -98,6 +98,7 @@ public class ConfigConstants {
     public static final String PROXY_CLUSTER_NAME = "proxy.cluster.name";
     public static final String DEFAULT_PROXY_CLUSTER_NAME = "DataProxy";
     public static final String PROXY_CLUSTER_TAG = "proxy.cluster.tag";
+    public static final String PROXY_CLUSTER_EXT_TAG = "proxy.cluster.extTag";
     public static final String PROXY_CLUSTER_INCHARGES = "proxy.cluster.inCharges";
     public static final String CONFIG_CHECK_INTERVAL = "configCheckInterval";
     public static final String SOURCE_NO_TOPIC_ACCEPT = "source.topic.notfound.accept";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
@@ -144,6 +144,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
                 ConfigConstants.PROXY_CLUSTER_NAME, DEFAULT_CLUSTER_NAME));
         heartbeatMsg.setInCharges(commonProperties.getOrDefault(
                 ConfigConstants.PROXY_CLUSTER_INCHARGES, DEFAULT_CLUSTER_INCHARGES));
+        heartbeatMsg.setClusterExtTag(commonProperties.get(ConfigConstants.PROXY_CLUSTER_EXT_TAG));
 
         Map<String, String> groupIdMappings = configManager.getGroupIdMappingProperties();
         Map<String, Map<String, String>> streamIdMappings = configManager.getStreamIdMappingProperties();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
@@ -144,7 +144,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
                 ConfigConstants.PROXY_CLUSTER_NAME, DEFAULT_CLUSTER_NAME));
         heartbeatMsg.setInCharges(commonProperties.getOrDefault(
                 ConfigConstants.PROXY_CLUSTER_INCHARGES, DEFAULT_CLUSTER_INCHARGES));
-        heartbeatMsg.setClusterExtTag(commonProperties.get(ConfigConstants.PROXY_CLUSTER_EXT_TAG));
+        heartbeatMsg.setExtTag(commonProperties.get(ConfigConstants.PROXY_CLUSTER_EXT_TAG));
 
         Map<String, String> groupIdMappings = configManager.getGroupIdMappingProperties();
         Map<String, Map<String, String>> streamIdMappings = configManager.getStreamIdMappingProperties();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneProducer.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.dataproxy.sink.mq;
 
+import org.apache.inlong.dataproxy.config.ConfigManager;
 import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -140,6 +141,9 @@ public class MessageQueueZoneProducer {
                 }
             }
             this.clusterList = newClusterList;
+            if (!ConfigManager.getInstance().isMqClusterReady()) {
+                ConfigManager.getInstance().updMqClusterStatus(true);
+            }
         } catch (Throwable e) {
             LOG.error(e.getMessage(), e);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -254,7 +254,7 @@ public class PulsarHandler implements MessageQueueHandler {
             builder.append(tenant).append("/");
         }
         String namespace = this.namespace;
-        if (config.getParams().get(PulsarHandler.KEY_NAMESPACE) != null) {
+        if (namespace == null) {
             namespace = config.getParams().get(PulsarHandler.KEY_NAMESPACE);
         }
         if (namespace != null) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.dataproxy.sink.mq.pulsar;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Context;
 import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
 import org.apache.inlong.dataproxy.config.pojo.IdTopicConfig;
@@ -27,6 +28,7 @@ import org.apache.inlong.dataproxy.sink.mq.MessageQueueZoneSinkContext;
 import org.apache.inlong.dataproxy.sink.mq.OrderBatchPackProfileV0;
 import org.apache.inlong.dataproxy.sink.mq.SimpleBatchPackProfileV0;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.MessageRoutingMode;
@@ -113,9 +115,12 @@ public class PulsarHandler implements MessageQueueHandler {
             String serviceUrl = config.getParams().get(KEY_SERVICE_URL);
             String authentication = config.getParams().get(KEY_AUTHENTICATION);
             Context context = sinkContext.getProducerContext();
-            this.client = PulsarClient.builder()
+            ClientBuilder builder = PulsarClient.builder();
+            if (StringUtils.isNotEmpty(authentication)) {
+                builder.authentication(AuthenticationFactory.token(authentication));
+            }
+            this.client = builder
                     .serviceUrl(serviceUrl)
-                    .authentication(AuthenticationFactory.token(authentication))
                     .ioThreads(context.getInteger(KEY_IOTHREADS, 1))
                     .memoryLimit(context.getLong(KEY_MEMORYLIMIT, 1073741824L), SizeUnit.BYTES)
                     .connectionsPerBroker(context.getInteger(KEY_CONNECTIONSPERBROKER, 10))
@@ -188,7 +193,7 @@ public class PulsarHandler implements MessageQueueHandler {
                 return false;
             }
             // topic
-            String producerTopic = this.getProducerTopic(baseTopic);
+            String producerTopic = this.getProducerTopic(baseTopic, idConfig);
             if (producerTopic == null) {
                 sinkContext.addSendResultMetric(event, event.getUid(), false, 0);
                 sinkContext.getDispatchQueue().release(event.getSize());
@@ -243,10 +248,14 @@ public class PulsarHandler implements MessageQueueHandler {
     /**
      * getProducerTopic
      */
-    private String getProducerTopic(String baseTopic) {
+    private String getProducerTopic(String baseTopic, IdTopicConfig config) {
         StringBuilder builder = new StringBuilder();
         if (tenant != null) {
             builder.append(tenant).append("/");
+        }
+        String namespace = this.namespace;
+        if (config.getParams().get(PulsarHandler.KEY_NAMESPACE) != null) {
+            namespace = config.getParams().get(PulsarHandler.KEY_NAMESPACE);
         }
         if (namespace != null) {
             builder.append(namespace).append("/");

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -40,7 +40,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flume.ChannelException;
 import org.apache.flume.Event;
 import org.apache.flume.channel.ChannelProcessor;
-import org.apache.flume.event.EventBuilder;
 import org.apache.inlong.common.monitor.MonitorIndex;
 import org.apache.inlong.common.monitor.MonitorIndexExt;
 import org.apache.inlong.common.msg.AttributeConstants;
@@ -57,6 +56,7 @@ import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
 import org.apache.inlong.dataproxy.utils.DateTimeUtils;
 import org.apache.inlong.dataproxy.utils.InLongMsgVer;
 import org.apache.inlong.dataproxy.utils.MessageUtils;
+import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -556,7 +556,9 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
                     strBuff.delete(0, strBuff.length());
                 }
                 final byte[] data = inLongMsg.buildArray();
-                Event event = EventBuilder.withBody(data, headers);
+                Event event = new ProxyEvent(groupId, streamIdEntry.getKey(), data,
+                        Long.parseLong(strDataTime), strRemoteIP);
+                event.getHeaders().putAll(headers);
                 inLongMsg.reset();
                 Pair<Boolean, String> evenProcType =
                         MessageUtils.getEventProcType(syncSend, proxySend);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/ConfStringUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/ConfStringUtils.java
@@ -26,6 +26,9 @@ public class ConfStringUtils {
         if (ip == null || ip.trim().isEmpty()) {
             return false;
         }
+        if (ip.equals("localhost")) {
+            ip = "127.0.0.1";
+        }
         boolean b = false;
         ip = ip.trim();
         if (ip.matches("\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}")) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
@@ -220,6 +220,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         final String clusterName = componentHeartbeat.getClusterName();
         final String type = componentHeartbeat.getComponentType();
         final String clusterTag = componentHeartbeat.getClusterTag();
+        final String extTag = componentHeartbeat.getExtTag();
         Preconditions.checkNotNull(clusterTag, "cluster tag cannot be null");
         Preconditions.checkNotNull(type, "cluster type cannot be null");
         Preconditions.checkNotNull(clusterName, "cluster name cannot be null");
@@ -234,6 +235,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         cluster.setName(clusterName);
         cluster.setType(type);
         cluster.setClusterTags(clusterTag);
+        cluster.setExtTag(extTag);
         String inCharges = componentHeartbeat.getInCharges();
         if (StringUtils.isBlank(inCharges)) {
             inCharges = InlongConstants.ADMIN_USER;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
@@ -94,6 +94,7 @@ public class DataProxyConfigRepository implements IRepository {
             .withKeyValueSeparator(KEY_VALUE_SEPARATOR);
     public static final String CACHE_CLUSTER_PRODUCER_TAG = "producer";
     public static final String CACHE_CLUSTER_CONSUMER_TAG = "consumer";
+    public static final String DEFAULT_EXT_TAG = "default=true";
     private static final Gson GSON = new Gson();
 
     // key: proxyClusterName, value: jsonString
@@ -245,7 +246,7 @@ public class DataProxyConfigRepository implements IRepository {
         Map<String, Map<String, List<CacheCluster>>> cacheClusterMap = new HashMap<>();
         for (CacheCluster cacheCluster : clusterSetMapper.selectCacheCluster()) {
             if (StringUtils.isEmpty(cacheCluster.getExtTag())) {
-                continue;
+                cacheCluster.setExtTag(DEFAULT_EXT_TAG);
             }
             Map<String, String> tagMap = MAP_SPLITTER.split(cacheCluster.getExtTag());
             String producerTag = tagMap.getOrDefault(CACHE_CLUSTER_PRODUCER_TAG, Boolean.TRUE.toString());
@@ -262,9 +263,13 @@ public class DataProxyConfigRepository implements IRepository {
             // cache
             String clusterTag = proxyObj.getSetName();
             String extTag = proxyObj.getZone();
+            if (StringUtils.isEmpty(extTag)) {
+                extTag = DEFAULT_EXT_TAG;
+            }
             Map<String, List<CacheCluster>> cacheClusterZoneMap = cacheClusterMap.get(clusterTag);
             if (cacheClusterZoneMap != null) {
-                Map<String, String> subTagMap = tagCache.computeIfAbsent(extTag, k -> MAP_SPLITTER.split(extTag));
+                String finalExtTag = extTag;
+                Map<String, String> subTagMap = tagCache.computeIfAbsent(extTag, k -> MAP_SPLITTER.split(finalExtTag));
                 for (Entry<String, List<CacheCluster>> cacheEntry : cacheClusterZoneMap.entrySet()) {
                     if (cacheEntry.getValue().size() == 0) {
                         continue;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
@@ -94,7 +94,6 @@ public class DataProxyConfigRepository implements IRepository {
             .withKeyValueSeparator(KEY_VALUE_SEPARATOR);
     public static final String CACHE_CLUSTER_PRODUCER_TAG = "producer";
     public static final String CACHE_CLUSTER_CONSUMER_TAG = "consumer";
-    public static final String DEFAULT_EXT_TAG = "default=true";
     private static final Gson GSON = new Gson();
 
     // key: proxyClusterName, value: jsonString
@@ -246,7 +245,7 @@ public class DataProxyConfigRepository implements IRepository {
         Map<String, Map<String, List<CacheCluster>>> cacheClusterMap = new HashMap<>();
         for (CacheCluster cacheCluster : clusterSetMapper.selectCacheCluster()) {
             if (StringUtils.isEmpty(cacheCluster.getExtTag())) {
-                cacheCluster.setExtTag(DEFAULT_EXT_TAG);
+                continue;
             }
             Map<String, String> tagMap = MAP_SPLITTER.split(cacheCluster.getExtTag());
             String producerTag = tagMap.getOrDefault(CACHE_CLUSTER_PRODUCER_TAG, Boolean.TRUE.toString());
@@ -264,12 +263,11 @@ public class DataProxyConfigRepository implements IRepository {
             String clusterTag = proxyObj.getSetName();
             String extTag = proxyObj.getZone();
             if (StringUtils.isEmpty(extTag)) {
-                extTag = DEFAULT_EXT_TAG;
+                continue;
             }
             Map<String, List<CacheCluster>> cacheClusterZoneMap = cacheClusterMap.get(clusterTag);
             if (cacheClusterZoneMap != null) {
-                String finalExtTag = extTag;
-                Map<String, String> subTagMap = tagCache.computeIfAbsent(extTag, k -> MAP_SPLITTER.split(finalExtTag));
+                Map<String, String> subTagMap = tagCache.computeIfAbsent(extTag, k -> MAP_SPLITTER.split(extTag));
                 for (Entry<String, List<CacheCluster>> cacheEntry : cacheClusterZoneMap.entrySet()) {
                     if (cacheEntry.getValue().size() == 0) {
                         continue;


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #6738]

### Motivation

The new sink layer does not integrate well with the default tcp/http source, such as 
- channel event type not match
- cluster zone tag by default is empty, leading to NPE
- null pulsar token not supported
- namespace is specified in the cluster level other than the group level
- other problems

### Modifications

Fix the problems mentioned above
