### PR TITLE
[INLONG-7035][SDK] Fix the id generator not globally unique for DataProxy

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
@@ -48,7 +48,7 @@ public class DefaultMessageSender implements MessageSender {
             new ConcurrentHashMap<>();
     private static final AtomicBoolean MANAGER_FETCHER_THREAD_STARTED = new AtomicBoolean(false);
     private static ManagerFetcherThread managerFetcherThread;
-    private static final SequentialID idGenerator;
+    private static final SequentialID idGenerator = new SequentialID(Utils.getLocalIp());
     private final Sender sender;
     private final IndexCollectThread indexCol;
     /* Store index <groupId_streamId,cnt> */
@@ -60,10 +60,6 @@ public class DefaultMessageSender implements MessageSender {
     private boolean isReport = false;
     private boolean isSupportLF = false;
     private int cpsSize = ConfigConstants.COMPRESS_SIZE;
-
-    static {
-        idGenerator = new SequentialID(Utils.getLocalIp());
-    }
 
     public DefaultMessageSender(ProxyClientConfig configure) throws Exception {
         this(configure, null);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
@@ -48,8 +48,8 @@ public class DefaultMessageSender implements MessageSender {
             new ConcurrentHashMap<>();
     private static final AtomicBoolean MANAGER_FETCHER_THREAD_STARTED = new AtomicBoolean(false);
     private static ManagerFetcherThread managerFetcherThread;
+    private static final SequentialID idGenerator;
     private final Sender sender;
-    private final SequentialID idGenerator;
     private final IndexCollectThread indexCol;
     /* Store index <groupId_streamId,cnt> */
     private final Map<String, Long> storeIndex = new ConcurrentHashMap<String, Long>();
@@ -61,6 +61,10 @@ public class DefaultMessageSender implements MessageSender {
     private boolean isSupportLF = false;
     private int cpsSize = ConfigConstants.COMPRESS_SIZE;
 
+    static {
+        idGenerator = new SequentialID(Utils.getLocalIp());
+    }
+
     public DefaultMessageSender(ProxyClientConfig configure) throws Exception {
         this(configure, null);
     }
@@ -68,7 +72,6 @@ public class DefaultMessageSender implements MessageSender {
     public DefaultMessageSender(ProxyClientConfig configure, ThreadFactory selfDefineFactory) throws Exception {
         ProxyUtils.validClientConfig(configure);
         sender = new Sender(configure, selfDefineFactory);
-        idGenerator = new SequentialID(Utils.getLocalIp());
         groupId = configure.getGroupId();
         indexCol = new IndexCollectThread(storeIndex);
         indexCol.start();


### PR DESCRIPTION
- Fixes #7035

### Motivation

The message sender generate repeated msg id when in concurrency.

### Modifications

Make it globally unique by static sharing 