### PR TITLE
[INLONG-6909][Manager] Rename Flink Job to avoid conflicts

### DIFF
--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -257,6 +257,8 @@ public class FlinkService {
         List<String> list = new ArrayList<>();
         list.add("-cluster-id");
         list.add(flinkInfo.getJobName());
+        list.add("-job.name");
+        list.add(flinkInfo.getJobName());
         list.add("-group.info.file");
         list.add(flinkInfo.getLocalConfPath());
         list.add("-checkpoint.interval");

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/Constants.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/flink/enums/Constants.java
@@ -17,6 +17,11 @@
 
 package org.apache.inlong.manager.plugin.flink.enums;
 
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm;
+import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
+
 /**
  * Constants info, including properties, dataflow info and rest api url info.
  */
@@ -46,7 +51,11 @@ public class Constants {
 
     public static final String ENTRYPOINT_CLASS = "org.apache.inlong.sort.Entrance";
 
-    public static final String INLONG = "INLONG_";
+    public static final String SORT_JOB_NAME_PREFIX = "InLong-Sort-";
+
+    public static final String SORT_JOB_NAME_TEMPLATE = SORT_JOB_NAME_PREFIX + "%s";
+
+    public static final String DEFAULT_SORT_JOB_NAME = SORT_JOB_NAME_PREFIX + "Job";
 
     public static final String RESOURCE_ID = "resource_id";
 
@@ -68,5 +77,16 @@ public class Constants {
     public static final String URL_SEPARATOR = "/";
 
     public static final String SEPARATOR = ":";
+
+    /**
+     * Generate the Job name through {@link ProcessForm}: <br/> 
+     * When the ProcessForm is {@link GroupResourceProcessForm}, the format of the job name is 'InLong-Sort-{Group ID}', 
+     * otherwise take the  {@link Constants#DEFAULT_SORT_JOB_NAME}: 'InLong-Sort-Job'. 
+     */
+    public static Function<ProcessForm, String> SORT_JOB_NAME_GENERATOR =
+            (ProcessForm processForm) -> Optional.of(processForm)
+                    .map(ProcessForm::getInlongGroupId)
+                    .map(groupId -> String.format(Constants.SORT_JOB_NAME_TEMPLATE, groupId))
+                    .orElse(DEFAULT_SORT_JOB_NAME);
 
 }

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/RestartSortListener.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/RestartSortListener.java
@@ -115,7 +115,7 @@ public class RestartSortListener implements SortOperateListener {
 
         FlinkInfo flinkInfo = new FlinkInfo();
         flinkInfo.setJobId(jobId);
-        String jobName = Constants.INLONG + context.getProcessForm().getInlongGroupId();
+        String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm);
         flinkInfo.setJobName(jobName);
         String sortUrl = kvConf.get(InlongConstants.SORT_URL);
         flinkInfo.setEndpoint(sortUrl);

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/RestartStreamListener.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/RestartStreamListener.java
@@ -125,7 +125,7 @@ public class RestartStreamListener implements SortOperateListener {
 
         FlinkInfo flinkInfo = new FlinkInfo();
         flinkInfo.setJobId(jobId);
-        String jobName = Constants.INLONG + context.getProcessForm().getInlongGroupId();
+        String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm);
         flinkInfo.setJobName(jobName);
         String sortUrl = kvConf.get(InlongConstants.SORT_URL);
         flinkInfo.setEndpoint(sortUrl);

--- a/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -116,7 +116,8 @@ public class StartupSortListener implements SortOperateListener {
         }
 
         FlinkInfo flinkInfo = new FlinkInfo();
-        String jobName = Constants.INLONG + context.getProcessForm().getInlongGroupId();
+
+        String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm);
         flinkInfo.setJobName(jobName);
         String sortUrl = kvConf.get(InlongConstants.SORT_URL);
         flinkInfo.setEndpoint(sortUrl);


### PR DESCRIPTION
### Prepare a Pull Request

 **[INLONG-6909][Manager] Rename Flink Job to avoid conflicts**

- Fixes #6909 

### Motivation

Generate job name in format `InLong-Sort-<GroupId>` from `org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm`




<img width="1096" alt="企业微信截图_cb3c450a-9e69-44b8-ba5f-2d7631dc2e73" src="https://user-images.githubusercontent.com/5709212/208225824-314dfbfa-f93d-4c4a-965f-15a0e9042d7c.png">





### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
