### PR TITLE
[INLONG-6867][CVE] Bump protobuf to 3.19.6 to fix Java vulnerable

### DIFF
--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -528,7 +528,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.G
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
   com.thoughtworks.paranamer:paranamer:2.8 - ParaNamer Core (https://github.com/paul-hammant/paranamer/tree/paranamer-parent-2.8), (BSD)
   org.postgresql:postgresql:42.4.1 - PostgreSQL JDBC Driver (https://jdbc.postgresql.org), (BSD-2-Clause)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   org.scala-lang.modules:scala-java8-compat_2.11:0.9.0 - scala-java8-compat (https://github.com/scala/scala-java8-compat/tree/v0.9.0), (BSD 3-clause)
   org.scala-lang:scala-library:2.11.12 - Scala Library (https://github.com/scala/scala/tree/v2.11.12), (BSD 3-clause)
   org.scala-lang.modules:scala-parser-combinators_2.11:1.1.1 - scala-parser-combinators (http://www.scala-lang.org/), (BSD 3-clause)

--- a/licenses/inlong-audit/LICENSE
+++ b/licenses/inlong-audit/LICENSE
@@ -499,7 +499,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
   org.postgresql:postgresql:42.4.1 - PostgreSQL JDBC Driver (https://jdbc.postgresql.org), (BSD-2-Clause)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   com.github.luben:zstd-jni:1.4.5-12 - zstd-jni (https://github.com/luben/zstd-jni/tree/v1.4.5-12), (BSD 2-Clause License)
 
 

--- a/licenses/inlong-dataproxy/LICENSE
+++ b/licenses/inlong-dataproxy/LICENSE
@@ -444,7 +444,7 @@ The following components are provided under BSD license. See project link for de
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   com.github.luben:zstd-jni:1.4.3-1 - zstd-jni (https://github.com/luben/zstd-jni), (BSD 2-Clause License)
 
 

--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -703,7 +703,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.fusesource.leveldbjni:leveldbjni-all:1.8 - leveldbjni-all (https://github.com/fusesource/leveldbjni/tree/leveldbjni-1.8), (The BSD 3-Clause License)
   com.esotericsoftware.minlog:minlog:1.2 - MinLog (https://github.com/EsotericSoftware/minlog/tree/1.2), (New BSD License)
   org.postgresql:postgresql:42.4.1 - PostgreSQL JDBC Driver (https://jdbc.postgresql.org), (BSD-2-Clause)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   org.scala-lang:scala-compiler:2.11.12 - Scala Compiler (http://www.scala-lang.org/), (BSD 3-Clause)
   org.scala-lang.modules:scala-java8-compat_2.11:0.7.0 - scala-java8-compat (https://github.com/scala/scala-java8-compat/tree/v0.7.0), (BSD 3-clause)
   org.scala-lang:scala-library:2.11.12 - Scala Library (http://www.scala-lang.org/), (BSD 3-Clause)

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -971,7 +971,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   com.jcraft:jsch:0.1.55 - JSch (http://www.jcraft.com/jsch/), (Revised BSD)
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
   org.postgresql:postgresql:42.4.1 - PostgreSQL JDBC Driver (https://jdbc.postgresql.org), (BSD-2-Clause)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   org.codehaus.woodstox:stax2-api:3.1.4 - Stax2 API (https://github.com/FasterXML/stax2-api), (The BSD License)
   org.threeten:threeten-extra:1.5.0 - ThreeTen-Extra (https://www.threeten.org/threeten-extra), (BSD 3-clause)
   xmlenc:xmlenc:0.52 - xmlenc Library (http://xmlenc.sourceforge.net), (The BSD License)

--- a/licenses/inlong-sort-standalone/LICENSE
+++ b/licenses/inlong-sort-standalone/LICENSE
@@ -582,7 +582,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   com.jcraft:jsch:0.1.55 - JSch (http://www.jcraft.com/jsch/), (Revised BSD)
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
   org.fusesource.leveldbjni:leveldbjni-all:1.8 - leveldbjni-all (https://github.com/fusesource/leveldbjni/tree/leveldbjni-1.8), (The BSD 3-Clause License)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.4), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf/tree/v3.19.6), (3-Clause BSD License)
   com.google.protobuf:protobuf-java-util:3.15.3 - Protocol Buffers [Util] (https://github.com/protocolbuffers/protobuf/tree/v3.15.3), (3-Clause BSD License)
   org.codehaus.woodstox:stax2-api:3.1.4 - Stax2 API (https://github.com/FasterXML/stax2-api), (The BSD License)
   xmlenc:xmlenc:0.52 - xmlenc Library (http://xmlenc.sourceforge.net), (The BSD License)

--- a/licenses/inlong-tubemq-server/LICENSE
+++ b/licenses/inlong-tubemq-server/LICENSE
@@ -445,7 +445,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
 
   org.dom4j:dom4j:2.1.3 - dom4j (http://dom4j.github.io), (BSD 3-clause New License)
   com.google.code.findbugs:jsr305:3.0.2 - FindBugs-jsr305 (http://findbugs.sourceforge.net/), (New BSD License)
-  com.google.protobuf:protobuf-java:3.19.4 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf), (3-Clause BSD License)
+  com.google.protobuf:protobuf-java:3.19.6 - Protocol Buffers [Core] (https://github.com/protocolbuffers/protobuf), (3-Clause BSD License)
 
 
 ========================================================================

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <shiro.version>1.10.1</shiro.version>
 
         <snappy.version>1.1.8.4</snappy.version>
-        <protobuf.version>3.19.4</protobuf.version>
+        <protobuf.version>3.19.6</protobuf.version>
         <bytebuddy.version>1.12.9</bytebuddy.version>
         <reflections.version>0.10.2</reflections.version>
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6867

### Motivation

Protobuf Java vulnerable to Uncontrolled Resource Consumption
