### PR TITLE
[INLONG-6804][Manager] Workflow initialization threw IllegalArgumentException: Unsupported FieldType text or keyword

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
@@ -51,7 +51,9 @@ public enum FieldType {
     ARRAY,
     MAP,
     STRUCT,
-    FUNCTION;
+    FUNCTION,
+    TEXT,
+    KEYWORD;
 
     public static FieldType forName(String name) {
         Preconditions.checkNotNull(name, "FieldType should not be null");


### PR DESCRIPTION
### Prepare a Pull Request
- Title: [INLONG-6804][Manager] Workflow initialization threw IllegalArgumentException: Unsupported FieldType text or keyword

- Fixes #6804 

### Motivation

Fix workflow initialization threw IllegalArgumentException: Unsupported FieldType text or keyword

### Modifications

Add `TEXT` and  `KEYWORD` data type.