### PR TITLE
[INLONG-6879][CI] Use ubuntu-22.04 to replace ubuntu-latest for workflows

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   chart-test:
     name: Lint and test charts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         kubernetes-version:

--- a/.github/workflows/ci_check_format.yml
+++ b/.github/workflows/ci_check_format.yml
@@ -22,7 +22,7 @@ on: [ push, pull_request ]
 jobs:
   build:
     name: Code Format Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -22,7 +22,7 @@ on: [ push, pull_request ]
 jobs:
   check-license:
     name: Check license header
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_check_pr_title.yml
+++ b/.github/workflows/ci_check_pr_title.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   check:
     name: Check pull request title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   docker:
     name: Docker build and push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Maximize build space
         uses: easimon/maximize-build-space@master

--- a/.github/workflows/ci_greeting.yml
+++ b/.github/workflows/ci_greeting.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   greeting:
     name: Greeting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ci_labeler.yml
+++ b/.github/workflows/ci_labeler.yml
@@ -22,7 +22,7 @@ on: pull_request_target
 jobs:
   label:
     name: Label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Label the PR
         uses: actions/labeler@v4

--- a/.github/workflows/ci_stale.yml
+++ b/.github/workflows/ci_stale.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   stale:
     name: Stale
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   unit-test:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -22,7 +22,7 @@ on: [ push, pull_request ]
 jobs:
   analyze:
     name: Analyze by CodeQL
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6879

### Motivation

Ubuntu 22.04 is ready to be the default version for the "ubuntu-latest" label in GitHub Actions and Azure DevOps.

see https://github.com/actions/runner-images/issues/6399