### PR TITLE
[INLONG-6884][Sort] Add dirty message for kafka connector

### DIFF
--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
@@ -170,6 +170,7 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
                         null,
                         valueSerialized);
             }
+            return null;
         }
         final byte[] keySerialized;
         boolean mayDirtyData = false;
@@ -228,6 +229,7 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
                             .setDirtyType(dirtyType)
                             .setLabels(dirtyOptions.getLabels())
                             .setLogTag(dirtyOptions.getLogTag())
+                            .setDirtyMessage(e.getMessage())
                             .setIdentifier(dirtyOptions.getIdentifier());
                     dirtySink.invoke(builder.build());
                 } catch (Exception ex) {
@@ -260,6 +262,7 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
                             .setDirtyType(DirtyType.VALUE_DESERIALIZE_ERROR)
                             .setLabels(jsonDynamicSchemaFormat.parse(rootNode, dirtyOptions.getLabels()))
                             .setLogTag(jsonDynamicSchemaFormat.parse(rootNode, dirtyOptions.getLogTag()))
+                            .setDirtyMessage(e.getMessage())
                             .setIdentifier(jsonDynamicSchemaFormat.parse(rootNode, dirtyOptions.getIdentifier()));
                     dirtySink.invoke(builder.build());
                 } catch (Exception ex) {

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
@@ -166,7 +166,6 @@ public class DynamicKafkaDeserializationSchema implements KafkaDeserializationSc
                 outputMetrics(record);
             }
         }
-
         keyCollector.buffer.clear();
     }
 
@@ -186,6 +185,7 @@ public class DynamicKafkaDeserializationSchema implements KafkaDeserializationSc
                                 .setDirtyType(dirtyType)
                                 .setLabels(dirtyOptions.getLabels())
                                 .setLogTag(dirtyOptions.getLogTag())
+                                .setDirtyMessage(e.getMessage())
                                 .setIdentifier(dirtyOptions.getIdentifier());
                         dirtySink.invoke(builder.build());
                     } catch (Exception ex) {


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-6884][Sort] Add dirty message for kafka connector

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6884

### Motivation

Add dirty message for kafka connector. The dirty message is the cause of dirty data, in this part, i will ingest it for kafka connector and it can be used by '${DIRTY_MESSAGE}' if needed.

### Modifications

Add  dirty message handle for 'DynamicKafkaDeserializationSchema' and 'DynamicKafkaSerializationSchema'

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
