### PR TITLE
[INLONG-6835][Manager] Fix the error about backup mq resource of DataProxy getAllConfig interface

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/repository/DataProxyConfigRepository.java
@@ -413,12 +413,12 @@ public class DataProxyConfigRepository implements IRepository {
 
                 Map<String, String> streamParam = streamParams.get(inlongId);
                 if (streamParam != null && !StringUtils.isBlank(streamParam.get(ClusterSwitch.BACKUP_MQ_RESOURCE))) {
-                    obj.setTopic(streamParam.get(ClusterSwitch.BACKUP_MQ_RESOURCE));
+                    backupObj.setTopic(streamParam.get(ClusterSwitch.BACKUP_MQ_RESOURCE));
                     backupObj.getParams().put(KEY_NAMESPACE, groupMqResource);
                 } else {
-                    obj.setTopic(groupMqResource);
+                    backupObj.setTopic(groupMqResource);
                 }
-                inlongIdMap.computeIfAbsent(clusterTag, k -> new ArrayList<>()).add(obj);
+                inlongIdMap.computeIfAbsent(clusterTag, k -> new ArrayList<>()).add(backupObj);
             }
         }
         return inlongIdMap;


### PR DESCRIPTION
- Title : [INLONG-6835][Manager] Error about backup mq resource of DataProxy getAllConfig interface.
- Fixes #6835 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
