### PR TITLE
[INLONG-6765][Sort] Supports dirty data side-output for Iceberg sink

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -227,11 +227,11 @@ public final class Constants {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "The identifier of dirty data, "
-                                    + "it will be used for filename generation of file dirty sink, "
+                            "The identifier of dirty data, it will be used for filename generation of file dirty sink, "
                                     + "topic generation of mq dirty sink, tablename generation of database, etc."
                                     + "and it supports variable replace like '${variable}'."
-                                    + "There are two system variables[SYSTEM_TIME|DIRTY_TYPE] are currently supported,"
+                                    + "There are several system variables[SYSTEM_TIME|DIRTY_TYPE|DIRTY_MESSAGE] "
+                                    + "are currently supported, "
                                     + "and the support of other variables is determined by the connector.");
     public static final ConfigOption<Boolean> DIRTY_SIDE_OUTPUT_ENABLE =
             ConfigOptions.key("dirty.side-output.enable")
@@ -266,7 +266,8 @@ public final class Constants {
                     .withDescription(
                             "The labels of dirty side-output, format is 'key1=value1&key2=value2', "
                                     + "it supports variable replace like '${variable}',"
-                                    + "There are two system variables[SYSTEM_TIME|DIRTY_TYPE] are currently supported,"
+                                    + "There are two system variables[SYSTEM_TIME|DIRTY_TYPE|DIRTY_MESSAGE] "
+                                    + "are currently supported,"
                                     + " and the support of other variables is determined by the connector.");
     public static final ConfigOption<String> DIRTY_SIDE_OUTPUT_LOG_TAG =
             ConfigOptions.key("dirty.side-output.log-tag")
@@ -274,7 +275,7 @@ public final class Constants {
                     .defaultValue("DirtyData")
                     .withDescription(
                             "The log tag of dirty side-output, it supports variable replace like '${variable}'."
-                                    + "There are two system variables[SYSTEM_TIME|DIRTY_TYPE] are currently supported,"
+                                    + "There are two system variables[SYSTEM_TIME|DIRTY_TYPE|DIRTY_MESSAGE] are currently supported,"
                                     + " and the support of other variables is determined by the connector.");
     public static final ConfigOption<String> DIRTY_SIDE_OUTPUT_FIELD_DELIMITER =
             ConfigOptions.key("dirty.side-output.field-delimiter")

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyData.java
@@ -17,8 +17,10 @@
 
 package org.apache.inlong.sort.base.dirty;
 
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.inlong.sort.base.util.PatternReplaceUtils;
 
+import javax.annotation.Nullable;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
@@ -65,15 +67,21 @@ public class DirtyData<T> {
      */
     private final String dirtyMessage;
     /**
+     * The row type of data, it is only used for 'RowData'
+     */
+    private @Nullable final LogicalType rowType;
+    /**
      * The real dirty data
      */
     private final T data;
 
     public DirtyData(T data, String identifier, String labels,
-            String logTag, DirtyType dirtyType, String dirtyMessage) {
+            String logTag, DirtyType dirtyType, String dirtyMessage,
+            @Nullable LogicalType rowType) {
         this.data = data;
         this.dirtyType = dirtyType;
         this.dirtyMessage = dirtyMessage;
+        this.rowType = rowType;
         Map<String, String> paramMap = genParamMap();
         this.labels = PatternReplaceUtils.replace(labels, paramMap);
         this.logTag = PatternReplaceUtils.replace(logTag, paramMap);
@@ -113,6 +121,11 @@ public class DirtyData<T> {
         return identifier;
     }
 
+    @Nullable
+    public LogicalType getRowType() {
+        return rowType;
+    }
+
     public static class Builder<T> {
 
         private String identifier;
@@ -120,6 +133,7 @@ public class DirtyData<T> {
         private String logTag;
         private DirtyType dirtyType = DirtyType.UNDEFINED;
         private String dirtyMessage;
+        private LogicalType rowType;
         private T data;
 
         public Builder<T> setDirtyType(DirtyType dirtyType) {
@@ -152,8 +166,13 @@ public class DirtyData<T> {
             return this;
         }
 
+        public Builder<T> setRowType(LogicalType rowType) {
+            this.rowType = rowType;
+            return this;
+        }
+
         public DirtyData<T> build() {
-            return new DirtyData<>(data, identifier, labels, logTag, dirtyType, dirtyMessage);
+            return new DirtyData<>(data, identifier, labels, logTag, dirtyType, dirtyMessage, rowType);
         }
     }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyData.java
@@ -45,7 +45,7 @@ public class DirtyData<T> {
      * The identifier of dirty data, it will be used for filename generation of file dirty sink,
      * topic generation of mq dirty sink, tablename generation of database, etc,
      * and it supports variable replace like '${variable}'.
-     * There are two system variables[SYSTEM_TIME|DIRTY_TYPE|DIRTY_MESSAGE] are currently supported,
+     * There are several system variables[SYSTEM_TIME|DIRTY_TYPE|DIRTY_MESSAGE] are currently supported,
      * and the support of other variables is determined by the connector.
      */
     private final String identifier;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
@@ -76,6 +76,18 @@ public enum DirtyType {
      * Json process error
      */
     JSON_PROCESS_ERROR("JsonProcessError"),
+    /**
+     * Table identifier parse error
+     */
+    TABLE_IDENTIFIER_PARSE_ERROR("TableIdentifierParseError"),
+    /**
+     * Extract schema error
+     */
+    EXTRACT_SCHEMA_ERROR("ExtractSchemaError"),
+    /**
+     * Extract RowData error
+     */
+    EXTRACT_ROWDATA_ERROR("ExtractRowDataError"),
     ;
 
     private final String format;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/utils/FormatUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/utils/FormatUtils.java
@@ -17,18 +17,24 @@
 
 package org.apache.inlong.sort.base.dirty.utils;
 
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions.MapNullKeyMode;
+import org.apache.flink.formats.json.RowDataToJsonConverters;
 import org.apache.flink.formats.json.RowDataToJsonConverters.RowDataToJsonConverter;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
 
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringJoiner;
+import static org.apache.flink.table.data.RowData.createFieldGetter;
 
 /**
  * Format utils
@@ -47,6 +53,30 @@ public final class FormatUtils {
     private static final ObjectNode reuse = MAPPER.createObjectNode();
 
     private FormatUtils() {
+    }
+
+    /**
+     * Parse FieldGetter from LogicalType
+     * @param rowType The row type
+     * @return A array of FieldGetter
+     */
+    public static RowData.FieldGetter[] parseFieldGetters(LogicalType rowType) {
+        List<LogicalType> logicalTypes = rowType.getChildren();
+        RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[logicalTypes.size()];
+        for (int i = 0; i < logicalTypes.size(); i++) {
+            fieldGetters[i] = createFieldGetter(logicalTypes.get(i), i);
+        }
+        return fieldGetters;
+    }
+
+    /**
+     * Parse RowDataToJsonConverter
+     * @param rowType The row type
+     * @return RowDataToJsonConverter
+     */
+    public static RowDataToJsonConverter parseRowDataToJsonConverter(LogicalType rowType) {
+        return new RowDataToJsonConverters(TimestampFormat.SQL, MapNullKeyMode.DROP, null)
+                .createConverter(rowType);
     }
 
     /**

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/sink/MultipleSinkOption.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/sink/MultipleSinkOption.java
@@ -149,7 +149,6 @@ public class MultipleSinkOption implements Serializable {
             LOG.warn("Ignore table {} schema change: {}.", tableName, tableChange);
             return false;
         }
-
         throw new UnsupportedOperationException(
                 String.format("Unsupported table %s schema change: %s.", tableName, tableChange));
     }

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/FormatUtilsTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/FormatUtilsTest.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.RowData.FieldGetter;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.inlong.sort.base.dirty.utils.FormatUtils;
 import org.junit.Assert;
@@ -41,7 +40,6 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import static org.apache.flink.table.data.RowData.createFieldGetter;
 
 /**
@@ -64,7 +62,7 @@ public class FormatUtilsTest {
                 Column.physical("name", DataTypes.STRING()),
                 Column.physical("age", DataTypes.INT()));
         List<LogicalType> logicalTypes = schema.toPhysicalRowDataType()
-                .getChildren().stream().map(DataType::getLogicalType).collect(Collectors.toList());
+                .getLogicalType().getChildren();
         fieldGetters = new RowData.FieldGetter[logicalTypes.size()];
         for (int i = 0; i < logicalTypes.size(); i++) {
             fieldGetters[i] = createFieldGetter(logicalTypes.get(i), i);

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
@@ -647,9 +647,11 @@ public class FlinkSink {
         TaskWriterFactory<RowData> taskWriterFactory = new RowDataTaskWriterFactory(
                 serializableTable, serializableTable.schema(), flinkRowType, targetFileSize,
                 fileFormat, equalityFieldIds, upsert, appendMode);
-
+        // Set null for flinkRowType of IcebergSingleStreamWriter
+        // to avoid frequent Field.Getter creation in dirty data sink.
         return new IcebergProcessOperator<>(new IcebergSingleStreamWriter<>(
-                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts, dirtyOptions, dirtySink));
+                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts,
+                null, dirtyOptions, dirtySink));
     }
 
     private static FileFormat getFileFormat(Map<String, String> properties) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
@@ -52,6 +52,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.sink.MultipleSinkOption;
 import org.apache.inlong.sort.iceberg.sink.multiple.IcebergMultipleFilesCommiter;
 import org.apache.inlong.sort.iceberg.sink.multiple.IcebergMultipleStreamWriter;
@@ -64,6 +66,7 @@ import org.apache.inlong.sort.iceberg.sink.multiple.DynamicSchemaHandleOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -166,6 +169,8 @@ public class FlinkSink {
         private CatalogLoader catalogLoader = null;
         private boolean multipleSink = false;
         private MultipleSinkOption multipleSinkOption = null;
+        private DirtyOptions dirtyOptions;
+        private @Nullable DirtySink<Object> dirtySink;
 
         private Builder() {
         }
@@ -280,6 +285,16 @@ public class FlinkSink {
         public Builder metric(String inlongMetric, String auditHostAndPorts) {
             this.inlongMetric = inlongMetric;
             this.auditHostAndPorts = auditHostAndPorts;
+            return this;
+        }
+
+        public Builder dirtyOptions(DirtyOptions dirtyOptions) {
+            this.dirtyOptions = dirtyOptions;
+            return this;
+        }
+
+        public Builder dirtySink(DirtySink<Object> dirtySink) {
+            this.dirtySink = dirtySink;
             return this;
         }
 
@@ -514,7 +529,8 @@ public class FlinkSink {
             }
 
             IcebergProcessOperator<RowData, WriteResult> streamWriter = createStreamWriter(
-                    table, flinkRowType, equalityFieldIds, upsertMode, appendMode, inlongMetric, auditHostAndPorts);
+                    table, flinkRowType, equalityFieldIds, upsertMode, appendMode, inlongMetric,
+                    auditHostAndPorts, dirtyOptions, dirtySink);
 
             int parallelism = writeParallelism == null ? input.getParallelism() : writeParallelism;
             SingleOutputStreamOperator<WriteResult> writerStream = input
@@ -534,8 +550,7 @@ public class FlinkSink {
 
             int parallelism = writeParallelism == null ? input.getParallelism() : writeParallelism;
             DynamicSchemaHandleOperator routeOperator = new DynamicSchemaHandleOperator(
-                    catalogLoader,
-                    multipleSinkOption);
+                    catalogLoader, multipleSinkOption, dirtyOptions, dirtySink);
             SingleOutputStreamOperator<RecordWithSchema> routeStream = input
                     .transform(operatorName(ICEBERG_WHOLE_DATABASE_MIGRATION_NAME),
                             TypeInformation.of(RecordWithSchema.class),
@@ -544,7 +559,8 @@ public class FlinkSink {
 
             IcebergProcessOperator streamWriter =
                     new IcebergProcessOperator(new IcebergMultipleStreamWriter(
-                            appendMode, catalogLoader, inlongMetric, auditHostAndPorts, multipleSinkOption));
+                            appendMode, catalogLoader, inlongMetric, auditHostAndPorts,
+                            multipleSinkOption, dirtyOptions, dirtySink));
             SingleOutputStreamOperator<MultipleWriteResult> writerStream = routeStream
                     .transform(operatorName(ICEBERG_MULTIPLE_STREAM_WRITER_NAME),
                             TypeInformation.of(IcebergProcessOperator.class),
@@ -618,7 +634,10 @@ public class FlinkSink {
             boolean upsert,
             boolean appendMode,
             String inlongMetric,
-            String auditHostAndPorts) {
+            String auditHostAndPorts,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
+        // flink A, iceberg a
         Preconditions.checkArgument(table != null, "Iceberg table should't be null");
         Map<String, String> props = table.properties();
         long targetFileSize = getTargetFileSizeBytes(props);
@@ -630,7 +649,7 @@ public class FlinkSink {
                 fileFormat, equalityFieldIds, upsert, appendMode);
 
         return new IcebergProcessOperator<>(new IcebergSingleStreamWriter<>(
-                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts));
+                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts, dirtyOptions, dirtySink));
     }
 
     private static FileFormat getFileFormat(Map<String, String> properties) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -216,6 +216,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
             } else { // only if second times schema will evolute
                 // Refresh new schema maybe cause previous file writer interrupted, so here should handle it
                 multipleWriters.get(tableId).schemaEvolution(taskWriterFactory);
+                multipleWriters.get(tableId).setFlinkRowType(flinkRowType);
             }
 
         }

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -30,11 +30,16 @@ import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.inlong.sort.base.dirty.DirtyData;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -48,6 +53,8 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
             CheckpointedFunction,
             SchemaEvolutionFunction<TaskWriterFactory<T>> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(IcebergSingleStreamWriter.class);
+
     private static final long serialVersionUID = 1L;
 
     private final String fullTableName;
@@ -58,20 +65,25 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     private transient TaskWriter<T> writer;
     private transient int subTaskId;
     private transient int attemptId;
-    @Nullable
-    private transient SinkMetricData metricData;
+    private @Nullable transient SinkMetricData metricData;
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
 
     public IcebergSingleStreamWriter(
             String fullTableName,
             TaskWriterFactory<T> taskWriterFactory,
             String inlongMetric,
-            String auditHostAndPorts) {
+            String auditHostAndPorts,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.fullTableName = fullTableName;
         this.taskWriterFactory = taskWriterFactory;
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
     }
 
     @Override
@@ -107,12 +119,33 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     }
 
     @Override
-    public void processElement(T value)
-            throws Exception {
-        writer.write(value);
-
+    public void processElement(T value) throws Exception {
+        try {
+            writer.write(value);
+        } catch (Exception e) {
+            LOGGER.error(String.format("write error, raw data: %s", value), e);
+            if (!dirtyOptions.ignoreDirty()) {
+                throw e;
+            }
+            if (dirtySink != null) {
+                DirtyData.Builder<Object> builder = DirtyData.builder();
+                try {
+                    builder.setData(value)
+                            .setLabels(dirtyOptions.getLabels())
+                            .setLogTag(dirtyOptions.getLogTag())
+                            .setIdentifier(dirtyOptions.getIdentifier())
+                            .setDirtyMessage(e.getMessage());
+                    dirtySink.invoke(builder.build());
+                } catch (Exception ex) {
+                    if (!dirtyOptions.ignoreSideOutputErrors()) {
+                        throw new RuntimeException(ex);
+                    }
+                    LOGGER.warn("Dirty sink failed", ex);
+                }
+            }
+        }
         if (metricData != null) {
-            metricData.invokeWithEstimate(value);
+            metricData.invokeWithEstimate(value == null ? "" : value);
         }
     }
 

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -69,7 +69,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     private @Nullable transient SinkMetricData metricData;
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
-    private @Nullable final RowType flinkRowType;
+    private @Nullable RowType flinkRowType;
     private final DirtyOptions dirtyOptions;
     private @Nullable final DirtySink<Object> dirtySink;
 
@@ -165,6 +165,10 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
             metricState = MetricStateUtils.restoreMetricState(metricStateListState,
                     getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getNumberOfParallelSubtasks());
         }
+    }
+
+    public void setFlinkRowType(@Nullable RowType flinkRowType) {
+        this.flinkRowType = flinkRowType;
     }
 
     @Override

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/IcebergNodeSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/IcebergNodeSqlParserTest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -116,7 +117,13 @@ public class IcebergNodeSqlParserTest extends AbstractTestBase {
                                 new FieldInfo("age", new IntFormatInfo())),
                         new FieldRelation(new FieldInfo("ts", new TimestampFormatInfo()),
                                 new FieldInfo("ts", new TimestampFormatInfo())));
-
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=inlong&table=inlong_iceberg");
         // set HIVE_CONF_DIR,or set uri and warehouse
         return new IcebergLoadNode(
                 "iceberg",
@@ -126,7 +133,7 @@ public class IcebergNodeSqlParserTest extends AbstractTestBase {
                 null,
                 null,
                 null,
-                null,
+                properties,
                 "inlong",
                 "inlong_iceberg",
                 null,


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-6765][Sort] Supports dirty data side-output for iceberg sink

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6765 

### Motivation

Supports dirty data side-output for iceberg sink.

In this part:
1. Load 'DirtySinkFactory' and create 'DirtySink' by the config
2. It needs to determine whether it is dirty data in the connector.
3. Side output dirty data by the 'DirtySink' dependents on the configured, the built-in side-out of dirty data has 'LogDirtySink'(#6618) and 'S3DirtySink'(#6655).

### Modifications

1. Create a dirty sink and inject it into Iceberg sink
2. Add dirty handle for 'IcebergSingleStreamWriter' and 'DynamicSchemaHandleOperator'
3. Add a unit test for this

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
