### PR TITLE
[INLONG-6827][Manager] Optimize the config managerment of SortStandalone

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -46,6 +46,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -109,7 +110,7 @@ public class SortClusterServiceImpl implements SortClusterService {
         try {
             reloadAllClusterConfigV2();
         } catch (Throwable t) {
-            LOGGER.error(t.getMessage(), t);
+            LOGGER.error("fail to reload cluster config", t);
         }
         LOGGER.debug("end to reload config");
     }
@@ -239,6 +240,7 @@ public class SortClusterServiceImpl implements SortClusterService {
                             .sinkParams(this.parseSinkParamsV2(nodeInfo))
                             .build();
                 })
+                .filter(config -> Objects.nonNull(config.getSinkParams()))
                 .collect(Collectors.toList());
 
         return SortClusterConfig.builder()
@@ -258,9 +260,10 @@ public class SortClusterServiceImpl implements SortClusterService {
                         LOGGER.error("fail to parse id params of groupId={}, streamId={} name={}, type={}}",
                                 streamSink.getInlongGroupId(), streamSink.getInlongStreamId(),
                                 streamSink.getSinkName(), streamSink.getSinkType(), e);
-                        return new HashMap<String, String>();
+                        return null;
                     }
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
     }
 
@@ -271,7 +274,7 @@ public class SortClusterServiceImpl implements SortClusterService {
         } catch (Exception e) {
             LOGGER.error("fail to parse sink params of nodeName={}, type={}",
                     nodeInfo.getName(), nodeInfo.getType(), e);
-            return new HashMap<>();
+            return null;
         }
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -273,8 +273,8 @@ public class SortClusterServiceImpl implements SortClusterService {
     }
 
     private Map<String, String> parseSinkParams(DataNodeInfo nodeInfo) {
-            DataNodeOperator operator = dataNodeOperatorFactory.getInstance(nodeInfo.getType());
-            return operator.parse2SinkParams(nodeInfo);
+        DataNodeOperator operator = dataNodeOperatorFactory.getInstance(nodeInfo.getType());
+        return operator.parse2SinkParams(nodeInfo);
     }
 
     /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -175,13 +175,16 @@ public class SortClusterServiceImpl implements SortClusterService {
         // get all task under a given cluster, has been reduced into cluster and task.
         List<SortTaskInfo> tasks = sortConfigLoader.loadAllTask();
         Map<String, List<SortTaskInfo>> clusterTaskMap = tasks.stream()
-                .filter(dto -> StringUtils.isNotBlank(dto.getSortClusterName()))
+                .filter(dto -> StringUtils.isNotBlank(dto.getSortClusterName())
+                        && StringUtils.isNotBlank(dto.getSortTaskName())
+                        && StringUtils.isNotBlank(dto.getDataNodeName())
+                        && StringUtils.isNotBlank(dto.getSinkType()))
                 .collect(Collectors.groupingBy(SortTaskInfo::getSortClusterName));
 
         // get all stream sinks
         Map<String, List<StreamSinkEntity>> task2AllStreams = sinkEntities.stream()
                 .filter(entity -> StringUtils.isNotBlank(entity.getInlongClusterName()))
-                .collect(Collectors.groupingBy(StreamSinkEntity::getSinkName));
+                .collect(Collectors.groupingBy(StreamSinkEntity::getSortTaskName));
 
         // get all data nodes and group by node name
         List<DataNodeEntity> dataNodeEntities = sortConfigLoader.loadAllDataNodeEntity();
@@ -233,7 +236,6 @@ public class SortClusterServiceImpl implements SortClusterService {
                         String dataNodeName = task.getDataNodeName();
                         DataNodeInfo nodeInfo = task2DataNodeMap.get(dataNodeName);
                         List<StreamSinkEntity> streams = task2AllStreams.get(taskName);
-
                         return SortTaskConfig.builder()
                                 .name(taskName)
                                 .type(type)


### PR DESCRIPTION
- Fixes #6827 

### Motivation

One dirty stream sink record should not result in config failed of cluster level, just skip the dirty record itself.

### Modifications

SortClusterService catch exceptions of parsing dirty stream sink and return a empty id params, instead of throw them to higher level. 
In this way, the dirty stream sink records will only affect itself, rather than resulting in cluster level config failure.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
