### PR TITLE
[INLONG-7194][DataProxy] Add index log statistics for MQ sink

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -337,9 +337,9 @@ public class MessageQueueZoneSinkContext extends SinkContext {
         if (isSuccess) {
             monitorIndex.addAndGet(newBase.toString(),
                     intMsgCnt, 1, event.getBody().length, 0);
-            monitorIndexExt.incrementAndGet("PULSAR_SINK_SUCCESS");
+            monitorIndexExt.incrementAndGet("MQ_SINK_SUCCESS");
         } else {
-            monitorIndexExt.incrementAndGet("PULSAR_SINK_EXP");
+            monitorIndexExt.incrementAndGet("MQ_SINK_EXP");
             monitorIndex.addAndGet(newBase.toString(),
                     0, 0, 0, intMsgCnt);
         }


### PR DESCRIPTION
- Fixes #7194

### Motivation

Missing old index log statistics for simple events. Migrate the old logic from pulsar sink and tube sink.