### PR TITLE
[INLONG-6797][Sort] Supports dirty data side-output for filesystem sink

### DIFF
--- a/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
@@ -36,12 +37,20 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.inlong.sort.base.dirty.DirtyData;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.DirtyType;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
@@ -61,6 +70,8 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractStreamingWriter.class);
+
     // ------------------------ configuration fields --------------------------
 
     private final long bucketCheckInterval;
@@ -69,6 +80,8 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
 
     private final String inlongMetric;
     private final String inlongAudit;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
 
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
@@ -88,11 +101,15 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
     public AbstractStreamingWriter(
             long bucketCheckInterval,
             StreamingFileSink.BucketsBuilder<IN, String, ? extends StreamingFileSink.BucketsBuilder<IN, String, ?>> bucketsBuilder,
-            String inlongMetric, String inlongAudit) {
+            String inlongMetric, String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.bucketCheckInterval = bucketCheckInterval;
         this.bucketsBuilder = bucketsBuilder;
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
         setChainingStrategy(ChainingStrategy.ALWAYS);
     }
 
@@ -130,6 +147,9 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
         if (metricOption != null) {
             sinkMetricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
         }
+        if (dirtySink != null) {
+            dirtySink.open(new Configuration());
+        }
     }
 
     /**
@@ -141,14 +161,10 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             if (sinkMetricData != null) {
                 sinkMetricData.invoke(rowSize, dataSize);
             }
-        } catch (Exception e) {
-            if (sinkMetricData != null) {
-                sinkMetricData.invokeDirty(rowSize, dataSize);
-            }
-            LOG.error("fileSystem sink commitUpToCheckpoint.", e);
-        } finally {
             rowSize = 0L;
             dataSize = 0L;
+        } catch (Exception e) {
+            LOG.error("fileSystem sink commitUpToCheckpoint.", e);
         }
     }
 
@@ -221,11 +237,34 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
                     currentWatermark);
             rowSize = rowSize + 1;
             dataSize = dataSize + element.getValue().toString().getBytes(StandardCharsets.UTF_8).length;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         } catch (Exception e) {
-            if (sinkMetricData != null) {
-                sinkMetricData.invokeDirty(1L, element.getValue().toString().getBytes(StandardCharsets.UTF_8).length);
+            LOG.error("StreamingWriter write failed", e);
+            if (!dirtyOptions.ignoreDirty()) {
+                throw new RuntimeException(e);
             }
-            LOG.error("fileSystem sink processElement.", e);
+            if (sinkMetricData != null) {
+                sinkMetricData.invokeDirty(1L,
+                        element.getValue().toString().getBytes(StandardCharsets.UTF_8).length);
+            }
+            if (dirtySink != null) {
+                DirtyData.Builder<Object> builder = DirtyData.builder();
+                try {
+                    builder.setData(element.getValue())
+                            .setDirtyType(DirtyType.UNDEFINED)
+                            .setLabels(dirtyOptions.getLabels())
+                            .setLogTag(dirtyOptions.getLogTag())
+                            .setDirtyMessage(e.getMessage())
+                            .setIdentifier(dirtyOptions.getIdentifier());
+                    dirtySink.invoke(builder.build());
+                } catch (Exception ex) {
+                    if (!dirtyOptions.ignoreSideOutputErrors()) {
+                        throw new RuntimeException(ex);
+                    }
+                    LOGGER.warn("Dirty sink failed", ex);
+                }
+            }
         }
     }
 

--- a/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
@@ -165,6 +165,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
             dataSize = 0L;
         } catch (Exception e) {
             LOG.error("fileSystem sink commitUpToCheckpoint.", e);
+            throw e;
         }
     }
 

--- a/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/StreamingFileWriter.java
+++ b/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/StreamingFileWriter.java
@@ -24,7 +24,10 @@ import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.filesystem.stream.PartitionCommitInfo;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.NavigableMap;
@@ -45,8 +48,10 @@ public class StreamingFileWriter<IN> extends AbstractStreamingWriter<IN, Partiti
     public StreamingFileWriter(
             long bucketCheckInterval,
             StreamingFileSink.BucketsBuilder<IN, String, ? extends StreamingFileSink.BucketsBuilder<IN, String, ?>> bucketsBuilder,
-            String inlongMetric, String inlongAudit) {
-        super(bucketCheckInterval, bucketsBuilder, inlongMetric, inlongAudit);
+            String inlongMetric, String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
+        super(bucketCheckInterval, bucketsBuilder, inlongMetric, inlongAudit, dirtyOptions, dirtySink);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/StreamingSink.java
+++ b/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/StreamingSink.java
@@ -42,8 +42,11 @@ import org.apache.flink.table.filesystem.stream.compact.CompactOperator;
 import org.apache.flink.table.filesystem.stream.compact.CompactReader;
 import org.apache.flink.table.filesystem.stream.compact.CompactWriter;
 import org.apache.flink.util.function.SupplierWithException;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.filesystem.stream.compact.CompactFileWriter;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
@@ -66,9 +69,12 @@ public class StreamingSink {
             DataStream<T> inputStream,
             long bucketCheckInterval,
             StreamingFileSink.BucketsBuilder<T, String, ? extends StreamingFileSink.BucketsBuilder<T, String, ?>> bucketsBuilder,
-            int parallelism, String inlongMetric, String inlongAudit) {
+            int parallelism, String inlongMetric, String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         StreamingFileWriter<T> fileWriter =
-                new StreamingFileWriter<>(bucketCheckInterval, bucketsBuilder, inlongMetric, inlongAudit);
+                new StreamingFileWriter<>(bucketCheckInterval, bucketsBuilder,
+                        inlongMetric, inlongAudit, dirtyOptions, dirtySink);
         return inputStream
                 .transform(
                         StreamingFileWriter.class.getSimpleName(),
@@ -89,9 +95,11 @@ public class StreamingSink {
             Path path,
             CompactReader.Factory<T> readFactory,
             long targetFileSize,
-            int parallelism, String inlongMetric, String inlongAudit) {
+            int parallelism, String inlongMetric, String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         CompactFileWriter<T> writer = new CompactFileWriter<>(bucketCheckInterval, bucketsBuilder, inlongMetric,
-                inlongAudit);
+                inlongAudit, dirtyOptions, dirtySink);
 
         SupplierWithException<FileSystem, IOException> fsSupplier =
                 (SupplierWithException<FileSystem, IOException> & Serializable) () -> fsFactory.create(path.toUri());
@@ -118,7 +126,6 @@ public class StreamingSink {
 
         CompactOperator<T> compacter =
                 new CompactOperator<>(fsSupplier, readFactory, writerFactory);
-
         return coordinatorOp
                 .broadcast()
                 .transform(

--- a/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/compact/CompactFileWriter.java
+++ b/inlong-sort/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/compact/CompactFileWriter.java
@@ -24,7 +24,11 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.table.filesystem.stream.compact.CompactMessages.CoordinatorInput;
 import org.apache.flink.table.filesystem.stream.compact.CompactMessages.EndCheckpoint;
 import org.apache.flink.table.filesystem.stream.compact.CompactMessages.InputFile;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.filesystem.stream.AbstractStreamingWriter;
+
+import javax.annotation.Nullable;
 
 /**
  * Writer for emitting {@link InputFile} and {@link EndCheckpoint} to downstream.
@@ -38,8 +42,10 @@ public class CompactFileWriter<T>
     public CompactFileWriter(
             long bucketCheckInterval,
             StreamingFileSink.BucketsBuilder<T, String, ? extends StreamingFileSink.BucketsBuilder<T, String, ?>> bucketsBuilder,
-            String inlongMetric, String inlongAudit) {
-        super(bucketCheckInterval, bucketsBuilder, inlongMetric, inlongAudit);
+            String inlongMetric, String inlongAudit,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
+        super(bucketCheckInterval, bucketsBuilder, inlongMetric, inlongAudit, dirtyOptions, dirtySink);
     }
 
     @Override

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/FlinkSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/FlinkSqlParserTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -154,9 +155,16 @@ public class FlinkSqlParserTest extends AbstractTestBase {
                                 new FieldInfo("age", new IntFormatInfo())),
                         new FieldRelation(new FieldInfo("ts", new TimestampFormatInfo()),
                                 new FieldInfo("ts", new TimestampFormatInfo())));
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=inlong&table=student");
         return new FileSystemLoadNode(id, "hdfs_output", fields, relations,
-                null, "hdfs://localhost:9000/file", "json",
-                1, null, null, null);
+                null, "hdfs://localhost:9000/inlong/student", "json",
+                1, properties, null, null);
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-6797][Sort] Supports dirty data side-output for filesystem sink

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6797

### Motivation

Supports dirty data side-output for filesystem sink.

In this part:
1. Load 'DirtySinkFactory' and create 'DirtySink' by the config
2. It needs to determine whether it is dirty data in the connector.
3. Side output dirty data by the 'DirtySink' dependents on the configured, the built-in side-out of dirty data has 'LogDirtySink'(#6618) and 'S3DirtySink'(#6655).

### Modifications

1. Create a dirty sink and inject it into filesystem sink
2. Add dirty handle for 'AbstractStreamingWriter'
3. Add a unit test for this

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
