### PR TITLE
[INLONG-6968][Sort] Fix the SqlParseException: Encountered "\'"

### DIFF
--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/NativeFlinkSqlParser.java
@@ -82,7 +82,7 @@ public class NativeFlinkSqlParser implements Parser {
         Preconditions.checkNotNull(tableEnv, "tableEnv is null");
         List<String> createTableSqls = new ArrayList<>();
         List<String> insertSqls = new ArrayList<>();
-        String[] statementSet = statements.split(";");
+        String[] statementSet = statements.split(";(\\r?\\n|\\r)");
         for (String statement : statementSet) {
             statement = statement.trim();
             if (statement.toUpperCase(Locale.ROOT).startsWith("CREATE TABLE") || statement.toUpperCase(Locale.ROOT)

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/NativeFlinkSqlParserTest.java
@@ -71,7 +71,7 @@ public class NativeFlinkSqlParserTest {
                 + "    SELECT \n"
                 + "    `name` AS `name`,\n"
                 + "    `age` AS `age`\n"
-                + "    FROM `table_1`;";
+                + "    FROM `table_1`;\n";
         NativeFlinkSqlParser parser = NativeFlinkSqlParser.getInstance(tableEnv, data);
         ParseResult result = parser.parse();
         Assert.assertTrue(result.tryExecute());


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-6968][Sort] SqlParseException: Encountered "\\'".

- Fixes #6968 

### Motivation

Fix SqlParseException: Encountered "\\'".

### Modifications
`NativeFlinkSqlParser` splits sql statements by semicolon and newline character.