### PR TITLE
[INLONG-7058][Sort] Support Apache Kudu connector

### DIFF
--- a/inlong-distribution/src/main/assemblies/sort-connectors.xml
+++ b/inlong-distribution/src/main/assemblies/sort-connectors.xml
@@ -180,6 +180,14 @@
             <fileMode>0644</fileMode>
         </fileSet>
         <fileSet>
+            <directory>../inlong-sort/sort-connectors/kudu/target</directory>
+            <outputDirectory>inlong-sort/connectors</outputDirectory>
+            <includes>
+                <include>sort-connector-kudu-${project.version}.jar</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
+        <fileSet>
             <directory>../inlong-sort/sort-connectors/redis/target</directory>
             <outputDirectory>inlong-sort/connectors</outputDirectory>
             <includes>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -47,7 +47,6 @@
         <hbase.version>2.2.3</hbase.version>
         <iceberg.hive.version>2.3.7</iceberg.hive.version>
         <hudi.hive.version>2.3.7</hudi.hive.version>
-        <kudu.version>1.16.0</kudu.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -47,6 +47,7 @@
         <hbase.version>2.2.3</hbase.version>
         <iceberg.hive.version>2.3.7</iceberg.hive.version>
         <hudi.hive.version>2.3.7</hudi.hive.version>
+        <kudu.version>1.16.0</kudu.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -74,6 +75,11 @@
                 <groupId>org.apache.hbase</groupId>
                 <artifactId>hbase-client</artifactId>
                 <version>${hbase.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kudu</groupId>
+                <artifactId>kudu-client</artifactId>
+                <version>${kudu.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/inlong-sort/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-connectors/kudu/pom.xml
@@ -32,11 +32,6 @@
     <properties />
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-base</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <dependency>
             <groupId>org.apache.kudu</groupId>
@@ -46,8 +41,55 @@
 
         <dependency>
             <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
             <artifactId>sort-format-common</artifactId>
-            <version>1.5.0-SNAPSHOT</version>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!--test dependencies-->
+        <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-test-utils</artifactId>
+            <version>${kudu.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-binary</artifactId>
+            <version>${kudu.version}</version>
+            <classifier>${os.detected.classifier}</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/inlong-sort/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-connectors/kudu/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors</artifactId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sort-connector-kudu</artifactId>
@@ -32,63 +32,89 @@
     <properties />
 
     <dependencies>
-
-        <dependency>
-            <groupId>org.apache.kudu</groupId>
-            <artifactId>kudu-client</artifactId>
-            <version>${kudu.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-connector-base</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-client</artifactId>
+            <version>${kudu.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-format-common</artifactId>
             <version>${project.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!--test dependencies-->
         <dependency>
-            <groupId>org.apache.kudu</groupId>
-            <artifactId>kudu-test-utils</artifactId>
-            <version>${kudu.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kudu</groupId>
-            <artifactId>kudu-binary</artifactId>
-            <version>${kudu.version}</version>
-            <classifier>${os.detected.classifier}</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <artifactId>flink-test-utils_${flink.scala.binary.version}</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-common</artifactId>
             <version>${flink.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-csv</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-planner_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
             <version>${flink.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-table-planner-blink_${scala.binary.version}</artifactId>
+            <artifactId>flink-table-planner-blink_${flink.scala.binary.version}</artifactId>
             <version>${flink.version}</version>
-            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_2.11</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -96,9 +122,11 @@
     <build>
         <plugins>
             <plugin>
-
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
                 <executions>
                     <execution>
                         <id>shade-flink</id>
@@ -107,16 +135,6 @@
                         </goals>
                         <phase>package</phase>
                         <configuration>
-                            <artifactSet>
-                                <includes>
-                                    <include>org.apache.hudi:*</include>
-                                    <include>org.apache.hive:hive-exec</include>
-                                    <include>org.apache.hadoop:*</include>
-                                    <include>com.fasterxml.woodstox:*</include>
-                                    <include>org.codehaus.woodstox:*</include>
-                                    <include>com.google.guava:*</include>
-                                </includes>
-                            </artifactSet>
                             <filters>
                                 <filter>
                                     <artifact>org.apache.inlong:sort-connector-*</artifact>

--- a/inlong-sort/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-connectors/kudu/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~  Licensed to the Apache Software Foundation (ASF) under one
+  ~  or more contributor license agreements.  See the NOTICE file
+  ~  distributed with this work for additional information
+  ~  regarding copyright ownership.  The ASF licenses this file
+  ~  to you under the Apache License, Version 2.0 (the
+  ~  "License"); you may not use this file except in compliance
+  ~  with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.inlong</groupId>
+        <artifactId>sort-connectors</artifactId>
+        <version>1.5.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sort-connector-kudu</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache InLong - Sort-connector-kudu</name>
+
+    <properties />
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-client</artifactId>
+            <version>${kudu.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-common</artifactId>
+            <version>1.5.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.hudi:*</include>
+                                    <include>org.apache.hive:hive-exec</include>
+                                    <include>org.apache.hadoop:*</include>
+                                    <include>com.fasterxml.woodstox:*</include>
+                                    <include>org.codehaus.woodstox:*</include>
+                                    <include>com.google.guava:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.inlong:sort-connector-*</artifact>
+                                    <includes>
+                                        <include>org/apache/inlong/**</include>
+                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/Kudu.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/Kudu.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.common;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The {@link ConnectorDescriptor} for kudu sinks.
+ */
+public class Kudu extends ConnectorDescriptor {
+
+    @Nonnull
+    private final Map<String, String> properties;
+    @Nonnull
+    private String table;
+    @Nonnull
+    private String masters;
+
+    /**
+     * Kudu connectorDescriptor.
+     */
+    public Kudu() {
+        super(KuduValidator.CONNECTOR_TYPE_VALUE_KUDU, 1, true);
+
+        this.properties = new HashMap<>();
+    }
+
+    /**
+     * Sets the kudu table name.
+     *
+     * @param table The kudu table name.
+     */
+    public Kudu table(String table) {
+        checkNotNull(table);
+        this.table = table;
+        return this;
+    }
+
+    /**
+     * Sets the kudu server masters.
+     *
+     * @param masters the kudu server masters.
+     */
+    public Kudu masters(String masters) {
+        checkNotNull(masters);
+        this.masters = masters;
+        return this;
+    }
+
+    /**
+     * Sets the kudu property.
+     *
+     * @param key   The key of the property.
+     * @param value The value of the property.
+     */
+    public Kudu property(String key, String value) {
+        checkNotNull(key);
+        checkNotNull(value);
+
+        properties.put(key, value);
+        return this;
+    }
+
+    @SuppressWarnings("checkstyle:FileTabCharacter")
+    @Override
+    protected Map<String, String> toConnectorProperties() {
+        DescriptorProperties descriptorProperties = new DescriptorProperties();
+
+        descriptorProperties.putString(KuduValidator.CONNECTOR_TABLE, table);
+        descriptorProperties.putString(KuduValidator.CONNECTOR_MASTERS, masters);
+
+        descriptorProperties
+                .putPropertiesWithPrefix(KuduValidator.CONNECTOR_PROPERTIES, properties);
+
+        return descriptorProperties.asMap();
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.common;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/**
+ * The configuration options for kudu sink.
+ */
+public class KuduOptions {
+
+    public static final ConfigOption<String> FLUSH_MODE =
+            ConfigOptions.key("flush-mode")
+                    .stringType()
+                    .defaultValue("AUTO_FLUSH_SYNC")
+                    .withDescription(
+                            "The flush mode of Kudu client session, AUTO_FLUSH_SYNC/AUTO_FLUSH_BACKGROUND/MANUAL_FLUSH.");
+
+    public static final ConfigOption<Integer> MAX_CACHE_SIZE =
+            ConfigOptions.key("lookup.max-cache-size")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription("The maximum number of results cached in the " +
+                            "lookup source.");
+
+    public static final ConfigOption<String> MAX_CACHE_TIME =
+            ConfigOptions.key("lookup.max-cache-time")
+                    .stringType()
+                    .defaultValue("60s")
+                    .withDescription("The maximum live time for cached results in " +
+                            "the lookup source.");
+    public static final ConfigOption<Boolean> SINK_START_NEW_CHAIN =
+            ConfigOptions.key("sink.start-new-chain")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("The sink operator will start a new chain if true.");
+
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("max-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("The maximum number of retries when an " +
+                            "exception is caught.");
+    public static final ConfigOption<Integer> MAX_BUFFER_SIZE =
+            ConfigOptions.key("sink.max-buffer-size")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("The maximum number of records buffered in the sink.");
+
+    public static final ConfigOption<Integer> WRITE_THREAD_COUNT =
+            ConfigOptions.key("sink.write-thread-count")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("The maximum number of thread in the sink.");
+
+    public static final ConfigOption<String> MAX_BUFFER_TIME =
+            ConfigOptions.key("sink.max-buffer-time")
+                    .stringType()
+                    .defaultValue("30s")
+                    .withDescription("The maximum wait time for buffered records in the sink.");
+
+    public static final ConfigOption<String> SINK_KEY_FIELD_NAMES =
+            ConfigOptions.key("sink.key-field-names")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("The key fields for updating DB when using upsert sink function.");
+    public static final ConfigOption<Boolean> ENABLE_KEY_FIELD_CHECK =
+            ConfigOptions.key("sink.enable-key-field-check")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("If true, the check to compare key fields assumed by flink " +
+                            "and key fields provided by user will be performed.");
+
+    public static final ConfigOption<Boolean> SINK_WRITE_WITH_ASYNC_MODE =
+            ConfigOptions.key("sink.write-with-async-mode")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Use async write mode for kudu producer if true.");
+
+    public static final ConfigOption<Boolean> SINK_FORCE_WITH_UPSERT_MODE =
+            ConfigOptions.key("sink.write-with-upsert-mode")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Force write kudu with upsert mode if true.");
+
+    public static final ConfigOption<Integer> CACHE_QUEUE_MAX_LENGTH =
+            ConfigOptions.key("sink.cache-queue-max-length")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription("The maximum queue lengths.");
+    public static final ConfigOption<String> CONNECTOR_TABLE =
+            ConfigOptions.key("connector.table")
+                    .stringType()
+                    .noDefaultValue().withDescription("The name of kudu table.");
+    public static final ConfigOption<String> CONNECTOR_MASTER =
+            ConfigOptions.key("connector.master")
+                    .stringType()
+                    .noDefaultValue().withDescription(" The masters of kudu server.");
+    public static final ConfigOption<Boolean> LAZY_LOAD_SCHEMA =
+            ConfigOptions.key("lazy.load.schema")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether get metadata from kudu after generating flink job graphic.");
+    public static final ConfigOption<Boolean> KUDU_IGNORE_ALL_CHANGELOG =
+            ConfigOptions.key("ignore.all.changelog")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Whether ignore delete/update_before/update_after message.");
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
@@ -25,6 +25,16 @@ import org.apache.flink.configuration.ConfigOptions;
  */
 public class KuduOptions {
 
+    public static final ConfigOption<String> CONNECTOR_TABLE =
+            ConfigOptions.key("connector.table")
+                    .stringType()
+                    .noDefaultValue().withDescription("The name of kudu table.");
+
+    public static final ConfigOption<String> CONNECTOR_MASTERS =
+            ConfigOptions.key("connector.masters")
+                    .stringType()
+                    .noDefaultValue().withDescription(" The masters of kudu server.");
+
     public static final ConfigOption<String> FLUSH_MODE =
             ConfigOptions.key("flush-mode")
                     .stringType()
@@ -104,20 +114,8 @@ public class KuduOptions {
                     .intType()
                     .defaultValue(-1)
                     .withDescription("The maximum queue lengths.");
-    public static final ConfigOption<String> CONNECTOR_TABLE =
-            ConfigOptions.key("connector.table")
-                    .stringType()
-                    .noDefaultValue().withDescription("The name of kudu table.");
-    public static final ConfigOption<String> CONNECTOR_MASTER =
-            ConfigOptions.key("connector.master")
-                    .stringType()
-                    .noDefaultValue().withDescription(" The masters of kudu server.");
-    public static final ConfigOption<Boolean> LAZY_LOAD_SCHEMA =
-            ConfigOptions.key("lazy.load.schema")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("Whether get metadata from kudu after generating flink job graphic.");
-    public static final ConfigOption<Boolean> KUDU_IGNORE_ALL_CHANGELOG =
+
+    public static final ConfigOption<Boolean> IGNORE_ALL_CHANGELOG =
             ConfigOptions.key("ignore.all.changelog")
                     .booleanType()
                     .defaultValue(false)

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
@@ -26,7 +26,7 @@ import org.apache.flink.configuration.ConfigOptions;
 public class KuduOptions {
 
     public static final ConfigOption<String> CONNECTOR_TABLE =
-            ConfigOptions.key("table")
+            ConfigOptions.key("table-name")
                     .stringType()
                     .noDefaultValue().withDescription("The name of kudu table.");
 

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduOptions.java
@@ -26,12 +26,12 @@ import org.apache.flink.configuration.ConfigOptions;
 public class KuduOptions {
 
     public static final ConfigOption<String> CONNECTOR_TABLE =
-            ConfigOptions.key("connector.table")
+            ConfigOptions.key("table")
                     .stringType()
                     .noDefaultValue().withDescription("The name of kudu table.");
 
     public static final ConfigOption<String> CONNECTOR_MASTERS =
-            ConfigOptions.key("connector.masters")
+            ConfigOptions.key("masters")
                     .stringType()
                     .noDefaultValue().withDescription(" The masters of kudu server.");
 
@@ -116,7 +116,7 @@ public class KuduOptions {
                     .withDescription("The maximum queue lengths.");
 
     public static final ConfigOption<Boolean> IGNORE_ALL_CHANGELOG =
-            ConfigOptions.key("ignore.all.changelog")
+            ConfigOptions.key("sink.ignore-all-changelog")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether ignore delete/update_before/update_after message.");

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduTableInfo.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduTableInfo.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.common;
+
+import org.apache.flink.table.types.DataType;
+import org.apache.kudu.client.SessionConfiguration;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * The meta info of Kudu table client.
+ */
+public class KuduTableInfo implements Serializable {
+
+    private final String masters;
+    private final String tableName;
+
+    private final String[] fieldNames;
+
+    private final DataType[] dataTypes;
+
+    /**
+     * The flush mode of kudu client. <br/>
+     * AUTO_FLUSH_BACKGROUND： calls will return immediately, but the writes will be sent in the background,
+     * potentially batched together with other writes from the same session. <br/>
+     * AUTO_FLUSH_SYNC: call will return only after being flushed to the server automatically. <br/>
+     * MANUAL_FLUSH: calls will return immediately, but the writes will not be sent
+     * until the user calls <code>KuduSession.flush()</code>.
+     */
+    private SessionConfiguration.FlushMode flushMode;
+
+    private boolean forceInUpsertMode;
+
+    public String getMasters() {
+        return masters;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String[] getFieldNames() {
+        return fieldNames;
+    }
+
+    public DataType[] getDataTypes() {
+        return dataTypes;
+    }
+
+    public FlushMode getFlushMode() {
+        return flushMode;
+    }
+
+    public void setFlushMode(FlushMode flushMode) {
+        this.flushMode = flushMode;
+    }
+
+    public boolean isForceInUpsertMode() {
+        return forceInUpsertMode;
+    }
+
+    public void setForceInUpsertMode(boolean forceInUpsertMode) {
+        this.forceInUpsertMode = forceInUpsertMode;
+    }
+
+    public KuduTableInfo(
+            String masters,
+            String tableName,
+            String[] fieldNames,
+            DataType[] dataTypes) {
+        this.masters = masters;
+        this.tableName = tableName;
+        this.fieldNames = fieldNames;
+        this.dataTypes = dataTypes;
+    }
+
+    public static KuduMetaInfoBuilder builder() {
+        return new KuduMetaInfoBuilder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KuduTableInfo that = (KuduTableInfo) o;
+        return forceInUpsertMode == that.forceInUpsertMode &&
+                masters.equals(that.masters) &&
+                tableName.equals(that.tableName) &&
+                Arrays.equals(fieldNames, that.fieldNames) &&
+                Arrays.equals(dataTypes, that.dataTypes) &&
+                flushMode == that.flushMode;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(masters, tableName, flushMode, forceInUpsertMode);
+        result = 31 * result + Arrays.hashCode(fieldNames);
+        result = 31 * result + Arrays.hashCode(dataTypes);
+        return result;
+    }
+
+    public static final class KuduMetaInfoBuilder {
+
+        private String masters;
+        private String tableName;
+        private String[] fieldNames;
+        private DataType[] dataTypes;
+        private FlushMode flushMode;
+        private boolean forceInUpsertMode;
+
+        private KuduMetaInfoBuilder() {
+        }
+
+        public static KuduMetaInfoBuilder aKuduMetaInfo() {
+            return new KuduMetaInfoBuilder();
+        }
+
+        public KuduMetaInfoBuilder masters(String masters) {
+            this.masters = masters;
+            return this;
+        }
+
+        public KuduMetaInfoBuilder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public KuduMetaInfoBuilder fieldNames(String[] fieldNames) {
+            this.fieldNames = fieldNames;
+            return this;
+        }
+
+        public KuduMetaInfoBuilder dataTypes(DataType[] dataTypes) {
+            this.dataTypes = dataTypes;
+            return this;
+        }
+
+        public KuduMetaInfoBuilder flushMode(FlushMode flushMode) {
+            this.flushMode = flushMode;
+            return this;
+        }
+
+        public KuduMetaInfoBuilder forceInUpsertMode(boolean forceInUpsertMode) {
+            this.forceInUpsertMode = forceInUpsertMode;
+            return this;
+        }
+
+        public KuduTableInfo build() {
+            KuduTableInfo kuduTableInfo = new KuduTableInfo(masters, tableName, fieldNames, dataTypes);
+            kuduTableInfo.forceInUpsertMode = this.forceInUpsertMode;
+            kuduTableInfo.flushMode = this.flushMode;
+            return kuduTableInfo;
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
@@ -64,8 +64,8 @@ import static org.apache.kudu.Type.VARCHAR;
  */
 public class KuduUtils {
 
-    private static final Map<Type, TypeInfo> KUDU_TYPE_2_TYPE_INFO_MAP = new HashMap<>(13);
-    private static final Map<Type, TypeInfo> KUDU_TYPE_2_DATA_TYPE_MAP = new HashMap<>(13);
+    private static final Map<Type, TypeInfo> KUDU_TYPE_2_TYPE_INFO_MAP = new HashMap<>();
+    private static final Map<Type, TypeInfo> KUDU_TYPE_2_DATA_TYPE_MAP = new HashMap<>();
 
     static {
         // kudu type to flink typeInfo

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.common;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.util.StringUtils;
+
+import org.apache.inlong.sort.formats.common.BooleanTypeInfo;
+import org.apache.inlong.sort.formats.common.ByteTypeInfo;
+import org.apache.inlong.sort.formats.common.DateTypeInfo;
+import org.apache.inlong.sort.formats.common.DecimalTypeInfo;
+import org.apache.inlong.sort.formats.common.DoubleTypeInfo;
+import org.apache.inlong.sort.formats.common.FloatTypeInfo;
+import org.apache.inlong.sort.formats.common.IntTypeInfo;
+import org.apache.inlong.sort.formats.common.LongTypeInfo;
+import org.apache.inlong.sort.formats.common.RowTypeInfo;
+import org.apache.inlong.sort.formats.common.StringTypeInfo;
+import org.apache.inlong.sort.formats.common.TimestampTypeInfo;
+import org.apache.inlong.sort.formats.common.TypeInfo;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.kudu.Type.*;
+
+/**
+ * The utility class for Kudu.
+ */
+public class KuduUtils {
+
+    private static final Map<Type, TypeInfo> KUDU_TYPE_2_TYPE_INFO_MAP = new HashMap<>(13);
+    private static final Map<Type, TypeInfo> KUDU_TYPE_2_DATA_TYPE_MAP = new HashMap<>(13);
+
+    static {
+        // kudu type to flink typeInfo
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(INT8, IntTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(INT16, IntTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(INT32, IntTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(INT64, LongTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(BINARY, ByteTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(STRING, StringTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(BOOL, BooleanTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(FLOAT, FloatTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(DOUBLE, DoubleTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(UNIXTIME_MICROS, TimestampTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(DECIMAL, DecimalTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(VARCHAR, StringTypeInfo.INSTANCE);
+        KUDU_TYPE_2_TYPE_INFO_MAP.put(DATE, DateTypeInfo.INSTANCE);
+    }
+
+    /**
+     * Check if types match.
+     *
+     * @param kuduTableSchema the table schema of kudu.
+     * @param fieldNames      the name of field.
+     * @param typeInfo        the type of user settings.
+     */
+    public static void checkSchema(Schema kuduTableSchema, String[] fieldNames, RowTypeInfo typeInfo) {
+        List<ColumnSchema> kuduColumns = kuduTableSchema.getColumns();
+        String actualTypes = kuduColumns.stream().map((ColumnSchema ti) -> {
+            String fieldName = ti.getName();
+            TypeInfo info = KUDU_TYPE_2_TYPE_INFO_MAP.get(ti.getType());
+            if (info == null) {
+                return fieldName + ":" + ti.getType().getName();
+            } else {
+                String simpleName = info.getClass().getSimpleName();
+                return fieldName + ":" + simpleName.substring(0, simpleName.length() - 8);
+            }
+        }).collect(Collectors.joining(", ", "[", "]"));
+
+        TypeInfo[] fieldTypeInfos = typeInfo.getFieldTypeInfos();
+        String expectedTypes = IntStream.range(0, fieldTypeInfos.length).boxed().map(index -> {
+            String simpleName = fieldTypeInfos[index].getClass().getSimpleName();
+            String typeName = simpleName.substring(0, simpleName.length() - 8);
+            String fieldName = fieldNames[index];
+            return fieldName + ":" + typeName;
+        }).collect(Collectors.joining(", ", "[", "]"));
+
+        checkState(kuduColumns.size() == fieldTypeInfos.length,
+                "The number of kudu fields mismatch, expected is %s, but actual is %s, "
+                        + "\nexpect: %s,\nactual: %s.",
+                kuduColumns.size(), fieldTypeInfos.length, expectedTypes, actualTypes);
+
+        for (int i = 0; i < kuduColumns.size(); i++) {
+            ColumnSchema columnSchema = kuduColumns.get(i);
+            Type columnSchemaType = columnSchema.getType();
+            TypeInfo actualTypeInfo = fieldTypeInfos[i];
+            TypeInfo expectedTypeInfo = KUDU_TYPE_2_TYPE_INFO_MAP.get(columnSchemaType);
+
+            checkState(Objects.equals(actualTypeInfo, expectedTypeInfo),
+                    "The %sth field type mismatch, \nexpect: %s, \nactual: %s.",
+                    i + 1, expectedTypes, actualTypes);
+        }
+    }
+
+    /**
+     * Check schema according to field name
+     */
+    public static void checkSchema(
+            TableSchema flinkSchema,
+            Schema kuduTableSchema) {
+        List<ColumnSchema> kuduColumns = kuduTableSchema.getColumns();
+        Map<String, ColumnSchema> columnMap = kuduColumns
+                .stream()
+                .map(col -> Tuple2.of(col.getName(), col))
+                .collect(Collectors.toMap(t2 -> t2.f0, t2 -> t2.f1));
+        String missFields = Arrays
+                .stream(flinkSchema.getFieldNames())
+                .filter(s -> !columnMap.containsKey(s))
+                .collect(Collectors.joining(","));
+        checkState(StringUtils.isNullOrWhitespaceOnly(missFields), "Can not find fields {} in kudu table!", missFields);
+    }
+
+    public static String[] getExpectedFieldNames(Schema kuduTableSchema) {
+        return kuduTableSchema.getColumns().stream().map(ColumnSchema::getName).toArray(String[]::new);
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduUtils.java
@@ -18,9 +18,8 @@
 package org.apache.inlong.sort.kudu.common;
 
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.StringUtils;
-
 import org.apache.inlong.sort.formats.common.BooleanTypeInfo;
 import org.apache.inlong.sort.formats.common.ByteTypeInfo;
 import org.apache.inlong.sort.formats.common.DateTypeInfo;
@@ -46,7 +45,19 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.apache.flink.util.Preconditions.checkState;
-import static org.apache.kudu.Type.*;
+import static org.apache.kudu.Type.BINARY;
+import static org.apache.kudu.Type.BOOL;
+import static org.apache.kudu.Type.DATE;
+import static org.apache.kudu.Type.DECIMAL;
+import static org.apache.kudu.Type.DOUBLE;
+import static org.apache.kudu.Type.FLOAT;
+import static org.apache.kudu.Type.INT16;
+import static org.apache.kudu.Type.INT32;
+import static org.apache.kudu.Type.INT64;
+import static org.apache.kudu.Type.INT8;
+import static org.apache.kudu.Type.STRING;
+import static org.apache.kudu.Type.UNIXTIME_MICROS;
+import static org.apache.kudu.Type.VARCHAR;
 
 /**
  * The utility class for Kudu.
@@ -77,8 +88,8 @@ public class KuduUtils {
      * Check if types match.
      *
      * @param kuduTableSchema the table schema of kudu.
-     * @param fieldNames      the name of field.
-     * @param typeInfo        the type of user settings.
+     * @param fieldNames the name of field.
+     * @param typeInfo the type of user settings.
      */
     public static void checkSchema(Schema kuduTableSchema, String[] fieldNames, RowTypeInfo typeInfo) {
         List<ColumnSchema> kuduColumns = kuduTableSchema.getColumns();
@@ -122,7 +133,8 @@ public class KuduUtils {
      * Check schema according to field name
      */
     public static void checkSchema(
-            TableSchema flinkSchema,
+            String[] fieldNames,
+            DataType[] dataTypes,
             Schema kuduTableSchema) {
         List<ColumnSchema> kuduColumns = kuduTableSchema.getColumns();
         Map<String, ColumnSchema> columnMap = kuduColumns
@@ -130,7 +142,7 @@ public class KuduUtils {
                 .map(col -> Tuple2.of(col.getName(), col))
                 .collect(Collectors.toMap(t2 -> t2.f0, t2 -> t2.f1));
         String missFields = Arrays
-                .stream(flinkSchema.getFieldNames())
+                .stream(fieldNames)
                 .filter(s -> !columnMap.containsKey(s))
                 .collect(Collectors.joining(","));
         checkState(StringUtils.isNullOrWhitespaceOnly(missFields), "Can not find fields {} in kudu table!", missFields);

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduValidator.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduValidator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.common;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+/**
+ * The validator for {@link Kudu}.
+ */
+public class KuduValidator extends ConnectorDescriptorValidator {
+
+    /**
+     * The type of connector.
+     */
+    public static final String CONNECTOR_TYPE_VALUE_KUDU = "kudu-inlong";
+
+    /**
+     * The name of kudu table.
+     */
+    public static final String CONNECTOR_TABLE = "connector.table";
+
+    /**
+     * The masters of kudu server.
+     */
+    public static final String CONNECTOR_MASTERS = "connector.masters";
+
+    /**
+     * The prefix of kudu properties (optional).
+     */
+    public static final String CONNECTOR_PROPERTIES = "connector.properties";
+
+    @Override
+    public void validate(DescriptorProperties properties) {
+        super.validate(properties);
+
+        // Validates that the connector type is kudu.
+        properties.validateValue(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_KUDU, false);
+        properties.validateString(CONNECTOR_TABLE, false);
+        properties.validateString(CONNECTOR_MASTERS, false);
+    }
+
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduValidator.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/common/KuduValidator.java
@@ -33,12 +33,12 @@ public class KuduValidator extends ConnectorDescriptorValidator {
     /**
      * The name of kudu table.
      */
-    public static final String CONNECTOR_TABLE = "connector.table";
+    public static final String CONNECTOR_TABLE = "table-name";
 
     /**
      * The masters of kudu server.
      */
-    public static final String CONNECTOR_MASTERS = "connector.masters";
+    public static final String CONNECTOR_MASTERS = "masters";
 
     /**
      * The prefix of kudu properties (optional).

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.util.MetricStateUtils;
+import org.apache.kudu.client.SessionConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.inlong.sort.base.Constants.*;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.*;
+
+/**
+ * The base for all kudu sinks.
+ */
+@PublicEvolving
+public abstract class AbstractKuduSinkFunction
+        extends
+            RichSinkFunction<RowData>
+        implements
+            CheckpointedFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractKuduSinkFunction.class);
+
+    /**
+     * The masters of kudu server.
+     */
+    protected final String masters;
+    /**
+     * The name of kudu table.
+     */
+    protected final String tableName;
+    /**
+     * The flink TableSchema.
+     */
+    protected final TableSchema flinkTableSchema;
+
+    protected String connectorMetricIdentify;
+
+    /**
+     * The configuration of kudu sinkFunction.
+     */
+    protected final Configuration configuration;
+
+    /**
+     * The maximum number of buffered records.
+     */
+    protected final int maxBufferSize;
+
+    /**
+     * The maximum number of retries.
+     */
+    protected final int maxRetries;
+
+    /**
+     * True if the sink is running.
+     */
+    protected volatile boolean running;
+
+    /**
+     * The exception thrown in asynchronous tasks.
+     */
+    private transient Throwable flushThrowable;
+
+    protected final SessionConfiguration.FlushMode flushMode;
+    /**
+     * whether load metadata in `open` function
+     */
+    protected boolean lazyLoadSchema;
+
+    private SinkMetricData sinkMetricData;
+
+    private transient ListState<MetricState> metricStateListState;
+    private transient MetricState metricState;
+
+    private final String auditHostAndPorts;
+
+    private final String inlongMetric;
+
+    public AbstractKuduSinkFunction(
+            TableSchema flinkTableSchema,
+            String masters,
+            String tableName,
+            SessionConfiguration.FlushMode flushMode,
+            Configuration configuration,
+            String inlongMetric,
+            String auditHostAndPorts) {
+        this.masters = masters;
+        this.flushMode = flushMode;
+        this.tableName = tableName;
+        this.flinkTableSchema = flinkTableSchema;
+        this.configuration = configuration;
+        this.maxRetries = configuration.getInteger(MAX_RETRIES);
+        this.maxBufferSize = configuration.getInteger(MAX_BUFFER_SIZE);
+        this.lazyLoadSchema = configuration.getBoolean(LAZY_LOAD_SCHEMA);
+        this.inlongMetric = inlongMetric;
+        this.auditHostAndPorts = auditHostAndPorts;
+        MetricOption metricOption = MetricOption.builder()
+                .withInlongLabels(inlongMetric)
+                .withInlongAudit(auditHostAndPorts)
+                .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
+                .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
+                .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
+                .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
+                .withRegisterMetric(MetricOption.RegisteredMetric.ALL)
+                .build();
+        if (metricOption != null) {
+            sinkMetricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
+        }
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        this.running = true;
+    }
+
+    @Override
+    public void invoke(
+            RowData row,
+            Context context) throws Exception {
+        addBatch(row);
+        sendMetrics(row.toString().getBytes());
+    }
+
+    /**
+     * Adds a record in the buffer.
+     */
+    protected abstract void addBatch(RowData in) throws Exception;
+
+    @Override
+    public void close() throws Exception {
+        this.running = false;
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) {
+        checkError();
+        // We must store the exception caught in the flushing so that the
+        // task thread can be aware of the failure.
+        try {
+            flush();
+        } catch (IOException e) {
+            this.flushThrowable = e;
+        }
+        checkError();
+    }
+
+    protected abstract void flush() throws IOException;
+
+    protected abstract void checkError();
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        if (this.inlongMetric != null) {
+            this.metricStateListState = context.getOperatorStateStore().getUnionListState(
+                    new ListStateDescriptor<>(
+                            INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
+                            })));
+        }
+
+        if (context.isRestored()) {
+            metricState = MetricStateUtils.restoreMetricState(metricStateListState,
+                    getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getNumberOfParallelSubtasks());
+        }
+    }
+
+    protected void sendMetrics(byte[] document) {
+        if (sinkMetricData != null) {
+            sinkMetricData.invoke(1, document.length);
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SinkMetricData;
-import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.kudu.common.KuduTableInfo;
 import org.slf4j.Logger;
@@ -97,8 +96,6 @@ public abstract class AbstractKuduSinkFunction
 
     private final String inLongMetric;
 
-    private SourceMetricData sourceMetricData;
-
     public AbstractKuduSinkFunction(
             KuduTableInfo kuduTableInfo,
             Configuration configuration,
@@ -148,8 +145,8 @@ public abstract class AbstractKuduSinkFunction
 
     @Override
     public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
-        if (sourceMetricData != null && metricStateListState != null) {
-            MetricStateUtils.snapshotMetricStateForSourceMetricData(metricStateListState, sourceMetricData,
+        if (sinkMetricData != null && metricStateListState != null) {
+            MetricStateUtils.snapshotMetricStateForSinkMetricData(metricStateListState, sinkMetricData,
                     getRuntimeContext().getIndexOfThisSubtask());
         }
         checkError();

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/AbstractKuduSinkFunction.java
@@ -131,9 +131,7 @@ public abstract class AbstractKuduSinkFunction
     }
 
     @Override
-    public void invoke(
-            RowData row,
-            Context context) throws Exception {
+    public void invoke(RowData row, Context context) throws Exception {
         addBatch(row);
         sendMetrics(row.toString().getBytes());
     }

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduAsyncSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduAsyncSinkFunction.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.kudu.source.KuduConsumerTask;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.util.TimeUtils.parseDuration;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.CACHE_QUEUE_MAX_LENGTH;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.MAX_BUFFER_TIME;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.SINK_FORCE_WITH_UPSERT_MODE;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.WRITE_THREAD_COUNT;
+
+/**
+ * The Flink kudu Producer in async Mode.
+ */
+@PublicEvolving
+public class KuduAsyncSinkFunction
+        extends
+            AbstractKuduSinkFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KuduAsyncSinkFunction.class);
+    private final Duration maxBufferTime;
+
+    private transient BlockingQueue<RowData> queue;
+
+    private transient List<KuduConsumerTask> consumerTasks;
+    private ExecutorService threadPool = null;
+
+    public KuduAsyncSinkFunction(
+            TableSchema flinkTableSchema,
+            String masters,
+            String tableName,
+            FlushMode flushMode,
+            String[] keyFieldNames,
+            Configuration configuration,
+            String inlongMetric,
+            String auditHostAndPorts) {
+        super(flinkTableSchema, masters, tableName, flushMode, configuration, inlongMetric, auditHostAndPorts);
+        this.maxBufferTime = parseDuration(configuration.getString(MAX_BUFFER_TIME));
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        int threadCnt = configuration.getInteger(WRITE_THREAD_COUNT);
+        int cacheQueueMaxLength = configuration.getInteger(CACHE_QUEUE_MAX_LENGTH);
+        if (cacheQueueMaxLength == -1) {
+            cacheQueueMaxLength = (maxBufferSize + 1) * (threadCnt + 1);
+        }
+        LOG.info("Opening KuduAsyncSinkFunction, threadCount:{}, cacheQueueMaxLength:{}, maxBufferSize:{}.",
+                threadCnt, cacheQueueMaxLength, maxBufferSize);
+
+        queue = new LinkedBlockingQueue<>(cacheQueueMaxLength);
+        consumerTasks = new ArrayList<>(threadCnt);
+        ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
+                .setNameFormat("kudu-sink-pool-%d").build();
+        threadPool = new ThreadPoolExecutor(
+                threadCnt + 1,
+                threadCnt + 1,
+                0L,
+                TimeUnit.MILLISECONDS,
+                new LinkedBlockingQueue<>(4),
+                namedThreadFactory,
+                new ThreadPoolExecutor.AbortPolicy());
+
+        boolean forceInUpsertMode = configuration.getBoolean(SINK_FORCE_WITH_UPSERT_MODE);
+        for (int threadIndex = 0; threadIndex < threadCnt; threadIndex++) {
+            KuduWriter kuduWriter = new KuduWriter(masters, tableName, flinkTableSchema, flushMode, forceInUpsertMode);
+            kuduWriter.open();
+            KuduConsumerTask task = new KuduConsumerTask(
+                    queue, kuduWriter, maxBufferSize, maxBufferTime, maxRetries);
+            consumerTasks.add(task);
+            threadPool.submit(task);
+        }
+    }
+
+    @Override
+    protected void addBatch(RowData in) throws Exception {
+        checkError();
+        try {
+            if (running) {
+                queue.put(in);
+            } else {
+                throw new FlinkRuntimeException("Canceled by KuduConsumerTask!");
+            }
+        } catch (InterruptedException e) {
+            LOG.error("writeKuduMsgToQueue error", e);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        for (KuduConsumerTask consumerTask : consumerTasks) {
+            consumerTask.close();
+        }
+        if (null != threadPool) {
+            threadPool.shutdown();
+        }
+    }
+
+    public void flush() throws IOException {
+        for (KuduConsumerTask consumerTask : consumerTasks) {
+            consumerTask.flush();
+        }
+    }
+
+    @Override
+    protected void checkError() {
+        for (KuduConsumerTask consumerTask : consumerTasks) {
+            consumerTask.checkError();
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduAsyncSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduAsyncSinkFunction.java
@@ -20,11 +20,10 @@ package org.apache.inlong.sort.kudu.sink;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.kudu.common.KuduTableInfo;
 import org.apache.inlong.sort.kudu.source.KuduConsumerTask;
-import org.apache.kudu.client.SessionConfiguration.FlushMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,15 +61,11 @@ public class KuduAsyncSinkFunction
     private ExecutorService threadPool = null;
 
     public KuduAsyncSinkFunction(
-            TableSchema flinkTableSchema,
-            String masters,
-            String tableName,
-            FlushMode flushMode,
-            String[] keyFieldNames,
+            KuduTableInfo kuduTableInfo,
             Configuration configuration,
             String inlongMetric,
             String auditHostAndPorts) {
-        super(flinkTableSchema, masters, tableName, flushMode, configuration, inlongMetric, auditHostAndPorts);
+        super(kuduTableInfo, configuration, inlongMetric, auditHostAndPorts);
         this.maxBufferTime = parseDuration(configuration.getString(MAX_BUFFER_TIME));
     }
 
@@ -100,7 +95,7 @@ public class KuduAsyncSinkFunction
 
         boolean forceInUpsertMode = configuration.getBoolean(SINK_FORCE_WITH_UPSERT_MODE);
         for (int threadIndex = 0; threadIndex < threadCnt; threadIndex++) {
-            KuduWriter kuduWriter = new KuduWriter(masters, tableName, flinkTableSchema, flushMode, forceInUpsertMode);
+            KuduWriter kuduWriter = new KuduWriter(kuduTableInfo);
             kuduWriter.open();
             KuduConsumerTask task = new KuduConsumerTask(
                     queue, kuduWriter, maxBufferSize, maxBufferTime, maxRetries);

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduSinkFunction.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.kudu.client.SessionConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.inlong.sort.kudu.common.KuduOptions.MAX_RETRIES;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.SINK_FORCE_WITH_UPSERT_MODE;
+
+/**
+ * The Flink kudu Producer.
+ */
+@PublicEvolving
+public class KuduSinkFunction
+        extends
+            AbstractKuduSinkFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KuduSinkFunction.class);
+    private int maxRetries;
+    private transient KuduWriter kuduWriter;
+
+    public KuduSinkFunction(
+            TableSchema flinkSchema,
+            String masters,
+            String tableName,
+            SessionConfiguration.FlushMode flushMode,
+            Configuration configuration,
+            String inlongMetric,
+            String auditHostAndPorts) {
+        super(
+                flinkSchema,
+                masters,
+                tableName,
+                flushMode,
+                configuration,
+                inlongMetric,
+                auditHostAndPorts);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        maxRetries = configuration.getInteger(MAX_RETRIES);
+
+        boolean forceWithUpsertMode = configuration.getBoolean(SINK_FORCE_WITH_UPSERT_MODE);
+
+        kuduWriter = new KuduWriter(
+                masters,
+                tableName,
+                flinkTableSchema,
+                flushMode,
+                forceWithUpsertMode);
+        kuduWriter.open();
+    }
+
+    @Override
+    protected void addBatch(RowData in) throws Exception {
+        kuduWriter.applyRow(in, maxRetries);
+    }
+
+    @Override
+    protected void flush() throws IOException {
+        kuduWriter.flush(maxRetries);
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        try {
+            kuduWriter.flushAndCheckErrors();
+        } finally {
+            try {
+                kuduWriter.close();
+            } catch (Exception e) {
+                LOG.error("Error while closing kuduWrite.", e);
+            }
+        }
+    }
+
+    @Override
+    protected void checkError() {
+        kuduWriter.checkError();
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduSinkFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduSinkFunction.java
@@ -19,9 +19,8 @@ package org.apache.inlong.sort.kudu.sink;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
-import org.apache.kudu.client.SessionConfiguration;
+import org.apache.inlong.sort.kudu.common.KuduTableInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,18 +42,12 @@ public class KuduSinkFunction
     private transient KuduWriter kuduWriter;
 
     public KuduSinkFunction(
-            TableSchema flinkSchema,
-            String masters,
-            String tableName,
-            SessionConfiguration.FlushMode flushMode,
+            KuduTableInfo kuduTableInfo,
             Configuration configuration,
             String inlongMetric,
             String auditHostAndPorts) {
         super(
-                flinkSchema,
-                masters,
-                tableName,
-                flushMode,
+                kuduTableInfo,
                 configuration,
                 inlongMetric,
                 auditHostAndPorts);
@@ -67,12 +60,7 @@ public class KuduSinkFunction
 
         boolean forceWithUpsertMode = configuration.getBoolean(SINK_FORCE_WITH_UPSERT_MODE);
 
-        kuduWriter = new KuduWriter(
-                masters,
-                tableName,
-                flinkTableSchema,
-                flushMode,
-                forceWithUpsertMode);
+        kuduWriter = new KuduWriter(kuduTableInfo);
         kuduWriter.open();
     }
 

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduWriter.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/sink/KuduWriter.java
@@ -1,0 +1,302 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.sink;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.apache.kudu.Schema;
+
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.KuduSession;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.Operation;
+import org.apache.kudu.client.PartialRow;
+import org.apache.kudu.client.RowError;
+import org.apache.kudu.client.SessionConfiguration;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.inlong.sort.kudu.common.KuduUtils.checkSchema;
+
+/**
+ * The WriteClient for kudu, which holds a client and session.
+ */
+public class KuduWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KuduWriter.class);
+
+    /**
+     * The flush mode of kudu client. <br/>
+     * AUTO_FLUSH_BACKGROUND： calls will return immediately, but the writes will be sent in the background,
+     * potentially batched together with other writes from the same session. <br/>
+     * AUTO_FLUSH_SYNC: call will return only after being flushed to the server automatically. <br/>
+     * MANUAL_FLUSH: calls will return immediately, but the writes will not be sent
+     * until the user calls <code>KuduSession.flush()</code>.
+     */
+    private final SessionConfiguration.FlushMode flushMode;
+
+    /**
+     * The masters of kudu server.
+     */
+    private final String masters;
+
+    /**
+     * The name of kudu table.
+     */
+    private final String tableName;
+
+    /**
+     * The name of kudu field.
+     */
+    private final TableSchema flinkSchema;
+
+    private String[] actualFieldNames;
+
+    /**
+     * The client of kudu.
+     */
+    private transient KuduClient client;
+
+    /**
+     * The session of kudu client.
+     */
+    private transient KuduSession session;
+
+    /**
+     * The kudu table object.
+     */
+    private transient KuduTable kuduTable;
+
+    private final boolean forceInUpsertMode;
+
+    /**
+     * The exception caught in asynchronous tasks.
+     */
+    private transient AtomicReference<Throwable> flushThrowable;
+
+    private final List<Tuple2<Long, Integer>> consumeTimes;
+    private final int timePrintingThreshold = 10;
+    private int applyNum = 0;
+    private DataType[] actualFieldTypes;
+
+    public KuduWriter(
+            String masters,
+            String tableName,
+            TableSchema flinkSchema,
+            FlushMode flushMode,
+            boolean forceInUpsertMode) {
+        this.masters = masters;
+        this.tableName = tableName;
+        this.flushMode = flushMode;
+        this.forceInUpsertMode = forceInUpsertMode;
+        this.flinkSchema = flinkSchema;
+
+        this.consumeTimes = Collections.synchronizedList(new ArrayList<>(100));
+    }
+
+    public void open() {
+        this.flushThrowable = new AtomicReference<>();
+
+        this.client = new KuduClient.KuduClientBuilder(masters)
+                .build();
+        this.session = client.newSession();
+        session.setFlushMode(flushMode);
+
+        try {
+            kuduTable = this.client.openTable(this.tableName);
+            checkState(client.tableExists(tableName), "Can not find table with name:{} in kudu.", tableName);
+        } catch (KuduException e) {
+            LOG.error("Error on Open kudu table", e);
+            throw new RuntimeException(e);
+        }
+
+        // check table schema
+        Schema schema = kuduTable.getSchema();
+        try {
+            checkSchema(flinkSchema, schema);
+        } catch (Exception e) {
+            LOG.error("The provided schema is invalid!", e);
+            throw new RuntimeException(e);
+        }
+        this.actualFieldNames = getExpectedFieldNames(flinkSchema);
+        LOG.info("Kudu actual fieldNames: {}.", Arrays.toString(actualFieldNames));
+        this.actualFieldTypes = getExpectedDataTypes(flinkSchema);
+    }
+
+    private DataType[] getExpectedDataTypes(TableSchema flinkSchema) {
+        return flinkSchema.getFieldDataTypes();
+    }
+
+    private String[] getExpectedFieldNames(TableSchema flinkSchema) {
+        return flinkSchema.getFieldNames();
+    }
+
+    private void onFailure(List<RowError> failure) throws IOException {
+        String errors = failure.stream()
+                .map(error -> error.toString() + System.lineSeparator())
+                .collect(Collectors.joining());
+
+        throw new IOException("Error while sending value. \n " + errors);
+    }
+
+    private void checkAsyncErrors() throws IOException {
+        if (session.countPendingErrors() == 0) {
+            return;
+        }
+
+        List<RowError> errors = Arrays.asList(session.getPendingErrors().getRowErrors());
+        onFailure(errors);
+    }
+
+    public void flushAndCheckErrors() throws IOException {
+        checkAsyncErrors();
+        flush();
+        checkAsyncErrors();
+    }
+
+    public void flush() throws IOException {
+        long startTime = System.currentTimeMillis();
+
+        session.flush();
+
+        Tuple2<Long, Integer> consumeTime = Tuple2.of(System.currentTimeMillis() - startTime, applyNum);
+        consumeTimes.add(consumeTime);
+        applyNum = 0;
+        printConsumeTimes(false);
+    }
+
+    private void printConsumeTimes(boolean force) {
+        if (consumeTimes.size() > 0 && (force || consumeTimes.size() >= timePrintingThreshold)) {
+            StringJoiner detailTimes = new StringJoiner(",");
+            StringJoiner detailNums = new StringJoiner(",");
+            long summaryTime = 0;
+            int summaryNum = 0;
+            try {
+                for (Tuple2<Long, Integer> consumeTime : consumeTimes) {
+                    Long time = consumeTime.f0;
+                    Integer count = consumeTime.f1;
+                    detailTimes.add(time + "");
+                    detailNums.add(count + "");
+                    summaryTime += time;
+                    summaryNum += count;
+                }
+                consumeTimes.clear();
+
+                LOG.info("Flushing time spent: [{}]:{}ms.",
+                        detailTimes, ((double) summaryTime / summaryNum));
+                LOG.info("Flushing records: [{}]", detailNums);
+            } catch (Exception e) {
+                LOG.error("error when print consumeTimes", e);
+            }
+
+        }
+    }
+
+    public void close() throws KuduException {
+        printConsumeTimes(true);
+        session.close();
+        client.close();
+    }
+
+    public void applyRow(RowData row) throws KuduException {
+
+        Operation operation;
+        if (row.getRowKind() == RowKind.UPDATE_AFTER) {
+            operation = forceInUpsertMode ? kuduTable.newUpsert() : kuduTable.newInsert();
+        } else {
+            operation = kuduTable.newDelete();
+        }
+        final PartialRow kuduRow = operation.getRow();
+
+        for (int j = 0; j < actualFieldNames.length; j++) {
+            String columnName = actualFieldNames[j];
+            DataType columnType = actualFieldTypes[j];
+
+            Object column = RowData.createFieldGetter(columnType.getLogicalType(), j).getFieldOrNull(row);
+            if (column == null) {
+                continue;
+            }
+            kuduRow.addObject(columnName, column);
+        }
+        session.apply(operation);
+        applyNum++;
+    }
+
+    public void checkError() {
+        // check session error
+        try {
+            checkAsyncErrors();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // check flush error
+        Throwable throwable = flushThrowable.get();
+        if (throwable != null) {
+            throw new RuntimeException("An asynchronous exception is caught " +
+                    "in the kudu sink.", throwable);
+        }
+    }
+
+    private void runWithRetry(ApplyAction action, int maxRetries) {
+        for (int retry = 0; retry <= maxRetries; retry++) {
+            try {
+                action.call();
+                break;
+            } catch (IOException e) {
+                LOG.error("Kudu applyRow error, retryTime:" + retry, e);
+                try {
+                    Thread.sleep((retry + 1) * 1000L);
+                } catch (InterruptedException ignore) {
+                }
+                if (retry >= maxRetries) {
+                    flushThrowable.compareAndSet(null, e);
+                }
+            }
+        }
+    }
+
+    @FunctionalInterface
+    interface ApplyAction {
+
+        void call() throws IOException;
+    }
+
+    public void applyRow(RowData row, int maxRetries) {
+        runWithRetry(() -> applyRow(row), maxRetries);
+    }
+
+    public void flush(int maxRetries) {
+        runWithRetry(this::flush, maxRetries);
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduConsumerTask.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduConsumerTask.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.source;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.kudu.sink.KuduWriter;
+import org.apache.kudu.client.KuduException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The runnable task for sink kudu.
+ */
+public class KuduConsumerTask implements Runnable {
+
+    private final Duration maxBufferTime;
+    private static final Logger LOG = LoggerFactory.getLogger(KuduConsumerTask.class);
+
+    private final KuduWriter kuduWriter;
+    private final BlockingQueue<RowData> queue;
+    private final long writeBatch;
+    private long cachedNum = 0;
+    private boolean running;
+    /**
+     * The maximum number of retries when an exception is caught.
+     */
+    private final int maxRetries;
+
+    public KuduConsumerTask(
+            BlockingQueue<RowData> queue,
+            KuduWriter kuduWriter,
+            long writeBatch,
+            Duration maxBufferTime,
+            int maxRetries) {
+        this.queue = queue;
+        this.kuduWriter = kuduWriter;
+        this.writeBatch = writeBatch;
+        this.maxBufferTime = maxBufferTime;
+        this.running = true;
+        this.maxRetries = maxRetries;
+
+        LOG.info("Creating KuduConsumerTask, writeBatch:{}, maxBufferTime:{}, maxRetries:{}.",
+                writeBatch, maxBufferTime, maxRetries);
+    }
+
+    @Override
+    public void run() {
+        LOG.info("KuduConsumerTask starting: {}.", Thread.currentThread());
+        try {
+            while (running) {
+                // Data flush conditions.
+                while (running && cachedNum < writeBatch) {
+                    RowData row = null;
+                    try {
+                        row = queue.poll(maxBufferTime.getSeconds(), TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        LOG.error("Poll message error, force flush", e);
+                        flush();
+                    }
+                    if (row != null) {
+                        applyRow(row);
+                    }
+                }
+                flush();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("", e);
+        }
+        LOG.info("KuduConsumerTask stopped: {}.", Thread.currentThread());
+    }
+
+    private void applyRow(RowData row) {
+        kuduWriter.applyRow(row, maxRetries);
+        cachedNum++;
+    }
+
+    public void flush() {
+        kuduWriter.flush(maxRetries);
+        cachedNum = 0;
+    }
+
+    public void close() {
+        LOG.info("Closing... KuduConsumerTask");
+        flush();
+        running = false;
+        try {
+            kuduWriter.close();
+        } catch (KuduException e) {
+            LOG.error("Error when close kuduWrite", e);
+        }
+    }
+
+    public void checkError() {
+        kuduWriter.checkError();
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.source;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.shaded.guava18.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava18.com.google.common.cache.CacheBuilder;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.TableFunction;
+import org.apache.flink.types.Row;
+import org.apache.inlong.sort.kudu.common.KuduOptions;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduPredicate;
+import org.apache.kudu.client.KuduScanToken;
+import org.apache.kudu.client.KuduScanner;
+import org.apache.kudu.client.KuduTable;
+import org.apache.kudu.client.LocatedTablet;
+import org.apache.kudu.client.RowResult;
+import org.apache.kudu.client.RowResultIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.TimeUtils.parseDuration;
+import static org.apache.kudu.client.KuduPredicate.ComparisonOp.EQUAL;
+
+/**
+ * The KuduLookupFunction is a standard user-defined table function, it can be
+ * used in tableAPI and also useful for temporal table join plan in SQL.
+ */
+public class KuduLookupFunction extends TableFunction<Row> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(KuduLookupFunction.class);
+
+    /**
+     * The names of lookup key.
+     */
+    private final String[] keyNames;
+
+    /**
+     * The configuration for the tde source.
+     */
+    private final Configuration configuration;
+
+    /**
+     * The masters of kudu server.
+     */
+    private final String masters;
+
+    /**
+     * The name of kudu table.
+     */
+    private final String tableName;
+
+    /**
+     * The maximum number of retries.
+     */
+    private transient int maxRetries;
+
+    /**
+     * The cache for lookup results.
+     */
+    private transient Cache<Row, List<Row>> cache;
+
+    /**
+     * The client of kudu.
+     */
+    private transient KuduClient client;
+
+    /**
+     * The table of kudu.
+     */
+    private transient KuduTable table;
+
+    public KuduLookupFunction(
+            String masters,
+            String tableName,
+            String[] keyNames,
+            Configuration configuration) {
+        checkNotNull(configuration,
+                "The configuration must not be null.");
+
+        this.masters = masters;
+        this.tableName = tableName;
+        this.keyNames = keyNames;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        maxRetries = configuration.getInteger(KuduOptions.MAX_RETRIES);
+        int maxCacheSize = configuration.getInteger(KuduOptions.MAX_CACHE_SIZE);
+        Duration maxCacheTime = parseDuration(configuration.getString(
+                KuduOptions.MAX_CACHE_TIME));
+        LOG.info("opening KuduLookupFunction, maxCacheSize:{}, maxCacheTime:{}.", maxCacheSize, maxCacheTime);
+
+        if (maxCacheSize > 0) {
+            cache =
+                    CacheBuilder.newBuilder()
+                            .maximumSize(maxCacheSize)
+                            .expireAfterWrite(maxCacheTime.toMillis(), TimeUnit.MILLISECONDS)
+                            .build();
+        }
+
+        this.client = new KuduClient.KuduClientBuilder(masters).build();
+
+        this.table = client.openTable(tableName);
+        LOG.info("KuduLookupFunction opened.");
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(configuration, masters, tableName);
+        result = 31 * result + Arrays.hashCode(keyNames);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KuduLookupFunction that = (KuduLookupFunction) o;
+        return Arrays.equals(keyNames, that.keyNames) && configuration.equals(that.configuration)
+                && masters.equals(that.masters) && tableName.equals(that.tableName);
+    }
+
+    private KuduPredicate predicateComparator(ColumnSchema column, Object value) {
+
+        KuduPredicate.ComparisonOp comparison = EQUAL;
+
+        KuduPredicate predicate;
+
+        switch (column.getType()) {
+            case STRING:
+                String data;
+                data = (String) value;
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, data);
+                break;
+            case FLOAT:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (float) value);
+                break;
+            case INT8:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (byte) value);
+                break;
+            case INT16:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (short) value);
+                break;
+            case INT32:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (int) value);
+                break;
+            case INT64:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (long) value);
+                break;
+            case DOUBLE:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (double) value);
+                break;
+            case BOOL:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (boolean) value);
+                break;
+            case UNIXTIME_MICROS:
+                Long time = (Long) value;
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, time * 1000);
+                break;
+            case BINARY:
+                predicate = KuduPredicate.newComparisonPredicate(column, comparison, (byte[]) value);
+                break;
+            default:
+                throw new IllegalArgumentException("Illegal var type: " + column.getType());
+        }
+        return predicate;
+    }
+
+    public void eval(Object... keys) throws Exception {
+        if (keys.length != keyNames.length) {
+            throw new RuntimeException("The length of lookUpKey and lookUpKeyVals is difference!");
+        }
+        Row keyRow = buildCacheKey(keys);
+        if (this.cache != null) {
+            ConcurrentMap<Row, List<Row>> cacheMap = this.cache.asMap();
+            int keyCount = cacheMap.size();
+            List<Row> cacheRows = this.cache.getIfPresent(keyRow);
+            if (CollectionUtils.isNotEmpty(cacheRows)) {
+                for (Row cacheRow : cacheRows) {
+                    collect(cacheRow);
+                }
+                return;
+            }
+        }
+
+        for (int retry = 1; retry <= maxRetries; retry++) {
+            try {
+                final KuduScanToken.KuduScanTokenBuilder scanTokenBuilder = client.newScanTokenBuilder(table);
+                final Schema kuduTableSchema = table.getSchema();
+                for (int i = 0; i < keyNames.length; i++) {
+                    String keyName = keyNames[i];
+                    Object value = keys[i];
+                    final ColumnSchema column = kuduTableSchema.getColumn(keyName);
+                    KuduPredicate predicate = predicateComparator(column, value);
+                    scanTokenBuilder.addPredicate(predicate);
+                }
+                final List<KuduScanToken> tokenList = scanTokenBuilder.build();
+                ArrayList<Row> rows = new ArrayList<>();
+                for (final KuduScanToken token : tokenList) {
+                    final List<LocatedTablet.Replica> replicas = token.getTablet().getReplicas();
+                    final String[] array = replicas
+                            .stream()
+                            .map(replica -> replica.getRpcHost() + ":" + replica.getRpcPort())
+                            .collect(Collectors.toList()).toArray(new String[replicas.size()]);
+                    final byte[] scanToken = token.serialize();
+                    final KuduScanner scanner = KuduScanToken.deserializeIntoScanner(scanToken, client);
+                    RowResultIterator rowIterator = scanner.nextRows();
+                    while (rowIterator.hasNext()
+                            || (scanner.hasMoreRows() && (rowIterator = scanner.nextRows()).hasNext())) {
+                        final RowResult rowResult = rowIterator.next();
+                        final Row row = convertor(rowResult);
+                        if (cache != null) {
+                            rows.add(row);
+                        }
+                        collect(row);
+                    }
+                }
+                rows.trimToSize();
+                if (cache != null) {
+                    cache.put(keyRow, rows);
+                }
+                break;
+            } catch (Exception e) {
+                LOG.error(String.format("Kudu scan error, retry times = %d", retry), e);
+                if (retry >= maxRetries) {
+                    throw new RuntimeException("Execution of Kudu scan failed.", e);
+                }
+                try {
+                    Thread.sleep(1000L * retry);
+                } catch (InterruptedException e1) {
+                    throw new RuntimeException(e1);
+                }
+            }
+        }
+    }
+
+    public Row convertor(RowResult row) {
+        Schema schema = row.getColumnProjection();
+
+        Row values = new Row(schema.getColumnCount());
+        schema.getColumns().forEach(column -> {
+            String name = column.getName();
+            int pos = schema.getColumnIndex(name);
+            values.setField(pos, row.getObject(name));
+        });
+        return values;
+
+    }
+
+    private Row buildCacheKey(Object... keys) {
+        return Row.of(keys);
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
@@ -25,9 +25,9 @@ import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.types.Row;
 import org.apache.inlong.sort.kudu.common.KuduOptions;
+import org.apache.inlong.sort.kudu.common.KuduTableInfo;
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.Schema;
-
 import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduPredicate;
 import org.apache.kudu.client.KuduScanToken;
@@ -102,16 +102,14 @@ public class KuduLookupFunction extends TableFunction<Row> {
     private transient KuduTable table;
 
     public KuduLookupFunction(
-            String masters,
-            String tableName,
-            String[] keyNames,
+            KuduTableInfo kuduTableInfo,
             Configuration configuration) {
         checkNotNull(configuration,
                 "The configuration must not be null.");
 
-        this.masters = masters;
-        this.tableName = tableName;
-        this.keyNames = keyNames;
+        this.masters = kuduTableInfo.getMasters();
+        this.tableName = kuduTableInfo.getTableName();
+        this.keyNames = kuduTableInfo.getFieldNames();
         this.configuration = configuration;
     }
 

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/source/KuduLookupFunction.java
@@ -35,7 +35,6 @@ import org.apache.kudu.client.KuduScanner;
 import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.LocatedTablet;
 import org.apache.kudu.client.RowResult;
-import org.apache.kudu.client.RowResultIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -245,10 +244,7 @@ public class KuduLookupFunction extends TableFunction<Row> {
                             .collect(Collectors.toList()).toArray(new String[replicas.size()]);
                     final byte[] scanToken = token.serialize();
                     final KuduScanner scanner = KuduScanToken.deserializeIntoScanner(scanToken, client);
-                    RowResultIterator rowIterator = scanner.nextRows();
-                    while (rowIterator.hasNext()
-                            || (scanner.hasMoreRows() && (rowIterator = scanner.nextRows()).hasNext())) {
-                        final RowResult rowResult = rowIterator.next();
+                    for (RowResult rowResult : scanner) {
                         final Row row = convertor(rowResult);
                         if (cache != null) {
                             rows.add(row);

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableFactory.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.SchemaValidator;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.inlong.sort.kudu.common.KuduOptions;
+import org.apache.inlong.sort.kudu.common.KuduValidator;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.*;
+import static org.apache.inlong.sort.kudu.common.KuduValidator.CONNECTOR_TYPE_VALUE_KUDU;
+
+/**
+ * Factory for creating configured instances of {@link KuduDynamicTableSink}.
+ */
+public class KuduDynamicTableFactory
+        implements
+            DynamicTableSourceFactory,
+            DynamicTableSinkFactory {
+
+    private void validateProperties(DescriptorProperties descriptorProperties) {
+        new SchemaValidator(true, false, false).validate(descriptorProperties);
+        new KuduValidator().validate(descriptorProperties);
+    }
+
+    private Configuration getConfiguration(
+            DescriptorProperties descriptorProperties) {
+        Map<String, String> properties =
+                descriptorProperties.getPropertiesWithPrefix(KuduValidator.CONNECTOR_PROPERTIES);
+
+        Configuration configuration = new Configuration();
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            configuration.setString(property.getKey(), property.getValue());
+        }
+
+        return configuration;
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        TableSchema schema = context.getCatalogTable().getSchema();
+        FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+
+        Configuration configuration = new Configuration();
+        context.getCatalogTable().getOptions().forEach(configuration::setString);
+
+        ReadableConfig options = helper.getOptions();
+        String master = options.getOptional(CONNECTOR_MASTER).orElse(null);
+        String tableName = options.getOptional(CONNECTOR_TABLE).orElse(null);
+        String inlongMetric = options.getOptional(INLONG_METRIC).orElse(null);
+        String auditHostAndPorts = options.getOptional(INLONG_AUDIT).orElse(null);
+
+        // Query the fields through the kudu client and select the fields in the tableSchema
+        return new KuduDynamicTableSink(
+                context.getCatalogTable(),
+                schema,
+                master,
+                tableName,
+                configuration,
+                inlongMetric,
+                auditHostAndPorts);
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        TableSchema schema = context.getCatalogTable().getSchema();
+        FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+
+        Configuration configuration = new Configuration();
+        context.getCatalogTable().getOptions().forEach(configuration::setString);
+
+        ReadableConfig options = helper.getOptions();
+        String master = options.getOptional(CONNECTOR_MASTER).orElse(null);
+        String tableName = options.getOptional(CONNECTOR_TABLE).orElse(null);
+        String inlongMetric = options.getOptional(INLONG_METRIC).orElse(null);
+        String auditHostAndPorts = options.getOptional(INLONG_AUDIT).orElse(null);
+
+        return new KuduDynamicTableSource(
+                schema,
+                master,
+                tableName,
+                configuration,
+                inlongMetric,
+                auditHostAndPorts);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return CONNECTOR_TYPE_VALUE_KUDU;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        HashSet<ConfigOption<?>> configOptions = new HashSet<>();
+        configOptions.add(KuduOptions.CONNECTOR_TABLE);
+        configOptions.add(KuduOptions.CONNECTOR_MASTER);
+        return configOptions;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(FLUSH_MODE);
+        options.add(MAX_CACHE_SIZE);
+        options.add(MAX_CACHE_TIME);
+        options.add(SINK_START_NEW_CHAIN);
+        options.add(MAX_RETRIES);
+        options.add(MAX_BUFFER_SIZE);
+        options.add(WRITE_THREAD_COUNT);
+        options.add(MAX_BUFFER_TIME);
+        options.add(SINK_KEY_FIELD_NAMES);
+        options.add(ENABLE_KEY_FIELD_CHECK);
+
+        options.add(INLONG_METRIC);
+        options.add(INLONG_AUDIT);
+        return options;
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
@@ -22,32 +22,26 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.utils.TableConnectorUtils;
 import org.apache.inlong.sort.kudu.common.KuduOptions;
+import org.apache.inlong.sort.kudu.common.KuduTableInfo;
 import org.apache.inlong.sort.kudu.sink.KuduAsyncSinkFunction;
 import org.apache.inlong.sort.kudu.sink.KuduSinkFunction;
-import org.apache.kudu.client.SessionConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
-import static org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkNotNull;
-import static org.apache.inlong.sort.kudu.common.KuduOptions.FLUSH_MODE;
-import static org.apache.inlong.sort.kudu.common.KuduOptions.KUDU_IGNORE_ALL_CHANGELOG;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.IGNORE_ALL_CHANGELOG;
 
 /**
  * The KuduLookupFunction is a standard user-defined table function, it can be
@@ -58,36 +52,12 @@ public class KuduDynamicTableSink implements DynamicTableSink {
     private static final Logger LOG = LoggerFactory.getLogger(KuduDynamicTableSink.class);
 
     /**
-     * The schema of the table.
-     */
-    private final TableSchema flinkSchema;
-
-    /**
-     * The masters of kudu server.
-     */
-    private final String masters;
-
-    /**
-     * The flush mode of kudu client. <br/>
-     * AUTO_FLUSH_BACKGROUND： calls will return immediately, but the writes will be sent in the background,
-     * potentially batched together with other writes from the same session. <br/>
-     * AUTO_FLUSH_SYNC: call will return only after being flushed to the server automatically. <br/>
-     * MANUAL_FLUSH: calls will return immediately, but the writes will not be sent
-     * until the user calls <code>KuduSession.flush()</code>.
-     */
-    private final SessionConfiguration.FlushMode flushMode;
-
-    /**
-     * The name of kudu table.
-     */
-    private final String tableName;
-
-    /**
      * The configuration for the kudu sink.
      */
     private final Configuration configuration;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final KuduTableInfo kuduTableInfo;
 
     /**
      * True if the data stream consumed by this sink is append-only.
@@ -99,36 +69,19 @@ public class KuduDynamicTableSink implements DynamicTableSink {
      */
     @Nullable
     private String[] keyFieldNames;
-    private ResolvedCatalogTable catalogTable;
+    private final boolean ignoreAllChangeLog;
 
     public KuduDynamicTableSink(
-            ResolvedCatalogTable catalogTable,
-            TableSchema flinkSchema,
-            String masters,
-            String tableName,
+            KuduTableInfo kuduTableInfo,
             Configuration configuration,
             String inlongMetric,
             String auditHostAndPorts) {
-        this.catalogTable = catalogTable;
-        this.flinkSchema = checkNotNull(flinkSchema,
-                "The schema must not be null.");
-        DataType dataType = flinkSchema.toRowDataType();
-        LogicalType logicalType = dataType.getLogicalType();
-
-        SessionConfiguration.FlushMode flushMode = SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND;
-        if (configuration.containsKey(FLUSH_MODE.key())) {
-            String flushModeConfig = configuration.getString(FLUSH_MODE);
-            flushMode = SessionConfiguration.FlushMode.valueOf(flushModeConfig);
-            checkNotNull(flushMode, "The flush mode must be one of " +
-                    "AUTO_FLUSH_SYNC AUTO_FLUSH_BACKGROUND or MANUAL_FLUSH.");
-        }
-
-        this.masters = masters;
-        this.flushMode = flushMode;
-        this.tableName = checkNotNull(tableName);
+        this.kuduTableInfo = kuduTableInfo;
         this.configuration = configuration;
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
+
+        ignoreAllChangeLog = configuration.getBoolean(IGNORE_ALL_CHANGELOG);
 
         String userKeyFieldsConfig = configuration.getString(KuduOptions.SINK_KEY_FIELD_NAMES);
         if (userKeyFieldsConfig != null) {
@@ -149,27 +102,20 @@ public class KuduDynamicTableSink implements DynamicTableSink {
         return dataStream
                 .addSink(kuduSinkFunction)
                 .setParallelism(dataStream.getParallelism())
-                .name(TableConnectorUtils.generateRuntimeName(this.getClass(), flinkSchema.getFieldNames()));
+                .name(TableConnectorUtils.generateRuntimeName(this.getClass(), kuduTableInfo.getFieldNames()));
     }
 
     private SinkFunction<RowData> createSinkFunction() {
         boolean sinkWithAsyncMode = configuration.getBoolean(KuduOptions.SINK_WRITE_WITH_ASYNC_MODE);
         if (sinkWithAsyncMode) {
             return new KuduAsyncSinkFunction(
-                    flinkSchema,
-                    masters,
-                    tableName,
-                    flushMode,
-                    keyFieldNames,
+                    kuduTableInfo,
                     configuration,
                     inlongMetric,
                     auditHostAndPorts);
         } else {
             return new KuduSinkFunction(
-                    flinkSchema,
-                    masters,
-                    tableName,
-                    flushMode,
+                    kuduTableInfo,
                     configuration,
                     inlongMetric,
                     auditHostAndPorts);
@@ -185,22 +131,19 @@ public class KuduDynamicTableSink implements DynamicTableSink {
             return false;
         }
         KuduDynamicTableSink that = (KuduDynamicTableSink) o;
-        return flinkSchema.equals(that.flinkSchema) &&
-                masters.equals(that.masters) &&
-                flushMode == that.flushMode &&
-                tableName.equals(that.tableName);
+        return Objects.equals(kuduTableInfo, that.kuduTableInfo);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(flinkSchema, masters, flushMode, tableName);
+        return Objects.hash(kuduTableInfo);
     }
 
     /**
      * Compare key fields given by flink planner and key fields specified by user.
      *
      * @param plannerKeyFields Key fields given by flink planner.
-     * @param userKeyFields    Key fields specified by user via {@link KuduOptions#SINK_KEY_FIELD_NAMES}.
+     * @param userKeyFields Key fields specified by user via {@link KuduOptions#SINK_KEY_FIELD_NAMES}.
      */
     private void compareKeyFields(String[] plannerKeyFields, String[] userKeyFields) {
         if (plannerKeyFields == null || plannerKeyFields.length == 0) {
@@ -225,8 +168,7 @@ public class KuduDynamicTableSink implements DynamicTableSink {
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-        if (org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions())
-                .get(KUDU_IGNORE_ALL_CHANGELOG)) {
+        if (ignoreAllChangeLog) {
             LOG.warn("Kudu sink receive all changelog record. "
                     + "Regard any other record as insert-only record.");
             return ChangelogMode.all();
@@ -248,7 +190,11 @@ public class KuduDynamicTableSink implements DynamicTableSink {
 
     @Override
     public DynamicTableSink copy() {
-        return null;
+        return new KuduDynamicTableSink(
+                kuduTableInfo,
+                configuration,
+                inlongMetric,
+                auditHostAndPorts);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.utils.TableConnectorUtils;
+import org.apache.inlong.sort.kudu.common.KuduOptions;
+import org.apache.inlong.sort.kudu.sink.KuduAsyncSinkFunction;
+import org.apache.inlong.sort.kudu.sink.KuduSinkFunction;
+import org.apache.kudu.client.SessionConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.FLUSH_MODE;
+import static org.apache.inlong.sort.kudu.common.KuduOptions.KUDU_IGNORE_ALL_CHANGELOG;
+
+/**
+ * The KuduLookupFunction is a standard user-defined table function, it can be
+ * used in tableAPI and also useful for temporal table join plan in SQL.
+ */
+public class KuduDynamicTableSink implements DynamicTableSink {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KuduDynamicTableSink.class);
+
+    /**
+     * The schema of the table.
+     */
+    private final TableSchema flinkSchema;
+
+    /**
+     * The masters of kudu server.
+     */
+    private final String masters;
+
+    /**
+     * The flush mode of kudu client. <br/>
+     * AUTO_FLUSH_BACKGROUND： calls will return immediately, but the writes will be sent in the background,
+     * potentially batched together with other writes from the same session. <br/>
+     * AUTO_FLUSH_SYNC: call will return only after being flushed to the server automatically. <br/>
+     * MANUAL_FLUSH: calls will return immediately, but the writes will not be sent
+     * until the user calls <code>KuduSession.flush()</code>.
+     */
+    private final SessionConfiguration.FlushMode flushMode;
+
+    /**
+     * The name of kudu table.
+     */
+    private final String tableName;
+
+    /**
+     * The configuration for the kudu sink.
+     */
+    private final Configuration configuration;
+    private final String inlongMetric;
+    private final String auditHostAndPorts;
+
+    /**
+     * True if the data stream consumed by this sink is append-only.
+     */
+    private boolean isAppendOnly;
+
+    /**
+     * The names of the key fields of the upsert stream consumed by this sink.
+     */
+    @Nullable
+    private String[] keyFieldNames;
+    private ResolvedCatalogTable catalogTable;
+
+    public KuduDynamicTableSink(
+            ResolvedCatalogTable catalogTable,
+            TableSchema flinkSchema,
+            String masters,
+            String tableName,
+            Configuration configuration,
+            String inlongMetric,
+            String auditHostAndPorts) {
+        this.catalogTable = catalogTable;
+        this.flinkSchema = checkNotNull(flinkSchema,
+                "The schema must not be null.");
+        DataType dataType = flinkSchema.toRowDataType();
+        LogicalType logicalType = dataType.getLogicalType();
+
+        SessionConfiguration.FlushMode flushMode = SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND;
+        if (configuration.containsKey(FLUSH_MODE.key())) {
+            String flushModeConfig = configuration.getString(FLUSH_MODE);
+            flushMode = SessionConfiguration.FlushMode.valueOf(flushModeConfig);
+            checkNotNull(flushMode, "The flush mode must be one of " +
+                    "AUTO_FLUSH_SYNC AUTO_FLUSH_BACKGROUND or MANUAL_FLUSH.");
+        }
+
+        this.masters = masters;
+        this.flushMode = flushMode;
+        this.tableName = checkNotNull(tableName);
+        this.configuration = configuration;
+        this.inlongMetric = inlongMetric;
+        this.auditHostAndPorts = auditHostAndPorts;
+
+        String userKeyFieldsConfig = configuration.getString(KuduOptions.SINK_KEY_FIELD_NAMES);
+        if (userKeyFieldsConfig != null) {
+            userKeyFieldsConfig = userKeyFieldsConfig.trim();
+            if (!userKeyFieldsConfig.isEmpty()) {
+                this.keyFieldNames = userKeyFieldsConfig.split("\\s*,\\s*");
+            }
+        }
+    }
+
+    public DataStreamSink<?> consumeStream(DataStream<RowData> dataStream) {
+
+        SinkFunction<RowData> kuduSinkFunction = createSinkFunction();
+        if (configuration.getBoolean(KuduOptions.SINK_START_NEW_CHAIN)) {
+            dataStream = ((SingleOutputStreamOperator) dataStream).startNewChain();
+        }
+
+        return dataStream
+                .addSink(kuduSinkFunction)
+                .setParallelism(dataStream.getParallelism())
+                .name(TableConnectorUtils.generateRuntimeName(this.getClass(), flinkSchema.getFieldNames()));
+    }
+
+    private SinkFunction<RowData> createSinkFunction() {
+        boolean sinkWithAsyncMode = configuration.getBoolean(KuduOptions.SINK_WRITE_WITH_ASYNC_MODE);
+        if (sinkWithAsyncMode) {
+            return new KuduAsyncSinkFunction(
+                    flinkSchema,
+                    masters,
+                    tableName,
+                    flushMode,
+                    keyFieldNames,
+                    configuration,
+                    inlongMetric,
+                    auditHostAndPorts);
+        } else {
+            return new KuduSinkFunction(
+                    flinkSchema,
+                    masters,
+                    tableName,
+                    flushMode,
+                    configuration,
+                    inlongMetric,
+                    auditHostAndPorts);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KuduDynamicTableSink that = (KuduDynamicTableSink) o;
+        return flinkSchema.equals(that.flinkSchema) &&
+                masters.equals(that.masters) &&
+                flushMode == that.flushMode &&
+                tableName.equals(that.tableName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(flinkSchema, masters, flushMode, tableName);
+    }
+
+    /**
+     * Compare key fields given by flink planner and key fields specified by user.
+     *
+     * @param plannerKeyFields Key fields given by flink planner.
+     * @param userKeyFields    Key fields specified by user via {@link KuduOptions#SINK_KEY_FIELD_NAMES}.
+     */
+    private void compareKeyFields(String[] plannerKeyFields, String[] userKeyFields) {
+        if (plannerKeyFields == null || plannerKeyFields.length == 0) {
+            return;
+        }
+        if (userKeyFields == null || userKeyFields.length == 0) {
+            return;
+        }
+
+        Set<String> assumedSet = new HashSet<>(Arrays.asList(plannerKeyFields));
+        Set<String> userSet = new HashSet<>(Arrays.asList(userKeyFields));
+
+        if (!assumedSet.equals(userSet)) {
+            String errorMsg = String.format(
+                    "Key fields provided by flink [%s] are not the same as key fields " +
+                            "provided by user [%s]. Please adjust your key fields settings, or " +
+                            "set %s to false.",
+                    assumedSet, userSet, KuduOptions.ENABLE_KEY_FIELD_CHECK.key());
+            throw new ValidationException(errorMsg);
+        }
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        if (org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions())
+                .get(KUDU_IGNORE_ALL_CHANGELOG)) {
+            LOG.warn("Kudu sink receive all changelog record. "
+                    + "Regard any other record as insert-only record.");
+            return ChangelogMode.all();
+        }
+        return ChangelogMode.all();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        return new DataStreamSinkProvider() {
+
+            @Override
+            public DataStreamSink<?> consumeDataStream(DataStream<RowData> dataStream) {
+                int parallelism = dataStream.getParallelism();
+                return consumeStream(dataStream);
+            }
+        };
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return null;
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "KuduSink";
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSink.java
@@ -20,7 +20,6 @@ package org.apache.inlong.sort.kudu.table;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -95,9 +94,6 @@ public class KuduDynamicTableSink implements DynamicTableSink {
     public DataStreamSink<?> consumeStream(DataStream<RowData> dataStream) {
 
         SinkFunction<RowData> kuduSinkFunction = createSinkFunction();
-        if (configuration.getBoolean(KuduOptions.SINK_START_NEW_CHAIN)) {
-            dataStream = ((SingleOutputStreamOperator) dataStream).startNewChain();
-        }
 
         return dataStream
                 .addSink(kuduSinkFunction)

--- a/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSource.java
+++ b/inlong-sort/sort-connectors/kudu/src/main/java/org/apache/inlong/sort/kudu/table/KuduDynamicTableSource.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kudu.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.TableFunctionProvider;
+import org.apache.inlong.sort.kudu.source.KuduLookupFunction;
+
+import java.util.Objects;
+
+/**
+ * Creates a TableSource to scan a kudu table.
+ */
+public class KuduDynamicTableSource implements LookupTableSource {
+
+    /**
+     * The schema of the table.
+     */
+    private final TableSchema schema;
+
+    /**
+     * The master addresses of kudu server.
+     */
+    private final String masters;
+
+    /**
+     * The name of kudu table.
+     */
+    private final String tableName;
+
+    /**
+     * The parameter collection for tde scanner.
+     */
+    private final Configuration configuration;
+    private final String inlongMetric;
+    private final String auditHostAndPorts;
+
+    public KuduDynamicTableSource(
+            TableSchema schema,
+            String masters,
+            String tableName,
+            Configuration configuration,
+            String inlongMetric,
+            String auditHostAndPorts) {
+        this.schema = schema;
+        this.masters = masters;
+        this.tableName = tableName;
+        this.configuration = configuration;
+        this.inlongMetric = inlongMetric;
+        this.auditHostAndPorts = auditHostAndPorts;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KuduDynamicTableSource that = (KuduDynamicTableSource) o;
+        return schema.equals(that.schema) &&
+                masters.equals(that.masters) &&
+                tableName.equals(that.tableName) &&
+                configuration.equals(that.configuration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(schema, masters, tableName, configuration);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new KuduDynamicTableSource(schema, masters, tableName, configuration, inlongMetric, auditHostAndPorts);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "KuduSource";
+    }
+
+    @Override
+    public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext lookupContext) {
+        return TableFunctionProvider.of(new KuduLookupFunction(
+                masters,
+                tableName,
+                null,
+                configuration));
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/inlong-sort/sort-connectors/kudu/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.inlong.sort.kudu.table.KuduDynamicTableFactory

--- a/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
+++ b/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
@@ -94,8 +94,8 @@ public class KuduTableFactoryTest extends KuduTestBase {
 
         properties.put("connector", "kudu-inlong");
         properties.put("connector.property-version", "1");
-        properties.put("connector.masters", masters);
-        properties.put("connector.table", tableName);
+        properties.put("masters", masters);
+        properties.put("table", tableName);
 
         properties.put("schema.0.name", "key");
         properties.put("schema.0.type", "STRING");
@@ -112,4 +112,5 @@ public class KuduTableFactoryTest extends KuduTestBase {
 
         return properties;
     }
+
 }

--- a/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
+++ b/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
@@ -95,7 +95,7 @@ public class KuduTableFactoryTest extends KuduTestBase {
         properties.put("connector", "kudu-inlong");
         properties.put("connector.property-version", "1");
         properties.put("masters", masters);
-        properties.put("table", tableName);
+        properties.put("table-name", tableName);
 
         properties.put("schema.0.name", "key");
         properties.put("schema.0.type", "STRING");

--- a/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
+++ b/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTableFactoryTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.connector.kudu;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.types.DataType;
+import org.apache.inlong.sort.kudu.common.KuduTableInfo;
+import org.apache.inlong.sort.kudu.table.KuduDynamicTableFactory;
+import org.apache.inlong.sort.kudu.table.KuduDynamicTableSink;
+import org.apache.inlong.sort.kudu.table.KuduDynamicTableSource;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.SessionConfiguration.FlushMode;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The unit tests for {@link KuduDynamicTableFactory}.
+ */
+public class KuduTableFactoryTest extends KuduTestBase {
+
+    public KuduTableFactoryTest() throws KuduException {
+    }
+
+    @Test
+    public void testCreateSink() {
+
+        Map<String, String> properties = getProperties();
+        DynamicTableSink actualSink = createTableSink(testSchema, properties);
+
+        KuduTableInfo kuduTableInfo = KuduTableInfo.builder()
+                .masters(masters)
+                .tableName(tableName)
+                .fieldNames(testSchema.getColumnNames().toArray(new String[0]))
+                .dataTypes(testSchema.getColumnDataTypes().toArray(new DataType[0]))
+                .flushMode(FlushMode.AUTO_FLUSH_BACKGROUND)
+                .build();
+        DynamicTableSink expectedSink =
+                new KuduDynamicTableSink(
+                        kuduTableInfo,
+                        new Configuration(),
+                        null,
+                        null);
+
+        assertEquals(expectedSink, actualSink);
+    }
+
+    @Test
+    public void testCreateLookup() {
+        Map<String, String> properties = getProperties();
+
+        DynamicTableSource actualSource = createTableSource(testSchema, properties);
+
+        KuduTableInfo kuduTableInfo = KuduTableInfo.builder()
+                .masters(masters)
+                .tableName(tableName)
+                .fieldNames(testSchema.getColumnNames().toArray(new String[0]))
+                .dataTypes(testSchema.getColumnDataTypes().toArray(new DataType[0]))
+                .flushMode(FlushMode.AUTO_FLUSH_BACKGROUND)
+                .build();
+
+        DynamicTableSource expectedSource =
+                new KuduDynamicTableSource(
+                        kuduTableInfo,
+                        new Configuration(),
+                        null,
+                        null);
+
+        assertEquals(expectedSource, actualSource);
+    }
+
+    private Map<String, String> getProperties() {
+        Map<String, String> properties = new HashMap<>();
+
+        properties.put("connector", "kudu-inlong");
+        properties.put("connector.property-version", "1");
+        properties.put("connector.masters", masters);
+        properties.put("connector.table", tableName);
+
+        properties.put("schema.0.name", "key");
+        properties.put("schema.0.type", "STRING");
+        properties.put("schema.1.name", "aaa");
+        properties.put("schema.1.type", "STRING");
+        properties.put("schema.2.name", "bbb");
+        properties.put("schema.2.type", "DOUBLE");
+        properties.put("schema.3.name", "ccc");
+        properties.put("schema.3.type", "INT");
+
+        properties.put("format.type", "csv");
+        properties.put("format.property-version", "1");
+        properties.put("format.derive-schema", "true");
+
+        return properties;
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTestBase.java
+++ b/inlong-sort/sort-connectors/kudu/src/test/java/org/apache/inlong/sort/connector/kudu/KuduTestBase.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.connector.kudu;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.types.DataType;
+import org.apache.inlong.sort.formats.common.DoubleFormatInfo;
+import org.apache.inlong.sort.formats.common.FormatInfo;
+import org.apache.inlong.sort.formats.common.IntFormatInfo;
+import org.apache.inlong.sort.formats.common.RowFormatInfo;
+import org.apache.inlong.sort.formats.common.StringFormatInfo;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.junit.BeforeClass;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.table.api.config.ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM;
+
+/**
+ * The test base for kudu.
+ */
+public class KuduTestBase {
+
+    protected static String masters = "localhost:8080,localhost:8081";
+    protected static String tableName = "demo_table";
+
+    protected static ResolvedSchema testSchema =
+            ResolvedSchema.of(
+                    Column.physical("key", DataTypes.STRING()),
+                    Column.physical("aaa", DataTypes.STRING()),
+                    Column.physical("bbb", DataTypes.DOUBLE()),
+                    Column.physical("ccc", DataTypes.INT()));
+
+    protected static RowFormatInfo rowFormatInfo = new RowFormatInfo(
+            new String[]{"key", "aaa", "bbb", "ccc"},
+            new FormatInfo[]{
+                    StringFormatInfo.INSTANCE,
+                    StringFormatInfo.INSTANCE,
+                    DoubleFormatInfo.INSTANCE,
+                    IntFormatInfo.INSTANCE
+            });
+
+    protected static StreamTableEnvironment tableEnv;
+    protected static StreamExecutionEnvironment env;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        env = StreamExecutionEnvironment.getExecutionEnvironment().setParallelism(1);
+        EnvironmentSettings settings = EnvironmentSettings.newInstance().inStreamingMode().build();
+        tableEnv = StreamTableEnvironment.create(env, settings);
+        tableEnv.getConfig().getConfiguration()
+                .setInteger(TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM.key(), 1);
+    }
+
+    private static Schema toKuduSchema(TableSchema testSchema) {
+        final List<ColumnSchema> cols = new ArrayList<>(testSchema.getFieldCount());
+        for (int i = 0; i < testSchema.getFieldCount(); i++) {
+            final Optional<String> fieldName = testSchema.getFieldName(i);
+            final Optional<DataType> fieldDataType = testSchema.getFieldDataType(i);
+            final DataType dataType = fieldDataType.get();
+            Type columnType;
+            if (DataTypes.STRING().equals(dataType)) {
+                columnType = Type.STRING;
+            } else if (DataTypes.DOUBLE().equals(dataType)) {
+                columnType = Type.DOUBLE;
+            } else if (DataTypes.INT().equals(dataType)) {
+                columnType = Type.INT32;
+            } else {
+                throw new UnsupportedOperationException("unsupport dataType: " + dataType + ".");
+            }
+            final ColumnSchema columnSchema = new ColumnSchema.ColumnSchemaBuilder(fieldName.get(), columnType).build();
+            cols.add(columnSchema);
+        }
+        return new Schema(cols);
+    }
+
+    private final ObjectIdentifier IDENTIFIER =
+            ObjectIdentifier.of("default", "default", "t1");
+
+    public DynamicTableSource createTableSource(
+            ResolvedSchema schema, Map<String, String> options) {
+        return FactoryUtil.createTableSource(
+                null,
+                IDENTIFIER,
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                org.apache.flink.table.api.Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock source",
+                                Collections.emptyList(),
+                                options),
+                        schema),
+                new Configuration(),
+                KuduTestBase.class.getClassLoader(),
+                false);
+    }
+
+    public DynamicTableSink createTableSink(
+            ResolvedSchema schema, Map<String, String> options) {
+        return createTableSink(schema, Collections.emptyList(), options);
+    }
+
+    public DynamicTableSink createTableSink(
+            ResolvedSchema schema, List<String> partitionKeys, Map<String, String> options) {
+        return FactoryUtil.createTableSink(
+                null,
+                IDENTIFIER,
+                new ResolvedCatalogTable(
+                        CatalogTable.of(
+                                org.apache.flink.table.api.Schema.newBuilder().fromResolvedSchema(schema).build(),
+                                "mock sink",
+                                partitionKeys,
+                                options),
+                        schema),
+                new Configuration(),
+                KuduTestBase.class.getClassLoader(),
+                false);
+    }
+}

--- a/inlong-sort/sort-connectors/kudu/src/test/resources/log4j-test.properties
+++ b/inlong-sort/sort-connectors/kudu/src/test/resources/log4j-test.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=[%d] %p %m (%c)%n

--- a/inlong-sort/sort-connectors/pom.xml
+++ b/inlong-sort/sort-connectors/pom.xml
@@ -56,6 +56,7 @@
         <module>doris</module>
         <module>starrocks</module>
         <module>hudi</module>
+        <module>kudu</module>
     </modules>
 
     <dependencies>

--- a/licenses/inlong-sort-connectors/licenses/LICENSE-kudu-client-1.16.0.txt
+++ b/licenses/inlong-sort-connectors/licenses/LICENSE-kudu-client-1.16.0.txt
@@ -1,0 +1,662 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+--------------------------------------------------------------------------------
+
+src/kudu/gutil (some portions): Apache 2.0, and 3-clause BSD
+
+Some portions of this module are derived from code in the Chromium project,
+copyright (c) Google inc and (c) The Chromium Authors and licensed under the
+Apache 2.0 License or the under the 3-clause BSD license:
+
+  Copyright (c) 2013 The Chromium Authors. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of Google Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+src/kudu/gutil/utf: licensed under the following terms:
+
+  UTF-8 Library
+
+  The authors of this software are Rob Pike and Ken Thompson.
+               Copyright (c) 1998-2002 by Lucent Technologies.
+  Permission to use, copy, modify, and distribute this software for any
+  purpose without fee is hereby granted, provided that this entire notice
+  is included in all copies of any software which is or includes a copy
+  or modification of this software and in all copies of the supporting
+  documentation for such software.
+  THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+  WARRANTY.  IN PARTICULAR, NEITHER THE AUTHORS NOR LUCENT TECHNOLOGIES MAKE ANY
+  REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
+  OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+
+--------------------------------------------------------------------------------
+
+src/kudu/util (some portions): 3-clause BSD license
+
+Some portions of this module are derived from code from LevelDB
+( https://github.com/google/leveldb ):
+
+  Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+     * Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following disclaimer
+  in the documentation and/or other materials provided with the
+  distribution.
+     * Neither the name of Google Inc. nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+src/kudu/util/array_view.h: 3-clause BSD license with patent grant
+
+  Copyright (c) 2015, The WebRTC project authors. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are
+  met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+
+    * Neither the name of Google nor the names of its contributors may
+      be used to endorse or promote products derived from this software
+      without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+  Additional IP Rights Grant (Patents)
+  ------------------------------------
+
+  "This implementation" means the copyrightable works distributed by
+  Google as part of the WebRTC code package.
+
+  Google hereby grants to you a perpetual, worldwide, non-exclusive,
+  no-charge, irrevocable (except as stated in this section) patent
+  license to make, have made, use, offer to sell, sell, import,
+  transfer, and otherwise run, modify and propagate the contents of this
+  implementation of the WebRTC code package, where such license applies
+  only to those patent claims, both currently owned by Google and
+  acquired in the future, licensable by Google that are necessarily
+  infringed by this implementation of the WebRTC code package. This
+  grant does not include claims that would be infringed only as a
+  consequence of further modification of this implementation. If you or
+  your agent or exclusive licensee institute or order or agree to the
+  institution of patent litigation against any entity (including a
+  cross-claim or counterclaim in a lawsuit) alleging that this
+  implementation of the WebRTC code package or any code incorporated
+  within this implementation of the WebRTC code package constitutes
+  direct or contributory patent infringement, or inducement of patent
+  infringement, then any patent rights granted to you under this License
+  for this implementation of the WebRTC code package shall terminate as
+  of the date such litigation is filed.
+
+--------------------------------------------------------------------------------
+
+src/kudu/common/zp7.cc: MIT license
+
+  ZP7 (Zach's Peppy Parallel-Prefix-Popcountin' PEXT/PDEP Polyfill)
+
+  Copyright (c) 2020 Zach Wegner
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+www/d3.v2.js: BSD 3-clause license
+
+   Copyright (c) 2012, Michael Bostock
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+   * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   * The name Michael Bostock may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+   DISCLAIMED. IN NO EVENT SHALL MICHAEL BOSTOCK BE LIABLE FOR ANY DIRECT,
+   INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+   BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+   OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+   EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+www/epoch.*: MIT license
+
+  Copyright (c) 2014 Fastly, Inc.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+www/jquery*.js: MIT license
+
+  Copyright 2005, 2014 jQuery Foundation and other contributors,
+  https://jquery.org/
+
+  This software consists of voluntary contributions made by many
+  individuals. For exact contribution history, see the revision history
+  available at https://github.com/jquery/jquery
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+java/kudu-client/: Some classes are derived from the AsyncHBase project
+under the following 3-clause BSD license:
+
+  Copyright (C) 2010-2012  The Async HBase Authors.  All rights reserved.
+  This file is part of Async HBase.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+    - Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    - Neither the name of the StumbleUpon nor the names of its contributors
+      may be used to endorse or promote products derived from this software
+      without specific prior written permission.
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+src/kudu/util/x509_check_host.*: OpenSSL software license:
+
+  LICENSE ISSUES
+  ==============
+
+  The OpenSSL toolkit stays under a dual license, i.e. both the conditions of
+  the OpenSSL License and the original SSLeay license apply to the toolkit.
+  See below for the actual license texts.
+
+  OpenSSL License
+  ---------------
+
+  ====================================================================
+  Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1. Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the
+     distribution.
+
+  3. All advertising materials mentioning features or use of this
+     software must display the following acknowledgment:
+     "This product includes software developed by the OpenSSL Project
+     for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+  4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+     endorse or promote products derived from this software without
+     prior written permission. For written permission, please contact
+     openssl-core@openssl.org.
+
+  5. Products derived from this software may not be called "OpenSSL"
+     nor may "OpenSSL" appear in their names without prior written
+     permission of the OpenSSL Project.
+
+  6. Redistributions of any form whatsoever must retain the following
+     acknowledgment:
+     "This product includes software developed by the OpenSSL Project
+     for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+  THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+  EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+  ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+  STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+  OF THE POSSIBILITY OF SUCH DAMAGE.
+  ====================================================================
+
+  This product includes cryptographic software written by Eric Young
+  (eay@cryptsoft.com).  This product includes software written by Tim
+  Hudson (tjh@cryptsoft.com).
+
+
+  Original SSLeay License
+  -----------------------
+
+  Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+  All rights reserved.
+
+  This package is an SSL implementation written
+  by Eric Young (eay@cryptsoft.com).
+  The implementation was written so as to conform with Netscapes SSL.
+
+  This library is free for commercial and non-commercial use as long as
+  the following conditions are aheared to.  The following conditions
+  apply to all code found in this distribution, be it the RC4, RSA,
+  lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+  included with this distribution is covered by the same copyright terms
+  except that the holder is Tim Hudson (tjh@cryptsoft.com).
+
+  Copyright remains Eric Young's, and as such any Copyright notices in
+  the code are not to be removed.
+  If this package is used in a product, Eric Young should be given attribution
+  as the author of the parts of the library used.
+  This can be in the form of a textual message at program startup or
+  in documentation (online or textual) provided with the package.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the copyright
+     notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. All advertising materials mentioning features or use of this software
+     must display the following acknowledgement:
+     "This product includes cryptographic software written by
+      Eric Young (eay@cryptsoft.com)"
+     The word 'cryptographic' can be left out if the rouines from the library
+     being used are not cryptographic related :-).
+  4. If you include any Windows specific code (or a derivative thereof) from
+     the apps directory (application code) you must include an acknowledgement:
+     "This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+
+  THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.
+
+  The licence and distribution terms for any publically available version or
+  derivative of this code cannot be changed.  i.e. this code cannot simply be
+  copied and put under another distribution licence
+  [including the GNU Public Licence.]
+
+================================================================================
+
+The following dependencies or pieces of incorporated source code have licenses
+under one of the following categories:
+
+  (a) do not require their license text to be re-distributed with binary
+      distributions (e.g. Boost license)
+
+  (b) have no requirements about re-distributing their license text in either
+      source or binary distributions (e.g. public domain)
+
+  (c) require inclusion of the license text in both source and binary distributions,
+      but are used only at build-time and thus not incorporated in binary artifacts
+      (e.g. BSD- or MIT-licensed build tooling)
+
+  (d) are the same Apache 2.0 license reproduced in its entirety above.
+
+Therefore, we do not reproduce their licenses in their entirety in this file.
+--------------------------------------------------------------------------------
+
+.ycm_extra_conf.py: public domain
+cmake_modules/FindGMock.cmake: MIT license, build-only
+cmake_modules/FindProtobuf.cmake: BSD 3-clause license, build-only
+src/kudu/util (HdrHistogram-related classes): public domain
+src/kudu/gutil/valgrind.h: Hybrid BSD (half BSD, half zlib)
+  - See the file headers for full license text.
+build-support/iwyu (some portions): LLVM Release License.
+  - See thirdparty/LICENSE.txt for full license text.
+
+src/kudu/server/url-coding.cc (some portions): Boost software license
+
+www/bootstrap: Apache 2.0 license
+java/kudu-client/src/main/java/org/apache/kudu/util/{Slice,Slices}.java: Apache 2.0 license
+java/gradlew: Apache 2.0 license
+  - See above for full text.
+
+================================================================================
+
+Note on thirdparty dependencies downloaded during the build process
+-------------------------------------------------------------------
+The Kudu build process downloads many thirdparty dependencies automatically.
+Many of these dependencies are statically linked into the resulting Kudu
+binaries. Please refer to thirdparty/LICENSE.txt for relevant information.

--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,7 @@
         <kubernetes.client.version>6.0.0</kubernetes.client.version>
         <protobuf.maven.plugin.version>0.6.1</protobuf.maven.plugin.version>
         <os.maven.plugin.version>1.6.0</os.maven.plugin.version>
+        <kudu.version>1.16.0</kudu.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Prepare a Pull Request
*[INLONG-7058][Sort] Support Apache kudu connector*

- Fixes #7058 

### Motivation


```sql
CREATE TABLE kudu_tbl(
uid int,
fee double,
event_id bigint,
remark varchar
)
WITH(
 'connector'='kudu-inlong',
 'masters'='localhost:8081;localhost:8080',
 'table'='actual_tbl',
 'flush-mode'='AUTO_FLUSH_SYNC',
 'lookup.max-cache-size' = '-1',
 'lookup.max-cache-time' = '60s',
 'sink.start-new-chain' = 'true',
 'max-retries' = '3',
 'sink.max-buffer-size' = '100',
 'sink.write-thread-count' = '5', 
 'sink.max-buffer-time' = '30s',
 'sink.write-with-async-mode' = 'false',
 'sink.write-with-upsert-mode' = 'true',
 'sink.cache-queue-max-length' = '-1',
 'sink.ignore-all-changelog' = 'false'
);
```

The `Apache Kudu` `sort-connector` is fully integrated with Flink 1.13.x's Table and SQL API. By configuring `KuduTableInfo` (`connector.masters`, `connector.table` and other attributes), the kudu table can be queried and inserted by Flink SQL.


### Modifications


#### DDL options

| Option | Default value| Required | Remarks |
| ---- | ---- | ---- | ---- |
| `connector.masters` | null  |   true | The master addresses of kudu server, like 'localhost:8080,localhost:8081' |
| `connector.table` | null  |   true | The table name of kudu |
| `flush-mode` | AUTO_FLUSH_SYNC  |   true | The flush mode of Kudu client session, AUTO_FLUSH_SYNC/AUTO_FLUSH_BACKGROUND/MANUAL_FLUSH. |
| `lookup.max-cache-size` | -1  |   true | The maximum number of results cached in the lookup source. |
| `lookup.max-cache-time` | 60s  |   true | The maximum live time for cached results in the lookup source. |
| `sink.start-new-chain` | true  |   true | The sink operator will start a new chain if true. |
| `max-retries` | 3  |   true | The maximum number of retries when an exception is caught. |
| `sink.max-buffer-size` | 100  |   true | The maximum number of records buffered in the sink. |
| `sink.write-thread-count` | 5  |   true | The maximum number of thread in the sink. |
| `sink.max-buffer-time` | 30s  |   true | The maximum wait time for buffered records in the sink. |
| `sink.write-with-async-mode` | false  |   true | Use async write mode for kudu producer if true. |
| `sink.write-with-upsert-mode` | true  |   true | Force write kudu with upsert mode if true.  This option is used for upsert using the primary key of the kudu table |
| `sink.cache-queue-max-length` | -1  |   true | The maximum queue lengths. |
| `sink.ignore-all-changelog` | false   |  true | Whether ignore delete/update_before/update_after message. If true, all message will insert|

#### Data type

| Flink/SQL | Kudu data type |
| --- | --- |
| STRING | STRING |
| BOOLEAN | BOOL |
| TINYINT | INT8 |
| SMALLINT | INT16 |
| INT | INT32 |
| BIGINT | INT64 |
| FLOAT | FLOAT |
| DOUBLE | DOUBLE |
| BYTES | BINARY |
| TIMESTAMP(3) | UNIXTIME_MICROS |

<img width="559" alt="image" src="https://user-images.githubusercontent.com/5709212/209534355-f904afe9-ffc2-4458-b921-270e49ac1c08.png">


<br class="Apple-interchange-newline">



### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
