### PR TITLE
[INLONG-7075][Sort] Add table level metric and dirty data backup for PostgreSQL

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtyType.java
@@ -69,6 +69,10 @@ public enum DirtyType {
      */
     BATCH_LOAD_ERROR("BatchLoadError"),
     /**
+     * Retry load error
+     */
+    RETRY_LOAD_ERROR("RetryLoadError"),
+    /**
      * Unsupported data type
      */
     UNSUPPORTED_DATA_TYPE("UnsupportedDataType"),

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -525,7 +525,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     private void outputMetrics(String tableIdentifier, Long rowSize, Long dataSize, boolean dirtyFlag) {
         String[] fieldArray = tableIdentifier.split("\\.");
         if (fieldArray.length == 3) {
-            if(dirtyFlag) {
+            if (dirtyFlag) {
                 sinkMetricData.outputDirtyMetrics(fieldArray[0], fieldArray[1], fieldArray[2],
                         rowSize, dataSize);
             } else {

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -46,7 +46,7 @@ import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricState;
-import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.jdbc.table.AbstractJdbcDialect;
@@ -111,9 +111,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     private final String tablePattern;
     private final String schemaPattern;
     private transient MetricState metricState;
-    private SinkMetricData sinkMetricData;
-    private Long dataSize = 0L;
-    private Long rowSize = 0L;
+    private SinkTableMetricData sinkMetricData;
     private final SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy;
 
     public JdbcMultiBatchingOutputFormat(
@@ -159,7 +157,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                 .withRegisterMetric(MetricOption.RegisteredMetric.ALL)
                 .build();
         if (metricOption != null) {
-            sinkMetricData = new SinkMetricData(metricOption, runtimeContext.getMetricGroup());
+            sinkMetricData = new SinkTableMetricData(metricOption, runtimeContext.getMetricGroup());
+            sinkMetricData.registerSubMetricsGroup(metricState);
         }
         jdbcExecMap = new HashMap<>();
         connectionExecProviderMap = new HashMap<>();
@@ -180,15 +179,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                                     if (!closed) {
                                         try {
                                             flush();
-                                            if (sinkMetricData != null) {
-                                                sinkMetricData.invoke(rowSize, dataSize);
-                                            }
-                                            resetStateAfterFlush();
                                         } catch (Exception e) {
-                                            if (sinkMetricData != null) {
-                                                sinkMetricData.invokeDirty(rowSize, dataSize);
-                                            }
-                                            resetStateAfterFlush();
+                                            LOG.info("Synchronized flush get Exception:", e);
                                         }
                                     }
                                 }
@@ -325,8 +317,6 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                 LOG.info("Cal tableIdentifier get Exception:", e);
                 return;
             }
-            rowSize++;
-            dataSize = dataSize + rootNode.toString().getBytes(StandardCharsets.UTF_8).length;
 
             GenericRowData record = null;
             try {
@@ -359,16 +349,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                 if (executionOptions.getBatchSize() > 0
                         && batchCount >= executionOptions.getBatchSize()) {
                     flush();
-                    if (sinkMetricData != null) {
-                        sinkMetricData.invoke(rowSize, dataSize);
-                    }
-                    resetStateAfterFlush();
                 }
             } catch (Exception e) {
-                if (sinkMetricData != null) {
-                    sinkMetricData.invokeDirty(rowSize, dataSize);
-                }
-                resetStateAfterFlush();
                 throw new IOException("Writing records to JDBC failed.", e);
             }
         }
@@ -413,11 +395,6 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
             }
         }
         return record;
-    }
-
-    private void resetStateAfterFlush() {
-        dataSize = 0L;
-        rowSize = 0L;
     }
 
     @Override
@@ -473,11 +450,15 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
             Exception tableException = null;
             try {
                 jdbcStatementExecutor = getOrCreateStatementExecutor(tableIdentifier);
+                Long totalDataSize = 0L;
                 for (GenericRowData record : tableIdRecordList) {
+                    totalDataSize = totalDataSize + record.toString().getBytes(StandardCharsets.UTF_8).length;
                     jdbcStatementExecutor.addToBatch((JdbcIn) record);
                 }
                 jdbcStatementExecutor.executeBatch();
                 flushFlag = true;
+                outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
+                        totalDataSize, false);
             } catch (Exception e) {
                 tableException = e;
                 LOG.warn("Flush all data for tableIdentifier:{} get err:", tableIdentifier, e);
@@ -499,6 +480,9 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                             jdbcStatementExecutor = getOrCreateStatementExecutor(tableIdentifier);
                             jdbcStatementExecutor.addToBatch((JdbcIn) record);
                             jdbcStatementExecutor.executeBatch();
+                            Long totalDataSize =
+                                    Long.valueOf(record.toString().getBytes(StandardCharsets.UTF_8).length);
+                            outputMetrics(tableIdentifier, 1L, totalDataSize, false);
                             flushFlag = true;
                             break;
                         } catch (Exception e) {
@@ -519,6 +503,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                     if (!flushFlag && null != tableException) {
                         LOG.info("Put tableIdentifier:{} exception:{}",
                                 tableIdentifier, tableException.getMessage());
+                        outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
+                                1L, true);
                         tableExceptionMap.put(tableIdentifier, tableException);
                         if (isIgnoreTableException) {
                             LOG.info("Stop write table:{} because occur exception",
@@ -529,6 +515,31 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                 }
             }
             tableIdRecordList.clear();
+        }
+    }
+
+    /**
+     * Output metrics with estimate for pg or other type jdbc connectors.
+     * tableIdentifier maybe: ${dbName}.${tbName} or ${dbName}.${schemaName}.${tbName}
+     */
+    private void outputMetrics(String tableIdentifier, Long rowSize, Long dataSize, boolean dirtyFlag) {
+        String[] fieldArray = tableIdentifier.split("\\.");
+        if (fieldArray.length == 3) {
+            if(dirtyFlag) {
+                sinkMetricData.outputDirtyMetrics(fieldArray[0], fieldArray[1], fieldArray[2],
+                        rowSize, dataSize);
+            } else {
+                sinkMetricData.outputMetrics(fieldArray[0], fieldArray[1], fieldArray[2],
+                        rowSize, dataSize);
+            }
+        } else if (fieldArray.length == 2) {
+            if (dirtyFlag) {
+                sinkMetricData.outputDirtyMetrics(fieldArray[0], null, fieldArray[1],
+                        rowSize, dataSize);
+            } else {
+                sinkMetricData.outputMetrics(fieldArray[0], null, fieldArray[1],
+                        rowSize, dataSize);
+            }
         }
     }
 

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicOutputFormatBuilder.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicOutputFormatBuilder.java
@@ -37,6 +37,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.base.dirty.DirtyOptions;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
@@ -336,6 +337,7 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
         checkNotNull(jdbcOptions, "jdbc options can not be null");
         checkNotNull(dmlOptions, "jdbc dml options can not be null");
         checkNotNull(executionOptions, "jdbc execution options can not be null");
+        final DirtySinkHelper<Object> dirtySinkHelper = new DirtySinkHelper<>(dirtyOptions, dirtySink);
         return new JdbcMultiBatchingOutputFormat<>(
                 new SimpleJdbcConnectionProvider(jdbcOptions),
                 executionOptions,
@@ -348,6 +350,7 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
                 schemaPattern,
                 inlongMetric,
                 auditHostAndPorts,
-                schemaUpdateExceptionPolicy);
+                schemaUpdateExceptionPolicy,
+                dirtySinkHelper);
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-7075][Sort] Add table level metric and dirty data backup for PostgreSQL
- Fixes #7075 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
