### PR TITLE
[INLONG-6815][Manager] Elasticsearch port parameter is missing

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/es/ElasticsearchSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/es/ElasticsearchSinkDTO.java
@@ -95,6 +95,7 @@ public class ElasticsearchSinkDTO {
         }
         return ElasticsearchSinkDTO.builder()
                 .host(request.getHost())
+                .port(request.getPort())
                 .username(request.getUsername())
                 .password(passwd)
                 .indexName(request.getIndexName())


### PR DESCRIPTION
### Prepare a Pull Request
- Title: [INLONG-6815][Manager] Elasticsearch port parameter is missing

- Fixes #6815 

### Motivation

Fix elasticsearch port parameter is missing problem.

### Modifications

`ElasticsearchSinkDTO` add get `port` parameter. 