### PR TITLE
[INLONG-6842][Sort] Improve mysql-cdc2.0 to support tables without primary key

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -169,15 +169,13 @@ public class MySqlSnapshotSplitReadTask extends AbstractSnapshotChangeEventSourc
      * @return highWatermark
      */
     private BinlogOffset determineHighWatermark(BinlogOffset lowWatermark) {
-        BinlogOffset highWatermark;
         if (snapshotSplit.isWholeSplit()) {
-            highWatermark = lowWatermark;
             LOG.info("for split {}, set highWatermark to lowWatermark {} since"
                     + " it reads the whole table ", snapshotSplit, lowWatermark);
+            return lowWatermark;
         } else {
-            highWatermark = currentBinlogOffset(jdbcConnection);
+            return currentBinlogOffset(jdbcConnection);
         }
-        return highWatermark;
     }
 
     @Override

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlSnapshotSplitReadTask.java
@@ -149,7 +149,8 @@ public class MySqlSnapshotSplitReadTask extends AbstractSnapshotChangeEventSourc
         LOG.info("Snapshot step 2 - Snapshotting data");
         createDataEvents(ctx, snapshotSplit.getTableId());
 
-        final BinlogOffset highWatermark = currentBinlogOffset(jdbcConnection);
+        BinlogOffset highWatermark = determineHighWatermark(lowWatermark);
+
         LOG.info(
                 "Snapshot step 3 - Determining high watermark {} for split {}",
                 highWatermark,
@@ -160,6 +161,23 @@ public class MySqlSnapshotSplitReadTask extends AbstractSnapshotChangeEventSourc
                 .setHighWatermark(highWatermark);
 
         return SnapshotResult.completed(ctx.offset);
+    }
+
+    /**
+     * for chunk that equals to the whole table we do not need to normalize
+     * the snapshot data and the binlog data, just set high watermark to low watermark
+     * @return highWatermark
+     */
+    private BinlogOffset determineHighWatermark(BinlogOffset lowWatermark) {
+        BinlogOffset highWatermark;
+        if (snapshotSplit.isWholeSplit()) {
+            highWatermark = lowWatermark;
+            LOG.info("for split {}, set highWatermark to lowWatermark {} since"
+                    + " it reads the whole table ", snapshotSplit, lowWatermark);
+        } else {
+            highWatermark = currentBinlogOffset(jdbcConnection);
+        }
+        return highWatermark;
     }
 
     @Override

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/ChunkSplitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/ChunkSplitter.java
@@ -153,15 +153,13 @@ class ChunkSplitter {
      * @return chunks
      */
     private Column getSplitColumn(Table table) {
-        Column splitColumn;
         if (table.primaryKeyColumns().isEmpty()) {
             // since we do not need a split column when there is no primary key
             // simply return the first column which won't be used
-            splitColumn = table.columns().get(0);
+            return table.columns().get(0);
         } else {
-            splitColumn = ChunkUtils.getSplitColumn(table);
+            return ChunkUtils.getSplitColumn(table);
         }
-        return splitColumn;
     }
 
     /**
@@ -170,20 +168,18 @@ class ChunkSplitter {
      * @return chunks
      */
     private List<ChunkRange> getChunks(TableId tableId, JdbcConnection jdbc, Table table) {
-        List<ChunkRange> chunks = new ArrayList<>();
         if (table.primaryKeyColumns().isEmpty()) {
             // take the whole table as chunk range
             // when there is no primary key presented
-            chunks.add(ChunkRange.all());
+            return Collections.singletonList(ChunkRange.all());
         } else {
             Column splitColumn = ChunkUtils.getSplitColumn(table);
             try {
-                chunks = splitTableIntoChunks(jdbc, tableId, splitColumn);
+                return splitTableIntoChunks(jdbc, tableId, splitColumn);
             } catch (SQLException e) {
                 throw new FlinkRuntimeException("Failed to split chunks for table " + tableId, e);
             }
         }
-        return chunks;
     }
 
     /**

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSnapshotSplit.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/split/MySqlSnapshotSplit.java
@@ -91,6 +91,14 @@ public class MySqlSnapshotSplit extends MySqlSplit {
         return highWatermark != null;
     }
 
+    /**
+     * read the whole table when split start and split end are null
+     * @return whether the split reads the whole table
+     */
+    public boolean isWholeSplit() {
+        return splitStart == null && splitEnd == null;
+    }
+
     @Override
     public Map<TableId, TableChange> getTableSchemas() {
         return tableSchemas;

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableInlongSourceFactory.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableInlongSourceFactory.java
@@ -154,7 +154,6 @@ public class MySqlTableInlongSourceFactory implements DynamicTableSourceFactory 
                 : config.get(ROW_KINDS_FILTERED);
         boolean enableParallelRead = config.get(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
         if (enableParallelRead) {
-            validatePrimaryKeyIfEnableParallel(physicalSchema);
             validateStartupOptionIfEnableParallel(startupOptions);
             validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
             validateIntegerOption(CHUNK_META_GROUP_SIZE, splitMetaGroupSize, 1);

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
@@ -62,7 +62,7 @@ public class AllMigrateTest {
         return new MySqlExtractNode("1", "mysql_input", fields,
                 null, option, null,
                 tables, "localhost", "root", "inlong",
-                "test", null, null, false, null,
+                "test", null, null, true, null,
                 ExtractMode.CDC, null, null);
     }
 


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #6842 

### Motivation
Fixes #6842

### Modifications

A minor modification and improvemnt for Dblog : https://netflixtechblog.com/dblog-a-generic-change-data-capture-framework-69351fb9099b 

1、remove the constraint in mysql-cdc 2.0 for primary key
2、for those tables which don't contain primary key, split the whole table as a chunk during split stage
3、since there's no need for the MySqlSourceEnumerator to upsert binlog with the snapshot data for a whole table 
split , just let the highwatermark equals to the lowwatermark to escape the upsert stage.

### Verifying this change

run AllmigrateTest

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
