### PR TITLE
[INLONG-7061][Sort] Support table level metrics for Apache Doris connector and add dirty metrics

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.formats.json.RowDataToJsonConverters.RowDataToJsonConverter;
@@ -244,7 +245,7 @@ public class S3DirtySink<T> implements DirtySink<T> {
         }
         String content = null;
         try {
-            content = StringUtils.join(values, s3Options.getLineDelimiter());
+            content = StringUtils.join(values, StringEscapeUtils.unescapeJava(s3Options.getLineDelimiter()));
             s3Helper.upload(identifier, content);
             LOGGER.info("Write {} records to s3 of identifier: {}", values.size(), identifier);
             writeOutNum.addAndGet(values.size());

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3Helper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3Helper.java
@@ -39,7 +39,7 @@ public class S3Helper implements Serializable {
     private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
     private static final int SEQUENCE_LENGTH = 4;
-    private static final String ESCAPE_PATTERN = "[\\pP\\p{Punct}\\s]";
+    private static final String ESCAPE_PATTERN = "[，,+=: ;()（）。/.；]";
     private static final String FILE_NAME_SUFFIX = ".txt";
     private final Random r = new Random();
     private final AmazonS3 s3Client;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -50,6 +50,11 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      */
     private final Map<String, SinkMetricData> subSinkMetricMap = Maps.newHashMap();
 
+    /**
+     * The sub sink metric data container of sink metric data
+     */
+    private final Map<String, SinkMetricData> dirtySinkMetricMap = Maps.newHashMap();
+
     public SinkTableMetricData(MetricOption option, MetricGroup metricGroup) {
         super(option, metricGroup);
     }
@@ -210,17 +215,17 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      */
     public void outputDirtyMetricsWithEstimate(String database, String schema, String table, long rowCount,
             long rowSize) {
-        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table) || StringUtils.isBlank(schema)) {
             invokeDirty(rowCount, rowSize);
             return;
         }
         String identify = buildSchemaIdentify(database, schema, table);
         SinkMetricData subSinkMetricData;
-        if (subSinkMetricMap.containsKey(identify)) {
-            subSinkMetricData = subSinkMetricMap.get(identify);
+        if (dirtySinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = dirtySinkMetricMap.get(identify);
         } else {
             subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
-            subSinkMetricMap.put(identify, subSinkMetricData);
+            dirtySinkMetricMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
         this.invokeDirty(rowCount, rowSize);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -216,7 +216,7 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     public void outputDirtyMetricsWithEstimate(String database, String schema, String table, long rowCount,
             long rowSize) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
-            invoke(rowCount, rowSize);
+            invokeDirty(rowCount, rowSize);
             return;
         }
         String identify = buildSchemaIdentify(database, schema, table);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -199,6 +199,25 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
         subSinkMetricData.invoke(rowCount, rowSize);
     }
 
+    public void outputDirtyMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
+            long rowCount, long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            invokeDirty(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, schema, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invokeDirty(rowCount, rowSize);
+        subSinkMetricData.invokeDirty(rowCount, rowSize);
+    }
+
     public void outputMetricsWithEstimate(Object data) {
         long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
         invoke(1, size);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -208,18 +208,18 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      * @param rowCount the row count of records
      * @param rowSize the row size of records
      */
-    public void outputDirtyMetricsWithEstimate(String database, String schema, String table, long rowCount,
+    public void outputDirtyMetricsWithEstimate(String database, String table, long rowCount,
             long rowSize) {
-        if (StringUtils.isBlank(database) || StringUtils.isBlank(table) || StringUtils.isBlank(schema)) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
             invokeDirty(rowCount, rowSize);
             return;
         }
-        String identify = buildSchemaIdentify(database, schema, table);
+        String identify = buildSchemaIdentify(database, null, table);
         SinkMetricData subSinkMetricData;
         if (subSinkMetricMap.containsKey(identify)) {
             subSinkMetricData = subSinkMetricMap.get(identify);
         } else {
-            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, table}, this);
             subSinkMetricMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -50,11 +50,6 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      */
     private final Map<String, SinkMetricData> subSinkMetricMap = Maps.newHashMap();
 
-    /**
-     * The sub sink metric data container of sink metric data
-     */
-    private final Map<String, SinkMetricData> dirtySinkMetricMap = Maps.newHashMap();
-
     public SinkTableMetricData(MetricOption option, MetricGroup metricGroup) {
         super(option, metricGroup);
     }
@@ -221,11 +216,11 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
         }
         String identify = buildSchemaIdentify(database, schema, table);
         SinkMetricData subSinkMetricData;
-        if (dirtySinkMetricMap.containsKey(identify)) {
-            subSinkMetricData = dirtySinkMetricMap.get(identify);
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
         } else {
             subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
-            dirtySinkMetricMap.put(identify, subSinkMetricData);
+            subSinkMetricMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
         this.invokeDirty(rowCount, rowSize);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -50,11 +50,6 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      */
     private final Map<String, SinkMetricData> subSinkMetricMap = Maps.newHashMap();
 
-    /**
-     * The sub sink metric data container of dirty sink metric data
-     */
-    private final Map<String, SinkTableMetricData> subSinkDirtyMap = Maps.newHashMap();
-
     public SinkTableMetricData(MetricOption option, MetricGroup metricGroup) {
         super(option, metricGroup);
     }
@@ -220,13 +215,12 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
             return;
         }
         String identify = buildSchemaIdentify(database, schema, table);
-        SinkTableMetricData subSinkMetricData;
-        if (subSinkDirtyMap.containsKey(identify)) {
-            subSinkMetricData = subSinkDirtyMap.get(identify);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
         } else {
-            subSinkMetricData =
-                    (SinkTableMetricData) buildSubSinkMetricData(new String[]{database, schema, table}, this);
-            subSinkDirtyMap.put(identify, subSinkMetricData);
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
         this.invokeDirty(rowCount, rowSize);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -50,6 +50,11 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      */
     private final Map<String, SinkMetricData> subSinkMetricMap = Maps.newHashMap();
 
+    /**
+     * The sub sink metric data container of dirty sink metric data
+     */
+    private final Map<String, SinkTableMetricData> subSinkDirtyMap = Maps.newHashMap();
+
     public SinkTableMetricData(MetricOption option, MetricGroup metricGroup) {
         super(option, metricGroup);
     }
@@ -199,19 +204,29 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
         subSinkMetricData.invoke(rowCount, rowSize);
     }
 
-    public void outputDirtyMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
-            long rowCount, long rowSize) {
+    /**
+     * output dirty metrics with estimate
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputDirtyMetricsWithEstimate(String database, String schema, String table, long rowCount,
+            long rowSize) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
-            invokeDirty(rowCount, rowSize);
+            invoke(rowCount, rowSize);
             return;
         }
         String identify = buildSchemaIdentify(database, schema, table);
-        SinkMetricData subSinkMetricData;
-        if (subSinkMetricMap.containsKey(identify)) {
-            subSinkMetricData = subSinkMetricMap.get(identify);
+        SinkTableMetricData subSinkMetricData;
+        if (subSinkDirtyMap.containsKey(identify)) {
+            subSinkMetricData = subSinkDirtyMap.get(identify);
         } else {
-            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
-            subSinkMetricMap.put(identify, subSinkMetricData);
+            subSinkMetricData =
+                    (SinkTableMetricData) buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkDirtyMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
         this.invokeDirty(rowCount, rowSize);

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -498,9 +498,15 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             throw ex;
         }
 
-        metricData.invokeDirty(rowSize, dataSize);
-        rowSize = 0;
-        dataSize = 0L;
+        if (multipleSink) {
+            String[] tableWithDb = tableIdentifier.split("\\.");
+            metricData.outputDirtyMetricsWithEstimate(tableWithDb[0], null, tableWithDb[1],
+                    false,rowSize, dataSize);
+        } else {
+            metricData.invokeDirty(rowSize, dataSize);
+            rowSize = 0;
+            dataSize = 0L;
+        }
 
         if (dirtySink != null) {
             DirtyData.Builder<Object> builder = DirtyData.builder();

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -417,7 +417,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                 }
             } catch (Exception e) {
                 LOG.error(String.format("json parse error, raw data: %s", new String(rowData.getBinary(0))), e);
-                handleDirtyData(new String(rowData.getBinary(0)), DirtyType.JSON_PROCESS_ERROR, e, rootNode);
+                handleDirtyData(new String(rowData.getBinary(0)), DirtyType.JSON_PROCESS_ERROR, e);
                 return;
             }
             for (int i = 0; i < physicalDataList.size(); i++) {

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -543,7 +543,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         try {
             metricData.outputDirtyMetricsWithEstimate(
                     jsonDynamicSchemaFormat.parse(rootNode, databasePattern),
-                    null, jsonDynamicSchemaFormat.parse(rootNode, tablePattern), 1,
+                    jsonDynamicSchemaFormat.parse(rootNode, tablePattern), 1,
                     ((RowData) dirtyData).getBinary(0).length);
         } catch (Exception ex) {
             metricData.invokeDirty(1, dirtyData.toString().getBytes(StandardCharsets.UTF_8).length);

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -504,9 +504,9 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                     false, rowSize, dataSize);
         } else {
             metricData.invokeDirty(rowSize, dataSize);
-            rowSize = 0;
-            dataSize = 0L;
         }
+        rowSize = 0;
+        dataSize = 0L;
 
         if (dirtySink != null) {
             DirtyData.Builder<Object> builder = DirtyData.builder();

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -499,6 +499,8 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         }
 
         metricData.invokeDirty(rowSize, dataSize);
+        rowSize = 0;
+        dataSize = 0L;
 
         if (dirtySink != null) {
             DirtyData.Builder<Object> builder = DirtyData.builder();

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -501,7 +501,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         if (multipleSink) {
             String[] tableWithDb = tableIdentifier.split("\\.");
             metricData.outputDirtyMetricsWithEstimate(tableWithDb[0], null, tableWithDb[1],
-                    false,rowSize, dataSize);
+                    false, rowSize, dataSize);
         } else {
             metricData.invokeDirty(rowSize, dataSize);
             rowSize = 0;

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -516,7 +516,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     }
 
     private void handleMultipleDirtyData(Object dirtyData, DirtyType dirtyType, Exception e) {
-        JsonNode rootNode = null;
+        JsonNode rootNode;
         try {
             rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
         } catch (Exception ex) {

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -112,8 +112,6 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     private static final String UNIQUE_KEYS_TYPE = "UNIQUE_KEYS";
     @SuppressWarnings({"rawtypes"})
     private final Map<String, List> batchMap = new HashMap<>();
-    @SuppressWarnings({"rawtypes"})
-    private final Map<String, List> errorMap = new HashMap<>();
     private final Map<String, String> columnsMap = new HashMap<>();
     private final List<String> errorTables = new ArrayList<>();
     private final DorisOptions options;

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -313,7 +313,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     public synchronized void writeRecord(T row) {
         addBatch(row);
         rowSize++;
-        try{
+        try {
             dataSize += row.toString().getBytes(StandardCharsets.UTF_8).length;
         } catch (Exception e) {
             LOG.warn("row parse failed for writeRecord", e);

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -313,7 +313,11 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     public synchronized void writeRecord(T row) {
         addBatch(row);
         rowSize++;
-        dataSize += row.toString().getBytes(StandardCharsets.UTF_8).length;
+        try{
+            dataSize += row.toString().getBytes(StandardCharsets.UTF_8).length;
+        } catch (Exception e) {
+            LOG.warn("row parse failed for writeRecord", e);
+        }
         boolean valid = (executionOptions.getBatchSize() > 0 && size >= executionOptions.getBatchSize())
                 || batchBytes >= executionOptions.getMaxBatchBytes();
         if (valid && !flushing) {
@@ -511,7 +515,6 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                 LOG.warn("Dirty sink failed", ex);
             }
         }
-
         try {
             JsonNode rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
             metricData.outputDirtyMetricsWithEstimate(

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -512,19 +512,13 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             }
         }
 
-        if (multipleSink) {
-            if (DirtyType.DESERIALIZE_ERROR.equals(dirtyType) || !(dirtyData instanceof RowData)) {
-                metricData.outputDirtyMetricsWithEstimate(null, null, null, rowSize, dataSize);
-            }
-            multipleDirtyHandler(dirtyData, rowSize, dataSize);
+        if (multipleSink && !DirtyType.DESERIALIZE_ERROR.equals(dirtyType)) {
+            executionOptions.getStreamLoadProp().put(COLUMNS_KEY, columnsMap.get(tableIdentifier));
+            String[] tableWithDb = tableIdentifier.split("\\.");
+            metricData.outputDirtyMetricsWithEstimate(tableWithDb[0], null, tableWithDb[1], rowSize, dataSize);
         } else {
             metricData.invokeDirty(rowSize, dataSize);
         }
-    }
-
-    private void multipleDirtyHandler(Object dirtyData, long rowSize, long dataSize) {
-        String[] tableWithDb = tableIdentifier.split("\\.");
-        metricData.outputDirtyMetricsWithEstimate(tableWithDb[0], null, tableWithDb[1], rowSize, dataSize);
     }
 
     private void handleColumnsChange(String tableIdentifier, JsonNode rootNode, JsonNode physicalData) {

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -512,17 +512,12 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             }
         }
 
-        if (multipleSink && !DirtyType.DESERIALIZE_ERROR.equals(dirtyType) && dirtyData instanceof RowData) {
-            JsonNode rootNode;
-            try {
-                rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
-                metricData.outputDirtyMetricsWithEstimate(
-                        jsonDynamicSchemaFormat.parse(rootNode, databasePattern),
-                        null, jsonDynamicSchemaFormat.parse(rootNode, tablePattern), rowSize, dataSize);
-            } catch (Exception ex) {
-                metricData.invokeDirty(rowSize, dataSize);
-            }
-        } else {
+        try {
+            JsonNode rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
+            metricData.outputDirtyMetricsWithEstimate(
+                    jsonDynamicSchemaFormat.parse(rootNode, databasePattern),
+                    null, jsonDynamicSchemaFormat.parse(rootNode, tablePattern), rowSize, dataSize);
+        } catch (Exception ex) {
             metricData.invokeDirty(rowSize, dataSize);
         }
     }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -520,7 +520,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         try {
             rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
         } catch (Exception ex) {
-            LOG.warn("handle dirty data: rootnode is null", ex);
+            handleDirtyData(dirtyData, DirtyType.DESERIALIZE_ERROR, e);
         }
 
         if (dirtySink != null) {

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -521,6 +521,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
         } catch (Exception ex) {
             handleDirtyData(dirtyData, DirtyType.DESERIALIZE_ERROR, e);
+            return;
         }
 
         if (dirtySink != null) {


### PR DESCRIPTION
Fixes #7061

Design:
for all incoming dirty data, try to parse and add table level metrics, no matter what the data is. If it fails for any reason, add global metrics instead.

the try block only works if 
1) the dirty data is rowdata, if deserialization causes error/npe, then just add global metric
2) the task is multiple sink，since table level metric is meaningless for single table tasks.

for single table and unparsable dirty data, either null pointer or ioexception will be thrown. In either case, just add node level metrics instead.