### PR TITLE
[INLONG-5776][Manager] Add tenant param to InlongGroup that uses Pulsar

### DIFF
--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/BaseExample.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/BaseExample.java
@@ -71,8 +71,6 @@ public class BaseExample {
         pulsarInfo.setInCharges("admin");
 
         // pulsar conf
-        pulsarInfo.setServiceUrl(pulsarServiceUrl);
-        pulsarInfo.setAdminUrl(pulsarAdminUrl);
         pulsarInfo.setTenant(tenant);
         pulsarInfo.setMqResource(namespace);
 

--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/ut/BaseTest.java
@@ -103,8 +103,6 @@ public class BaseTest {
         pulsarInfo.setInCharges(IN_CHARGES);
 
         // pulsar conf
-        pulsarInfo.setServiceUrl(PULSAR_SERVICE_URL);
-        pulsarInfo.setAdminUrl(PULSAR_ADMIN_URL);
         pulsarInfo.setTenant(TENANT);
         pulsarInfo.setMqResource(NAMESPACE);
 

--- a/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
+++ b/inlong-manager/manager-client/src/test/java/org/apache/inlong/manager/client/api/inner/ClientFactoryTest.java
@@ -717,7 +717,6 @@ class ClientFactoryTest {
                 .clusterTags("test_cluster_tag")
                 .type(ClusterType.PULSAR)
                 .adminUrl("http://127.0.0.1:8080")
-                .tenant("public")
                 .build();
 
         stubFor(

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -166,7 +166,8 @@
     </select>
     <select id="selectBriefList" parameterType="org.apache.inlong.manager.pojo.group.InlongGroupPageRequest"
             resultType="org.apache.inlong.manager.pojo.group.InlongGroupBriefInfo">
-        select id, inlong_group_id, name, mq_type, mq_resource, inlong_cluster_tag, modify_time
+        select id, inlong_group_id, name, mq_type, mq_resource, dataReportType, inlong_cluster_tag, ext_params,
+               in_charges, status, creator, modifier, create_time, modify_time
         from inlong_group
         <where>
             is_deleted = 0
@@ -189,10 +190,8 @@
                 </foreach>
             </if>
         </where>
-        order by modify_time desc
-        limit 100
     </select>
-    <select id="selectByTopicRequest" resultType="org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest">
+    <select id="selectByTopicRequest" resultType="org.apache.inlong.manager.dao.entity.InlongGroupEntity">
         select
         <include refid="Base_Column_List"/>
         from inlong_group

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/kafka/KafkaClusterDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/kafka/KafkaClusterDTO.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.pojo.cluster.kafka;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -43,6 +44,7 @@ public class KafkaClusterDTO {
     private String messageQueueHandler = "org.apache.inlong.dataproxy.sink.mq.kafka.KafkaHandler";
 
     @JsonProperty("bootstrap.servers")
+    @ApiModelProperty(value = "Kafka bootstrap servers' URL, is the 'url' field of the cluster")
     private String bootstrapServers;
 
     /**
@@ -50,6 +52,7 @@ public class KafkaClusterDTO {
      */
     public static KafkaClusterDTO getFromRequest(KafkaClusterRequest request) {
         return KafkaClusterDTO.builder()
+                .bootstrapServers(request.getUrl())
                 .build();
     }
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/kafka/KafkaClusterDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/kafka/KafkaClusterDTO.java
@@ -40,12 +40,18 @@ import javax.validation.constraints.NotNull;
 @ApiModel("Kafka cluster info")
 public class KafkaClusterDTO {
 
-    @Builder.Default
-    private String messageQueueHandler = "org.apache.inlong.dataproxy.sink.mq.kafka.KafkaHandler";
-
+    /**
+     * Repeated save to ext_params field, it is convenient for DataProxy to obtain.
+     */
     @JsonProperty("bootstrap.servers")
     @ApiModelProperty(value = "Kafka bootstrap servers' URL, is the 'url' field of the cluster")
     private String bootstrapServers;
+
+    /**
+     * Saved to ext_params field, it is convenient for DataProxy to obtain.
+     */
+    @Builder.Default
+    private String messageQueueHandler = "org.apache.inlong.dataproxy.sink.mq.kafka.KafkaHandler";
 
     /**
      * Get the dto instance from the request

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterDTO.java
@@ -39,16 +39,16 @@ import javax.validation.constraints.NotNull;
 @ApiModel("Pulsar cluster info")
 public class PulsarClusterDTO {
 
-    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'url' field of the cluster")
+    @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080")
     private String adminUrl;
 
     @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
-    @Builder.Default
-    private String tenant = "public";
+    private String tenant;
 
     @Builder.Default
     private String messageQueueHandler = "org.apache.inlong.dataproxy.sink.mq.pulsar.PulsarHandler";
 
+    @ApiModelProperty(value = "Pulsar service URL, is the 'url' field of the cluster")
     private String serviceUrl;
 
     /**
@@ -57,6 +57,7 @@ public class PulsarClusterDTO {
     public static PulsarClusterDTO getFromRequest(PulsarClusterRequest request) {
         return PulsarClusterDTO.builder()
                 .adminUrl(request.getAdminUrl())
+                .serviceUrl(request.getUrl())
                 .tenant(request.getTenant())
                 .build();
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterDTO.java
@@ -42,14 +42,20 @@ public class PulsarClusterDTO {
     @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080")
     private String adminUrl;
 
+    /**
+     * Repeated save to ext_params field, it is convenient for DataProxy to obtain.
+     */
+    @ApiModelProperty(value = "Pulsar service URL, is the 'url' field of the cluster")
+    private String serviceUrl;
+
     @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
     private String tenant;
 
+    /**
+     * Saved to ext_params field, it is convenient for DataProxy to obtain.
+     */
     @Builder.Default
     private String messageQueueHandler = "org.apache.inlong.dataproxy.sink.mq.pulsar.PulsarHandler";
-
-    @ApiModelProperty(value = "Pulsar service URL, is the 'url' field of the cluster")
-    private String serviceUrl;
 
     /**
      * Get the dto instance from the request

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterInfo.java
@@ -19,12 +19,10 @@ package org.apache.inlong.manager.pojo.cluster.pulsar;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
@@ -44,9 +42,8 @@ public class PulsarClusterInfo extends ClusterInfo {
     @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'url' field of the cluster")
     private String adminUrl;
 
-    @Builder.Default
     @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
-    private String tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+    private String tenant;
 
     public PulsarClusterInfo() {
         this.setType(ClusterType.PULSAR);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterInfo.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
@@ -43,9 +44,9 @@ public class PulsarClusterInfo extends ClusterInfo {
     @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'url' field of the cluster")
     private String adminUrl;
 
-    @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
     @Builder.Default
-    private String tenant = "public";
+    @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
+    private String tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
 
     public PulsarClusterInfo() {
         this.setType(ClusterType.PULSAR);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterRequest.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
@@ -40,7 +41,7 @@ public class PulsarClusterRequest extends ClusterRequest {
     private String adminUrl;
 
     @ApiModelProperty(value = "Pulsar tenant, default is 'public'")
-    private String tenant = "public";
+    private String tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
 
     public PulsarClusterRequest() {
         this.setType(ClusterType.PULSAR);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupBriefInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupBriefInfo.java
@@ -54,8 +54,11 @@ public class InlongGroupBriefInfo {
     @ApiModelProperty(value = "MQ resource")
     private String mqResource;
 
-    @ApiModelProperty(value = "Inlong cluster tag")
+    @ApiModelProperty(value = "Inlong cluster tag, which links to inlong_cluster table")
     private String inlongClusterTag;
+
+    @ApiModelProperty(value = "Inlong cluster tag, which links to inlong_cluster table")
+    private String extParams;
 
     @ApiModelProperty(value = "Name of responsible person, separated by commas")
     private String inCharges;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarDTO.java
@@ -22,6 +22,7 @@ import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
@@ -38,8 +39,12 @@ import javax.validation.constraints.NotNull;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(callSuper = true)
 @ApiModel("Inlong group info for Pulsar")
 public class InlongPulsarDTO extends BaseInlongGroup {
+
+    @ApiModelProperty(value = "Pulsar tenant")
+    private String tenant;
 
     @ApiModelProperty(value = "Queue model, parallel: multiple partitions, high throughput, out-of-order messages;"
             + "serial: single partition, low throughput, and orderly messages")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarInfo.java
@@ -42,12 +42,6 @@ public class InlongPulsarInfo extends InlongGroupInfo {
     @ApiModelProperty(value = "Pulsar tenant")
     private String tenant;
 
-    @ApiModelProperty(value = "Pulsar admin URL")
-    private String adminUrl;
-
-    @ApiModelProperty(value = "Pulsar service URL")
-    private String serviceUrl;
-
     @ApiModelProperty(value = "Queue model, parallel: multiple partitions, high throughput, out-of-order messages;"
             + "serial: single partition, low throughput, and orderly messages")
     private String queueModule = "PARALLEL";

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
@@ -36,6 +36,9 @@ import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 @JsonTypeDefine(value = MQType.PULSAR)
 public class InlongPulsarRequest extends InlongGroupRequest {
 
+    @ApiModelProperty(value = "Pulsar tenant")
+    private String tenant;
+
     @ApiModelProperty(value = "Queue model, parallel: multiple partitions, high throughput, out-of-order messages;"
             + "serial: single partition, low throughput, and orderly messages")
     private String queueModule = "PARALLEL";

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
@@ -36,6 +36,10 @@ import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 @JsonTypeDefine(value = MQType.PULSAR)
 public class InlongPulsarRequest extends InlongGroupRequest {
 
+    /**
+     * TODO Add default value InlongConstants.DEFAULT_PULSAR_TENANT when you remove the 'tenant'
+     *  from {@link org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterRequest}
+     */
     @ApiModelProperty(value = "Pulsar tenant")
     private String tenant;
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/KafkaClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/KafkaClusterOperator.java
@@ -75,7 +75,6 @@ public class KafkaClusterOperator extends AbstractClusterOperator {
             CommonBeanUtils.copyProperties(dto, kafkaClusterInfo);
         }
 
-        LOGGER.info("success to get kafka cluster info from entity");
         return kafkaClusterInfo;
     }
 
@@ -85,7 +84,6 @@ public class KafkaClusterOperator extends AbstractClusterOperator {
         CommonBeanUtils.copyProperties(kafkaRequest, targetEntity, true);
         try {
             KafkaClusterDTO dto = KafkaClusterDTO.getFromRequest(kafkaRequest);
-            dto.setBootstrapServers(kafkaRequest.getUrl());
             targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
             LOGGER.info("success to set entity for kafka cluster");
         } catch (Exception e) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/PulsarClusterOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/PulsarClusterOperator.java
@@ -70,7 +70,6 @@ public class PulsarClusterOperator extends AbstractClusterOperator {
             CommonBeanUtils.copyProperties(dto, pulsarInfo);
         }
 
-        LOGGER.info("success to get pulsar cluster info from entity");
         return pulsarInfo;
     }
 
@@ -80,7 +79,6 @@ public class PulsarClusterOperator extends AbstractClusterOperator {
         CommonBeanUtils.copyProperties(pulsarRequest, targetEntity, true);
         try {
             PulsarClusterDTO dto = PulsarClusterDTO.getFromRequest(pulsarRequest);
-            dto.setServiceUrl(request.getUrl());
             targetEntity.setExtParams(objectMapper.writeValueAsString(dto));
             LOGGER.info("success to set entity for pulsar cluster");
         } catch (Exception e) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
@@ -37,6 +37,7 @@ import org.apache.inlong.manager.pojo.consume.pulsar.ConsumePulsarInfo;
 import org.apache.inlong.manager.pojo.consume.pulsar.ConsumePulsarRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
+import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarTopicInfo;
 import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.apache.inlong.manager.service.group.InlongGroupService;
@@ -111,12 +112,25 @@ public class ConsumePulsarOperator extends AbstractConsumeOperator {
         }
         String groupId = entity.getInlongGroupId();
         InlongGroupInfo groupInfo = groupService.get(groupId);
+        if (!(groupInfo instanceof InlongPulsarInfo)) {
+            throw new BusinessException("the mqType must be PULSAR for this consume with inlongGroupId=" + groupId);
+        }
+
         String clusterTag = groupInfo.getInlongClusterTag();
         List<ClusterInfo> clusterInfos = clusterService.listByTagAndType(clusterTag, ClusterType.PULSAR);
         Preconditions.checkNotEmpty(clusterInfos, "pulsar cluster not exist for groupId=" + groupId);
         consumeInfo.setClusterInfos(clusterInfos);
-        PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfos.get(0);
-        consumeInfo.setTopic(getFullPulsarTopic(groupInfo, pulsarCluster.getTenant(), entity.getTopic()));
+
+        // First get the tenant from the InlongGroup, and then get it from the PulsarCluster.
+        String tenant = ((InlongPulsarInfo) groupInfo).getTenant();
+        if (StringUtils.isBlank(tenant)) {
+            // If there are multiple Pulsar clusters, take the first one.
+            // Note that the tenants in multiple Pulsar clusters must be identical.
+            PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfos.get(0);
+            tenant = pulsarCluster.getTenant();
+        }
+
+        consumeInfo.setTopic(getFullPulsarTopic(groupInfo, tenant, entity.getTopic()));
         return consumeInfo;
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/ConsumePulsarOperator.java
@@ -112,10 +112,6 @@ public class ConsumePulsarOperator extends AbstractConsumeOperator {
         }
         String groupId = entity.getInlongGroupId();
         InlongGroupInfo groupInfo = groupService.get(groupId);
-        if (!(groupInfo instanceof InlongPulsarInfo)) {
-            throw new BusinessException("the mqType must be PULSAR for this consume with inlongGroupId=" + groupId);
-        }
-
         String clusterTag = groupInfo.getInlongClusterTag();
         List<ClusterInfo> clusterInfos = clusterService.listByTagAndType(clusterTag, ClusterType.PULSAR);
         Preconditions.checkNotEmpty(clusterInfos, "pulsar cluster not exist for groupId=" + groupId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupOperator4Pulsar.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupOperator4Pulsar.java
@@ -18,7 +18,6 @@
 package org.apache.inlong.manager.service.group;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.common.constant.MQType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -115,10 +114,12 @@ public class InlongGroupOperator4Pulsar extends AbstractGroupOperator {
     public InlongGroupTopicInfo getTopic(InlongGroupInfo groupInfo) {
         PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterService.getOne(
                 groupInfo.getInlongClusterTag(), null, ClusterType.PULSAR);
-        String tenant = StringUtils.isEmpty(pulsarCluster.getTenant())
-                ? InlongConstants.DEFAULT_PULSAR_TENANT
-                : pulsarCluster.getTenant();
 
+        // First get the tenant from the InlongGroup, and then get it from the PulsarCluster.
+        String tenant = ((InlongPulsarInfo) groupInfo).getTenant();
+        if (StringUtils.isBlank(tenant)) {
+            tenant = pulsarCluster.getTenant();
+        }
         InlongPulsarTopicInfo topicInfo = new InlongPulsarTopicInfo();
         topicInfo.setTenant(tenant);
         topicInfo.setNamespace(groupInfo.getMqResource());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/consume/apply/ApproveConsumeProcessListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/consume/apply/ApproveConsumeProcessListener.java
@@ -19,8 +19,8 @@ package org.apache.inlong.manager.service.listener.consume.apply;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ConsumeStatus;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -36,6 +36,7 @@ import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.tubemq.TubeClusterInfo;
 import org.apache.inlong.manager.pojo.queue.pulsar.PulsarTopicInfo;
+import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarDTO;
 import org.apache.inlong.manager.pojo.workflow.form.process.ApplyConsumeProcessForm;
 import org.apache.inlong.manager.service.cluster.InlongClusterService;
 import org.apache.inlong.manager.service.resource.queue.pulsar.PulsarOperator;
@@ -87,11 +88,10 @@ public class ApproveConsumeProcessListener implements ProcessEventListener {
         String mqType = entity.getMqType();
         if (MQType.TUBEMQ.equals(mqType)) {
             this.createTubeConsumerGroup(entity, context.getOperator());
-            return ListenerResult.success("Create TubeMQ consumer group successful");
         } else if (MQType.PULSAR.equals(mqType) || MQType.TDMQ_PULSAR.equals(mqType)) {
             this.createPulsarSubscription(entity);
         } else if (MQType.KAFKA.equals(mqType)) {
-            // TODO add Kafka
+            // Kafka consumers do not need to register in advance
         } else {
             throw new WorkflowListenerException("Unsupported MQ type " + mqType);
         }
@@ -130,17 +130,17 @@ public class ApproveConsumeProcessListener implements ProcessEventListener {
         ClusterInfo clusterInfo = clusterService.getOne(clusterTag, null, ClusterType.PULSAR);
         PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
         try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
-            PulsarTopicInfo topicMessage = new PulsarTopicInfo();
-            String tenant = pulsarCluster.getTenant();
+            InlongPulsarDTO pulsarDTO = InlongPulsarDTO.getFromJson(groupEntity.getExtParams());
+            String tenant = pulsarDTO.getTenant();
             if (StringUtils.isEmpty(tenant)) {
-                tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+                tenant = pulsarCluster.getTenant();
             }
+            PulsarTopicInfo topicMessage = new PulsarTopicInfo();
             topicMessage.setTenant(tenant);
             topicMessage.setNamespace(mqResource);
 
-            String consumerGroup = entity.getConsumerGroup();
             List<String> topics = Arrays.asList(entity.getTopic().split(InlongConstants.COMMA));
-            this.createPulsarSubscription(pulsarAdmin, consumerGroup, topicMessage, topics);
+            this.createPulsarSubscription(pulsarAdmin, entity.getConsumerGroup(), topicMessage, topics);
         } catch (Exception e) {
             log.error("create pulsar topic failed", e);
             throw new WorkflowListenerException("failed to create pulsar topic for groupId=" + groupId + ", reason: "

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/consume/apply/ApproveConsumeProcessListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/consume/apply/ApproveConsumeProcessListener.java
@@ -132,7 +132,7 @@ public class ApproveConsumeProcessListener implements ProcessEventListener {
         try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
             InlongPulsarDTO pulsarDTO = InlongPulsarDTO.getFromJson(groupEntity.getExtParams());
             String tenant = pulsarDTO.getTenant();
-            if (StringUtils.isEmpty(tenant)) {
+            if (StringUtils.isBlank(tenant)) {
                 tenant = pulsarCluster.getTenant();
             }
             PulsarTopicInfo topicMessage = new PulsarTopicInfo();

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarResourceOperator.java
@@ -21,10 +21,11 @@ import com.google.common.base.Objects;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.GroupStatus;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
@@ -83,22 +84,27 @@ public class PulsarResourceOperator implements QueueResourceOperator {
         String clusterTag = groupInfo.getInlongClusterTag();
         log.info("begin to create pulsar resource for groupId={}, clusterTag={}", groupId, clusterTag);
 
+        if (!(groupInfo instanceof InlongPulsarInfo)) {
+            throw new BusinessException("the mqType must be PULSAR for inlongGroupId=" + groupId);
+        }
+
+        InlongPulsarInfo pulsarInfo = (InlongPulsarInfo) groupInfo;
+        String tenant = pulsarInfo.getTenant();
         // get pulsar cluster via the inlong cluster tag from the inlong group
         List<ClusterInfo> clusterInfos = clusterService.listByTagAndType(clusterTag, ClusterType.PULSAR);
         for (ClusterInfo clusterInfo : clusterInfos) {
             PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
             try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
                 // create pulsar tenant and namespace
-                String tenant = pulsarCluster.getTenant();
-                if (StringUtils.isEmpty(tenant)) {
-                    tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+                if (StringUtils.isBlank(tenant)) {
+                    tenant = pulsarCluster.getTenant();
                 }
 
                 // if the group was not successful, need create tenant and namespace
                 if (!Objects.equal(GroupStatus.CONFIG_SUCCESSFUL.getCode(), groupInfo.getStatus())) {
                     pulsarOperator.createTenant(pulsarAdmin, tenant);
                     String namespace = groupInfo.getMqResource();
-                    pulsarOperator.createNamespace(pulsarAdmin, (InlongPulsarInfo) groupInfo, tenant, namespace);
+                    pulsarOperator.createNamespace(pulsarAdmin, pulsarInfo, tenant, namespace);
 
                     log.info("success to create pulsar resource for groupId={}, tenant={}, namespace={}, cluster={}",
                             groupId, tenant, namespace, pulsarCluster);
@@ -131,7 +137,7 @@ public class PulsarResourceOperator implements QueueResourceOperator {
             PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
             try {
                 for (InlongStreamBriefInfo streamInfo : streamInfos) {
-                    this.deletePulsarTopic(groupInfo, pulsarCluster, streamInfo.getMqResource());
+                    this.deletePulsarTopic((InlongPulsarInfo) groupInfo, pulsarCluster, streamInfo.getMqResource());
                 }
             } catch (Exception e) {
                 String msg = "failed to delete pulsar resource for groupId=" + groupId;
@@ -192,7 +198,7 @@ public class PulsarResourceOperator implements QueueResourceOperator {
         for (ClusterInfo clusterInfo : clusterInfos) {
             PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
             try {
-                this.deletePulsarTopic(groupInfo, pulsarCluster, streamInfo.getMqResource());
+                this.deletePulsarTopic((InlongPulsarInfo) groupInfo, pulsarCluster, streamInfo.getMqResource());
                 log.info("success to delete pulsar topic for groupId={}, streamId={}, topic={}, cluster={}",
                         groupId, streamId, streamInfo.getMqResource(), pulsarCluster);
             } catch (Exception e) {
@@ -211,9 +217,9 @@ public class PulsarResourceOperator implements QueueResourceOperator {
     private void createTopic(InlongPulsarInfo pulsarInfo, PulsarClusterInfo pulsarCluster, String topicName)
             throws Exception {
         try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
-            String tenant = pulsarCluster.getTenant();
-            if (StringUtils.isEmpty(tenant)) {
-                tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+            String tenant = pulsarInfo.getTenant();
+            if (StringUtils.isBlank(tenant)) {
+                tenant = pulsarCluster.getTenant();
             }
             String namespace = pulsarInfo.getMqResource();
             PulsarTopicInfo topicInfo = PulsarTopicInfo.builder()
@@ -233,9 +239,9 @@ public class PulsarResourceOperator implements QueueResourceOperator {
     private void createSubscription(InlongPulsarInfo pulsarInfo, PulsarClusterInfo pulsarCluster, String topicName,
             String streamId) throws Exception {
         try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
-            String tenant = pulsarCluster.getTenant();
-            if (StringUtils.isEmpty(tenant)) {
-                tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+            String tenant = pulsarInfo.getTenant();
+            if (StringUtils.isBlank(tenant)) {
+                tenant = pulsarCluster.getTenant();
             }
             String namespace = pulsarInfo.getMqResource();
             String fullTopicName = tenant + "/" + namespace + "/" + topicName;
@@ -274,14 +280,14 @@ public class PulsarResourceOperator implements QueueResourceOperator {
      * Delete Pulsar Topic and Subscription, and delete the consumer group info.
      * TODO delete Subscription and InlongConsume info
      */
-    private void deletePulsarTopic(InlongGroupInfo groupInfo, PulsarClusterInfo pulsarCluster, String topicName)
+    private void deletePulsarTopic(InlongPulsarInfo pulsarInfo, PulsarClusterInfo pulsarCluster, String topicName)
             throws Exception {
         try (PulsarAdmin pulsarAdmin = PulsarUtils.getPulsarAdmin(pulsarCluster)) {
-            String tenant = pulsarCluster.getTenant();
-            if (StringUtils.isEmpty(tenant)) {
-                tenant = InlongConstants.DEFAULT_PULSAR_TENANT;
+            String tenant = pulsarInfo.getTenant();
+            if (StringUtils.isBlank(tenant)) {
+                tenant = pulsarCluster.getTenant();
             }
-            String namespace = groupInfo.getMqResource();
+            String namespace = pulsarInfo.getMqResource();
             PulsarTopicInfo topicInfo = PulsarTopicInfo.builder()
                     .tenant(tenant)
                     .namespace(namespace)

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.enums.DataTypeEnum;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -33,6 +32,7 @@ import org.apache.inlong.manager.dao.entity.StreamSourceEntity;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
+import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.pojo.source.SourceRequest;
 import org.apache.inlong.manager.pojo.source.StreamSource;
 import org.apache.inlong.manager.pojo.source.kafka.KafkaSource;
@@ -112,12 +112,15 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
         PulsarClusterInfo pulsarCluster = (PulsarClusterInfo) clusterInfo;
         String adminUrl = pulsarCluster.getAdminUrl();
         String serviceUrl = pulsarCluster.getUrl();
-        String tenant = StringUtils.isEmpty(pulsarCluster.getTenant())
-                ? InlongConstants.DEFAULT_PULSAR_TENANT
-                : pulsarCluster.getTenant();
+
+        // First get the tenant from the InlongGroup, and then get it from the PulsarCluster.
+        String tenant = ((InlongPulsarInfo) groupInfo).getTenant();
+        if (StringUtils.isBlank(tenant)) {
+            tenant = pulsarCluster.getTenant();
+        }
 
         Map<String, List<StreamSource>> sourceMap = Maps.newHashMap();
-        streamInfos.forEach(streamInfo -> {
+        for (InlongStreamInfo streamInfo : streamInfos) {
             PulsarSource pulsarSource = new PulsarSource();
             String streamId = streamInfo.getInlongStreamId();
             pulsarSource.setSourceName(streamId);
@@ -166,7 +169,7 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
             pulsarSource.setScanStartupMode(PulsarScanStartupMode.EARLIEST.getValue());
             pulsarSource.setFieldList(streamInfo.getFieldList());
             sourceMap.computeIfAbsent(streamId, key -> Lists.newArrayList()).add(pulsarSource);
-        });
+        }
 
         return sourceMap;
     }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceTest.java
@@ -76,7 +76,6 @@ public class InlongClusterServiceTest extends ServiceBaseTest {
         request.setName(clusterName);
         request.setType(ClusterType.PULSAR);
         request.setAdminUrl(adminUrl);
-        request.setTenant("public");
         request.setInCharges(GLOBAL_OPERATOR);
         return clusterService.save(request, GLOBAL_OPERATOR);
     }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/consume/InlongConsumeServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/consume/InlongConsumeServiceTest.java
@@ -156,8 +156,6 @@ public class InlongConsumeServiceTest extends ServiceBaseTest {
         request.setType(ClusterType.PULSAR);
         String adminUrl = "http://127.0.0.1:8080";
         request.setAdminUrl(adminUrl);
-        String tenant = "public";
-        request.setTenant(tenant);
         request.setInCharges(GLOBAL_OPERATOR);
         clusterId = clusterService.save(request, GLOBAL_OPERATOR);
     }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #5776

### Motivation

**Add tenant param to InlongGroup that uses Pulsar.**

Currently, the tenant parameter is stored in the Pulsar cluster information, which is not reasonable.

Because a Pulsar cluster supports many tenants, just like its namespaces and topics, **it is a one-to-many relationship with the cluster, not a one-to-one relationship.**

### Modifications

1. Add `tenant` param for `InlongPulsarInfo`.
2. First, get the tenant from `InlongPulsarInfo`, and then get it from the `PulsarCluster`, finally, use the default tenant `public`.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
