### PR TITLE
[INLONG-7028][Manager] Fix query task status list failed

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -38,6 +38,7 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -80,7 +81,15 @@ public class SortServiceImpl implements SortService, PluginBinder {
 
         try {
             List<InlongGroupInfo> groupInfoList = request.getInlongGroupIds().stream()
-                    .map(groupId -> groupService.get(groupId))
+                    .map(groupId -> {
+                        try {
+                            return groupService.get(groupId);
+                        } catch (Exception e) {
+                            log.debug("{} may have already been deleted, skip it", groupId);
+                            return null;
+                        }
+                    })
+                    .filter(Objects::nonNull)
                     .collect(Collectors.toList());
 
             List<SortStatusInfo> statusInfos = sortPoller.pollSortStatus(groupInfoList, request.getCredentials());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortServiceImpl.java
@@ -85,7 +85,7 @@ public class SortServiceImpl implements SortService, PluginBinder {
                         try {
                             return groupService.get(groupId);
                         } catch (Exception e) {
-                            log.debug("{} may have already been deleted, skip it", groupId);
+                            log.error("can not get groupId: {}, skip it", groupId, e);
                             return null;
                         }
                     })


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7028 

### Motivation

Failed to query the task status when one of them have deleted.

### Modifications

Skip this task, guaranteed to return normal information.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
