### PR TITLE
[INLONG-6792][Sort] Supports dirty data side-output for hbase sink

### DIFF
--- a/inlong-sort/sort-connectors/hbase/src/main/java/org/apache/inlong/sort/hbase/sink/HBaseDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/hbase/src/main/java/org/apache/inlong/sort/hbase/sink/HBaseDynamicTableSink.java
@@ -28,6 +28,10 @@ import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
+
+import javax.annotation.Nullable;
 
 /** HBase table sink implementation. */
 @Internal
@@ -40,6 +44,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
     private final String nullStringLiteral;
     private final String inlongMetric;
     private final String inlongAudit;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
 
     public HBaseDynamicTableSink(
             String tableName,
@@ -48,7 +54,9 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
             HBaseWriteOptions writeOptions,
             String nullStringLiteral,
             String inlongMetric,
-            String inlongAudit) {
+            String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.tableName = tableName;
         this.hbaseTableSchema = hbaseTableSchema;
         this.hbaseConf = hbaseConf;
@@ -56,6 +64,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
         this.nullStringLiteral = nullStringLiteral;
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
     }
 
     @Override
@@ -68,7 +78,7 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
                         writeOptions.getBufferFlushMaxSizeInBytes(),
                         writeOptions.getBufferFlushMaxRows(),
                         writeOptions.getBufferFlushIntervalMillis(),
-                        inlongMetric, inlongAudit);
+                        inlongMetric, inlongAudit, dirtyOptions, dirtySink);
         return SinkFunctionProvider.of(sinkFunction, writeOptions.getParallelism());
     }
 
@@ -80,7 +90,8 @@ public class HBaseDynamicTableSink implements DynamicTableSink {
     @Override
     public DynamicTableSink copy() {
         return new HBaseDynamicTableSink(
-                tableName, hbaseTableSchema, hbaseConf, writeOptions, nullStringLiteral, inlongMetric, inlongAudit);
+                tableName, hbaseTableSchema, hbaseConf, writeOptions,
+                nullStringLiteral, inlongMetric, inlongAudit, dirtyOptions, dirtySink);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/hbase/src/main/java/org/apache/inlong/sort/hbase/sink/HBaseSinkFunction.java
+++ b/inlong-sort/sort-connectors/hbase/src/main/java/org/apache/inlong/sort/hbase/sink/HBaseSinkFunction.java
@@ -34,6 +34,7 @@ import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.StringUtils;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
@@ -42,7 +43,12 @@ import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.BufferedMutatorParams;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.inlong.sort.base.dirty.DirtyData;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.DirtyType;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
@@ -51,6 +57,7 @@ import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.Executors;
@@ -81,7 +88,7 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             BufferedMutator.ExceptionListener {
 
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(HBaseSinkFunction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HBaseSinkFunction.class);
 
     private final String hTableName;
     private final byte[] serializedConfig;
@@ -114,6 +121,8 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
     private transient volatile boolean closed = false;
     private Long dataSize = 0L;
     private Long rowSize = 0L;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
 
     public HBaseSinkFunction(
             String hTableName,
@@ -123,7 +132,9 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             long bufferFlushMaxMutations,
             long bufferFlushIntervalMillis,
             String inlongMetric,
-            String inlongAudit) {
+            String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.hTableName = hTableName;
         // Configuration is not serializable
         this.serializedConfig = HBaseConfigurationUtil.serializeConfiguration(conf);
@@ -133,11 +144,13 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
         this.bufferFlushIntervalMillis = bufferFlushIntervalMillis;
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
     }
 
     @Override
     public void open(Configuration parameters) throws Exception {
-        LOG.info("start open ...");
+        LOGGER.info("start open ...");
         org.apache.hadoop.conf.Configuration config = prepareRuntimeConfiguration();
         try {
             this.runtimeContext = getRuntimeContext();
@@ -152,6 +165,9 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
                     .build();
             if (metricOption != null) {
                 sinkMetricData = new SinkMetricData(metricOption, runtimeContext.getMetricGroup());
+            }
+            if (dirtySink != null) {
+                dirtySink.open(parameters);
             }
             this.mutationConverter.open();
             this.numPendingRequests = new AtomicLong(0);
@@ -184,13 +200,13 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
                                 TimeUnit.MILLISECONDS);
             }
         } catch (TableNotFoundException tnfe) {
-            LOG.error("The table " + hTableName + " not found ", tnfe);
+            LOGGER.error("The table " + hTableName + " not found ", tnfe);
             throw new RuntimeException("HBase table '" + hTableName + "' not found.", tnfe);
         } catch (IOException ioe) {
-            LOG.error("Exception while creating connection to HBase.", ioe);
+            LOGGER.error("Exception while creating connection to HBase.", ioe);
             throw new RuntimeException("Cannot create connection to HBase.", ioe);
         }
-        LOG.info("end open.");
+        LOGGER.info("end open.");
     }
 
     private org.apache.hadoop.conf.Configuration prepareRuntimeConfiguration() throws IOException {
@@ -205,7 +221,7 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
 
         // do validation: check key option(s) in final runtime configuration
         if (StringUtils.isNullOrWhitespaceOnly(runtimeConfig.get(HConstants.ZOOKEEPER_QUORUM))) {
-            LOG.error(
+            LOGGER.error(
                     "Can not connect to HBase without {} configuration",
                     HConstants.ZOOKEEPER_QUORUM);
             throw new IOException(
@@ -220,29 +236,51 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
     private void checkErrorAndRethrow() {
         Throwable cause = failureThrowable.get();
         if (cause != null) {
-            LOG.error("An error occurred in HBaseSink.", cause);
+            LOGGER.error("An error occurred in HBaseSink.", cause);
             failureThrowable.compareAndSet(cause, null);
         }
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     public void invoke(T value, Context context) {
         checkErrorAndRethrow();
-        try {
-            RowData rowData = (RowData) value;
-            if (RowKind.UPDATE_BEFORE != rowData.getRowKind()) {
-                mutator.mutate(mutationConverter.convertToMutation(value));
-            }
-            rowSize++;
-            dataSize = dataSize + value.toString().getBytes(StandardCharsets.UTF_8).length;
-        } catch (Exception e) {
-            if (sinkMetricData != null) {
+        RowData rowData = (RowData) value;
+        if (RowKind.UPDATE_BEFORE != rowData.getRowKind()) {
+            Mutation mutation = null;
+            try {
+                mutation = Preconditions.checkNotNull(mutationConverter.convertToMutation(value));
+                rowSize++;
+                dataSize = dataSize + value.toString().getBytes(StandardCharsets.UTF_8).length;
+            } catch (Exception e) {
+                LOGGER.error("Convert to mutation error", e);
+                if (!dirtyOptions.ignoreDirty()) {
+                    throw new RuntimeException(e);
+                }
                 sinkMetricData.invokeDirty(1, value.toString().getBytes(StandardCharsets.UTF_8).length);
+                if (dirtySink != null) {
+                    DirtyData.Builder<Object> builder = DirtyData.builder();
+                    try {
+                        builder.setData(rowData)
+                                .setDirtyType(DirtyType.DATA_TYPE_MAPPING_ERROR)
+                                .setLabels(dirtyOptions.getLabels())
+                                .setLogTag(dirtyOptions.getLogTag())
+                                .setDirtyMessage(e.getMessage())
+                                .setIdentifier(dirtyOptions.getIdentifier());
+                        dirtySink.invoke(builder.build());
+                    } catch (Exception ex) {
+                        if (!dirtyOptions.ignoreSideOutputErrors()) {
+                            throw new RuntimeException(ex);
+                        }
+                        LOGGER.warn("Dirty sink failed", ex);
+                    }
+                }
             }
-            failureThrowable.compareAndSet(null, e);
+            try {
+                mutator.mutate(mutation);
+            } catch (Exception e) {
+                failureThrowable.compareAndSet(null, e);
+            }
         }
-
         // flush when the buffer number of mutations greater than the configured max size.
         if (bufferFlushMaxMutations > 0
                 && numPendingRequests.incrementAndGet() >= bufferFlushMaxMutations) {
@@ -258,10 +296,6 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             }
             resetStateAfterFlush();
         } catch (Exception e) {
-            if (sinkMetricData != null) {
-                sinkMetricData.invokeDirty(rowSize, dataSize);
-            }
-            resetStateAfterFlush();
             // fail the sink and skip the rest of the items
             // if the failure handler decides to throw an exception
             failureThrowable.compareAndSet(null, e);
@@ -288,7 +322,7 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             try {
                 mutator.close();
             } catch (IOException e) {
-                LOG.warn("Exception occurs while closing HBase BufferedMutator.", e);
+                LOGGER.warn("Exception occurs while closing HBase BufferedMutator.", e);
             }
             this.mutator = null;
         }
@@ -297,7 +331,7 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
             try {
                 connection.close();
             } catch (IOException e) {
-                LOG.warn("Exception occurs while closing HBase Connection.", e);
+                LOGGER.warn("Exception occurs while closing HBase Connection.", e);
             }
             this.connection = null;
         }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/HbaseLoadFlinkSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/HbaseLoadFlinkSqlParseTest.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,6 +72,13 @@ public class HbaseLoadFlinkSqlParseTest extends AbstractTestBase {
      * @return hbase load node
      */
     private HbaseLoadNode buildHbaseLoadNode() {
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=inlong&table=inlong_iceberg");
         return new HbaseLoadNode("2", "test_hbase",
                 Arrays.asList(new FieldInfo("cf:age", new LongFormatInfo()), new FieldInfo("cf:name",
                         new StringFormatInfo())),
@@ -78,7 +86,7 @@ public class HbaseLoadFlinkSqlParseTest extends AbstractTestBase {
                         new FieldInfo("cf:age", new LongFormatInfo())),
                         new FieldRelation(new FieldInfo("name", new StringFormatInfo()),
                                 new FieldInfo("cf:name", new StringFormatInfo()))),
-                null, null, 1, null, "mytable",
+                null, null, 1, properties, "mytable",
                 "default",
                 "localhost:2181", "MD5(`name`)", null, null, null, null);
     }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-6792][Sort] Supports dirty data side-output for hbase sink
*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6792

### Motivation

Supports dirty data side-output for hbase sink.

In this part:
1. Load 'DirtySinkFactory' and create 'DirtySink' by the config
2. It needs to determine whether it is dirty data in the connector.
3. Side output dirty data by the 'DirtySink' dependents on the configured, the built-in side-out of dirty data has 'LogDirtySink'(#6618) and 'S3DirtySink'(#6655).

### Modifications

1. Create a dirty sink and inject it into hbase sink
2. Add dirty handle for 'HBaseSinkFunction'
3. Add a unit test for this

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
