### PR TITLE
[INLONG-6998][Dashboard][Manager] Support ignore deserialization error

### DIFF
--- a/inlong-dashboard/src/locales/cn.json
+++ b/inlong-dashboard/src/locales/cn.json
@@ -367,6 +367,7 @@
   "meta.Stream.DataEncoding": "数据编码",
   "meta.Stream.Description": "介绍",
   "meta.Stream.SourceDataField": "源数据字段",
+  "meta.Stream.IgnoreParseError": "忽略数据解析错误",
   "meta.Stream.Status.New": "新建",
   "meta.Stream.Status.Pending": "配置中",
   "meta.Stream.Status.Error": "配置失败",

--- a/inlong-dashboard/src/locales/en.json
+++ b/inlong-dashboard/src/locales/en.json
@@ -367,6 +367,7 @@
   "meta.Stream.DataEncoding": "Data encoding",
   "meta.Stream.Description": "Description",
   "meta.Stream.SourceDataField": "Source fields",
+  "meta.Stream.IgnoreParseError": "Ignore parse error",
   "meta.Stream.Status.New": "New",
   "meta.Stream.Status.Pending": "Pending",
   "meta.Stream.Status.Error": "Error",

--- a/inlong-dashboard/src/metas/streams/common/StreamDefaultInfo.ts
+++ b/inlong-dashboard/src/metas/streams/common/StreamDefaultInfo.ts
@@ -118,6 +118,27 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
 
   @FieldDecorator({
     type: 'radio',
+    rules: [{ required: true }],
+    initialValue: true,
+    props: values => ({
+      disabled: [110, 130].includes(values?.status),
+      options: [
+        {
+          label: i18n.t('basic.Yes'),
+          value: true,
+        },
+        {
+          label: i18n.t('basic.No'),
+          value: false,
+        },
+      ],
+    }),
+  })
+  @I18n('meta.Stream.IgnoreParseError')
+  ignoreParseError: boolean;
+
+  @FieldDecorator({
+    type: 'radio',
     initialValue: 'UTF-8',
     props: values => ({
       disabled: [110, 130].includes(values?.status),
@@ -189,28 +210,6 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
   dataSeparator: string;
 
   @FieldDecorator({
-    type: 'radio',
-    isPro: true,
-    rules: [{ required: true }],
-    initialValue: 1,
-    tooltip: i18n.t('meta.Stream.WrapWithInlongMsgHelp'),
-    props: values => ({
-      options: [
-        {
-          label: i18n.t('basic.Yes'),
-          value: 1,
-        },
-        {
-          label: i18n.t('basic.No'),
-          value: 0,
-        },
-      ],
-    }),
-  })
-  @I18n('meta.Stream.WrapWithInlongMsg')
-  wrapWithInlongMsg: number;
-
-  @FieldDecorator({
     type: EditableTable,
     props: values => ({
       size: 'small',
@@ -250,6 +249,29 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
   })
   @I18n('meta.Stream.SourceDataField')
   rowTypeFields: Record<string, string>[];
+
+  @FieldDecorator({
+    type: 'radio',
+    isPro: true,
+    rules: [{ required: true }],
+    initialValue: true,
+    tooltip: i18n.t('meta.Stream.WrapWithInlongMsgHelp'),
+    props: values => ({
+      disabled: [110, 130].includes(values?.status),
+      options: [
+        {
+          label: i18n.t('basic.Yes'),
+          value: true,
+        },
+        {
+          label: i18n.t('basic.No'),
+          value: false,
+        },
+      ],
+    }),
+  })
+  @I18n('meta.Stream.WrapWithInlongMsg')
+  wrapWithInlongMsg: boolean;
 
   parse(data) {
     return data;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -138,4 +138,8 @@ public class InlongConstants {
 
     public static final String DATA_TYPE_RAW_PREFIX = "RAW_";
 
+    public static final int DEFAULT_ENABLE_VALUE = 1;
+
+    public static final String EXT_PARAM_IGNORE_PARSE_ERROR = "ignoreParseError";
+    public static final String EXT_PARAM_WRAP_WITH_INLONG_MSG = "wrapWithInlongMsg";
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -140,6 +140,4 @@ public class InlongConstants {
 
     public static final int DEFAULT_ENABLE_VALUE = 1;
 
-    public static final String EXT_PARAM_IGNORE_PARSE_ERROR = "ignoreParseError";
-    public static final String EXT_PARAM_WRAP_WITH_INLONG_MSG = "wrapWithInlongMsg";
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/ExtractNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/ExtractNodeUtils.java
@@ -172,8 +172,11 @@ public class ExtractNodeUtils {
         String topic = kafkaSource.getTopic();
         String bootstrapServers = kafkaSource.getBootstrapServers();
 
-        Format format = parsingFormat(kafkaSource.getSerializationType(),
-                kafkaSource.isWrapWithInlongMsg(), kafkaSource.getDataSeparator());
+        Format format = parsingFormat(
+                kafkaSource.getSerializationType(),
+                kafkaSource.isWrapWithInlongMsg(),
+                kafkaSource.getDataSeparator(),
+                kafkaSource.isIgnoreParseErrors());
 
         KafkaOffset kafkaOffset = KafkaOffset.forName(kafkaSource.getAutoOffsetReset());
         KafkaScanStartupMode startupMode;
@@ -223,7 +226,9 @@ public class ExtractNodeUtils {
                 pulsarSource.getTenant() + "/" + pulsarSource.getNamespace() + "/" + pulsarSource.getTopic();
 
         Format format = parsingFormat(pulsarSource.getSerializationType(),
-                pulsarSource.isWrapWithInlongMsg(), pulsarSource.getDataSeparator());
+                pulsarSource.isWrapWithInlongMsg(),
+                pulsarSource.getDataSeparator(),
+                pulsarSource.isIgnoreParseError());
 
         PulsarScanStartupMode startupMode = PulsarScanStartupMode.forName(pulsarSource.getScanStartupMode());
         final String primaryKey = pulsarSource.getPrimaryKey();
@@ -441,9 +446,14 @@ public class ExtractNodeUtils {
      * @param serializationType data serialization, support: csv, json, canal, avro, etc
      * @param wrapWithInlongMsg whether wrap content with {@link InLongMsgFormat}
      * @param separatorStr the separator of data content
+     * @param ignoreParseErrors whether ignore deserialization error data
      * @return the format for serialized content
      */
-    private static Format parsingFormat(String serializationType, boolean wrapWithInlongMsg, String separatorStr) {
+    private static Format parsingFormat(
+            String serializationType,
+            boolean wrapWithInlongMsg,
+            String separatorStr,
+            boolean ignoreParseErrors) {
         Format format;
         DataTypeEnum dataType = DataTypeEnum.forType(serializationType);
         switch (dataType) {
@@ -452,19 +462,25 @@ public class ExtractNodeUtils {
                     char dataSeparator = (char) Integer.parseInt(separatorStr);
                     separatorStr = Character.toString(dataSeparator);
                 }
-                format = new CsvFormat(separatorStr);
+                CsvFormat csvFormat = new CsvFormat(separatorStr);
+                csvFormat.setIgnoreParseErrors(ignoreParseErrors);
+                format = csvFormat;
                 break;
             case AVRO:
                 format = new AvroFormat();
                 break;
             case JSON:
-                format = new JsonFormat();
+                JsonFormat jsonFormat = new JsonFormat();
+                jsonFormat.setIgnoreParseErrors(ignoreParseErrors);
+                format = jsonFormat;
                 break;
             case CANAL:
                 format = new CanalJsonFormat();
                 break;
             case DEBEZIUM_JSON:
-                format = new DebeziumJsonFormat();
+                DebeziumJsonFormat debeziumJsonFormat = new DebeziumJsonFormat();
+                debeziumJsonFormat.setIgnoreParseErrors(ignoreParseErrors);
+                format = debeziumJsonFormat;
                 break;
             case RAW:
                 format = new RawFormat();

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/StreamSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/StreamSource.java
@@ -110,6 +110,9 @@ public abstract class StreamSource extends StreamNode {
     @ApiModelProperty("Sub source information of existing agents")
     private List<SubSourceDTO> subSourceList;
 
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value, true as default")
+    private boolean ignoreParseError;
+
     public SourceRequest genSourceRequest() {
         return null;
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.stream;
+
+import java.io.Serializable;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Extended params, will be saved as JSON string
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel("Inlong stream info")
+public class InlongStreamExtParam implements Serializable {
+
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value")
+    private boolean ignoreParseError;
+
+    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg")
+    private boolean wrapWithInlongMsg;
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
@@ -34,7 +34,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ApiModel("Inlong stream info")
+@ApiModel("Inlong stream ext param info")
 public class InlongStreamExtParam implements Serializable {
 
     @ApiModelProperty(value = "Whether to ignore the parse errors of field value")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamExtParam.java
@@ -17,6 +17,10 @@
 
 package org.apache.inlong.manager.pojo.stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonUtils;
+
 import java.io.Serializable;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
@@ -43,4 +47,41 @@ public class InlongStreamExtParam implements Serializable {
     @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg")
     private boolean wrapWithInlongMsg;
 
+    /**
+     * Pack extended attributes into ExtParams
+     *
+     * @param request the request
+     * @return the packed extParams
+     */
+    public static String packExtParams(InlongStreamRequest request) {
+        InlongStreamExtParam extParam = CommonBeanUtils.copyProperties(request, InlongStreamExtParam::new,
+                true);
+        return JsonUtils.toJsonString(extParam);
+    }
+
+    /**
+     * Unpack extended attributes from {@link InlongStreamExtInfo}, will remove target attributes from it.
+     *
+     * @param extParams the extParams value load from db
+     * @param targetObject the targetObject with to fill up
+     */
+    public static void unpackExtParams(
+            String extParams,
+            Object targetObject) {
+        if (StringUtils.isNoneBlank(extParams)) {
+            InlongStreamExtParam inlongStreamExtParam = JsonUtils.parseObject(extParams, InlongStreamExtParam.class);
+            if (inlongStreamExtParam != null) {
+                CommonBeanUtils.copyProperties(inlongStreamExtParam, targetObject, true);
+            }
+        }
+    }
+
+    /**
+     * Expand extParam filed, and fill in {@link InlongStreamInfo}
+     *
+     * @param streamInfo the InlongStreamInfo need to filled
+     */
+    public static void unpackExtParams(InlongStreamInfo streamInfo) {
+        unpackExtParams(streamInfo.getExtParams(), streamInfo);
+    }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamInfo.java
@@ -129,15 +129,11 @@ public class InlongStreamInfo extends BaseInlongStream {
     @ApiModelProperty(value = "Version number")
     private Integer version;
 
-    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg, 0: no, 1: yes (as default)")
+    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg")
     private Boolean wrapWithInlongMsg = true;
 
-    @ApiModelProperty(value = "Whether to ignore the parse errors of field value, 0: no, 1: yes (as default)")
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value")
     private Boolean ignoreParseError = true;
-
-    public boolean ifIgnoreParseError() {
-        return ignoreParseError == null || ignoreParseError.booleanValue();
-    }
 
     public InlongStreamRequest genRequest() {
         return CommonBeanUtils.copyProperties(this, InlongStreamRequest::new);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamInfo.java
@@ -65,9 +65,6 @@ public class InlongStreamInfo extends BaseInlongStream {
     @ApiModelProperty(value = "Data type, including: TEXT, KV, etc.")
     private String dataType;
 
-    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg, 0: no, 1: yes (as default)")
-    private Integer wrapWithInlongMsg;
-
     @ApiModelProperty(value = "Data encoding format: UTF-8, GBK")
     private String dataEncoding;
 
@@ -131,6 +128,16 @@ public class InlongStreamInfo extends BaseInlongStream {
 
     @ApiModelProperty(value = "Version number")
     private Integer version;
+
+    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg, 0: no, 1: yes (as default)")
+    private Boolean wrapWithInlongMsg = true;
+
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value, 0: no, 1: yes (as default)")
+    private Boolean ignoreParseError = true;
+
+    public boolean ifIgnoreParseError() {
+        return ignoreParseError == null || ignoreParseError.booleanValue();
+    }
 
     public InlongStreamRequest genRequest() {
         return CommonBeanUtils.copyProperties(this, InlongStreamRequest::new);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamRequest.java
@@ -101,9 +101,9 @@ public class InlongStreamRequest extends BaseInlongStream {
     @ApiModelProperty(value = "Version number")
     private Integer version;
 
-    @ApiModelProperty(value = "Whether to ignore the parse errors of field value, 0: no, 1: yes (as default)")
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value")
     private boolean ignoreParseError = true;
 
-    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg, 0: no, 1: yes (as default)")
+    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg")
     private boolean wrapWithInlongMsg = true;
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/InlongStreamRequest.java
@@ -101,4 +101,9 @@ public class InlongStreamRequest extends BaseInlongStream {
     @ApiModelProperty(value = "Version number")
     private Integer version;
 
+    @ApiModelProperty(value = "Whether to ignore the parse errors of field value, 0: no, 1: yes (as default)")
+    private boolean ignoreParseError = true;
+
+    @ApiModelProperty(value = "Whether the message body wrapped with InlongMsg, 0: no, 1: yes (as default)")
+    private boolean wrapWithInlongMsg = true;
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -113,7 +113,7 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setSerializationType(streamInfo.getDataType());
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             kafkaSource.setSerializationType(serializationType);
-            kafkaSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
+            kafkaSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
             for (StreamSource sourceInfo : streamSources) {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -17,11 +17,10 @@
 
 package org.apache.inlong.manager.service.source.kafka;
 
-import static org.apache.inlong.manager.pojo.stream.InlongStreamInfo.ENABLE_WRAP_WITH_INLONG_MSG;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.inlong.common.enums.DataTypeEnum;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -111,6 +110,11 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setSourceName(streamId);
             kafkaSource.setBootstrapServers(bootstrapServers);
             kafkaSource.setTopic(streamInfo.getMqResource());
+            kafkaSource.setSerializationType(streamInfo.getDataType());
+            String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+            kafkaSource.setSerializationType(serializationType);
+            kafkaSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
+
             for (StreamSource sourceInfo : streamSources) {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {
                     continue;
@@ -118,9 +122,7 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
                 kafkaSource.setSerializationType(sourceInfo.getSerializationType());
             }
 
-            Integer wrapWithInlongMsg = streamInfo.getWrapWithInlongMsg();
-            kafkaSource.setWrapWithInlongMsg(
-                    null == wrapWithInlongMsg || ENABLE_WRAP_WITH_INLONG_MSG == wrapWithInlongMsg);
+            kafkaSource.setWrapWithInlongMsg(streamInfo.getWrapWithInlongMsg());
 
             kafkaSource.setAutoOffsetReset(KafkaOffset.EARLIEST.getName());
             kafkaSource.setFieldList(streamInfo.getFieldList());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -110,7 +110,6 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setSourceName(streamId);
             kafkaSource.setBootstrapServers(bootstrapServers);
             kafkaSource.setTopic(streamInfo.getMqResource());
-            kafkaSource.setSerializationType(streamInfo.getDataType());
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             kafkaSource.setSerializationType(serializationType);
             kafkaSource.setIgnoreParseError(streamInfo.getIgnoreParseError());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -130,7 +130,7 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             pulsarSource.setSerializationType(serializationType);
             pulsarSource.setWrapWithInlongMsg(streamInfo.getWrapWithInlongMsg());
-            pulsarSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
+            pulsarSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
             // set the token info
             if (StringUtils.isNotBlank(pulsarCluster.getToken())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.manager.service.source.pulsar;
 
-import static org.apache.inlong.manager.pojo.stream.InlongStreamInfo.ENABLE_WRAP_WITH_INLONG_MSG;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Objects;
 import com.google.common.collect.Lists;
@@ -129,10 +127,10 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
             pulsarSource.setAdminUrl(adminUrl);
             pulsarSource.setServiceUrl(serviceUrl);
             pulsarSource.setInlongComponent(true);
-
-            Integer wrapWithInlongMsg = streamInfo.getWrapWithInlongMsg();
-            pulsarSource.setWrapWithInlongMsg(
-                    null == wrapWithInlongMsg || ENABLE_WRAP_WITH_INLONG_MSG == wrapWithInlongMsg);
+            String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+            pulsarSource.setSerializationType(serializationType);
+            pulsarSource.setWrapWithInlongMsg(streamInfo.getWrapWithInlongMsg());
+            pulsarSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
 
             // set the token info
             if (StringUtils.isNotBlank(pulsarCluster.getToken())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.service.source.tubemq;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.inlong.common.enums.DataTypeEnum;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -107,6 +108,10 @@ public class TubeMQSourceOperator extends AbstractSourceOperator {
             tubeMQSource.setTopic(streamInfo.getMqResource());
             tubeMQSource.setGroupId(streamId);
             tubeMQSource.setMasterRpc(masterRpc);
+            String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+            tubeMQSource.setSerializationType(serializationType);
+            tubeMQSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
+
             for (StreamSource sourceInfo : streamSources) {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {
                     continue;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -110,7 +110,7 @@ public class TubeMQSourceOperator extends AbstractSourceOperator {
             tubeMQSource.setMasterRpc(masterRpc);
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             tubeMQSource.setSerializationType(serializationType);
-            tubeMQSource.setIgnoreParseError(streamInfo.ifIgnoreParseError());
+            tubeMQSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
             for (StreamSource sourceInfo : streamSources) {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
@@ -49,7 +49,6 @@ import org.apache.inlong.manager.pojo.stream.InlongStreamApproveRequest;
 import org.apache.inlong.manager.pojo.stream.InlongStreamBriefInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamExtParam;
-import org.apache.inlong.manager.pojo.stream.InlongStreamExtParam.InlongStreamExtParamBuilder;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamPageRequest;
 import org.apache.inlong.manager.pojo.stream.InlongStreamRequest;
@@ -258,6 +257,10 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         }
     }
 
+    private void unpackExtParams(InlongStreamInfo streamInfo) {
+        unpackExtParams(streamInfo.getExtParams(), streamInfo);
+    }
+
     @Override
     public InlongStreamInfo get(String groupId, String streamId, UserInfo opInfo) {
         // check operator info
@@ -424,10 +427,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         return pageResult;
     }
 
-    private void unpackExtParams(InlongStreamInfo streamInfo) {
-        unpackExtParams(streamInfo.getExtParams(), streamInfo);
-    }
-
     @Override
     public List<InlongStreamBriefInfo> listBriefWithSink(String groupId) {
         LOGGER.debug("begin to get inlong stream brief list by groupId={}", groupId);
@@ -577,14 +576,8 @@ public class InlongStreamServiceImpl implements InlongStreamService {
      * @return the packed extParams
      */
     private String packExtParams(InlongStreamRequest request) {
-        InlongStreamExtParamBuilder builder = InlongStreamExtParam.builder();
-        // whether wrap with InlongMsg
-        boolean wrapWithInlongMsg = request.isWrapWithInlongMsg();
-        builder.wrapWithInlongMsg(wrapWithInlongMsg);
-        // whether ignore parse error
-        boolean ignoreParseError = request.isIgnoreParseError();
-        builder.ignoreParseError(ignoreParseError);
-        InlongStreamExtParam extParam = builder.build();
+        InlongStreamExtParam extParam = CommonBeanUtils.copyProperties(request, InlongStreamExtParam::new,
+                true);
         return JsonUtils.toJsonString(extParam);
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
@@ -29,7 +29,6 @@ import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.UserTypeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
-import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
 import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
@@ -48,7 +47,6 @@ import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.stream.InlongStreamApproveRequest;
 import org.apache.inlong.manager.pojo.stream.InlongStreamBriefInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
-import org.apache.inlong.manager.pojo.stream.InlongStreamExtParam;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamPageRequest;
 import org.apache.inlong.manager.pojo.stream.InlongStreamRequest;
@@ -73,6 +71,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
+import static org.apache.inlong.manager.pojo.stream.InlongStreamExtParam.packExtParams;
+import static org.apache.inlong.manager.pojo.stream.InlongStreamExtParam.unpackExtParams;
 
 /**
  * Inlong stream service layer implementation
@@ -238,27 +239,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         streamInfo.setSourceList(sourceList);
         LOGGER.info("success to get inlong stream for groupId={}", groupId);
         return streamInfo;
-    }
-
-    /**
-     * Unpack extended attributes from {@link InlongStreamExtInfo}, will remove target attributes from it.
-     *
-     * @param extParams the {@link InlongStreamEntity} load from db 
-     * @param targetObject the targetObject with to fill up
-     */
-    private void unpackExtParams(
-            String extParams,
-            Object targetObject) {
-        if (StringUtils.isNoneBlank(extParams)) {
-            InlongStreamExtParam inlongStreamExtParam = JsonUtils.parseObject(extParams, InlongStreamExtParam.class);
-            if (inlongStreamExtParam != null) {
-                CommonBeanUtils.copyProperties(inlongStreamExtParam, targetObject, true);
-            }
-        }
-    }
-
-    private void unpackExtParams(InlongStreamInfo streamInfo) {
-        unpackExtParams(streamInfo.getExtParams(), streamInfo);
     }
 
     @Override
@@ -567,18 +547,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
 
         LOGGER.info("success to update inlong stream without check for groupId={} streamId={}", groupId, streamId);
         return true;
-    }
-
-    /**
-     * Pack extended attributes into ExtParams 
-     *
-     * @param request the request
-     * @return the packed extParams
-     */
-    private String packExtParams(InlongStreamRequest request) {
-        InlongStreamExtParam extParam = CommonBeanUtils.copyProperties(request, InlongStreamExtParam::new,
-                true);
-        return JsonUtils.toJsonString(extParam);
     }
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
@@ -253,7 +253,7 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         if (StringUtils.isNoneBlank(extParams)) {
             InlongStreamExtParam inlongStreamExtParam = JsonUtils.parseObject(extParams, InlongStreamExtParam.class);
             if (inlongStreamExtParam != null) {
-                CommonBeanUtils.copyProperties(inlongStreamExtParam, targetObject);
+                CommonBeanUtils.copyProperties(inlongStreamExtParam, targetObject, true);
             }
         }
     }
@@ -425,13 +425,7 @@ public class InlongStreamServiceImpl implements InlongStreamService {
     }
 
     private void unpackExtParams(InlongStreamInfo streamInfo) {
-        String extParams = streamInfo.getExtParams();
-        if (StringUtils.isNoneBlank(extParams)) {
-            InlongStreamExtParam inlongStreamExtParam = JsonUtils.parseObject(extParams, InlongStreamExtParam.class);
-            if (inlongStreamExtParam != null) {
-                CommonBeanUtils.copyProperties(inlongStreamExtParam, streamInfo);
-            }
-        }
+        unpackExtParams(streamInfo.getExtParams(), streamInfo);
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request
*[INLONG-6998][Dashboard][Manager] Support ignore deserialization erro…*

- Fixes #6998 

### Motivation

When the reported message contains garbage data, any problem of the message format will cause the Flink job to automatically restart until the data in the MQ is repaired; 
Otherwise, all the data is piled into the MQ to continue processing.

This option `ignoreParseError` is exposed in the hope that the user can adjust it according to the data format requirements.

### Modifications

Pass the attribute `ignoreParseError` to the concrete implementation of format, which is enabled by default.


<img width="996" alt="image" src="https://user-images.githubusercontent.com/5709212/209153178-8c736e4b-eb89-4c53-bf81-56fa0d47c9ff.png">
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/5709212/209153260-00f6f054-af9e-49f8-b763-129b5c7ee1e2.png">

The follow sql generated:

```sql
CREATE TABLE `table_s-v3`(
    `uid` INT,
    `uname` STRING,
    `cata` STRING,
    `eid` STRING,
    `fee` DOUBLE,
    `ftime` TIMESTAMP(2))
    WITH (
    'inlong.metric.labels' = 'groupId=sg-v2&streamId=s-v3&nodeId=s-v3',
    'metrics.audit.proxy.hosts' = '127.0.0.1:10081',
    'connector' = 'pulsar-inlong',
    'csv.allow-comments' = 'false',
    'csv.disable-quote-character' = 'true',
    'csv.array-element-delimiter' = ';',
    'csv.ignore-parse-errors' = 'false',
    'format' = 'csv',
    'csv.field-delimiter' = ',',
    'admin-url' = 'http://127.0.0.1:8080',
    'generic' = 'true',
    'service-url' = 'pulsar://127.0.0.1:6650',
    'topic' = 'public/sg-v2/s-v3',
    'scan.startup.mode' = 'earliest'
) 
```

The extended params `ignoreParseError` and `wrapWithInlongMsg` will saved as `ExtList` in `inlong_stream_ext` table of database:

<img width="979" alt="image" src="https://user-images.githubusercontent.com/5709212/209157002-28f46aef-b8da-41bc-bb51-8837addc128e.png">




### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
