### PR TITLE
[INLONG-7213][Manager] Add encoding check to the MySQL JDBC URL

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -32,6 +32,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
+import java.net.URLDecoder;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -47,6 +49,15 @@ public class MySQLSinkDTO {
     /**
      * The sensitive param may lead the attack.
      */
+    private static final Map<String, String> SENSITIVE_PARAM_MAP = new HashMap<String, String>() {
+        {
+            put("autoDeserialize=true", "autoDeserialize=false");
+            put("allowLoadLocalInfile=true", "allowLoadLocalInfile=false");
+            put("allowUrlInLocalInfile=true", "allowUrlInLocalInfile=false");
+            put("allowLoadLocalInfileInPath=/", "allowLoadLocalInfileInPath=");
+        }
+    };
+
     private static final String SENSITIVE_PARAM_TRUE = "autoDeserialize=true";
     private static final String SENSITIVE_PARAM_FALSE = "autoDeserialize=false";
     private static final Logger LOGGER = LoggerFactory.getLogger(MySQLSinkDTO.class);
@@ -178,14 +189,20 @@ public class MySQLSinkDTO {
         if (StringUtils.isBlank(url)) {
             return url;
         }
-
-        String resultUrl = url;
-        if (StringUtils.containsIgnoreCase(url, SENSITIVE_PARAM_TRUE)) {
-            resultUrl = StringUtils.replaceIgnoreCase(url, SENSITIVE_PARAM_TRUE, SENSITIVE_PARAM_FALSE);
+        try {
+            String resultUrl = URLDecoder.decode(url, "UTF-8");
+            for (String sensitiveParam : SENSITIVE_PARAM_MAP.keySet()) {
+                if (StringUtils.containsIgnoreCase(resultUrl, sensitiveParam)) {
+                    resultUrl = StringUtils.replaceIgnoreCase(resultUrl, sensitiveParam,
+                            SENSITIVE_PARAM_MAP.get(sensitiveParam));
+                }
+            }
+            LOGGER.info("the origin url [{}] was replaced to: [{}]", url, resultUrl);
+            return resultUrl;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT,
+                    ErrorCodeEnum.SINK_INFO_INCORRECT.getMessage() + ": " + e.getMessage());
         }
-
-        LOGGER.debug("the origin url [{}] was replaced to: [{}]", url, resultUrl);
-        return resultUrl;
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -59,8 +59,6 @@ public class MySQLSinkDTO {
         }
     };
 
-    private static final String SENSITIVE_PARAM_TRUE = "autoDeserialize=true";
-    private static final String SENSITIVE_PARAM_FALSE = "autoDeserialize=false";
     private static final Logger LOGGER = LoggerFactory.getLogger(MySQLSinkDTO.class);
 
     @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port/database")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -50,6 +50,7 @@ public class MySQLSinkDTO {
      * The sensitive param may lead the attack.
      */
     private static final Map<String, String> SENSITIVE_PARAM_MAP = new HashMap<String, String>() {
+
         {
             put("autoDeserialize=true", "autoDeserialize=false");
             put("allowLoadLocalInfile=true", "allowLoadLocalInfile=false");

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
@@ -20,25 +20,58 @@ package org.apache.inlong.manager.pojo.sink.mysql;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.net.URLEncoder;
+
 /**
  * Test for {@link MySQLSinkDTO}
  */
 public class MySQLSinkDTOTest {
 
     @Test
-    public void testFilterSensitive() {
-        // the sensitive params at the first
-        String originUrl = MySQLSinkDTO.filterSensitive("autoDeserialize=TRue&autoReconnect=true");
-        Assertions.assertEquals("autoDeserialize=false&autoReconnect=true", originUrl);
+    public void testFilterSensitive() throws Exception {
+        // the sensitive params no use url code
+        String originUrl = MySQLSinkDTO.filterSensitive(
+                "autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true");
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=&autoReconnect=true",
+                originUrl);
 
-        // the sensitive params at the end
-        originUrl = MySQLSinkDTO.filterSensitive("autoReconnect=true&autoDeserialize=trUE");
-        Assertions.assertEquals("autoReconnect=true&autoDeserialize=false", originUrl);
-
-        // the sensitive params in the middle
         originUrl = MySQLSinkDTO.filterSensitive(
-                "useSSL=false&autoDeserialize=TRUE&autoReconnect=true");
-        Assertions.assertEquals("useSSL=false&autoDeserialize=false&autoReconnect=true", originUrl);
+                "autoReconnect=true&autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
+        Assertions.assertEquals(
+                "autoReconnect=true&autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
+
+        originUrl = MySQLSinkDTO.filterSensitive(
+                "autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
+
+        // the sensitive params use url code
+        originUrl = MySQLSinkDTO.filterSensitive(
+                URLEncoder.encode(
+                        "autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true",
+                        "UTF-8"));
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=&autoReconnect=true",
+                originUrl);
+
+        originUrl = MySQLSinkDTO.filterSensitive(
+                URLEncoder.encode(
+                        "autoReconnect=true&autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                        "UTF-8"));
+        Assertions.assertEquals(
+                "autoReconnect=true&autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
+
+        originUrl = MySQLSinkDTO.filterSensitive(
+                URLEncoder.encode(
+                        "autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                        "UTF-8"));
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
     }
 
 }


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7213 
### Motivation

Add a check to the URL encoding of mysql JDBC URL.

### Modifications
1.Add a check to the URL encoding of mysql JDBC URL.

2.Add checks for three unsafe parameters that can cause arbitrary file reading problems.  They are
allowLoadLocalInfile, allowUrlInLocalInfile, allowLoadLocalInfileInPath.
