### PR TITLE
[INLONG-6745][Manager] Support StarRocks load node management

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SinkType.java
@@ -37,4 +37,5 @@ public class SinkType {
     public static final String TDSQLPOSTGRESQL = "TDSQLPOSTGRESQL";
     public static final String DLCICEBERG = "DLCICEBERG";
     public static final String DORIS = "DORIS";
+    public static final String STARROCKS = "STARROCKS";
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSink.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.starrocks;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.pojo.sink.StreamSink;
+
+/**
+ * StarRocks sink info
+ */
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "StarRocks sink info")
+@JsonTypeDefine(value = SinkType.DORIS)
+public class StarRocksSink extends StreamSink {
+
+    @ApiModelProperty("StarRocks jdbc url")
+    private String jdbcUrl;
+
+    @ApiModelProperty("StarRocks FE http address")
+    private String loadUrl;
+
+    @ApiModelProperty("Username for StarRocks accessing")
+    private String username;
+
+    @ApiModelProperty("Password for StarRocks accessing")
+    private String password;
+
+    @ApiModelProperty("Database name")
+    private String databaseName;
+
+    @ApiModelProperty("Table name")
+    private String tableName;
+
+    @ApiModelProperty("The primary key of sink table")
+    private String primaryKey;
+
+    @ApiModelProperty("The multiple enable of sink")
+    private Boolean sinkMultipleEnable = false;
+
+    @ApiModelProperty("The multiple format of sink")
+    private String sinkMultipleFormat;
+
+    @ApiModelProperty("The multiple database-pattern of sink")
+    private String databasePattern;
+
+    @ApiModelProperty("The multiple table-pattern of sink")
+    private String tablePattern;
+
+    public StarRocksSink() {
+        this.setSinkType(SinkType.STARROCKS);
+    }
+
+    @Override
+    public SinkRequest genSinkRequest() {
+        return CommonBeanUtils.copyProperties(this, StarRocksSinkRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSink.java
@@ -39,7 +39,7 @@ import org.apache.inlong.manager.pojo.sink.StreamSink;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @ApiModel(value = "StarRocks sink info")
-@JsonTypeDefine(value = SinkType.DORIS)
+@JsonTypeDefine(value = SinkType.STARROCKS)
 public class StarRocksSink extends StreamSink {
 
     @ApiModelProperty("StarRocks jdbc url")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkDTO.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.starrocks;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.AESUtils;
+import org.apache.inlong.manager.common.util.JsonUtils;
+
+/**
+ * Sink info of StarRocks
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StarRocksSinkDTO {
+
+    @ApiModelProperty("StarRocks jdbc url")
+    private String jdbcUrl;
+
+    @ApiModelProperty("StarRocks FE http address")
+    private String loadUrl;
+
+    @ApiModelProperty("Username for StarRocks accessing")
+    private String username;
+
+    @ApiModelProperty("Password for StarRocks accessing")
+    private String password;
+
+    @ApiModelProperty("Database name")
+    private String databaseName;
+
+    @ApiModelProperty("Table name")
+    private String tableName;
+
+    @ApiModelProperty("The primary key of sink table")
+    private String primaryKey;
+
+    @ApiModelProperty("The multiple enable of sink")
+    private Boolean sinkMultipleEnable = false;
+
+    @ApiModelProperty("The multiple format of sink")
+    private String sinkMultipleFormat;
+
+    @ApiModelProperty("The multiple database-pattern of sink")
+    private String databasePattern;
+
+    @ApiModelProperty("The multiple table-pattern of sink")
+    private String tablePattern;
+
+    @ApiModelProperty("Password encrypt version")
+    private Integer encryptVersion;
+
+    @ApiModelProperty("Properties for StarRocks")
+    private Map<String, Object> properties;
+
+    /**
+     * Get the dto instance from the request
+     */
+    public static StarRocksSinkDTO getFromRequest(StarRocksSinkRequest request) throws Exception {
+        Integer encryptVersion = AESUtils.getCurrentVersion(null);
+        String passwd = null;
+        if (StringUtils.isNotEmpty(request.getPassword())) {
+            passwd = AESUtils.encryptToString(request.getPassword().getBytes(StandardCharsets.UTF_8),
+                    encryptVersion);
+        }
+        return StarRocksSinkDTO.builder()
+                .jdbcUrl(request.getJdbcUrl())
+                .loadUrl(request.getLoadUrl())
+                .username(request.getUsername())
+                .password(passwd)
+                .databaseName(request.getDatabaseName())
+                .tableName(request.getTableName())
+                .sinkMultipleEnable(request.getSinkMultipleEnable())
+                .sinkMultipleFormat(request.getSinkMultipleFormat())
+                .databasePattern(request.getDatabasePattern())
+                .tablePattern(request.getTablePattern())
+                .encryptVersion(encryptVersion)
+                .properties(request.getProperties())
+                .build();
+    }
+
+    public static StarRocksSinkDTO getFromJson(@NotNull String extParams) {
+        try {
+            return JsonUtils.parseObject(extParams, StarRocksSinkDTO.class).decryptPassword();
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT.getMessage() + ": " + e.getMessage());
+        }
+    }
+
+    private StarRocksSinkDTO decryptPassword() throws Exception {
+        if (StringUtils.isNotEmpty(this.password)) {
+            byte[] passwordBytes = AESUtils.decryptAsString(this.password, this.encryptVersion);
+            this.password = new String(passwordBytes, StandardCharsets.UTF_8);
+        }
+        return this;
+    }
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
@@ -33,7 +33,7 @@ import org.apache.inlong.manager.pojo.sink.SinkRequest;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @ApiModel(value = "StarRocks sink request")
-@JsonTypeDefine(value = SinkType.DORIS)
+@JsonTypeDefine(value = SinkType.STARROCKS)
 public class StarRocksSinkRequest extends SinkRequest {
 
     @ApiModelProperty("StarRocks jdbc url")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sink.starrocks;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+
+/**
+ * StarRocks sink request.
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "StarRocks sink request")
+@JsonTypeDefine(value = SinkType.DORIS)
+public class StarRocksSinkRequest extends SinkRequest {
+
+    @ApiModelProperty("StarRocks jdbc url")
+    private String jdbcUrl;
+
+    @ApiModelProperty("StarRocks FE http address")
+    private String loadUrl;
+
+    @ApiModelProperty("Username for StarRocks accessing")
+    private String username;
+
+    @ApiModelProperty("Password for StarRocks accessing")
+    private String password;
+
+    @ApiModelProperty("Database name")
+    private String databaseName;
+
+    @ApiModelProperty("Table name")
+    private String tableName;
+
+    @ApiModelProperty("The primary key of sink table")
+    private String primaryKey;
+
+    @ApiModelProperty("The multiple enable of sink")
+    private Boolean sinkMultipleEnable = false;
+
+    @ApiModelProperty("The multiple format of sink")
+    private String sinkMultipleFormat;
+
+    @ApiModelProperty("The multiple database-pattern of sink")
+    private String databasePattern;
+
+    @ApiModelProperty("The multiple table-pattern of sink")
+    private String tablePattern;
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/starrocks/StarRocksSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/starrocks/StarRocksSinkOperator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.sink.starrocks;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
+import org.apache.inlong.manager.pojo.sink.SinkField;
+import org.apache.inlong.manager.pojo.sink.SinkRequest;
+import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.pojo.sink.starrocks.StarRocksSink;
+import org.apache.inlong.manager.pojo.sink.starrocks.StarRocksSinkDTO;
+import org.apache.inlong.manager.pojo.sink.starrocks.StarRocksSinkRequest;
+import org.apache.inlong.manager.service.sink.AbstractSinkOperator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * StarRocks sink operator, such as save or update StarRocks field, etc.
+ */
+@Service
+public class StarRocksSinkOperator extends AbstractSinkOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(StarRocksSinkOperator.class);
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public Boolean accept(String sinkType) {
+        return SinkType.STARROCKS.equals(sinkType);
+    }
+
+    @Override
+    protected String getSinkType() {
+        return SinkType.STARROCKS;
+    }
+
+    @Override
+    protected void setTargetEntity(SinkRequest request, StreamSinkEntity targetEntity) {
+        Preconditions.checkTrue(this.getSinkType().equals(request.getSinkType()),
+                ErrorCodeEnum.SINK_TYPE_NOT_SUPPORT.getMessage() + ": " + getSinkType());
+        StarRocksSinkRequest sinkRequest = (StarRocksSinkRequest) request;
+        try {
+            StarRocksSinkDTO dto = StarRocksSinkDTO.getFromRequest(sinkRequest);
+            targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
+        } catch (Exception e) {
+            LOGGER.error("parsing json string to sink info failed", e);
+            throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED.getMessage());
+        }
+    }
+
+    @Override
+    public StreamSink getFromEntity(@NotNull StreamSinkEntity entity) {
+        StarRocksSink sink = new StarRocksSink();
+        if (entity == null) {
+            return sink;
+        }
+
+        StarRocksSinkDTO dto = StarRocksSinkDTO.getFromJson(entity.getExtParams());
+        Preconditions.checkNotEmpty(dto.getLoadUrl(), "StarRocks load url is empty");
+        Preconditions.checkNotEmpty(dto.getJdbcUrl(), "StarRocks jdbc url is empty");
+        CommonBeanUtils.copyProperties(entity, sink, true);
+        CommonBeanUtils.copyProperties(dto, sink, true);
+        List<SinkField> sinkFields = super.getSinkFields(entity.getId());
+        sink.setSinkFieldList(sinkFields);
+        return sink;
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/StarRocksConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/StarRocksConstant.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.constant;
+
+/**
+ * StarRocks options constant
+ */
+public class StarRocksConstant {
+
+    /**
+     * 'connector' = 'starrocks-inlong'
+     */
+    public static final String CONNECTOR = "connector";
+
+    /**
+     * Host of the stream load like: `jdbc:mysql://fe_ip1:query_port,fe_ip2:query_port...`.
+     */
+    public static final String JDBC_URL = "jdbc-url";
+
+    /**
+     * Host of the stream load like: `fe_ip1:http_port;fe_ip2:http_port;fe_ip3:http_port`.
+     */
+    public static final String LOAD_URL = "load-url";
+
+    /**
+     * StarRocks user name.
+     */
+    public static final String USERNAME = "username";
+
+    /**
+     * StarRocks user password.
+     */
+    public static final String PASSWORD = "password";
+
+    /**
+     * StarRocks stream load format, support json and csv.
+     */
+    public static final String FORMAT = "sink.properties.format";
+
+    /**
+     * StarRocks stream load strip outer array for json format.
+     */
+    public static final String STRIP_OUTER_ARRAY = "sink.properties.strip_outer_array";
+
+    /**
+     * Database name of the stream load.
+     */
+    public static final String DATABASE_NAME = "database-name";
+
+    /**
+     * Table name of the stream load.
+     */
+    public static final String TABLE_NAME = "table-name";
+
+    /**
+     * The multiple enable of sink
+     */
+    public static final String SINK_MULTIPLE_ENABLE = "sink.multiple.enable";
+
+    /**
+     * The multiple format of sink
+     */
+    public static final String SINK_MULTIPLE_FORMAT = "sink.multiple.format";
+
+    /**
+     * The multiple database-pattern of sink
+     */
+    public static final String SINK_MULTIPLE_DATABASE_PATTERN = "sink.multiple.database-pattern";
+    /**
+     * The multiple table-pattern of sink
+     */
+    public static final String SINK_MULTIPLE_TABLE_PATTERN = "sink.multiple.table-pattern";
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/StarRocksLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/StarRocksLoadNode.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.load;
+
+import com.google.common.base.Preconditions;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InlongMetric;
+import org.apache.inlong.sort.protocol.constant.StarRocksConstant;
+import org.apache.inlong.sort.protocol.enums.FilterStrategy;
+import org.apache.inlong.sort.protocol.node.LoadNode;
+import org.apache.inlong.sort.protocol.node.format.Format;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.FilterFunction;
+
+/**
+ * starrocks load node using flink-connector-starrocks-1.13.5_2.11
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("starRocksLoad")
+@JsonInclude(Include.NON_NULL)
+@Data
+@NoArgsConstructor
+public class StarRocksLoadNode extends LoadNode implements InlongMetric, Serializable {
+
+    private static final long serialVersionUID = -8002903269814211382L;
+
+    @JsonProperty("jdbc-url")
+    @Nonnull
+    private String jdbcUrl;
+
+    @JsonProperty("load-url")
+    @Nonnull
+    private String loadUrl;
+
+    @JsonProperty("username")
+    @Nonnull
+    private String username;
+
+    @JsonProperty("password")
+    @Nonnull
+    private String password;
+
+    @JsonProperty("database-name")
+    @Nullable
+    private String databaseName;
+
+    @JsonProperty("table-name")
+    private String tableName;
+
+    @JsonProperty("primaryKey")
+    private String primaryKey;
+
+    @Nullable
+    @JsonProperty("sinkMultipleEnable")
+    private Boolean sinkMultipleEnable = false;
+
+    @Nullable
+    @JsonProperty("sinkMultipleFormat")
+    private Format sinkMultipleFormat;
+
+    @Nullable
+    @JsonProperty("databasePattern")
+    private String databasePattern;
+
+    @Nullable
+    @JsonProperty("tablePattern")
+    private String tablePattern;
+
+    @JsonCreator
+    public StarRocksLoadNode(@JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @JsonProperty("fieldRelations") List<FieldRelation> fieldRelations,
+            @JsonProperty("filters") List<FilterFunction> filters,
+            @JsonProperty("filterStrategy") FilterStrategy filterStrategy,
+            @Nullable @JsonProperty("sinkParallelism") Integer sinkParallelism,
+            @JsonProperty("properties") Map<String, String> properties,
+            @Nonnull @JsonProperty("jdbc-url") String jdbcUrl,
+            @Nonnull @JsonProperty("load-url") String loadUrl,
+            @Nonnull @JsonProperty("username") String userName,
+            @Nonnull @JsonProperty("password") String password,
+            @Nullable @JsonProperty("database-name") String databaseName,
+            @JsonProperty("table-name") String tableName,
+            @JsonProperty("primaryKey") String primaryKey,
+            @Nullable @JsonProperty(value = "sinkMultipleEnable", defaultValue = "false") Boolean sinkMultipleEnable,
+            @Nullable @JsonProperty("sinkMultipleFormat") Format sinkMultipleFormat,
+            @Nullable @JsonProperty("databasePattern") String databasePattern,
+            @Nullable @JsonProperty("tablePattern") String tablePattern) {
+        super(id, name, fields, fieldRelations, filters, filterStrategy, sinkParallelism, properties);
+        this.jdbcUrl = Preconditions.checkNotNull(jdbcUrl, "jdbc-url is null");
+        this.loadUrl = Preconditions.checkNotNull(loadUrl, "load-url is null");
+        this.username = Preconditions.checkNotNull(userName, "username is null");
+        this.password = Preconditions.checkNotNull(password, "password is null");
+        this.databaseName = Preconditions.checkNotNull(databaseName, "database-name is null");
+        this.tableName = Preconditions.checkNotNull(tableName, "table-name is null");
+        this.primaryKey = primaryKey;
+        this.sinkMultipleEnable = sinkMultipleEnable;
+        if (sinkMultipleEnable != null && sinkMultipleEnable) {
+            this.databasePattern = Preconditions.checkNotNull(databasePattern, "databasePattern is null");
+            this.tablePattern = Preconditions.checkNotNull(tablePattern, "tablePattern is null");
+            this.sinkMultipleFormat = Preconditions.checkNotNull(sinkMultipleFormat, "sinkMultipleFormat is null");
+        }
+    }
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        if (getProperties() != null && !getProperties().isEmpty()) {
+            options.putAll(getProperties());
+        }
+        options.put(StarRocksConstant.CONNECTOR, "starrocks-inlong");
+        options.put(StarRocksConstant.JDBC_URL, jdbcUrl);
+        options.put(StarRocksConstant.LOAD_URL, loadUrl);
+        options.put(StarRocksConstant.USERNAME, username);
+        options.put(StarRocksConstant.PASSWORD, password);
+        options.put(StarRocksConstant.DATABASE_NAME, databaseName);
+        options.put(StarRocksConstant.TABLE_NAME, tableName);
+        if (sinkMultipleEnable != null && sinkMultipleEnable) {
+            options.put(StarRocksConstant.SINK_MULTIPLE_ENABLE, sinkMultipleEnable.toString());
+            options.put(StarRocksConstant.SINK_MULTIPLE_FORMAT,
+                    Objects.requireNonNull(sinkMultipleFormat).identifier());
+            options.put(StarRocksConstant.SINK_MULTIPLE_DATABASE_PATTERN, databasePattern);
+            options.put(StarRocksConstant.SINK_MULTIPLE_TABLE_PATTERN, tablePattern);
+        } else {
+            options.put(StarRocksConstant.SINK_MULTIPLE_ENABLE, "false");
+        }
+        options.put(StarRocksConstant.FORMAT, "json");
+        options.put(StarRocksConstant.STRIP_OUTER_ARRAY, "true");
+        return options;
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+
+    @Override
+    public String getPrimaryKey() {
+        return primaryKey;
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-6745][Manager] Support StarRocks load node management

- Fixes #6745

### Motivation

Inspired by doris-inlong, starrocks-inlong can also support transferring all tables in one database on time.

StarRocks FE api has changed, been different from Doris FE api. If you use doris-cdc-inlong to handle StarRocks tables writing, it will give a error: http://x.x.x.x:xxxx/api/backends?is_alive=true failed. java.io.IOException: Failed to get response from Doris. That is why we need a sarrocks-inlong connector.

This PR provides StarRocks load node management is InLong Manager.

### Modifications

1. SinkType has new STARROCKS type.

2. manager-pojo has new StarRocksSink, StarRocksSinkDTO and StarRocksSinkRequest classes.

3. LoadNodeUtils has new createLoadNode method for creating StarRocksLoadNode object.

4. manager-service has new StarRocksSinkOperator class.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
