### PR TITLE
[INLONG-6952][Sort] Cancel parsing fault tolerance for JsonDynamicSchemaFormat

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/JsonDynamicSchemaFormat.java
@@ -265,7 +265,9 @@ public abstract class JsonDynamicSchemaFormat extends AbstractDynamicSchemaForma
                 replacement = extract(rootNode, keyText);
             }
             if (replacement == null) {
-                replacement = "";
+                // The variable replacement here is mainly used for
+                // multi-sink scenario synchronization destination positioning, so the value of null cannot be ignored.
+                throw new IOException(String.format("Can't find value for key: %s", keyText));
             }
             matcher.appendReplacement(sb, replacement);
         }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-6952][Sort] Cancel parsing fault tolerance for JsonDynamicSchemaFormat

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #6952

### Motivation

Cancel parsing fault tolerance for JsonDynamicSchemaFormat. The variable replacement here is mainly used for
multi-sink scenario synchronization destination positioning, so the value of null cannot be ignored.

### Modifications

Cancel parsing fault tolerance for 'JsonDynamicSchemaFormat'

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
