### PR TITLE
[INLONG-6830][Manager] Optimize the config managerment of SortSDK

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -387,9 +388,10 @@ public class SortSourceServiceImpl implements SortSourceService {
                                 .build();
                     } catch (Exception e) {
                         LOGGER.error("fail to parse topic of groupId={}, streamId={}", groupId, streamId, e);
-                        return Topic.builder().build();
+                        return null;
                     }
                 })
+                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
         return CacheZone.builder()
                 .zoneName(cluster.getName())

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sdk.sort.manager;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sdk.sort.api.ClientContext;
 import org.apache.inlong.sdk.sort.api.InlongTopicTypeEnum;
 import org.apache.inlong.sdk.sort.api.QueryConsumeConfig;
@@ -160,6 +161,7 @@ public class InlongMultiTopicManager extends TopicManager {
         }
         this.allTopics = assignedTopics.stream()
                 .map(InLongTopic::getTopic)
+                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toSet());
 
         assignedTopics.stream()

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sdk.sort.api.ClientContext;
 import org.apache.inlong.sdk.sort.api.InlongTopicTypeEnum;
 import org.apache.inlong.sdk.sort.api.QueryConsumeConfig;
@@ -264,6 +265,7 @@ public class InlongSingleTopicManager extends TopicManager {
 
         List<String> newTopics = assignedTopics.stream()
                 .map(InLongTopic::getTopicKey)
+                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toList());
         LOGGER.debug("assignedTopics name: {}", Arrays.toString(newTopics.toArray()));
 

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -264,8 +264,8 @@ public class InlongSingleTopicManager extends TopicManager {
         }
 
         List<String> newTopics = assignedTopics.stream()
+                .filter(inlongTopic -> StringUtils.isNotBlank(inlongTopic.getTopic()))
                 .map(InLongTopic::getTopicKey)
-                .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toList());
         LOGGER.debug("assignedTopics name: {}", Arrays.toString(newTopics.toArray()));
 


### PR DESCRIPTION
- Fixes #6830 

### Motivation

One dirty stream sink should not affect other sdk configs

### Modifications

Catch exceptions in **InlongTopic** level,  instead of **CacheZone** level. All dirty stream sinks will result in a empty InlongTopic in the related **CacheZones**. 
SortSdk just fillter these empty topics.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? ( no)
