### PR TITLE
[INLONG-6810][POM] unify versions of os-maven-plugin and protobuf-maven-plugin

### DIFF
--- a/inlong-audit/audit-common/pom.xml
+++ b/inlong-audit/audit-common/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
@@ -63,7 +63,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>${os.maven.plugin.version}</version>
             </extension>
         </extensions>
     </build>

--- a/inlong-audit/audit-common/pom.xml
+++ b/inlong-audit/audit-common/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
@@ -63,7 +63,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>1.6.0</version>
             </extension>
         </extensions>
     </build>

--- a/inlong-sdk/sdk-common/pom.xml
+++ b/inlong-sdk/sdk-common/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.1</version>
+                <version>0.6.1</version>
                 <extensions>true</extensions>
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
@@ -61,7 +61,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>1.6.0</version>
             </extension>
         </extensions>
     </build>

--- a/inlong-sdk/sdk-common/pom.xml
+++ b/inlong-sdk/sdk-common/pom.xml
@@ -42,7 +42,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <protoSourceRoot>${project.basedir}/src/main/proto</protoSourceRoot>
@@ -61,7 +61,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>${os.maven.plugin.version}</version>
             </extension>
         </extensions>
     </build>

--- a/inlong-tubemq/tubemq-core/pom.xml
+++ b/inlong-tubemq/tubemq-core/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.1</version>
+                <version>${protobuf.maven.plugin.version}</version>
                 <configuration>
                     <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
@@ -137,7 +137,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.6.0</version>
+                <version>${os.maven.plugin.version}</version>
             </extension>
         </extensions>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,8 @@
         <paho.client.version>1.2.5</paho.client.version>
 
         <kubernetes.client.version>6.0.0</kubernetes.client.version>
+        <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
+        <os.maven.plugin.version>1.6.0</os.maven.plugin.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

- Fixes #6810 

### Motivation

Unify versions of `os-maven-plugin` and `protobuf-maven-plugin`.



### Modifications

Bump up `os-maven-plugin` to version `1.6.0` and `protobuf-maven-plugin` to `0.6.1`

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.


### Documentation
-no docs needed
