### PR TITLE
[INLONG-6978][Sort] Get primary keys for PostgreSQL

### DIFF
--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
@@ -19,6 +19,7 @@ package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.clickhouse.ClickHouseRowConverter;
@@ -246,4 +247,11 @@ public class ClickHouseDialect extends AbstractJdbcDialect {
                 + quoteIdentifier(pair.getRight())
                 + " WHERE " + fieldExpressions;
     }
+
+    @Override
+    public List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+            JdbcOptions jdbcOptions) {
+        return null;
+    }
+
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
@@ -249,7 +249,7 @@ public class ClickHouseDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+    public List<String> getPkNamesFromDb(String tableIdentifier,
             JdbcOptions jdbcOptions) {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
@@ -251,7 +251,7 @@ public class ClickHouseDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public PreparedStatement setQuerySql(Connection conn,
+    public PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/ClickHouseDialect.java
@@ -19,7 +19,6 @@ package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
-import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.clickhouse.ClickHouseRowConverter;
@@ -27,6 +26,9 @@ import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -249,8 +251,8 @@ public class ClickHouseDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getPkNamesFromDb(String tableIdentifier,
-            JdbcOptions jdbcOptions) {
+    public PreparedStatement setQuerySql(Connection conn,
+            String tableIdentifier) throws SQLException {
         return null;
     }
 

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
@@ -176,7 +176,7 @@ public class OracleDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public PreparedStatement setQuerySql(Connection conn,
+    public PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.oracle.OracleRowConverter;
@@ -170,5 +171,11 @@ public class OracleDialect extends AbstractJdbcDialect {
                 LogicalTypeRoot.RAW,
                 LogicalTypeRoot.SYMBOL,
                 LogicalTypeRoot.UNRESOLVED);
+    }
+
+    @Override
+    public List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+            JdbcOptions jdbcOptions) {
+        return null;
     }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
@@ -18,12 +18,14 @@
 package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
-import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.oracle.OracleRowConverter;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -174,8 +176,8 @@ public class OracleDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getPkNamesFromDb(String tableIdentifier,
-            JdbcOptions jdbcOptions) {
+    public PreparedStatement setQuerySql(Connection conn,
+            String tableIdentifier) throws SQLException {
         return null;
     }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/OracleDialect.java
@@ -174,7 +174,7 @@ public class OracleDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+    public List<String> getPkNamesFromDb(String tableIdentifier,
             JdbcOptions jdbcOptions) {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/PostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/PostgresDialect.java
@@ -169,7 +169,7 @@ public class PostgresDialect extends AbstractJdbcDialect {
     public PreparedStatement setQuerySql(Connection conn,
             String tableIdentifier) throws SQLException {
         PreparedStatement st = conn.prepareStatement(QUERY_PK_SQL);
-        st.setString(1, JdbcMultiBatchingComm.getTbNameFromIdentifier(tableIdentifier));
+        st.setString(1, JdbcMultiBatchingComm.getTableNameFromIdentifier(tableIdentifier));
         return st;
     }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/PostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/PostgresDialect.java
@@ -23,8 +23,6 @@ import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.internal.JdbcMultiBatchingComm;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -37,11 +35,10 @@ import java.util.stream.Collectors;
 /** JDBC dialect for PostgreSQL. */
 public class PostgresDialect extends AbstractJdbcDialect {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PostgresDialect.class);
     private static final long serialVersionUID = 1L;
 
-    private static final String QUERY_PK_SQL = "SELECT\n" +
-            "\tstring_agg (DISTINCT t3.attname, ',') AS " + PK_COLUMN_NAME + ",\n" +
+    private static final String QUERY_PRIMARY_KEY_SQL = "SELECT\n" +
+            "\tstring_agg (DISTINCT t3.attname, ',') AS " + PRIMARY_KEY_COLUMN + ",\n" +
             "    \tt4.tablename AS tableName\n" +
             "FROM\n" +
             "\tpg_constraint t1\n" +
@@ -166,9 +163,9 @@ public class PostgresDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public PreparedStatement setQuerySql(Connection conn,
+    public PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException {
-        PreparedStatement st = conn.prepareStatement(QUERY_PK_SQL);
+        PreparedStatement st = conn.prepareStatement(QUERY_PRIMARY_KEY_SQL);
         st.setString(1, JdbcMultiBatchingComm.getTableNameFromIdentifier(tableIdentifier));
         return st;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
@@ -19,6 +19,7 @@ package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.sqlserver.SqlServerRowConvert;
@@ -186,6 +187,12 @@ public class SqlServerDialect extends AbstractJdbcDialect {
                         + " =ISNULL(" + quoteIdentifier("T2") + "." + quoteIdentifier(col)
                         + "," + quoteIdentifier("T1") + "." + quoteIdentifier(col) + ")")
                 .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public List<String> getAndSetPkNamesFromDb(String tableIdentifierm,
+            JdbcOptions jdbcOptions) {
+        return null;
     }
 
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
@@ -190,7 +190,7 @@ public class SqlServerDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getAndSetPkNamesFromDb(String tableIdentifierm,
+    public List<String> getPkNamesFromDb(String tableIdentifierm,
             JdbcOptions jdbcOptions) {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
@@ -192,7 +192,7 @@ public class SqlServerDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public PreparedStatement setQuerySql(Connection conn,
+    public PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/SqlServerDialect.java
@@ -19,12 +19,14 @@ package org.apache.inlong.sort.jdbc.dialect;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
-import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.converter.sqlserver.SqlServerRowConvert;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -190,8 +192,8 @@ public class SqlServerDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getPkNamesFromDb(String tableIdentifierm,
-            JdbcOptions jdbcOptions) {
+    public PreparedStatement setQuerySql(Connection conn,
+            String tableIdentifier) throws SQLException {
         return null;
     }
 

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
@@ -20,11 +20,13 @@ package org.apache.inlong.sort.jdbc.dialect;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.flink.connector.jdbc.internal.converter.PostgresRowConverter;
-import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -148,8 +150,8 @@ public class TDSQLPostgresDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getPkNamesFromDb(String tableIdentifierm,
-            JdbcOptions jdbcOptions) {
+    public PreparedStatement setQuerySql(Connection conn,
+            String tableIdentifier) throws SQLException {
         return null;
     }
 

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
@@ -150,7 +150,7 @@ public class TDSQLPostgresDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public PreparedStatement setQuerySql(Connection conn,
+    public PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
@@ -148,7 +148,7 @@ public class TDSQLPostgresDialect extends AbstractJdbcDialect {
     }
 
     @Override
-    public List<String> getAndSetPkNamesFromDb(String tableIdentifierm,
+    public List<String> getPkNamesFromDb(String tableIdentifierm,
             JdbcOptions jdbcOptions) {
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/TDSQLPostgresDialect.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.jdbc.dialect;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.connector.jdbc.internal.converter.JdbcRowConverter;
 import org.apache.flink.connector.jdbc.internal.converter.PostgresRowConverter;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
@@ -144,6 +145,12 @@ public class TDSQLPostgresDialect extends AbstractJdbcDialect {
                 LogicalTypeRoot.RAW,
                 LogicalTypeRoot.SYMBOL,
                 LogicalTypeRoot.UNRESOLVED);
+    }
+
+    @Override
+    public List<String> getAndSetPkNamesFromDb(String tableIdentifierm,
+            JdbcOptions jdbcOptions) {
+        return null;
     }
 
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
@@ -28,6 +28,7 @@ import org.apache.flink.connector.jdbc.internal.executor.TableBufferedStatementE
 import org.apache.flink.connector.jdbc.internal.executor.TableInsertOrUpdateStatementExecutor;
 import org.apache.flink.connector.jdbc.internal.executor.TableSimpleStatementExecutor;
 import org.apache.flink.connector.jdbc.internal.options.JdbcDmlOptions;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.connector.jdbc.statement.FieldNamedPreparedStatement;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -171,6 +172,21 @@ public class JdbcMultiBatchingComm {
             pkRow.setField(i, fieldGetters[i].getFieldOrNull(row));
         }
         return pkRow;
+    }
+
+    public static JdbcOptions getExecJdbcOptions(JdbcOptions jdbcOptions, String tableIdentifier) {
+        JdbcOptions jdbcExecOptions =
+                JdbcOptions.builder()
+                        .setDBUrl(jdbcOptions.getDbURL() + "/" + getTDbNameFromIdentifier(tableIdentifier))
+                        .setTableName(getTbNameFromIdentifier(tableIdentifier))
+                        .setDialect(jdbcOptions.getDialect())
+                        .setParallelism(jdbcOptions.getParallelism())
+                        .setConnectionCheckTimeoutSeconds(jdbcOptions.getConnectionCheckTimeoutSeconds())
+                        .setDriverName(jdbcOptions.getDriverName())
+                        .setUsername(jdbcOptions.getUsername().orElse(""))
+                        .setPassword(jdbcOptions.getPassword().orElse(""))
+                        .build();
+        return jdbcExecOptions;
     }
 
     /**

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
@@ -196,12 +196,12 @@ public class JdbcMultiBatchingComm {
      * @param tableIdentifier The table identifier for which to get table name.
      */
     public static String getTableNameFromIdentifier(String tableIdentifier) {
-        String[] fileArray = tableIdentifier.split("\\.");
-        if (2 == fileArray.length) {
-            return fileArray[1];
+        String[] fieldArray = tableIdentifier.split("\\.");
+        if (2 == fieldArray.length) {
+            return fieldArray[1];
         }
-        if (3 == fileArray.length) {
-            return fileArray[1] + "." + fileArray[2];
+        if (3 == fieldArray.length) {
+            return fieldArray[1] + "." + fieldArray[2];
         }
         return null;
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
@@ -177,8 +177,8 @@ public class JdbcMultiBatchingComm {
     public static JdbcOptions getExecJdbcOptions(JdbcOptions jdbcOptions, String tableIdentifier) {
         JdbcOptions jdbcExecOptions =
                 JdbcOptions.builder()
-                        .setDBUrl(jdbcOptions.getDbURL() + "/" + getTDbNameFromIdentifier(tableIdentifier))
-                        .setTableName(getTbNameFromIdentifier(tableIdentifier))
+                        .setDBUrl(jdbcOptions.getDbURL() + "/" + getDatabaseNameFromIdentifier(tableIdentifier))
+                        .setTableName(getTableNameFromIdentifier(tableIdentifier))
                         .setDialect(jdbcOptions.getDialect())
                         .setParallelism(jdbcOptions.getParallelism())
                         .setConnectionCheckTimeoutSeconds(jdbcOptions.getConnectionCheckTimeoutSeconds())
@@ -195,7 +195,7 @@ public class JdbcMultiBatchingComm {
      *
      * @param tableIdentifier The table identifier for which to get table name.
      */
-    public static String getTbNameFromIdentifier(String tableIdentifier) {
+    public static String getTableNameFromIdentifier(String tableIdentifier) {
         String[] fileArray = tableIdentifier.split("\\.");
         if (2 == fileArray.length) {
             return fileArray[1];
@@ -206,7 +206,13 @@ public class JdbcMultiBatchingComm {
         return null;
     }
 
-    public static String getTDbNameFromIdentifier(String tableIdentifier) {
+    /**
+     * Get database name From tableIdentifier
+     * tableIdentifier maybe: ${dbName}.${tbName} or ${dbName}.${schemaName}.${tbName}
+     *
+     * @param tableIdentifier The table identifier for which to get table name.
+     */
+    public static String getDatabaseNameFromIdentifier(String tableIdentifier) {
         String[] fileArray = tableIdentifier.split("\\.");
         return fileArray[0];
     }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingComm.java
@@ -173,4 +173,26 @@ public class JdbcMultiBatchingComm {
         return pkRow;
     }
 
+    /**
+     * Get table name From tableIdentifier
+     * tableIdentifier maybe: ${dbName}.${tbName} or ${dbName}.${schemaName}.${tbName}
+     *
+     * @param tableIdentifier The table identifier for which to get table name.
+     */
+    public static String getTbNameFromIdentifier(String tableIdentifier) {
+        String[] fileArray = tableIdentifier.split("\\.");
+        if (2 == fileArray.length) {
+            return fileArray[1];
+        }
+        if (3 == fileArray.length) {
+            return fileArray[1] + "." + fileArray[2];
+        }
+        return null;
+    }
+
+    public static String getTDbNameFromIdentifier(String tableIdentifier) {
+        String[] fileArray = tableIdentifier.split("\\.");
+        return fileArray[0];
+    }
+
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -232,7 +232,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
         if (CollectionUtils.isNotEmpty(pkNameList) && !appendMode) {
             // upsert query
             JdbcDmlOptions createDmlOptions = JdbcDmlOptions.builder()
-                    .withTableName(JdbcMultiBatchingComm.getTbNameFromIdentifier(tableIdentifier))
+                    .withTableName(JdbcMultiBatchingComm.getTableNameFromIdentifier(tableIdentifier))
                     .withDialect(jdbcOptions.getDialect())
                     .withFieldNames(filedNames)
                     .withKeyFields(pkNameList.toArray(new String[pkNameList.size()]))
@@ -244,7 +244,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
             // append only query
             final String sql = dmlOptions
                     .getDialect()
-                    .getInsertIntoStatement(JdbcMultiBatchingComm.getTbNameFromIdentifier(tableIdentifier), filedNames);
+                    .getInsertIntoStatement(JdbcMultiBatchingComm.getTableNameFromIdentifier(tableIdentifier),
+                            filedNames);
             statementExecutorFactory = ctx -> (JdbcExec) JdbcMultiBatchingComm.createSimpleBufferedExecutor(
                     ctx,
                     dmlOptions.getDialect(),

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.jdbc.table;
 
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.internal.connection.SimpleJdbcConnectionProvider;
 import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
@@ -26,13 +27,24 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.inlong.sort.jdbc.internal.JdbcMultiBatchingComm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * Default JDBC dialects implements for validate.
  */
 public abstract class AbstractJdbcDialect implements JdbcDialect {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcDialect.class);
+    public static final String PK_COLUMN_NAME = "pkColumn";
 
     @Override
     public void validate(TableSchema schema) throws ValidationException {
@@ -100,11 +112,47 @@ public abstract class AbstractJdbcDialect implements JdbcDialect {
      */
     public abstract List<LogicalTypeRoot> unsupportedTypes();
 
+    public abstract PreparedStatement setQuerySql(Connection conn,
+            String tableIdentifier) throws SQLException;
+
     /**
      * get getPkNames from query db.tb
      *
      * @return a list of PkNames.
      */
-    public abstract List<String> getPkNamesFromDb(String tableIdentifier,
-            JdbcOptions jdbcOptions);
+    public List<String> getPkNamesFromDb(String tableIdentifier,
+            JdbcOptions jdbcOptions) {
+        PreparedStatement st = null;
+        try {
+            JdbcOptions jdbcExecOptions = JdbcMultiBatchingComm.getExecJdbcOptions(jdbcOptions, tableIdentifier);
+            SimpleJdbcConnectionProvider tableConnectionProvider = new SimpleJdbcConnectionProvider(jdbcExecOptions);
+            Connection conn = tableConnectionProvider.getOrEstablishConnection();
+            st = setQuerySql(conn, tableIdentifier);
+            ResultSet rs = st.executeQuery();
+            if (rs.next()) {
+                String pkColumn = rs.getString(PK_COLUMN_NAME);
+                LOG.info("TableIdentifier:{} get pkColumn:{}", tableIdentifier, pkColumn);
+                checkAndClose(st);
+                return Arrays.asList(pkColumn.split(","));
+            } else {
+                LOG.info("TableIdentifier:{} get pkColumn: null", tableIdentifier);
+                checkAndClose(st);
+                return null;
+            }
+        } catch (Exception e) {
+            LOG.error("TableIdentifier:{} getAndSetPkNamesFromDb get err:", tableIdentifier, e);
+            checkAndClose(st);
+        }
+        return null;
+    }
+
+    private void checkAndClose(PreparedStatement st) {
+        if (null != st) {
+            try {
+                st.close();
+            } catch (Exception e) {
+                LOG.error("CheckAndClose PreparedStatement get err:", e);
+            }
+        }
+    }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
@@ -100,6 +100,11 @@ public abstract class AbstractJdbcDialect implements JdbcDialect {
      */
     public abstract List<LogicalTypeRoot> unsupportedTypes();
 
-    public abstract List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+    /**
+     * get getPkNames from query db.tb
+     *
+     * @return a list of PkNames.
+     */
+    public abstract List<String> getPkNamesFromDb(String tableIdentifier,
             JdbcOptions jdbcOptions);
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
@@ -44,7 +44,7 @@ import java.util.List;
 public abstract class AbstractJdbcDialect implements JdbcDialect {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcDialect.class);
-    public static final String PK_COLUMN_NAME = "pkColumn";
+    public static final String PRIMARY_KEY_COLUMN = "pkColumn";
 
     @Override
     public void validate(TableSchema schema) throws ValidationException {
@@ -112,7 +112,7 @@ public abstract class AbstractJdbcDialect implements JdbcDialect {
      */
     public abstract List<LogicalTypeRoot> unsupportedTypes();
 
-    public abstract PreparedStatement setQuerySql(Connection conn,
+    public abstract PreparedStatement setQueryPrimaryKeySql(Connection conn,
             String tableIdentifier) throws SQLException;
 
     /**
@@ -127,10 +127,10 @@ public abstract class AbstractJdbcDialect implements JdbcDialect {
             JdbcOptions jdbcExecOptions = JdbcMultiBatchingComm.getExecJdbcOptions(jdbcOptions, tableIdentifier);
             SimpleJdbcConnectionProvider tableConnectionProvider = new SimpleJdbcConnectionProvider(jdbcExecOptions);
             Connection conn = tableConnectionProvider.getOrEstablishConnection();
-            st = setQuerySql(conn, tableIdentifier);
+            st = setQueryPrimaryKeySql(conn, tableIdentifier);
             ResultSet rs = st.executeQuery();
             if (rs.next()) {
-                String pkColumn = rs.getString(PK_COLUMN_NAME);
+                String pkColumn = rs.getString(PRIMARY_KEY_COLUMN);
                 LOG.info("TableIdentifier:{} get pkColumn:{}", tableIdentifier, pkColumn);
                 checkAndClose(st);
                 return Arrays.asList(pkColumn.split(","));

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/AbstractJdbcDialect.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.jdbc.table;
 
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
+import org.apache.flink.connector.jdbc.internal.options.JdbcOptions;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.types.DataType;
@@ -98,4 +99,7 @@ public abstract class AbstractJdbcDialect implements JdbcDialect {
      * @return a list of logical type roots.
      */
     public abstract List<LogicalTypeRoot> unsupportedTypes();
+
+    public abstract List<String> getAndSetPkNamesFromDb(String tableIdentifier,
+            JdbcOptions jdbcOptions);
 }


### PR DESCRIPTION
### Prepare a Pull Request
- [INLONG-6978][Sort] get PG primary keys from connection query db
- Fixes #6978 

### Motivation

Get primary key from exception can't meet all conditions, change to query db.

### Modifications
1.  AbstractJdbcDialect add getPkNamesFromDb function: get getPkNames from query db.tb.
2. JdbcMultiBatchingOutputFormat query getPkNamesFromDb when getOrCreateStatementExecutor.

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
