### PR TITLE
[INLONG-6899][Sort] StarRocks supports table level metric

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkSubMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkSubMetricData.java
@@ -17,17 +17,18 @@
 
 package org.apache.inlong.sort.base.metric.sub;
 
+import java.util.Map;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
 
-import java.util.Map;
-
+/**
+ * A collection class for handling sub metrics
+ */
 public interface SinkSubMetricData {
 
     /**
      * Get sub sink metric map
      *
-     * @return The sub sink metric map
+     * @return The sub source metric map
      */
-    Map<String, SinkMetricData> getSubSourceMetricMap();
-
+    Map<String, SinkMetricData> getSubSinkMetricMap();
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkSubMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkSubMetricData.java
@@ -28,7 +28,7 @@ public interface SinkSubMetricData {
     /**
      * Get sub sink metric map
      *
-     * @return The sub source metric map
+     * @return The sub sink metric map
      */
     Map<String, SinkMetricData> getSubSinkMetricMap();
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.metric.sub;
+
+import static org.apache.inlong.sort.base.Constants.DELIMITER;
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
+import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
+
+import com.google.common.collect.Maps;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.inlong.sort.base.Constants;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A collection class for handling sub metrics of table schema type
+ */
+public class SinkTableMetricData extends SinkMetricData implements SinkSubMetricData {
+
+    public static final Logger LOGGER = LoggerFactory.getLogger(SinkTableMetricData.class);
+
+    /**
+     * The sub sink metric data container of sink metric data
+     */
+    private final Map<String, SinkMetricData> subSinkMetricMap = Maps.newHashMap();
+
+    public SinkTableMetricData(MetricOption option, MetricGroup metricGroup) {
+        super(option, metricGroup);
+    }
+
+    /**
+     * register sub sink metrics group from metric state
+     *
+     * @param metricState MetricState
+     */
+    public void registerSubMetricsGroup(MetricState metricState) {
+        if (metricState == null) {
+            return;
+        }
+
+        // register sub sink metric data
+        if (metricState.getSubMetricStateMap() == null) {
+            return;
+        }
+        Map<String, MetricState> subMetricStateMap = metricState.getSubMetricStateMap();
+        for (Entry<String, MetricState> subMetricStateEntry : subMetricStateMap.entrySet()) {
+            String[] schemaInfoArray = parseSchemaIdentify(subMetricStateEntry.getKey());
+            final MetricState subMetricState = subMetricStateEntry.getValue();
+            SinkMetricData subSinkMetricData = buildSubSinkMetricData(schemaInfoArray, subMetricState, this);
+            subSinkMetricMap.put(subMetricStateEntry.getKey(), subSinkMetricData);
+        }
+        LOGGER.info("register subMetricsGroup from metricState,sub metric map size:{}", subSinkMetricMap.size());
+    }
+
+    /**
+     * build sub sink metric data
+     *
+     * @param schemaInfoArray sink record schema info
+     * @param sinkMetricData sink metric data
+     * @return sub sink metric data
+     */
+    private SinkMetricData buildSubSinkMetricData(String[] schemaInfoArray, SinkMetricData sinkMetricData) {
+        return buildSubSinkMetricData(schemaInfoArray, null, sinkMetricData);
+    }
+
+    /**
+     * build sub sink metric data
+     *
+     * @param schemaInfoArray the schema info array of record
+     * @param subMetricState sub metric state
+     * @param sinkMetricData sink metric data
+     * @return sub sink metric data
+     */
+    private SinkMetricData buildSubSinkMetricData(String[] schemaInfoArray, MetricState subMetricState,
+            SinkMetricData sinkMetricData) {
+        if (sinkMetricData == null || schemaInfoArray == null) {
+            return null;
+        }
+        // build sub sink metric data
+        Map<String, String> labels = sinkMetricData.getLabels();
+        String metricGroupLabels = labels.entrySet().stream().map(entry -> entry.getKey() + "=" + entry.getValue())
+                .collect(Collectors.joining(DELIMITER));
+        StringBuilder labelBuilder = new StringBuilder(metricGroupLabels);
+        if (schemaInfoArray.length == 2) {
+            labelBuilder.append(DELIMITER).append(Constants.DATABASE_NAME).append("=").append(schemaInfoArray[0])
+                    .append(DELIMITER).append(Constants.TABLE_NAME).append("=").append(schemaInfoArray[1]);
+        } else if (schemaInfoArray.length == 3) {
+            labelBuilder.append(DELIMITER).append(Constants.DATABASE_NAME).append("=").append(schemaInfoArray[0])
+                    .append(DELIMITER).append(Constants.SCHEMA_NAME).append("=").append(schemaInfoArray[1])
+                    .append(DELIMITER).append(Constants.TABLE_NAME).append("=").append(schemaInfoArray[2]);
+        }
+
+        MetricOption metricOption = MetricOption.builder()
+                .withInitRecords(subMetricState != null ? subMetricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
+                .withInitBytes(subMetricState != null ? subMetricState.getMetricValue(NUM_BYTES_OUT) : 0L)
+                .withInitDirtyRecords(subMetricState != null ? subMetricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
+                .withInitDirtyBytes(subMetricState != null ? subMetricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
+                .withInlongLabels(labelBuilder.toString()).withRegisterMetric(RegisteredMetric.ALL).build();
+        return new SinkTableMetricData(metricOption, sinkMetricData.getMetricGroup());
+    }
+
+    /**
+     * build record schema identify,in the form of database.schema.table or database.table
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @return the record schema identify
+     */
+    public String buildSchemaIdentify(String database, String schema, String table) {
+        if (schema == null) {
+            return database + Constants.SEMICOLON + table;
+        }
+        return database + Constants.SEMICOLON + schema + Constants.SEMICOLON + table;
+    }
+
+    /**
+     * parse record schema identify
+     *
+     * @param schemaIdentify the schema identify of record
+     * @return the record schema identify array,String[]{database,table}
+     */
+    public String[] parseSchemaIdentify(String schemaIdentify) {
+        return schemaIdentify.split(Constants.SPILT_SEMICOLON);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param data the data of record
+     */
+    public void outputMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
+            Object data) {
+        // sink metric and sub sink metric output metrics
+        long rowCountSize = 1L;
+        long rowDataSize = 0L;
+        if (data != null) {
+            rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
+        }
+        outputMetricsWithEstimate(database, schema, table, isSnapshotRecord, rowCountSize, rowDataSize);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
+            long rowCount, long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            invoke(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, schema, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invoke(rowCount, rowSize);
+        subSinkMetricData.invoke(rowCount, rowSize);
+    }
+
+    public void outputMetricsWithEstimate(Object data) {
+        long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
+        invoke(1, size);
+    }
+
+    @Override
+    public Map<String, SinkMetricData> getSubSinkMetricMap() {
+        return this.subSinkMetricMap;
+    }
+
+    @Override
+    public String toString() {
+        return "SinkTableMetricData{" + "subSinkMetricMap=" + subSinkMetricMap + '}';
+    }
+}

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTopicMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTopicMetricData.java
@@ -96,7 +96,7 @@ public class SinkTopicMetricData extends SinkMetricData implements SinkSubMetric
     }
 
     @Override
-    public Map<String, SinkMetricData> getSubSourceMetricMap() {
+    public Map<String, SinkMetricData> getSubSinkMetricMap() {
         return this.sinkMetricMap;
     }
 }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/util/MetricStateUtils.java
@@ -249,7 +249,7 @@ public class MetricStateUtils {
         }
         SinkSubMetricData sinkSubMetricData = (SinkSubMetricData) sinkMetricData;
 
-        Map<String, SinkMetricData> subSinkMetricMap = sinkSubMetricData.getSubSourceMetricMap();
+        Map<String, SinkMetricData> subSinkMetricMap = sinkSubMetricData.getSubSinkMetricMap();
         if (subSinkMetricMap != null && !subSinkMetricMap.isEmpty()) {
             Map<String, MetricState> subMetricStateMap = new HashMap<>();
             Set<Entry<String, SinkMetricData>> entries = subSinkMetricMap.entrySet();

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
@@ -63,7 +63,7 @@ import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricState;
-import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.starrocks.manager.StarRocksSinkManager;
@@ -95,7 +95,7 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
     private final String tablePattern;
 
     private final String inlongMetric;
-    private transient SinkMetricData metricData;
+    private transient SinkTableMetricData metricData;
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
     private final String auditHostAndPorts;
@@ -152,7 +152,11 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
                 .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
                 .withRegisterMetric(MetricOption.RegisteredMetric.ALL).build();
         if (metricOption != null) {
-            metricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
+            metricData = new SinkTableMetricData(metricOption, getRuntimeContext().getMetricGroup());
+            if (multipleSink) {
+                // register sub sink metric data from metric state
+                metricData.registerSubMetricsGroup(metricState);
+            }
             sinkManager.setSinkMetricData(metricData);
         }
     }


### PR DESCRIPTION
### Prepare a Pull Request

- StarRocks supports table level metric

- Fixes #6899

### Motivation

StarRocks supports table level metrics.

![image](https://user-images.githubusercontent.com/2731242/207813379-8954f55d-1e5c-4f07-b348-8d3298453f56.png)


### Modifications

*Describe the modifications you've done.*

1. `SinkSubMetricData` and `SinkTableMetricData` provide method to collect the metrics,   inspired by SourceSubMetricData and SourceTableMetricData.
2. Replaced SinkMetricData with SinkTableMetricData in `StarRocksSinkManager` and `StarRocksDynamicSinkFunction`.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
