### PR TITLE
[INLONG-7103][Sort] Support InLongMsg format in Kafka

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -136,7 +136,17 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
     }
 
     /**
-     * generate table options
+     * Generate table options for Kafka extract node.
+     * <p/>
+     * Upsert Kafka stores message keys and values as bytes, so no need specified the schema or data types for Kafka.
+     * <br/>
+     * The messages of Kafka are serialized and deserialized by formats, e.g. csv, json, avro.
+     * <br/>
+     * Thus, the data type mapping is determined by specific formats.
+     * <p/>
+     * For more details:
+     * <a href="https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/table/upsert-kafka/">
+     * upsert-kafka</a>
      *
      * @return options
      */
@@ -148,14 +158,6 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
 
         boolean wrapWithInlongMsg = format instanceof InLongMsgFormat;
         Format realFormat = wrapWithInlongMsg ? ((InLongMsgFormat) format).getInnerFormat() : format;
-
-        // Please refer to the documentation of flink 1.13 kafka connector：
-        // Upsert Kafka stores message keys and values as bytes, so Upsert Kafka doesn’t
-        // have schema or data types. The messages are serialized and deserialized by formats,
-        // e.g. csv, json, avro. Thus, the data type mapping is determined by specific formats.
-        // Please check the details:
-        // https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/table/upsert-kafka/
-
         if (realFormat instanceof JsonFormat
                 || realFormat instanceof AvroFormat
                 || realFormat instanceof CsvFormat) {

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -149,6 +149,13 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
         boolean wrapWithInlongMsg = format instanceof InLongMsgFormat;
         Format realFormat = wrapWithInlongMsg ? ((InLongMsgFormat) format).getInnerFormat() : format;
 
+        // Please refer to the documentation of flink 1.13 kafka connector：
+        // Upsert Kafka stores message keys and values as bytes, so Upsert Kafka doesn’t
+        // have schema or data types. The messages are serialized and deserialized by formats,
+        // e.g. csv, json, avro. Thus, the data type mapping is determined by specific formats.
+        // Please check the details:
+        // https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/table/upsert-kafka/
+
         if (realFormat instanceof JsonFormat
                 || realFormat instanceof AvroFormat
                 || realFormat instanceof CsvFormat) {
@@ -198,6 +205,7 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
             String key = entry.getKey();
             String value = entry.getValue();
             if ("format".equals(key)) {
+                options.put("format", "inlong-msg");
                 options.put("inlong-msg.inner.format", value);
             } else {
                 options.put("inlong-msg." + key, value);

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -188,14 +188,20 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
     }
 
     private Map<String, String> delegateInlongFormat(
-            Map<String, String> formatOptions,
+            Map<String, String> realOptions,
             boolean wrapWithInlongMsg) {
         if (!wrapWithInlongMsg) {
-            return formatOptions;
+            return realOptions;
         }
         Map<String, String> options = new HashMap<>();
-        for (Entry<String, String> entry : formatOptions.entrySet()) {
-            options.put("inlong-msg." + entry.getKey(), entry.getValue());
+        for (Entry<String, String> entry : realOptions.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if ("format".equals(key)) {
+                options.put("inlong-msg.inner.format", value);
+            } else {
+                options.put("inlong-msg." + key, value);
+            }
         }
         return options;
     }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNodeTest.java
@@ -26,6 +26,7 @@ import org.apache.inlong.sort.formats.common.StringFormatInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.enums.KafkaScanStartupMode;
 import org.apache.inlong.sort.protocol.node.format.CsvFormat;
+import org.apache.inlong.sort.protocol.node.format.InLongMsgFormat;
 import org.apache.inlong.sort.protocol.node.format.RawFormat;
 import org.junit.Assert;
 import org.junit.Test;
@@ -111,5 +112,26 @@ public class KafkaExtractNodeTest extends SerializeBaseTest<KafkaExtractNode> {
             }
         }
         Assert.assertTrue(formatEquals);
+    }
+
+    @Test
+    public void testInLongFormat() {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("name", new StringFormatInfo()),
+                new FieldInfo("age", new IntFormatInfo()));
+
+        KafkaExtractNode kafkaNode = getTestObject();
+        InLongMsgFormat inLongMsgFormat = new InLongMsgFormat(new CsvFormat(), false);
+        kafkaNode.setFormat(inLongMsgFormat);
+
+        Map<String, String> options = kafkaNode.tableOptions();
+        assertEquals("inlong-msg", options.get("format"));
+        assertEquals("csv", options.get("inlong-msg.inner.format"));
+        assertEquals("true", options.get("inlong-msg.csv.ignore-parse-errors"));
+
+        kafkaNode.setFormat(new CsvFormat());
+        Map<String, String> csvOptions = kafkaNode.tableOptions();
+        assertEquals("csv", csvOptions.get("format"));
+        assertEquals("true", csvOptions.get("csv.ignore-parse-errors"));
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7103][Sort] Support InLongMsg format in Kafka

- Fixes #7103 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
