### PR TITLE
[INLONG-6754][Sort] Bump version of pulsar-connector to 1.13.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <flink.jackson.version>2.12.1-13.0</flink.jackson.version>
         <flink.connector.postgres.cdc.version>2.2.1</flink.connector.postgres.cdc.version>
         <flink.connector.sqlserver.cdc.version>2.2.1</flink.connector.sqlserver.cdc.version>
-        <flink.pulsar.version>1.13.6.1-rc9</flink.pulsar.version>
+        <flink.pulsar.version>1.13.6.2</flink.pulsar.version>
         <flink.protobuf.version>2.7.6</flink.protobuf.version>
         <flink.connector.mongodb.cdc.version>2.2.1</flink.connector.mongodb.cdc.version>
         <flink.connector.oracle.cdc.version>2.2.1</flink.connector.oracle.cdc.version>


### PR DESCRIPTION
### Prepare a Pull Request

Bump version of pulsar-connector to 1.13.6.2

- Fixes #6754 

### Motivation

Currently, the release candidate version used in sort-connector/pulsar may have unknown bugs, upgrade to a stable version

### Modifications

Version 1.13.6.2 is close to the currently used stable version, update to this version

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
