### PR TITLE
[INLONG-6907][SortStandalone] Support to close StatsRecorder of pulsar client

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -144,6 +144,7 @@ public class ConfigConstants {
 
     public static final String KEY_SERVICE_URL = "serviceUrl";
     public static final String KEY_AUTHENTICATION = "authentication";
+    public static final String KEY_STATS_INTERVAL_SECONDS = "statsIntervalSeconds";
 
     public static final String KEY_ENABLEBATCHING = "enableBatching";
     public static final String KEY_BATCHINGMAXBYTES = "batchingMaxBytes";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.dataproxy.sink.mq.pulsar;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Context;
 import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
@@ -48,6 +49,8 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_STATS_INTERVAL_SECONDS;
 
 /**
  * PulsarHandler
@@ -125,6 +128,8 @@ public class PulsarHandler implements MessageQueueHandler {
                     .ioThreads(context.getInteger(KEY_IOTHREADS, 1))
                     .memoryLimit(context.getLong(KEY_MEMORYLIMIT, 1073741824L), SizeUnit.BYTES)
                     .connectionsPerBroker(context.getInteger(KEY_CONNECTIONSPERBROKER, 10))
+                    .statsInterval(NumberUtils.toLong(config.getParams().get(KEY_STATS_INTERVAL_SECONDS), -1),
+                            TimeUnit.SECONDS)
                     .build();
             this.baseBuilder = client.newProducer();
             // Map<String, Object> builderConf = new HashMap<>();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/impl/pulsarzone/PulsarClusterProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/impl/pulsarzone/PulsarClusterProducer.java
@@ -17,23 +17,7 @@
 
 package org.apache.inlong.dataproxy.sink.mqzone.impl.pulsarzone;
 
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_AUTHENTICATION;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXBYTES;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXMESSAGES;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXPUBLISHDELAY;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BLOCKIFQUEUEFULL;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_COMPRESSIONTYPE;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_CONNECTIONSPERBROKER;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_ENABLEBATCHING;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_IOTHREADS;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MAXPENDINGMESSAGES;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MAXPENDINGMESSAGESACROSSPARTITIONS;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MEMORYLIMIT;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_NAMESPACE;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_ROUNDROBINROUTERBATCHINGPARTITIONSWITCHFREQUENCY;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_SENDTIMEOUT;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_SERVICE_URL;
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_TENANT;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.flume.lifecycle.LifecycleState;
 import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
 import org.apache.inlong.dataproxy.dispatch.DispatchProfile;
@@ -58,6 +42,25 @@ import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_AUTHENTICATION;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXBYTES;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXMESSAGES;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BATCHINGMAXPUBLISHDELAY;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_BLOCKIFQUEUEFULL;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_COMPRESSIONTYPE;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_CONNECTIONSPERBROKER;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_ENABLEBATCHING;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_IOTHREADS;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MAXPENDINGMESSAGES;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MAXPENDINGMESSAGESACROSSPARTITIONS;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_MEMORYLIMIT;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_NAMESPACE;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_ROUNDROBINROUTERBATCHINGPARTITIONSWITCHFREQUENCY;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_SENDTIMEOUT;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_SERVICE_URL;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_STATS_INTERVAL_SECONDS;
+import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_TENANT;
 
 /**
  * PulsarClusterProducer
@@ -105,6 +108,8 @@ public class PulsarClusterProducer extends AbstractZoneClusterProducer {
                     .ioThreads(producerContext.getInteger(KEY_IOTHREADS, 1))
                     .memoryLimit(producerContext.getLong(KEY_MEMORYLIMIT, 1073741824L), SizeUnit.BYTES)
                     .connectionsPerBroker(producerContext.getInteger(KEY_CONNECTIONSPERBROKER, 10))
+                    .statsInterval(NumberUtils.toLong(config.getParams().get(KEY_STATS_INTERVAL_SECONDS), -1),
+                            TimeUnit.SECONDS)
                     .build();
             this.baseBuilder = client.newProducer();
             // Map<String, Object> builderConf = new HashMap<>();
@@ -141,17 +146,17 @@ public class PulsarClusterProducer extends AbstractZoneClusterProducer {
     private CompressionType getPulsarCompressionType() {
         String type = this.producerContext.getString(KEY_COMPRESSIONTYPE, CompressionType.SNAPPY.name());
         switch (type) {
-            case "LZ4":
+            case "LZ4" :
                 return CompressionType.LZ4;
-            case "NONE":
+            case "NONE" :
                 return CompressionType.NONE;
-            case "ZLIB":
+            case "ZLIB" :
                 return CompressionType.ZLIB;
-            case "ZSTD":
+            case "ZSTD" :
                 return CompressionType.ZSTD;
-            case "SNAPPY":
+            case "SNAPPY" :
                 return CompressionType.SNAPPY;
-            default:
+            default :
                 return CompressionType.NONE;
         }
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/impl/pulsarzone/PulsarClusterProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mqzone/impl/pulsarzone/PulsarClusterProducer.java
@@ -146,17 +146,17 @@ public class PulsarClusterProducer extends AbstractZoneClusterProducer {
     private CompressionType getPulsarCompressionType() {
         String type = this.producerContext.getString(KEY_COMPRESSIONTYPE, CompressionType.SNAPPY.name());
         switch (type) {
-            case "LZ4" :
+            case "LZ4":
                 return CompressionType.LZ4;
-            case "NONE" :
+            case "NONE":
                 return CompressionType.NONE;
-            case "ZLIB" :
+            case "ZLIB":
                 return CompressionType.ZLIB;
-            case "ZSTD" :
+            case "ZSTD":
                 return CompressionType.ZSTD;
-            case "SNAPPY" :
+            case "SNAPPY":
                 return CompressionType.SNAPPY;
-            default :
+            default:
                 return CompressionType.NONE;
         }
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/pulsar/PulsarClientService.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/pulsar/PulsarClientService.java
@@ -18,14 +18,7 @@
 package org.apache.inlong.dataproxy.sink.pulsar;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Event;
 import org.apache.flume.FlumeException;
@@ -48,9 +41,19 @@ import org.apache.pulsar.client.api.PulsarClientException.NotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
 public class PulsarClientService {
 
     private static final Logger logger = LoggerFactory.getLogger(PulsarClientService.class);
+    private MQClusterConfig pulsarConfig;
     public Map<String, List<TopicProducerInfo>> producerInfoMap;
     public Map<String, AtomicLong> topicSendIndexMap;
     public Map<String, PulsarClient> pulsarClients = new ConcurrentHashMap<>();
@@ -86,7 +89,7 @@ public class PulsarClientService {
      * @param pulsarConfig
      */
     public PulsarClientService(MQClusterConfig pulsarConfig, int sinkThreadPoolSize) {
-
+        this.pulsarConfig = pulsarConfig;
         this.sinkThreadPoolSize = sinkThreadPoolSize;
 
         authType = pulsarConfig.getAuthType();
@@ -266,7 +269,9 @@ public class PulsarClientService {
         builder.serviceUrl(pulsarUrl)
                 .ioThreads(pulsarClientIoThreads)
                 .connectionsPerBroker(pulsarConnectionsPreBroker)
-                .connectionTimeout(clientTimeout, TimeUnit.SECONDS);
+                .connectionTimeout(clientTimeout, TimeUnit.SECONDS)
+                .statsInterval(pulsarConfig.getStatIntervalSec(),
+                        TimeUnit.SECONDS);
         return builder.build();
     }
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/pulsar/federation/PulsarProducerCluster.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/pulsar/federation/PulsarProducerCluster.java
@@ -57,6 +57,7 @@ public class PulsarProducerCluster implements LifecycleAware {
 
     public static final String KEY_SERVICE_URL = "serviceUrl";
     public static final String KEY_AUTHENTICATION = "authentication";
+    public static final String KEY_STATS_INTERVAL_SECONDS = "statsIntervalSeconds";
 
     public static final String KEY_ENABLEBATCHING = "enableBatching";
     public static final String KEY_BATCHINGMAXBYTES = "batchingMaxBytes";
@@ -121,6 +122,8 @@ public class PulsarProducerCluster implements LifecycleAware {
                     .ioThreads(context.getInteger(KEY_IOTHREADS, 1))
                     .memoryLimit(context.getLong(KEY_MEMORYLIMIT, 1073741824L), SizeUnit.BYTES)
                     .connectionsPerBroker(context.getInteger(KEY_CONNECTIONSPERBROKER, 10))
+                    .statsInterval(NumberUtils.toLong(config.getParams().get(KEY_STATS_INTERVAL_SECONDS), -1),
+                            TimeUnit.SECONDS)
                     .build();
             this.baseBuilder = client.newProducer();
             // Map<String, Object> builderConf = new HashMap<>();

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/utils/MockUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/utils/MockUtils.java
@@ -98,6 +98,7 @@ public class MockUtils {
         PowerMockito.when(PulsarClient.builder()).thenReturn(clientBuilder);
         PowerMockito.when(clientBuilder.serviceUrl(anyString())).thenReturn(clientBuilder);
         PowerMockito.when(clientBuilder.authentication(any())).thenReturn(clientBuilder);
+        PowerMockito.when(clientBuilder.statsInterval(anyLong(), any())).thenReturn(clientBuilder);
         PowerMockito.when(clientBuilder.ioThreads(anyInt())).thenReturn(clientBuilder);
         PowerMockito.when(clientBuilder.memoryLimit(anyLong(), any())).thenReturn(clientBuilder);
         PowerMockito.when(clientBuilder.connectionsPerBroker(anyInt())).thenReturn(clientBuilder);

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ConfigConstants.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ConfigConstants.java
@@ -24,6 +24,7 @@ public class ConfigConstants {
 
     public static final String CALLBACK_QUEUE_SIZE = "callbackQueueSize";
     public static final String PULSAR_RECEIVE_QUEUE_SIZE = "pulsarReceiveQueueSize";
+    public static final String STATS_INTERVAL_SECONDS = "statsIntervalSeconds";
     public static final String KAFKA_FETCH_WAIT_MS = "kafkaFetchWaitMs";
     public static final String KAFKA_FETCH_SIZE_BYTES = "kafkaFetchSizeBytes";
     public static final String KAFKA_SOCKET_RECV_BUFFER_SIZE = "kafkaSocketRecvBufferSize";

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
@@ -36,6 +36,7 @@ public class SortClientConfig implements Serializable {
     private ReadCallback callback;
     private int callbackQueueSize = 100;
     private int pulsarReceiveQueueSize = 2000;
+    private long statsIntervalSeconds = -1;
     private int kafkaFetchWaitMs = 5000;
     private int kafkaFetchSizeBytes = 3 * 1024 * 1024;
     private int kafkaSocketRecvBufferSize = 5 * 1024 * 1024;
@@ -180,6 +181,22 @@ public class SortClientConfig implements Serializable {
 
     public void setPulsarReceiveQueueSize(int pulsarReceiveQueueSize) {
         this.pulsarReceiveQueueSize = pulsarReceiveQueueSize;
+    }
+
+    /**
+     * get statsIntervalSeconds
+     * @return the statsIntervalSeconds
+     */
+    public long getStatsIntervalSeconds() {
+        return statsIntervalSeconds;
+    }
+    
+    /**
+     * set statsIntervalSeconds
+     * @param statsIntervalSeconds the statsIntervalSeconds to set
+     */
+    public void setStatsIntervalSeconds(long statsIntervalSeconds) {
+        this.statsIntervalSeconds = statsIntervalSeconds;
     }
 
     public int getKafkaFetchWaitMs() {
@@ -366,6 +383,8 @@ public class SortClientConfig implements Serializable {
                 NumberUtils.toInt(sortSdkParams.get(ConfigConstants.CALLBACK_QUEUE_SIZE), callbackQueueSize);
         this.pulsarReceiveQueueSize = NumberUtils.toInt(sortSdkParams.get(ConfigConstants.PULSAR_RECEIVE_QUEUE_SIZE),
                 pulsarReceiveQueueSize);
+        this.statsIntervalSeconds = NumberUtils.toLong(sortSdkParams.get(ConfigConstants.STATS_INTERVAL_SECONDS),
+                statsIntervalSeconds);
         this.kafkaFetchWaitMs =
                 NumberUtils.toInt(sortSdkParams.get(ConfigConstants.KAFKA_FETCH_WAIT_MS), kafkaFetchWaitMs);
         this.kafkaFetchSizeBytes =

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
@@ -186,7 +186,7 @@ public class SortClientConfig implements Serializable {
     public long getStatsIntervalSeconds() {
         return statsIntervalSeconds;
     }
-    
+
     public void setStatsIntervalSeconds(long statsIntervalSeconds) {
         this.statsIntervalSeconds = statsIntervalSeconds;
     }

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/SortClientConfig.java
@@ -183,18 +183,10 @@ public class SortClientConfig implements Serializable {
         this.pulsarReceiveQueueSize = pulsarReceiveQueueSize;
     }
 
-    /**
-     * get statsIntervalSeconds
-     * @return the statsIntervalSeconds
-     */
     public long getStatsIntervalSeconds() {
         return statsIntervalSeconds;
     }
     
-    /**
-     * set statsIntervalSeconds
-     * @param statsIntervalSeconds the statsIntervalSeconds to set
-     */
     public void setStatsIntervalSeconds(long statsIntervalSeconds) {
         this.statsIntervalSeconds = statsIntervalSeconds;
     }

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/InlongTopicManagerImpl.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/InlongTopicManagerImpl.java
@@ -374,6 +374,7 @@ public class InlongTopicManagerImpl extends InlongTopicManager {
                     PulsarClient pulsarClient = PulsarClient.builder()
                             .serviceUrl(inLongTopic.getInLongCluster().getBootstraps())
                             .authentication(AuthenticationFactory.token(inLongTopic.getInLongCluster().getToken()))
+                            .statsInterval(context.getConfig().getStatsIntervalSeconds(), TimeUnit.SECONDS)
                             .build();
                     pulsarClients.put(inLongTopic.getInLongCluster().getClusterId(), pulsarClient);
                     logger.debug("create pulsar client succ {}",

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
@@ -212,6 +212,7 @@ public class InlongMultiTopicManager extends TopicManager {
                 PulsarClient pulsarClient = PulsarClient.builder()
                         .serviceUrl(topic.getInLongCluster().getBootstraps())
                         .authentication(AuthenticationFactory.token(topic.getInLongCluster().getToken()))
+                        .statsInterval(context.getConfig().getStatsIntervalSeconds(), TimeUnit.SECONDS)
                         .build();
                 TopicFetcher fetcher = TopicFetcherBuilder.newPulsarBuilder()
                         .pulsarClient(pulsarClient)

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -363,6 +363,7 @@ public class InlongSingleTopicManager extends TopicManager {
                     PulsarClient pulsarClient = PulsarClient.builder()
                             .serviceUrl(topic.getInLongCluster().getBootstraps())
                             .authentication(AuthenticationFactory.token(topic.getInLongCluster().getToken()))
+                            .statsInterval(context.getConfig().getStatsIntervalSeconds(), TimeUnit.SECONDS)
                             .build();
                     pulsarClients.put(topic.getInLongCluster().getClusterId(), pulsarClient);
                     LOGGER.debug("create pulsar client succ {}",

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
@@ -147,17 +147,17 @@ public class PulsarProducerCluster implements LifecycleAware {
     private CompressionType getPulsarCompressionType() {
         String type = this.context.getString(KEY_COMPRESSIONTYPE);
         switch (type) {
-            case "LZ4" :
+            case "LZ4":
                 return CompressionType.LZ4;
-            case "NONE" :
+            case "NONE":
                 return CompressionType.NONE;
-            case "ZLIB" :
+            case "ZLIB":
                 return CompressionType.ZLIB;
-            case "ZSTD" :
+            case "ZSTD":
                 return CompressionType.ZSTD;
-            case "SNAPPY" :
+            case "SNAPPY":
                 return CompressionType.SNAPPY;
-            default :
+            default:
                 return CompressionType.NONE;
         }
     }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sort.standalone.sink.pulsar;
 
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.flume.Context;
 import org.apache.flume.Transaction;
 import org.apache.flume.lifecycle.LifecycleAware;
@@ -53,6 +54,7 @@ public class PulsarProducerCluster implements LifecycleAware {
 
     public static final String KEY_SERVICE_URL = "serviceUrl";
     public static final String KEY_AUTHENTICATION = "authentication";
+    public static final String KEY_STATS_INTERVAL_SECONDS = "statsIntervalSeconds";
 
     public static final String KEY_ENABLEBATCHING = "enableBatching";
     public static final String KEY_BATCHINGMAXBYTES = "batchingMaxBytes";
@@ -112,6 +114,8 @@ public class PulsarProducerCluster implements LifecycleAware {
             this.client = PulsarClient.builder()
                     .serviceUrl(serviceUrl)
                     .authentication(AuthenticationFactory.token(authentication))
+                    .statsInterval(NumberUtils.toLong(config.getParams().get(KEY_STATS_INTERVAL_SECONDS), -1),
+                            TimeUnit.SECONDS)
                     .build();
             this.baseBuilder = client.newProducer();
             this.baseBuilder
@@ -143,17 +147,17 @@ public class PulsarProducerCluster implements LifecycleAware {
     private CompressionType getPulsarCompressionType() {
         String type = this.context.getString(KEY_COMPRESSIONTYPE);
         switch (type) {
-            case "LZ4":
+            case "LZ4" :
                 return CompressionType.LZ4;
-            case "NONE":
+            case "NONE" :
                 return CompressionType.NONE;
-            case "ZLIB":
+            case "ZLIB" :
                 return CompressionType.ZLIB;
-            case "ZSTD":
+            case "ZSTD" :
                 return CompressionType.ZSTD;
-            case "SNAPPY":
+            case "SNAPPY" :
                 return CompressionType.SNAPPY;
-            default:
+            default :
                 return CompressionType.NONE;
         }
     }


### PR DESCRIPTION
- Title Example: [INLONG-6907][SortStandalone] Support to close StatsRecorder of pulsar client
- Fixes #6907 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
