### PR TITLE
[INLONG-7218][CI] Add Windows and MacOS support on GitHub Actions

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -69,6 +69,11 @@ jobs:
           java-version: 8
           distribution: adopt
 
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
       - name: Cache Maven packages
         uses: actions/cache@v3
         with:
@@ -88,7 +93,7 @@ jobs:
       - name: Get InLong version
         if: ${{ success() }}
         run: |
-          version=`mvn -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive exec:exec -q`
+          version=$(python docker/get-project-version.py)
           echo "VERSION=${version}" >> $GITHUB_ENV
 
       - name: Upload binary package

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -55,7 +55,10 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: [ windows-2022, ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests
         env:
           CI: false
 

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-22.04
+    runs-on: [ windows-2022, ubuntu-22.04 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_greeting.yml
+++ b/.github/workflows/ci_greeting.yml
@@ -42,9 +42,7 @@ jobs:
             Hello @${{ github.actor }}, thank you for submitting a PR to InLong 💖 We will respond as soon as possible ⏳
             This seems to be your first PR 🌠 Please be sure to follow our [Contribution Guidelines](https://inlong.apache.org/community/how-to-contribute).
             If you have any questions in the meantime, you can also ask us on the [InLong Discussions](https://github.com/apache/inlong/discussions) 🔍
-          Footer
           issue-message: |
             Hello @${{ github.actor }}, thank you for opening your first issue in InLong 🧡 We will respond as soon as possible ⏳
             If this is a bug report, please provide screenshots or error logs for us to reproduce your issue, so we can do our best to fix it.
             If you have any questions in the meantime, you can also ask us on the [InLong Discussions](https://github.com/apache/inlong/discussions) 🔍
-          Footer

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -55,7 +55,7 @@ on:
 jobs:
   unit-test:
     name: Unit Test
-    runs-on: ubuntu-22.04
+    runs-on: [ windows-2022, ubuntu-22.04 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -55,7 +55,10 @@ on:
 jobs:
   unit-test:
     name: Unit Test
-    runs-on: [ windows-2022, ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -79,7 +79,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests
         env:
           CI: false
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/PathUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/PathUtils.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,8 +68,9 @@ public class PathUtils {
      */
     public static boolean antPathIncluded(String dirStr, String patternStr) {
         // todo:Determines whether a path is a possible prefix of the path expression
-        List<String> dirArr = Stream.of(dirStr.split(File.separator)).collect(Collectors.toList());
-        List<String> patternDirArr = Stream.of(patternStr.split(File.separator)).collect(Collectors.toList());
+        String fileSeparator = Matcher.quoteReplacement(File.separator);
+        List<String> dirArr = Stream.of(dirStr.split(fileSeparator)).collect(Collectors.toList());
+        List<String> patternDirArr = Stream.of(patternStr.split(fileSeparator)).collect(Collectors.toList());
         int everything = patternDirArr.indexOf("**");
         if (everything != -1) {
             return antPathMatch(


### PR DESCRIPTION
Fixes #7218

### Motivation

We can use `jobs.<job_id>.runs-on` to define the type of machine to run the job on.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on

Reference: https://stackoverflow.com/questions/59295795/run-github-action-on-multiple-environments

### Modifications

Add Windows and MacOS support on GitHub Actions when building and testing InLong.

