### PR TITLE
[INLONG-6813][Sort] MetricStateUtils threw NPE when write to es and no dirtyRecordsOut counter

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
@@ -222,8 +222,12 @@ public class MetricStateUtils {
         Map<String, Long> metricDataMap = new HashMap<>();
         metricDataMap.put(NUM_RECORDS_OUT, sinkMetricData.getNumRecordsOut().getCount());
         metricDataMap.put(NUM_BYTES_OUT, sinkMetricData.getNumBytesOut().getCount());
-        metricDataMap.put(DIRTY_RECORDS_OUT, sinkMetricData.getDirtyRecordsOut().getCount());
-        metricDataMap.put(DIRTY_BYTES_OUT, sinkMetricData.getDirtyBytesOut().getCount());
+        if (sinkMetricData.getDirtyRecordsOut() != null) {
+            metricDataMap.put(DIRTY_RECORDS_OUT, sinkMetricData.getDirtyRecordsOut().getCount());
+        }
+        if (sinkMetricData.getDirtyBytesOut() != null) {
+            metricDataMap.put(DIRTY_BYTES_OUT, sinkMetricData.getDirtyBytesOut().getCount());
+        }
         MetricState metricState = new MetricState(subtaskIndex, metricDataMap);
         metricStateListState.add(metricState);
     }

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -104,7 +104,7 @@ public class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<R
                 .withInlongAudit(auditHostAndPorts)
                 .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
                 .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
-                .withRegisterMetric(RegisteredMetric.ALL)
+                .withRegisterMetric(RegisteredMetric.NORMAL)
                 .build();
         if (metricOption != null) {
             sinkMetricData = new SinkMetricData(metricOption, runtimeContext.getMetricGroup());

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -104,7 +104,7 @@ public class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<R
                 .withInlongAudit(auditHostAndPorts)
                 .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
                 .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
-                .withRegisterMetric(RegisteredMetric.NORMAL)
+                .withRegisterMetric(RegisteredMetric.ALL)
                 .build();
         if (metricOption != null) {
             sinkMetricData = new SinkMetricData(metricOption, runtimeContext.getMetricGroup());


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-6813][Sort] MetricStateUtils threw NPE when write to es and no dirtyRecordsOut counter

- Fixes #6813 

### Motivation

Fix metricStateUtils threw NPE when write to es and no dirtyRecordsOut counter.

### Modifications

Register a `DIRTY` counter.
