### PR TITLE
[INLONG-7159][Audit] Fix the problem of audit sdk create thread not deployed

### DIFF
--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/ClientPipelineFactory.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/ClientPipelineFactory.java
@@ -18,21 +18,20 @@
 package org.apache.inlong.audit.send;
 
 import io.netty.channel.ChannelInitializer;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.socket.SocketChannel;
 import org.apache.inlong.audit.util.Decoder;
 
 public class ClientPipelineFactory extends ChannelInitializer<SocketChannel> {
 
-    private final SimpleChannelInboundHandler sendHandler;
+    private SenderManager senderManager;
 
-    public ClientPipelineFactory(SimpleChannelInboundHandler sendHandler) {
-        this.sendHandler = sendHandler;
+    public ClientPipelineFactory(SenderManager senderManager) {
+        this.senderManager = senderManager;
     }
 
     @Override
     public void initChannel(SocketChannel ch) throws Exception {
         ch.pipeline().addLast("contentDecoder", new Decoder());
-        ch.pipeline().addLast("handler", sendHandler);
+        ch.pipeline().addLast("handler", new SenderHandler(senderManager));
     }
 }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderChannel.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderChannel.java
@@ -130,8 +130,7 @@ public class SenderChannel {
         client.option(ChannelOption.SO_REUSEADDR, true);
         client.option(ChannelOption.SO_RCVBUF, DEFAULT_RECEIVE_BUFFER_SIZE);
         client.option(ChannelOption.SO_SNDBUF, DEFAULT_SEND_BUFFER_SIZE);
-        SenderHandler senderHandler = new SenderHandler(senderManager);
-        client.handler(new ClientPipelineFactory(senderHandler));
+        client.handler(new ClientPipelineFactory(senderManager));
     }
 
     /**
@@ -144,7 +143,10 @@ public class SenderChannel {
             return true;
         }
         try {
-            init();
+            if (client == null) {
+                init();
+            }
+
             synchronized (client) {
                 ChannelFuture future = client.connect(this.ipPort.addr).sync();
                 this.channel = future.channel();

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/Config.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/Config.java
@@ -33,6 +33,8 @@ public class Config {
     private static final Logger logger = LoggerFactory.getLogger(Config.class);
     private String localIP = "";
     private String dockerId = "";
+    private static final int CGROUP_FILE_LENGTH = 50;
+    private static final int DOCKERID_LENGTH = 10;
 
     public void init() {
         initIP();
@@ -78,15 +80,12 @@ public class Config {
         }
         try (BufferedReader in = new BufferedReader(new FileReader("/proc/self/cgroup"))) {
             String dockerID = in.readLine();
-            if (dockerID != null) {
-                int n = dockerID.indexOf("/");
-                String dockerID2 = dockerID.substring(n + 1, (dockerID.length() - n - 1));
-                n = dockerID2.indexOf("/");
-                if (dockerID2.length() > 12) {
-                    dockerId = dockerID2.substring(n + 1, 12);
-                }
+            if (dockerID == null || dockerID.length() < CGROUP_FILE_LENGTH) {
                 in.close();
+                return;
             }
+            dockerId = dockerID.substring(dockerID.length() - DOCKERID_LENGTH);
+            in.close();
         } catch (Exception ex) {
             logger.error(ex.toString());
         }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-7159][Audit] Fix the problem of audit sdk create thread  when the audit service is not deployed 

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes  #7159  
