### PR TITLE
[INLONG-6839][Sort] Clean up remain event when the related stream is offline

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
@@ -72,8 +72,12 @@ public class KafkaFederationSinkContext extends SinkContext {
             Map<String, KafkaIdConfig> newIdConfigMap = new ConcurrentHashMap<>();
             List<Map<String, String>> idList = this.sortTaskConfig.getIdParams();
             for (Map<String, String> idParam : idList) {
-                KafkaIdConfig idConfig = new KafkaIdConfig(idParam);
-                newIdConfigMap.put(idConfig.getUid(), idConfig);
+                try {
+                    KafkaIdConfig idConfig = new KafkaIdConfig(idParam);
+                    newIdConfigMap.put(idConfig.getUid(), idConfig);
+                } catch (Exception e) {
+                    LOG.error("fail to parse kafka id config", e);
+                }
             }
 
             LOG.info("reload clusterConfig");

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -25,7 +25,6 @@ import org.apache.flume.Event;
 import org.apache.flume.Transaction;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
-import org.apache.inlong.sort.standalone.config.pojo.InlongId;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.utils.Constants;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationWorker.java
@@ -19,6 +19,7 @@ package org.apache.inlong.sort.standalone.sink.kafka;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Event;
 import org.apache.flume.Transaction;
@@ -106,8 +107,17 @@ public class KafkaFederationWorker extends Thread {
                     LOG.error("The type of row event is not compatible with ProfileEvent");
                     continue;
                 }
+
                 ProfileEvent profileEvent = (ProfileEvent) rowEvent;
-                String topic = this.fillTopic(profileEvent);
+                String topic = this.context.getTopic(profileEvent.getUid());
+                if (StringUtils.isBlank(topic)) {
+                    this.context.addSendResultMetric(profileEvent, profileEvent.getUid(),
+                            false, System.currentTimeMillis());
+                    profileEvent.ack();
+                    tx.commit();
+                    tx.close();
+                }
+                profileEvent.getHeaders().put(Constants.TOPIC, topic);
                 this.context.addSendMetric(profileEvent, topic);
                 this.producerFederation.send(profileEvent, tx);
             } catch (Exception e) {
@@ -123,21 +133,6 @@ public class KafkaFederationWorker extends Thread {
                 sleepOneInterval();
             }
         }
-    }
-
-    /**
-     * FillTopic
-     *
-     * @param event
-     */
-    private String fillTopic(Event event) {
-        Map<String, String> headers = event.getHeaders();
-        String inlongGroupId = headers.get(Constants.INLONG_GROUP_ID);
-        String inlongStreamId = headers.get(Constants.INLONG_STREAM_ID);
-        String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
-        String topic = this.context.getTopic(uid);
-        headers.put(Constants.TOPIC, topic);
-        return topic;
     }
 
     /** sleepOneInterval */


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #6839 

### Motivation

The remain event will stay in memory forever since there is no any idConfig related to this event when stream offline.
This will cause memory leak and poor performance.

### Modifications

Just ack and discards those events which does not relate any idConfigs.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
