### PR TITLE
[INLONG-7172][Sort] Fix new table write into iceberg failed

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -161,6 +161,10 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
         this.checkpointsState = context.getOperatorStateStore().getListState(stateDescriptor);
         this.jobIdState = context.getOperatorStateStore().getListState(jobIdDescriptor);
         if (context.isRestored()) {
+            // Newly table doesn't have restored flink job id.
+            if (!jobIdState.get().iterator().hasNext()) {
+                return;
+            }
             String restoredFlinkJobId = jobIdState.get().iterator().next();
             Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
                     "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -160,6 +160,7 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
 
         this.checkpointsState = context.getOperatorStateStore().getListState(stateDescriptor);
         this.jobIdState = context.getOperatorStateStore().getListState(jobIdDescriptor);
+        // New table doesn't have state.
         if (context.isRestored() && jobIdState.get().iterator().hasNext()) {
             String restoredFlinkJobId = jobIdState.get().iterator().next();
             Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -161,7 +161,7 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
         this.checkpointsState = context.getOperatorStateStore().getListState(stateDescriptor);
         this.jobIdState = context.getOperatorStateStore().getListState(jobIdDescriptor);
         if (context.isRestored()) {
-            // Newly table doesn't have restored flink job id.
+            // New table doesn't have restored flink job id.
             if (!jobIdState.get().iterator().hasNext()) {
                 return;
             }

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -160,11 +160,7 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
 
         this.checkpointsState = context.getOperatorStateStore().getListState(stateDescriptor);
         this.jobIdState = context.getOperatorStateStore().getListState(jobIdDescriptor);
-        if (context.isRestored()) {
-            // New table doesn't have restored flink job id.
-            if (!jobIdState.get().iterator().hasNext()) {
-                return;
-            }
+        if (context.isRestored() && jobIdState.get().iterator().hasNext()) {
             String restoredFlinkJobId = jobIdState.get().iterator().next();
             Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),
                     "Flink job id parsed from checkpoint snapshot shouldn't be null or empty");

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -160,7 +160,7 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
 
         this.checkpointsState = context.getOperatorStateStore().getListState(stateDescriptor);
         this.jobIdState = context.getOperatorStateStore().getListState(jobIdDescriptor);
-        // New table doesn't have state.
+        // New table doesn't have state, so it doesn't need to do restore operation.
         if (context.isRestored() && jobIdState.get().iterator().hasNext()) {
             String restoredFlinkJobId = jobIdState.get().iterator().next();
             Preconditions.checkState(!Strings.isNullOrEmpty(restoredFlinkJobId),


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7172][Sort] Fix new table write into iceberg failed

- Fixes #7172 

### Motivation

When a new table is added in the Flink job,  and then restart the job with status. The new table can be successfully written to iceberg.

### Modifications

The new table has no state after the job is restarted, so we need to ignore the subsequent operations when the state is restored.

```java
       if (context.isRestored()) {
            // New table doesn't have restored flink job id.
            if (!jobIdState.get().iterator().hasNext()) {
                return;
            }
            /**
             * ...
             */
        }
```