### PR TITLE
[INLONG-7083][Sort] StarRocks connector supports dirty data archives and metric

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -168,11 +168,11 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
         if (data != null) {
             rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
         }
-        outputMetricsWithEstimate(database, schema, table, isSnapshotRecord, rowCountSize, rowDataSize);
+        outputMetrics(database, schema, table, isSnapshotRecord, rowCountSize, rowDataSize);
     }
 
     /**
-     * output metrics with estimate
+     * output metrics
      *
      * @param database the database name of record
      * @param schema the schema name of record
@@ -181,7 +181,7 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      * @param rowCount the row count of records
      * @param rowSize the row size of records
      */
-    public void outputMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
+    public void outputMetrics(String database, String schema, String table, boolean isSnapshotRecord,
             long rowCount, long rowSize) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
             invoke(rowCount, rowSize);
@@ -203,6 +203,40 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     public void outputMetricsWithEstimate(Object data) {
         long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
         invoke(1, size);
+    }
+
+    /**
+     * output dirty metrics
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputDirtyMetrics(String database, String schema, String table, boolean isSnapshotRecord,
+            long rowCount, long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            invokeDirty(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, schema, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invokeDirty(rowCount, rowSize);
+        subSinkMetricData.invokeDirty(rowCount, rowSize);
+    }
+
+    public void outputDirtyMetricsWithEstimate(Object data) {
+        long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
+        invokeDirty(1, size);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -157,18 +157,16 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      * @param database the database name of record
      * @param schema the schema name of record
      * @param table the table name of record
-     * @param isSnapshotRecord is it snapshot record
      * @param data the data of record
      */
-    public void outputMetricsWithEstimate(String database, String schema, String table, boolean isSnapshotRecord,
-            Object data) {
+    public void outputMetricsWithEstimate(String database, String schema, String table, Object data) {
         // sink metric and sub sink metric output metrics
         long rowCountSize = 1L;
         long rowDataSize = 0L;
         if (data != null) {
             rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
         }
-        outputMetrics(database, schema, table, isSnapshotRecord, rowCountSize, rowDataSize);
+        outputMetrics(database, schema, table, rowCountSize, rowDataSize);
     }
 
     /**
@@ -177,12 +175,10 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      * @param database the database name of record
      * @param schema the schema name of record
      * @param table the table name of record
-     * @param isSnapshotRecord is it snapshot record
      * @param rowCount the row count of records
      * @param rowSize the row size of records
      */
-    public void outputMetrics(String database, String schema, String table, boolean isSnapshotRecord,
-            long rowCount, long rowSize) {
+    public void outputMetrics(String database, String schema, String table, long rowCount, long rowSize) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
             invoke(rowCount, rowSize);
             return;
@@ -211,12 +207,10 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
      * @param database the database name of record
      * @param schema the schema name of record
      * @param table the table name of record
-     * @param isSnapshotRecord is it snapshot record
      * @param rowCount the row count of records
      * @param rowSize the row size of records
      */
-    public void outputDirtyMetrics(String database, String schema, String table, boolean isSnapshotRecord,
-            long rowCount, long rowSize) {
+    public void outputDirtyMetrics(String database, String schema, String table, long rowCount, long rowSize) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
             invokeDirty(rowCount, rowSize);
             return;

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -613,7 +613,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                     if (multipleSink) {
                         String[] tableWithDb = tableIdentifier.split("\\.");
                         metricData.outputMetrics(tableWithDb[0], null, tableWithDb[1],
-                                false, respContent.getNumberLoadedRows(), respContent.getLoadBytes());
+                                respContent.getNumberLoadedRows(), respContent.getLoadBytes());
                     } else {
                         metricData.invoke(respContent.getNumberLoadedRows(), respContent.getLoadBytes());
                     }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -612,7 +612,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                 if (null != metricData && null != respContent) {
                     if (multipleSink) {
                         String[] tableWithDb = tableIdentifier.split("\\.");
-                        metricData.outputMetricsWithEstimate(tableWithDb[0], null, tableWithDb[1],
+                        metricData.outputMetrics(tableWithDb[0], null, tableWithDb[1],
                                 false, respContent.getNumberLoadedRows(), respContent.getLoadBytes());
                     } else {
                         metricData.invoke(respContent.getNumberLoadedRows(), respContent.getLoadBytes());

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -405,7 +405,7 @@ public class StarRocksSinkManager implements Serializable {
 
                     if (null != metricData) {
                         if (multipleSink) {
-                            metricData.outputMetrics(flushData.getDatabase(), null, flushData.getTable(), false,
+                            metricData.outputMetrics(flushData.getDatabase(), null, flushData.getTable(),
                                     flushData.getBatchCount(), flushData.getBatchSize());
                         } else {
                             metricData.invoke(flushData.getBatchCount(), flushData.getBatchSize());
@@ -462,7 +462,7 @@ public class StarRocksSinkManager implements Serializable {
         // upload metrics for dirty data
         if (null != metricData) {
             if (multipleSink) {
-                metricData.outputDirtyMetrics(flushData.getDatabase(), null, flushData.getTable(), false,
+                metricData.outputDirtyMetrics(flushData.getDatabase(), null, flushData.getTable(),
                         flushData.getBatchCount(), flushData.getBatchSize());
             } else {
                 metricData.invokeDirty(flushData.getBatchCount(), flushData.getBatchSize());

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -451,6 +451,15 @@ public class StarRocksSinkManager implements Serializable {
     }
 
     private void handleDirtyData(StarRocksSinkBufferEntity bufferEntity, DirtyType dirtyType, Exception e) {
+        if (!dirtyOptions.ignoreDirty()) {
+            RuntimeException ex;
+            if (e instanceof RuntimeException) {
+                ex = (RuntimeException) e;
+            } else {
+                ex = new RuntimeException(e);
+            }
+            throw ex;
+        }
         if (dirtySink != null) {
             DirtyData.Builder<Object> builder = DirtyData.builder();
             try {

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Histogram;
@@ -51,6 +52,10 @@ import org.apache.flink.table.api.TableColumn;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.constraints.UniqueConstraint;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.inlong.sort.base.dirty.DirtyData;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.DirtyType;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.slf4j.Logger;
@@ -117,6 +122,9 @@ public class StarRocksSinkManager implements Serializable {
     private final SchemaUpdateExceptionPolicy schemaUpdatePolicy;
     private transient SinkTableMetricData metricData;
 
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
+
     /**
      * If a table writing throws exception, ignore it when receiving data later again
      */
@@ -129,7 +137,9 @@ public class StarRocksSinkManager implements Serializable {
     public StarRocksSinkManager(StarRocksSinkOptions sinkOptions,
             TableSchema flinkSchema,
             boolean multipleSink,
-            SchemaUpdateExceptionPolicy schemaUpdatePolicy) {
+            SchemaUpdateExceptionPolicy schemaUpdatePolicy,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.sinkOptions = sinkOptions;
         StarRocksJdbcConnectionOptions jdbcOptions = new StarRocksJdbcConnectionOptions(sinkOptions.getJdbcUrl(),
                 sinkOptions.getUsername(), sinkOptions.getPassword());
@@ -140,6 +150,9 @@ public class StarRocksSinkManager implements Serializable {
         this.multipleSink = multipleSink;
         this.schemaUpdatePolicy = schemaUpdatePolicy;
 
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
+
         init(flinkSchema);
     }
 
@@ -148,13 +161,18 @@ public class StarRocksSinkManager implements Serializable {
             StarRocksJdbcConnectionProvider jdbcConnProvider,
             StarRocksQueryVisitor starrocksQueryVisitor,
             boolean multipleSink,
-            SchemaUpdateExceptionPolicy schemaUpdatePolicy) {
+            SchemaUpdateExceptionPolicy schemaUpdatePolicy,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.sinkOptions = sinkOptions;
         this.jdbcConnProvider = jdbcConnProvider;
         this.starrocksQueryVisitor = starrocksQueryVisitor;
 
         this.multipleSink = multipleSink;
         this.schemaUpdatePolicy = schemaUpdatePolicy;
+
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
 
         init(flinkSchema);
     }
@@ -392,8 +410,8 @@ public class StarRocksSinkManager implements Serializable {
 
                     if (null != metricData) {
                         if (multipleSink) {
-                            metricData.outputMetricsWithEstimate(flushData.getDatabase(), null, flushData.getTable(),
-                                    false, flushData.getBatchCount(), flushData.getBatchSize());
+                            metricData.outputMetrics(flushData.getDatabase(), null, flushData.getTable(), false,
+                                    flushData.getBatchCount(), flushData.getBatchSize());
                         } else {
                             metricData.invoke(flushData.getBatchCount(), flushData.getBatchSize());
                         }
@@ -407,6 +425,7 @@ public class StarRocksSinkManager implements Serializable {
                 }
                 LOGGER.warn("Failed to flush batch data to StarRocks, retry times = {}", i, e);
                 if (i >= sinkOptions.getSinkMaxRetries()) {
+                    handleDirtyData(flushData, DirtyType.BATCH_LOAD_ERROR, e);
                     if (schemaUpdatePolicy == null
                             || schemaUpdatePolicy == SchemaUpdateExceptionPolicy.THROW_WITH_STOP) {
                         throw e;
@@ -429,6 +448,37 @@ public class StarRocksSinkManager implements Serializable {
             }
         }
         return true;
+    }
+
+    private void handleDirtyData(StarRocksSinkBufferEntity bufferEntity, DirtyType dirtyType, Exception e) {
+        if (dirtySink != null) {
+            DirtyData.Builder<Object> builder = DirtyData.builder();
+            try {
+                byte[] dirtyData = starrocksStreamLoadVisitor.joinRows(bufferEntity.getBuffer(),
+                        (int) bufferEntity.getBatchSize());
+                builder.setData(new String(dirtyData, StandardCharsets.UTF_8))
+                        .setDirtyType(dirtyType)
+                        .setLabels(dirtyOptions.getLabels())
+                        .setLogTag(dirtyOptions.getLogTag())
+                        .setDirtyMessage(e.getMessage())
+                        .setIdentifier(dirtyOptions.getIdentifier());
+                dirtySink.invoke(builder.build());
+
+                if (null != metricData) {
+                    if (multipleSink) {
+                        metricData.outputDirtyMetrics(bufferEntity.getDatabase(), null, bufferEntity.getTable(), false,
+                                bufferEntity.getBatchCount(), bufferEntity.getBatchSize());
+                    } else {
+                        metricData.invokeDirty(bufferEntity.getBatchCount(), bufferEntity.getBatchSize());
+                    }
+                }
+            } catch (Exception ex) {
+                if (!dirtyOptions.ignoreSideOutputErrors()) {
+                    throw new RuntimeException(ex);
+                }
+                LOGGER.warn("Dirty sink failed", ex);
+            }
+        }
     }
 
     private void waitAsyncFlushingDone() throws InterruptedException {

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
@@ -222,7 +222,7 @@ public class StarRocksStreamLoadVisitor implements Serializable {
         }
     }
 
-    private byte[] joinRows(List<byte[]> rows, int totalBytes) throws IOException {
+    public byte[] joinRows(List<byte[]> rows, int totalBytes) throws IOException {
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             byte[] lineDelimiter = StarRocksDelimiterParser.parse(
                     sinkOptions.getSinkStreamLoadProperties().get("row_delimiter"), "\n")

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
@@ -222,7 +222,7 @@ public class StarRocksStreamLoadVisitor implements Serializable {
         }
     }
 
-    public byte[] joinRows(List<byte[]> rows, int totalBytes) throws IOException {
+    private byte[] joinRows(List<byte[]> rows, int totalBytes) throws IOException {
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             byte[] lineDelimiter = StarRocksDelimiterParser.parse(
                     sinkOptions.getSinkStreamLoadProperties().get("row_delimiter"), "\n")

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.starrocks.table.sink;
 
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
@@ -156,6 +158,8 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
                 .withInlongAudit(auditHostAndPorts)
                 .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
                 .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
+                .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
+                .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
                 .withRegisterMetric(MetricOption.RegisteredMetric.ALL).build();
         if (metricOption != null) {
             metricData = new SinkTableMetricData(metricOption, getRuntimeContext().getMetricGroup());

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
@@ -19,15 +19,13 @@ package org.apache.inlong.sort.starrocks.table.sink;
 
 import com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
-import javax.annotation.Nullable;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
-import org.apache.inlong.sort.base.dirty.DirtyOptions;
-import org.apache.inlong.sort.base.dirty.sink.DirtySink;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 
 public class StarRocksDynamicTableSink implements DynamicTableSink {
@@ -41,8 +39,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
     private final String inlongMetric;
     private final String auditHostAndPorts;
     private final SchemaUpdateExceptionPolicy schemaUpdatePolicy;
-    private final DirtyOptions dirtyOptions;
-    private @Nullable final DirtySink<Object> dirtySink;
+    private final DirtySinkHelper<Object> dirtySinkHelper;
 
     public StarRocksDynamicTableSink(StarRocksSinkOptions sinkOptions,
             TableSchema schema,
@@ -53,8 +50,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
             String inlongMetric,
             String auditHostAndPorts,
             SchemaUpdateExceptionPolicy schemaUpdatePolicy,
-            DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            DirtySinkHelper<Object> dirtySinkHelper) {
         this.flinkSchema = schema;
         this.sinkOptions = sinkOptions;
         this.multipleSink = multipleSink;
@@ -64,8 +60,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
         this.schemaUpdatePolicy = schemaUpdatePolicy;
-        this.dirtyOptions = dirtyOptions;
-        this.dirtySink = dirtySink;
+        this.dirtySinkHelper = dirtySinkHelper;
     }
 
     @Override
@@ -87,8 +82,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtyOptions,
-                dirtySink);
+                dirtySinkHelper);
         return SinkFunctionProvider.of(starrocksSinkFunction, sinkOptions.getSinkParallelism());
     }
 
@@ -103,8 +97,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtyOptions,
-                dirtySink);
+                dirtySinkHelper);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
@@ -19,12 +19,15 @@ package org.apache.inlong.sort.starrocks.table.sink;
 
 import com.starrocks.connector.flink.row.sink.StarRocksTableRowTransformer;
 import com.starrocks.connector.flink.table.sink.StarRocksSinkOptions;
+import javax.annotation.Nullable;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 
 public class StarRocksDynamicTableSink implements DynamicTableSink {
@@ -38,6 +41,8 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
     private final String inlongMetric;
     private final String auditHostAndPorts;
     private final SchemaUpdateExceptionPolicy schemaUpdatePolicy;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
 
     public StarRocksDynamicTableSink(StarRocksSinkOptions sinkOptions,
             TableSchema schema,
@@ -47,7 +52,9 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
             String tablePattern,
             String inlongMetric,
             String auditHostAndPorts,
-            SchemaUpdateExceptionPolicy schemaUpdatePolicy) {
+            SchemaUpdateExceptionPolicy schemaUpdatePolicy,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink) {
         this.flinkSchema = schema;
         this.sinkOptions = sinkOptions;
         this.multipleSink = multipleSink;
@@ -57,6 +64,8 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
         this.schemaUpdatePolicy = schemaUpdatePolicy;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
     }
 
     @Override
@@ -77,7 +86,9 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 tablePattern,
                 inlongMetric,
                 auditHostAndPorts,
-                schemaUpdatePolicy);
+                schemaUpdatePolicy,
+                dirtyOptions,
+                dirtySink);
         return SinkFunctionProvider.of(starrocksSinkFunction, sinkOptions.getSinkParallelism());
     }
 
@@ -91,7 +102,9 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 tablePattern,
                 inlongMetric,
                 auditHostAndPorts,
-                schemaUpdatePolicy);
+                schemaUpdatePolicy,
+                dirtyOptions,
+                dirtySink);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -17,21 +17,7 @@
 
 package org.apache.inlong.sort.starrocks.table.sink;
 
-import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER;
-import static org.apache.inlong.sort.base.Constants.DIRTY_IGNORE;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_BYTES;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_INTERVAL;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_SIZE;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_CONNECTOR;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_ENABLE;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_FIELD_DELIMITER;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_FORMAT;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_IGNORE_ERRORS;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LABELS;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LINE_DELIMITER;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LOG_ENABLE;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LOG_TAG;
-import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_RETRIES;
+import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_DATABASE_PATTERN;
@@ -55,6 +41,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.utils.TableSchemaUtils;
 import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
@@ -65,7 +52,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         final FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-        helper.validateExcept(StarRocksSinkOptions.SINK_PROPERTIES_PREFIX);
+        helper.validateExcept(StarRocksSinkOptions.SINK_PROPERTIES_PREFIX, DIRTY_PREFIX);
         ReadableConfig options = helper.getOptions();
         // validate some special properties
         StarRocksSinkOptions sinkOptions = new StarRocksSinkOptions(options, context.getCatalogTable().getOptions());
@@ -82,6 +69,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         // Build the dirty data side-output
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(helper.getOptions());
         final DirtySink<Object> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
+        final DirtySinkHelper<Object> dirtySinkHelper = new DirtySinkHelper<>(dirtyOptions, dirtySink);
 
         validateSinkMultiple(physicalSchema.toPhysicalRowDataType(),
                 multipleSink,
@@ -98,8 +86,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtyOptions,
-                dirtySink);
+                dirtySinkHelper);
     }
 
     @Override
@@ -138,22 +125,6 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY);
         optionalOptions.add(INLONG_METRIC);
         optionalOptions.add(INLONG_AUDIT);
-
-        optionalOptions.add(DIRTY_IGNORE);
-        optionalOptions.add(DIRTY_IDENTIFIER);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_ENABLE);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_CONNECTOR);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_FORMAT);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_IGNORE_ERRORS);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_LOG_ENABLE);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_LABELS);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_LOG_TAG);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_FIELD_DELIMITER);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_LINE_DELIMITER);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_SIZE);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_RETRIES);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_INTERVAL);
-        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_BYTES);
 
         return optionalOptions;
     }

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -17,6 +17,21 @@
 
 package org.apache.inlong.sort.starrocks.table.sink;
 
+import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER;
+import static org.apache.inlong.sort.base.Constants.DIRTY_IGNORE;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_BYTES;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_INTERVAL;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_BATCH_SIZE;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_CONNECTOR;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_ENABLE;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_FIELD_DELIMITER;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_FORMAT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_IGNORE_ERRORS;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LABELS;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LINE_DELIMITER;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LOG_ENABLE;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_LOG_TAG;
+import static org.apache.inlong.sort.base.Constants.DIRTY_SIDE_OUTPUT_RETRIES;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_DATABASE_PATTERN;
@@ -123,6 +138,23 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY);
         optionalOptions.add(INLONG_METRIC);
         optionalOptions.add(INLONG_AUDIT);
+
+        optionalOptions.add(DIRTY_IGNORE);
+        optionalOptions.add(DIRTY_IDENTIFIER);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_ENABLE);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_CONNECTOR);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_FORMAT);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_IGNORE_ERRORS);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_LOG_ENABLE);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_LABELS);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_LOG_TAG);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_FIELD_DELIMITER);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_LINE_DELIMITER);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_SIZE);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_RETRIES);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_INTERVAL);
+        optionalOptions.add(DIRTY_SIDE_OUTPUT_BATCH_BYTES);
+
         return optionalOptions;
     }
 

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -39,6 +39,9 @@ import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.inlong.sort.base.dirty.DirtyOptions;
+import org.apache.inlong.sort.base.dirty.sink.DirtySink;
+import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 
@@ -61,6 +64,10 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         String inlongMetric = helper.getOptions().getOptional(INLONG_METRIC).orElse(INLONG_METRIC.defaultValue());
         String auditHostAndPorts = helper.getOptions().getOptional(INLONG_AUDIT).orElse(INLONG_AUDIT.defaultValue());
 
+        // Build the dirty data side-output
+        final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(helper.getOptions());
+        final DirtySink<Object> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
+
         validateSinkMultiple(physicalSchema.toPhysicalRowDataType(),
                 multipleSink,
                 sinkMultipleFormat,
@@ -75,7 +82,9 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
                 tablePattern,
                 inlongMetric,
                 auditHostAndPorts,
-                schemaUpdatePolicy);
+                schemaUpdatePolicy,
+                dirtyOptions,
+                dirtySink);
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7083][Sort] StarRocks connector supports dirty data archives and metric

- Fixes #7083

### Motivation

StarRocks connector supports dirty data archives

### Modifications

1. `StarRocksDynamicTableSinkFactory.java` has new DirtyOptions, DirtySink and DirtySinkHelper objects.
2. `StarRocksDynamicTableSink.java`, `StarRocksDynamicSinkFunction.java` and `StarRocksSinkManager.java` get `DirtySinkHelper` tool from `StarRocksDynamicTableSinkFactory` one by one.
3. `StarRocksSinkManager.java` uses `DirtySinkHelper` to write dirty data and upload dirty data metrics when catching exceptions.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
