### PR TITLE
[INLONG-7073][Sort]  Remove exception when topic does not exist

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Context of kafka sink. */
@@ -119,10 +120,7 @@ public class KafkaFederationSinkContext extends SinkContext {
      */
     public String getTopic(String uid) {
         KafkaIdConfig idConfig = this.idConfigMap.get(uid);
-        if (idConfig == null) {
-            throw new NullPointerException("uid " + uid + "got null topic");
-        }
-        return idConfig.getTopic();
+        return Objects.isNull(idConfig) ? null : idConfig.getTopic();
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7037

### Motivation

Make sure that when one stream offline from a task, the remain event will be ack and commit successfully.

### Modifications

When the related topic does not exist, should return **_Null Kafka IdConfig_** instead of throw exception.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature?  no
