### PR TITLE
[INLONG-7067][Manager] Provide MQ cluster info in consumption details

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -35,6 +35,8 @@ public class InlongConstants {
      */
     public static final String COMMA = ",";
 
+    public static final String SLASH = "/";
+
     public static final String COLON = ":";
 
     public static final String SEMICOLON = ";";

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/InlongConsumeInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/InlongConsumeInfo.java
@@ -25,8 +25,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 
 import java.util.Date;
+import java.util.List;
 
 /**
  * Base inlong consume info
@@ -86,6 +88,9 @@ public abstract class InlongConsumeInfo extends BaseInlongConsume {
 
     @ApiModelProperty(value = "Version number")
     private Integer version;
+
+    @ApiModelProperty(value = "MQ cluster info list")
+    private List<? extends ClusterInfo> clusterInfos;
 
     public abstract InlongConsumeRequest genRequest();
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/pulsar/ConsumePulsarInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/pulsar/ConsumePulsarInfo.java
@@ -37,6 +37,9 @@ import org.apache.inlong.manager.pojo.consume.InlongConsumeInfo;
 @ApiModel("Inlong consume info of Pulsar")
 public class ConsumePulsarInfo extends InlongConsumeInfo {
 
+    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'clusterUrl' field of the InlongConsumeInfo")
+    private String adminUrl;
+
     @ApiModelProperty("Whether to configure the dead letter queue, 0: not configure, 1: configure")
     private Integer isDlq;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/pulsar/ConsumePulsarInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/pulsar/ConsumePulsarInfo.java
@@ -37,9 +37,6 @@ import org.apache.inlong.manager.pojo.consume.InlongConsumeInfo;
 @ApiModel("Inlong consume info of Pulsar")
 public class ConsumePulsarInfo extends InlongConsumeInfo {
 
-    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'clusterUrl' field of the InlongConsumeInfo")
-    private String adminUrl;
-
     @ApiModelProperty("Whether to configure the dead letter queue, 0: not configure, 1: configure")
     private Integer isDlq;
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
@@ -71,7 +71,7 @@ public abstract class AbstractConsumeOperator implements InlongConsumeOperator {
     @Transactional(rollbackFor = Throwable.class, isolation = Isolation.REPEATABLE_READ)
     public void updateOpt(InlongConsumeRequest request, String operator) {
         // firstly check the topic info
-        if (StringUtils.isNotBlank(request.getTopic())){
+        if (StringUtils.isNotBlank(request.getTopic())) {
             this.checkTopicInfo(request);
         }
         // get the entity from request

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
@@ -69,6 +69,8 @@ public abstract class AbstractConsumeOperator implements InlongConsumeOperator {
     @Override
     @Transactional(rollbackFor = Throwable.class, isolation = Isolation.REPEATABLE_READ)
     public void updateOpt(InlongConsumeRequest request, String operator) {
+        // firstly check the topic info
+        this.checkTopicInfo(request);
         // get the entity from request
         InlongConsumeEntity entity = CommonBeanUtils.copyProperties(request, InlongConsumeEntity::new);
         // set the ext params

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/AbstractConsumeOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.service.consume;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ConsumeStatus;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -70,7 +71,9 @@ public abstract class AbstractConsumeOperator implements InlongConsumeOperator {
     @Transactional(rollbackFor = Throwable.class, isolation = Isolation.REPEATABLE_READ)
     public void updateOpt(InlongConsumeRequest request, String operator) {
         // firstly check the topic info
-        this.checkTopicInfo(request);
+        if (StringUtils.isNotBlank(request.getTopic())){
+            this.checkTopicInfo(request);
+        }
         // get the entity from request
         InlongConsumeEntity entity = CommonBeanUtils.copyProperties(request, InlongConsumeEntity::new);
         // set the ext params

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
@@ -93,6 +93,7 @@ public class ConsumePulsarOperator extends AbstractConsumeOperator {
         String originTopic = request.getTopic();
         if (originTopic.startsWith("persistent")) {
             originTopic = originTopic.substring(originTopic.lastIndexOf(InlongConstants.SLASH) + 1);
+            request.setTopic(originTopic);
         }
         Preconditions.checkTrue(pulsarTopic.getTopics().contains(originTopic),
                 "Pulsar topic not exist for " + originTopic);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
@@ -113,18 +113,10 @@ public class ConsumePulsarOperator extends AbstractConsumeOperator {
         InlongGroupInfo groupInfo = groupService.get(groupId);
         String clusterTag = groupInfo.getInlongClusterTag();
         List<ClusterInfo> clusterInfos = clusterService.listByTagAndType(clusterTag, ClusterType.PULSAR);
-        StringBuilder adminUrls = new StringBuilder();
-        StringBuilder serverUrls = new StringBuilder();
-        String topic = entity.getTopic();
         Preconditions.checkNotEmpty(clusterInfos, "pulsar cluster not exist for groupId=" + groupId);
-        for (ClusterInfo clusterInfo : clusterInfos) {
-            PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
-            adminUrls.append(pulsarCluster.getAdminUrl()).append(InlongConstants.SEMICOLON);
-            serverUrls.append(pulsarCluster.getUrl()).append(InlongConstants.SEMICOLON);
-            consumeInfo.setTopic(getFullPulsarTopic(groupInfo, pulsarCluster.getTenant(), topic));
-        }
-        consumeInfo.setAdminUrl(adminUrls.toString());
-        consumeInfo.setClusterUrl(serverUrls.toString());
+        consumeInfo.setClusterInfos(clusterInfos);
+        PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfos.get(0);
+        consumeInfo.setTopic(getFullPulsarTopic(groupInfo, pulsarCluster.getTenant(), entity.getTopic()));
         return consumeInfo;
     }
 


### PR DESCRIPTION
### Prepare a Pull Request

Fixes #7067 

### Motivation

Data consumption details provide serverUrl, adminUrl and topic information.

### Modifications

- Provide the complete topic name, serverUrl and adminUrl when obtaining the topic of data consumption.
- Remove the topic prefix when saving topic information.
