### PR TITLE
[INLONG-7060][Sort] Support write redis in sort-connector-redis 

### DIFF
--- a/inlong-distribution/src/main/assemblies/sort-connectors.xml
+++ b/inlong-distribution/src/main/assemblies/sort-connectors.xml
@@ -179,5 +179,13 @@
             </includes>
             <fileMode>0644</fileMode>
         </fileSet>
+        <fileSet>
+            <directory>../inlong-sort/sort-connectors/redis/target</directory>
+            <outputDirectory>inlong-sort/connectors</outputDirectory>
+            <includes>
+                <include>sort-connector-redis-${project.version}.jar</include>
+            </includes>
+            <fileMode>0644</fileMode>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/inlong-sort/README.md
+++ b/inlong-sort/README.md
@@ -37,6 +37,7 @@ informations and storage informations).
 - PostgreSQL
 - HDFS
 - TDSQL Postgres
+- Redis 
 
 ## Future Plans
 

--- a/inlong-sort/README.md
+++ b/inlong-sort/README.md
@@ -34,6 +34,7 @@ informations and storage informations).
 - HBase
 - ClickHouse
 - Iceberg
+- Hudi 
 - PostgreSQL
 - HDFS
 - TDSQL Postgres

--- a/inlong-sort/sort-connectors/redis/README.md
+++ b/inlong-sort/sort-connectors/redis/README.md
@@ -1,0 +1,245 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# inlong-sort-connector-redis
+
+## data-type
+
+See detail:  <a href="https://redis.io/topics/data-types-intro">redis data type</a>
+
+### PLAIN
+
+| c1     | c2  | c3  | c4  | c5  | c6  | c7  | 
+|--------|-----|-----|-----|-----|-----|-----|
+| rowKey |     |     |     |     |     |     |
+
+Redis strings commands are used for managing string values in Redis
+
+The first element is Redis row key,must be string type.
+The remaining fields(`c2`~`c6`) will be serialized into one value and put into redis
+
+### HASH
+
+* A Redis hash is a data type that represents a mapping between a string field and a string
+  value.<br/>
+* There are two members in hash DataType: <br/>
+* the first member is Redis hash field.<br/>
+* the second member is Redis hash value.
+
+### SET
+
+* Redis Lists are simply lists of strings, sorted by insertion order.
+* You can add elements in Redis lists in the head or the tail of the list.
+
+### BITMAP
+
+* Bitmaps are not an actual data type, but a set of bit-oriented operations defined on the String
+  type. <br/>
+* Since strings are binary safe blobs and their maximum length is 512 MB, <br/>
+* they are suitable to set up to 2^32 different bits.
+
+## SchemaMappingMode
+
+### DYNAMIC
+
+* The DYNAMIC mode witch mapping a {@link java.util.Map} to {@link RedisDataType}.
+* There are two members in DYNAMIC mode: <br/>
+* the first member is Redis key. <br/>
+* the second member is a {@link java.util.Map} object, witch will be iterated, <br/>
+* the entry key is redis key, and the entry value is redis value.
+
+### STATIC_PREFIX_MATCH
+
+* The are at least two fields, the first member is redis key, <br/>
+* and each field from the second field represents a redis value.<br/>
+* ex: <br/>
+
+```shell
+key, field, value1, value2, value3, [value]...
+```
+
+### STATIC_KV_PAIR;
+
+* There are two fields, the first field is key, <br/>
+* and the other fields are pairs of field and value. <br/>
+* ex:<br/>
+
+```shell
+ key, field1, value1,field2,value2,field3,value3,[field,value]...
+```
+
+## SQL demo
+
+### PLAIN
+
+> Plain only support STATIC_PREFIX_MATCH schema mapping mode
+
+```sql
+CREATE TABLE sink (
+    key STRING,
+    aaa STRING,
+    bbb DOUBLE,    
+    ccc BIGINT,    
+    PRIMARY KEY (`key`) NOT ENFORCED
+) WITH (  
+    'connector' = 'redis-inlong',  
+    'sink.batch-size' = '1',  
+    'format' = 'csv',  
+    'data-type' = 'PLAIN',  
+    'redis-mode' = 'standalone',  
+    'host' = 'localhost',  
+    'port' = '56615',  
+    'maxIdle' = '8',  
+    'minIdle' = '1',  
+    'maxTotal' = '2',  
+    'timeout' = '2000'
+);
+```
+
+### HASH with PREFIX_MATCH
+
+| c1     | c2            | c3  | c4  | c5  | c6  | c7  | 
+|--------|---------------|-----|-----|-----|-----|-----|
+| rowKey | field: String |     |     |     |     |     |
+
+The first element is Redis row key, must be string type.
+The second element is Redis field name in Hash DataType.
+The remaining fields(`c2`~`c7`) will be serialized into one value and put into redis
+
+```sql
+CREATE TABLE sink (
+    KEY STRING, 
+    field_name STRING, 
+    value_1 DOUBLE,
+    value_2 BIGINT, 
+    PRIMARY KEY (`key`) NOT ENFORCED
+) WITH (
+   'connector' = 'redis-inlong',
+   'sink.batch-size' = '1',
+   'format' = 'csv',
+   'data-type' = 'HASH',
+   'redis-mode' = 'standalone',
+   'host' = 'localhost',
+   'port' = '56869',
+   'maxIdle' = '8',
+   'minIdle' = '1',
+   'maxTotal' = '2',
+   'timeout' = '2000'
+);
+```
+
+### HASH with STATIC_KV_PAIR
+
+| c1     | c2             | c3             | c4              | c5             | c6              | c7             | 
+|--------|----------------|----------------|-----------------|----------------|-----------------|----------------|
+| rowKey | field1: String | value 1:String | field 2: String | value 2:String | field 3: String | value 3:String |
+
+The first element is Redis row key, must be string type.
+The odd elements(`c2` / `c4` / `c6`) are Redis field names in Hash DataType, must be String type.
+The even elements(`c3` / `c5` / `c7`) are Redis field values in Hash DataType, must be String type.
+
+```sql
+CREATE TABLE sink (
+    key STRING,
+    field1 STRING,
+    value1 STRING,
+    field2 STRING,
+    value2 STRING,
+    PRIMARY KEY (`key`) NOT ENFORCED
+) WITH (
+  'connector' = 'redis-inlong',
+  'sink.batch-size' = '1',
+  'format' = 'csv',
+  'data-type' = 'HASH',
+  'schema-mapping-mode' = 'STATIC_KV_PAIR',
+  'redis-mode' = 'standalone',
+  'host' = 'localhost',
+  'port' = '6379',
+  'maxIdle' = '8',
+  'minIdle' = '1',
+  'maxTotal' = '2',
+  'timeout' = '2000'
+);
+```
+
+### HASH with DYNAMIC
+
+| c1     | c2            | 
+|--------|---------------|
+| rowKey | fieldValueMap |
+
+The first element is Redis row key, must be string type.
+The second element is must be `Map<String,String>` type: key is fieldName, value is fieldValue.
+
+```sql
+CREATE TABLE sink (
+    key STRING,
+    fieldValueMap MAP<STRING,STRING>,
+    PRIMARY KEY (`key`) NOT ENFORCED
+) WITH (
+  'connector' = 'redis-inlong',
+  'sink.batch-size' = '1',
+  'format' = 'csv',
+  'data-type' = 'HASH',
+  'schema-mapping-mode' = 'DYNAMIC',
+  'redis-mode' = 'standalone',
+  'host' = 'localhost',
+  'port' = '6379',
+  'maxIdle' = '8',
+  'minIdle' = '1',
+  'maxTotal' = '2',
+  'timeout' = '2000'
+)"
+```
+
+### BITMAP with STATIC_KV_PAIR
+
+| c1     | c2           | c3              | c4            | c5              | c6            | c7              | 
+|--------|--------------|-----------------|---------------|-----------------|---------------|-----------------|
+| rowKey | field1: Long | value 1:Boolean | field 2: Long | value 2:Boolean | field 3: Long | value 3:Boolean |
+
+The first element is Redis row key, must be string type.
+The odd elements(`c2` /`c4` /`c6` ) are Redis offsets in Bitmap DataType, must be Long type.
+The even elements(`c3` / `c5` / `c7`) are Redis values in Bitmap DataType, must be Boolean type.
+
+```sql
+CREATE TABLE sink (
+    key STRING,
+    offset_1 BIGINT,
+    value_1 BOOLEAN,
+    offset_2 BIGINT,
+    value_2 BOOLEAN,
+    PRIMARY KEY (`key`) NOT ENFORCED
+) WITH (
+  'connector' = 'redis-inlong',
+  'sink.batch-size' = '1',
+  'format' = 'csv',
+  'data-type' = 'BITMAP',
+  'schema-mapping-mode' = 'STATIC_KV_PAIR',
+  'redis-mode' = 'standalone',
+  'host' = 'localhost',
+  'port' = '6379',
+  'maxIdle' = '8',
+  'minIdle' = '1',
+  'maxTotal' = '2',
+  'timeout' = '2000'
+)
+```

--- a/inlong-sort/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-connectors/redis/pom.xml
@@ -34,7 +34,90 @@
             <groupId>org.apache.bahir</groupId>
             <artifactId>flink-connector-redis_${flink.scala.binary.version}</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--        test utils     -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-csv</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-base</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.kstyrc</groupId>
+            <artifactId>embedded-redis</artifactId>
+            <version>0.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-common</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner-blink_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_2.11</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.config;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Redis data type Enum.
+ * See detail: @see <a href="https://redis.io/topics/data-types-intro">redis data type</a>
+ */
+@Internal
+public enum RedisDataType {
+    /**
+     * Redis strings commands are used for managing string values in Redis.
+     */
+    PLAIN,
+    /**
+     * A Redis hash is a data type that represents a mapping between a string field and a string value.<br/>
+     * There are two members in hash DataType: <br/>
+     * the first member is Redis hash field.<br/>
+     * the second member is Redis hash value.
+     */
+    HASH,
+    /**
+     * Redis Sets are an unordered collection of unique strings.
+     * Unique means sets does not allow repetition of data in a key.
+     */
+    SET,
+    /**
+     * Redis Lists are simply lists of strings, sorted by insertion order.
+     * You can add elements in Redis lists in the head or the tail of the list.
+     */
+    LIST,
+
+    /**
+     * Bitmaps are not an actual data type, but a set of bit-oriented operations defined on the String type. <br/>
+     * Since strings are binary safe blobs and their maximum length is 512 MB, <br/>
+     * they are suitable to set up to 2^32 different bits.
+     */
+    BITMAP,
+    ;
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
@@ -41,11 +41,6 @@ public enum RedisDataType {
      * Unique means sets does not allow repetition of data in a key.
      */
     SET,
-    /**
-     * Redis Lists are simply lists of strings, sorted by insertion order.
-     * You can add elements in Redis lists in the head or the tail of the list.
-     */
-    LIST,
 
     /**
      * Bitmaps are not an actual data type, but a set of bit-oriented operations defined on the String type. <br/>

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisOptions.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisOptions.java
@@ -236,13 +236,6 @@ public class RedisOptions {
                     .withDescription("Set the value for max waiting time if there is " +
                             "no connection resource.");
 
-    public static final ConfigOption<Integer> MAX_CACHE_SIZE =
-            ConfigOptions.key("sink.max-cache-size")
-                    .intType()
-                    .defaultValue(-1)
-                    .withDescription("The maximum number of results cached in the " +
-                            "lookup source.");
-
     public static final ConfigOption<String> MAX_CACHE_TIME =
             ConfigOptions.key("sink.max-cache-time")
                     .stringType()
@@ -266,7 +259,7 @@ public class RedisOptions {
             ConfigOptions.key("data-type")
                     .enumType(RedisDataType.class)
                     .defaultValue(RedisDataType.PLAIN)
-                    .withDescription("Defines the redis data type, valid types are: 'PLAIN', 'HASH'");
+                    .withDescription("Defines the redis data type, valid types are: 'PLAIN', 'HASH','BITMAP'");
 
     public static final ConfigOption<SchemaMappingMode> SCHEMA_MAPPING_MODE =
             ConfigOptions.key("schema-mapping-mode")

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisOptions.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisOptions.java
@@ -57,7 +57,7 @@ public class RedisOptions {
             .key("password")
             .stringType()
             .noDefaultValue()
-            .withDescription("Optional password for connect to redis");
+            .withDescription("The password for client connecting to server");
     /**
      * Cluster nodes used to connect redis with cluster mode
      */
@@ -199,6 +199,81 @@ public class RedisOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("whether to set async lookup.");
+
+    public static final ConfigOption<String> EXPIRE_TIME =
+            ConfigOptions.key("expire-time")
+                    .stringType()
+                    .defaultValue("0s")
+                    .withDescription("The redis record expired time. If value set to " +
+                            "zero or negative, " +
+                            "record in redis will never expired.");
+
+    public static final ConfigOption<Integer> SINK_MAX_RETRIES =
+            ConfigOptions.key("sink.max-retries")
+                    .intType()
+                    .defaultValue(5)
+                    .withDescription("The maximum number of retries when an " +
+                            "exception is caught.");
+
+    public static final ConfigOption<Integer> CLUSTER_MAX_TOTAL =
+            ConfigOptions.key("sink.max-connections")
+                    .intType()
+                    .defaultValue(2)
+                    .withDescription("Set the value for connection instances created " +
+                            "in pool.");
+
+    public static final ConfigOption<Integer> CLUSTER_MAX_IDLE =
+            ConfigOptions.key("sink.max-idle-connections")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("Set the value for max idle connection " +
+                            "instances created in pool.");
+
+    public static final ConfigOption<String> CLUSTER_MAX_WAIT =
+            ConfigOptions.key("sink.max-wait-time")
+                    .stringType()
+                    .defaultValue("10s")
+                    .withDescription("Set the value for max waiting time if there is " +
+                            "no connection resource.");
+
+    public static final ConfigOption<Integer> MAX_CACHE_SIZE =
+            ConfigOptions.key("sink.max-cache-size")
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription("The maximum number of results cached in the " +
+                            "lookup source.");
+
+    public static final ConfigOption<String> MAX_CACHE_TIME =
+            ConfigOptions.key("sink.max-cache-time")
+                    .stringType()
+                    .defaultValue("60s")
+                    .withDescription("The maximum live time for cached results in " +
+                            "the lookup source.");
+
+    public static final ConfigOption<Long> SINK_BATCH_SIZE =
+            ConfigOptions.key("sink.batch-size")
+                    .longType()
+                    .defaultValue(100L)
+                    .withDescription("The batch size of the sink operator to send data.");
+
+    public static final ConfigOption<String> SINK_FLUSH_INTERVAL =
+            ConfigOptions.key("sink.flush-interval")
+                    .stringType()
+                    .defaultValue("10s")
+                    .withDescription("The maximum waiting time for batch data sent by the sink operator ");
+
+    public static final ConfigOption<RedisDataType> DATA_TYPE =
+            ConfigOptions.key("data-type")
+                    .enumType(RedisDataType.class)
+                    .defaultValue(RedisDataType.PLAIN)
+                    .withDescription("Defines the redis data type, valid types are: 'PLAIN', 'HASH'");
+
+    public static final ConfigOption<SchemaMappingMode> SCHEMA_MAPPING_MODE =
+            ConfigOptions.key("schema-mapping-mode")
+                    .enumType(SchemaMappingMode.class)
+                    .defaultValue(SchemaMappingMode.STATIC_PREFIX_MATCH)
+                    .withDescription("Defines the mapping mode between SQL schema and redisDataType, " +
+                            "Valid enumerations are [\"STATIC_PREFIX_MATCH\",\"STATIC_KV_PAIR\", \"DYNAMIC\"]");
 
     private RedisOptions() {
     }

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/SchemaMappingMode.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/SchemaMappingMode.java
@@ -26,7 +26,7 @@ public enum SchemaMappingMode {
      * The DYNAMIC mode witch mapping a {@link java.util.Map} to {@link RedisDataType}.
      * There are two members in DYNAMIC mode: <br/>
      * the first member is Redis key. <br/>
-     * the second member is a {@link java.util.Map} object, witch will be iterated, <br/>
+     * the second member is a {@link java.util.Map} object, which will be iterated, <br/>
      * the entry key is redis key, and the entry value is redis value.
      */
     DYNAMIC,

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/SchemaMappingMode.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/SchemaMappingMode.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.config;
+
+/**
+ * The MappingMode between Sql Schema and {@link RedisDataType}.
+ */
+public enum SchemaMappingMode {
+
+    /**
+     * The DYNAMIC mode witch mapping a {@link java.util.Map} to {@link RedisDataType}.
+     * There are two members in DYNAMIC mode: <br/>
+     * the first member is Redis key. <br/>
+     * the second member is a {@link java.util.Map} object, witch will be iterated, <br/>
+     * the entry key is redis key, and the entry value is redis value.
+     */
+    DYNAMIC,
+
+    /**
+     * The are at least two fields, the first member is redis key, <br/>
+     * and each field from the second field represents a redis value.<br/>
+     * ex: <br/>
+     * <code>
+     *   key, field, value1, value2, value3, [value]...
+     * </code>
+     */
+    STATIC_PREFIX_MATCH,
+    /**
+     * There are two fields, the first field is key, <br/>
+     * and the other fields are pairs of field and value. <br/>
+     * ex:<br/>
+     * <code>
+     * key, field1, value1,field2,value2,field3,value3,[field,value]...
+     * </code>
+     */
+    STATIC_KV_PAIR;
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisClusterContainer.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisClusterContainer.java
@@ -112,4 +112,18 @@ public class InlongRedisClusterContainer extends RedisClusterContainer implement
             throw e;
         }
     }
+
+    @Override
+    public void setBit(String key, Long offset, Boolean value) {
+        try {
+            jedisCluster.setbit(key, offset, value);
+        } catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error(
+                        "Cannot send Redis message with command setBit, key: {}, offset: {}, value: {}, error message {}",
+                        key, offset, value, e.getMessage());
+            }
+            throw e;
+        }
+    }
 }

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisCommandsContainer.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisCommandsContainer.java
@@ -74,4 +74,5 @@ public interface InlongRedisCommandsContainer extends RedisCommandsContainer {
      */
     Long zrevrank(String key, String member);
 
+    void setBit(String key, Long offset, Boolean value);
 }

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisContainer.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/container/InlongRedisContainer.java
@@ -158,6 +158,23 @@ public class InlongRedisContainer extends RedisContainer implements InlongRedisC
         }
     }
 
+    @Override
+    public void setBit(String key, Long offset, Boolean value) {
+        Jedis jedis = null;
+        try {
+            jedis = getInstance();
+            jedis.setbit(key, offset, value);
+        } catch (Exception e) {
+            if (LOG.isErrorEnabled()) {
+                LOG.error("Cannot properly execute setBit command, key: {}, offset: {}, value:{}, error message {}",
+                        key, offset, value, e.getMessage());
+            }
+            throw e;
+        } finally {
+            releaseInstance(jedis);
+        }
+    }
+
     public Jedis getInstance() {
         if (jedisSentinelPool != null) {
             return jedisSentinelPool.getResource();

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/RedisSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/RedisSchema.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema;
+
+import java.io.Serializable;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink.Context;
+import org.apache.flink.table.data.RowData;
+
+public interface RedisSchema<T> extends Serializable {
+
+    /**
+     * Validate the schema.
+     */
+    void validate(ResolvedSchema resolvedSchema);
+
+    /**
+     * The position of redis rowKey.
+     */
+    int getKeyIndex();
+
+    /**
+     * The start position of redis value.
+     */
+    int getValueIndex();
+
+    /**
+     * The serialization schema for parsing rowData to
+     */
+    SerializationSchema<RowData> getSerializationSchema(Context context,
+            EncodingFormat<SerializationSchema<RowData>> format);
+
+    /**
+     * The {@link StateEncoder} for encoding row to stateType.
+     */
+    StateEncoder<T> getStateEncoder();
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/RedisSchemaFactory.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/RedisSchemaFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema;
+
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.inlong.sort.redis.common.config.RedisDataType;
+import org.apache.inlong.sort.redis.common.config.SchemaMappingMode;
+import org.apache.inlong.sort.redis.common.schema.impl.BitmapStaticKvPairSchema;
+import org.apache.inlong.sort.redis.common.schema.impl.HashDynamicSchema;
+import org.apache.inlong.sort.redis.common.schema.impl.HashStaticKvPairSchema;
+import org.apache.inlong.sort.redis.common.schema.impl.HashStaticPrefixMatchSchema;
+import org.apache.inlong.sort.redis.common.schema.impl.PlainPrefixMatchSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The factory for creating RedisSchema.
+ */
+public class RedisSchemaFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RedisSchemaFactory.class);
+
+    /**
+     * Create a new {@link RedisSchema}
+     */
+    public static RedisSchema<?> createRedisSchema(
+            RedisDataType dataType,
+            SchemaMappingMode schemaMappingMode,
+            ResolvedSchema resolvedSchema) {
+
+        if (dataType == RedisDataType.BITMAP) {
+            if (schemaMappingMode == SchemaMappingMode.STATIC_KV_PAIR) {
+                return new BitmapStaticKvPairSchema(resolvedSchema);
+            } else {
+                String message = "Unsupported '" + schemaMappingMode + "' in Bitmap dataType currently !";
+                LOG.error(message);
+                throw new UnsupportedOperationException(message);
+            }
+        }
+
+        if (dataType == RedisDataType.HASH) {
+            switch (schemaMappingMode) {
+                case DYNAMIC:
+                    return new HashDynamicSchema(resolvedSchema);
+                case STATIC_KV_PAIR:
+                    return new HashStaticKvPairSchema(resolvedSchema);
+                case STATIC_PREFIX_MATCH:
+                    return new HashStaticPrefixMatchSchema(resolvedSchema);
+                default:
+                    String message = "Unsupported '" + schemaMappingMode + "' in HASH dataType currently !";
+                    LOG.error(message);
+                    throw new UnsupportedOperationException(message);
+            }
+        }
+
+        if (dataType == RedisDataType.PLAIN) {
+            if (schemaMappingMode == SchemaMappingMode.STATIC_PREFIX_MATCH) {
+                return new PlainPrefixMatchSchema(resolvedSchema);
+            } else {
+                String message = "Unsupported '" + schemaMappingMode + "' in PLAIN dataType currently !";
+                LOG.error(message);
+                throw new UnsupportedOperationException(message);
+            }
+        }
+        throw new UnsupportedOperationException("Unsupported dataType: '" + dataType + "' !");
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/StateEncoder.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/StateEncoder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.RowData;
+
+@FunctionalInterface
+public interface StateEncoder<T> extends Serializable {
+
+    List<T> serialize(RowData in, SerializationSchema<RowData> serializationSchema) throws Exception;
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/AbstractRedisSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/AbstractRedisSchema.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.shaded.guava18.com.google.common.base.Preconditions;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink.Context;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.KeyValueDataType;
+import org.apache.flink.table.types.utils.DataTypeUtils;
+import org.apache.flink.table.utils.TableSchemaUtils;
+import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.redis.common.schema.RedisSchema;
+
+/**
+ * The base class of {@link RedisSchema}
+ *
+ * @param <T> The type of Flink state.
+ */
+public abstract class AbstractRedisSchema<T> implements RedisSchema<T> {
+
+    private final DataType physicalFormatDataType;
+
+    public AbstractRedisSchema(ResolvedSchema resolvedSchema) {
+        TableSchema physicalSchema = TableSchemaUtils.getPhysicalSchema(
+                TableSchema.fromResolvedSchema(resolvedSchema));
+        int valueIndex = getValueIndex();
+        int[] projection = IntStream.range(valueIndex, physicalSchema.getFieldCount()).toArray();
+
+        physicalFormatDataType = DataTypeUtils.projectRow(physicalSchema.toPhysicalRowDataType(), projection);
+    }
+
+    @Override
+    public SerializationSchema<RowData> getSerializationSchema(
+            Context context,
+            EncodingFormat<SerializationSchema<RowData>> format) {
+        return format.createRuntimeEncoder(context, physicalFormatDataType);
+    }
+
+    protected boolean getRowKind(RowKind rowKind) {
+        return rowKind == RowKind.INSERT || rowKind == RowKind.UPDATE_AFTER;
+    }
+
+    protected void validateStaticKvPair(ResolvedSchema resolvedSchema, Class keyClass, Class valueClass) {
+        validateRowKey(resolvedSchema);
+        List<Column> columns = resolvedSchema.getColumns();
+        Preconditions.checkState(columns.size() % 2 == 1,
+                "The number of elements must be odd, and all even elements are field.");
+        for (int i = 1; i < columns.size(); i += 2) {
+            Column offsetColumn = columns.get(i);
+            Column valueColumn = columns.get(i + 1);
+            Preconditions.checkState(offsetColumn.getDataType().getConversionClass() == keyClass,
+                    "The type of key/offset field (odd column) must be " + keyClass.getName());
+            Preconditions.checkState(valueColumn.getDataType().getConversionClass() == valueClass,
+                    "The type of value field (even column) must be " + valueClass.getName());
+        }
+    }
+
+    protected void validateStaticPrefixMatch(ResolvedSchema resolvedSchema) {
+        validateRowKey(resolvedSchema);
+    }
+
+    protected void validateDynamic(ResolvedSchema resolvedSchema) {
+        validateRowKey(resolvedSchema);
+        List<Column> columns = resolvedSchema.getColumns();
+        Preconditions.checkState(columns.size() == 2,
+                "The number of elements must be 2.");
+        Column column = columns.get(1);
+        DataType dataType = column.getDataType();
+        Preconditions.checkState(dataType instanceof KeyValueDataType, "The second element's Type must be Map");
+        Preconditions.checkState(((KeyValueDataType) dataType).getKeyDataType().getConversionClass() == String.class,
+                "The key type of second element(Map) must be String");
+        Preconditions.checkState(((KeyValueDataType) dataType).getValueDataType().getConversionClass() == String.class,
+                "The value type of second element(Map) must be String");
+    }
+
+    private void validateRowKey(ResolvedSchema resolvedSchema) {
+        Optional<Column> column = resolvedSchema.getColumn(0);
+        checkState(column.get().getDataType().getConversionClass() == String.class,
+                "The rowKey (first element) must be String");
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/BitmapStaticKvPairSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/BitmapStaticKvPairSchema.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import static org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkState;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+/**
+ * The RedisSchema for Bitmap data-type and StaticKvPair mode.
+ */
+public class BitmapStaticKvPairSchema
+        extends
+            AbstractRedisSchema<Tuple4<Boolean, String, Long, Boolean>> {
+
+    public BitmapStaticKvPairSchema(ResolvedSchema resolvedSchema) {
+        super(resolvedSchema);
+    }
+
+    @Override
+    public void validate(ResolvedSchema resolvedSchema) {
+        validateStaticKvPair(resolvedSchema, Long.class, Boolean.class);
+    }
+
+    @Override
+    public int getKeyIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return 1;
+    }
+
+    @Override
+    public StateEncoder<Tuple4<Boolean, String, Long, Boolean>> getStateEncoder() {
+        return (in, serializationSchema) -> {
+            boolean rowKind = getRowKind(in.getRowKind());
+            GenericRowData row = (GenericRowData) in;
+            String rowKey = row.getString(getKeyIndex()).toString();
+
+            checkState(row.getArity() % 2 == 1,
+                    "The number of elements must be odd, and all even elements are field.");
+
+            return IntStream
+                    .range(1, row.getArity() / 2 + 1)
+                    .boxed()
+                    .map(i -> {
+                        int keyPos = 2 * i - 1;
+                        long offset = row.getLong(keyPos);
+                        boolean aBoolean = row.getBoolean(keyPos + 1);
+                        return Tuple4.of(rowKind, rowKey, offset, aBoolean);
+                    })
+                    .collect(Collectors.toList());
+
+        };
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashDynamicSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashDynamicSchema.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.StringData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+/**
+ * The RedisSchema for Hash data-type and Dynamic mode.
+ */
+public class HashDynamicSchema extends HashStaticPrefixMatchSchema {
+
+    public HashDynamicSchema(ResolvedSchema resolvedSchema) {
+        super(resolvedSchema);
+    }
+
+    @Override
+    public void validate(ResolvedSchema resolvedSchema) {
+        validateDynamic(resolvedSchema);
+    }
+
+    @Override
+    public int getKeyIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return 1;
+    }
+
+    @Override
+    public StateEncoder<Tuple4<Boolean, String, String, String>> getStateEncoder() {
+        return (in, serializationSchema) -> {
+            boolean rowKind = getRowKind(in.getRowKind());
+
+            GenericRowData row = (GenericRowData) in;
+            String rowKey = row.getString(getKeyIndex()).toString();
+            MapData fieldMap = row.getMap(getValueIndex());
+
+            ArrayData keyArray = fieldMap.keyArray();
+            ArrayData valueMap = fieldMap.valueArray();
+            return IntStream
+                    .range(0, fieldMap.size())
+                    .boxed()
+                    .map(i -> {
+                        String fieldName = keyArray.getString(i).toString();
+                        byte[] binary = valueMap.getBinary(i);
+                        String fieldValue = StringData.fromBytes(binary).toString();
+                        return Tuple4.of(rowKind, rowKey, fieldName, fieldValue);
+                    })
+                    .collect(Collectors.toList());
+        };
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashStaticKvPairSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashStaticKvPairSchema.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import static org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkState;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+public class HashStaticKvPairSchema extends HashStaticPrefixMatchSchema {
+
+    public HashStaticKvPairSchema(ResolvedSchema resolvedSchema) {
+        super(resolvedSchema);
+    }
+
+    @Override
+    public void validate(ResolvedSchema resolvedSchema) {
+        validateStaticKvPair(resolvedSchema, String.class, String.class);
+    }
+
+    @Override
+    public int getKeyIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return 1;
+    }
+
+    @Override
+    public StateEncoder<Tuple4<Boolean, String, String, String>> getStateEncoder() {
+        return (in, serializationSchema) -> {
+            boolean rowKind = getRowKind(in.getRowKind());
+
+            GenericRowData row = (GenericRowData) in;
+            String rowKey = row.getString(getKeyIndex()).toString();
+
+            checkState(row.getArity() % 2 == 1,
+                    "The number of elements must be odd, and even elements are field.");
+
+            return IntStream.range(getValueIndex(), row.getArity() / 2 + 1)
+                    .boxed()
+                    .map(i -> {
+                        int keyPos = 2 * i - 1;
+                        int valuePos = keyPos + 1;
+                        String fieldName = row.getString(keyPos).toString();
+                        String value = row.getString(valuePos).toString();
+                        return Tuple4.of(rowKind, rowKey, fieldName, value);
+                    }).collect(Collectors.toList());
+        };
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashStaticPrefixMatchSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/HashStaticPrefixMatchSchema.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import java.util.Collections;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+public class HashStaticPrefixMatchSchema extends AbstractRedisSchema<Tuple4<Boolean, String, String, String>> {
+
+    public HashStaticPrefixMatchSchema(ResolvedSchema resolvedSchema) {
+        super(resolvedSchema);
+    }
+
+    @Override
+    public void validate(ResolvedSchema resolvedSchema) {
+        validateStaticPrefixMatch(resolvedSchema);
+    }
+
+    @Override
+    public int getKeyIndex() {
+        return 0;
+    }
+
+    public int getFieldIndex() {
+        return 1;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return 2;
+    }
+
+    @Override
+    public StateEncoder<Tuple4<Boolean, String, String, String>> getStateEncoder() {
+        return (in, serializationSchema) -> {
+            boolean rowKind = getRowKind(in.getRowKind());
+            GenericRowData row = (GenericRowData) in;
+            String rowKey = row.getString(getKeyIndex()).toString();
+            String fieldName = row.getString(getFieldIndex()).toString();
+
+            GenericRowData value = new GenericRowData(in.getRowKind(), row.getArity() - getValueIndex());
+            for (int i = 0; i < row.getArity() - getValueIndex(); ++i) {
+                value.setField(i, row.getField(i + getValueIndex()));
+            }
+            final byte[] valueBytes = serializationSchema.serialize(value);
+            String v = StringData.fromBytes(valueBytes).toString();
+            return Collections.singletonList(Tuple4.of(rowKind, rowKey, fieldName, v));
+        };
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/PlainPrefixMatchSchema.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/schema/impl/PlainPrefixMatchSchema.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.common.schema.impl;
+
+import java.util.Collections;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+public class PlainPrefixMatchSchema extends AbstractRedisSchema<Tuple3<Boolean, String, String>> {
+
+    public PlainPrefixMatchSchema(ResolvedSchema resolvedSchema) {
+        super(resolvedSchema);
+    }
+
+    @Override
+    public void validate(ResolvedSchema resolvedSchema) {
+        validateStaticPrefixMatch(resolvedSchema);
+    }
+
+    @Override
+    public int getKeyIndex() {
+        return 0;
+    }
+
+    @Override
+    public int getValueIndex() {
+        return 1;
+    }
+
+    @Override
+    public StateEncoder<Tuple3<Boolean, String, String>> getStateEncoder() {
+        return (in, serializationSchema) -> {
+            boolean rowKind = getRowKind(in.getRowKind());
+            GenericRowData rowData = (GenericRowData) in;
+            String rowKey = rowData.getString(getKeyIndex()).toString();
+
+            GenericRowData valueRowData = new GenericRowData(in.getRowKind(), in.getArity() - 1);
+            for (int i = 0; i < rowData.getArity() - 1; ++i) {
+                valueRowData.setField(i, rowData.getField(i + 1));
+            }
+            byte[] valueBytes = serializationSchema.serialize(valueRowData);
+            String value = StringData.fromBytes(valueBytes).toString();
+            return Collections.singletonList(Tuple3.of(rowKind, rowKey, value));
+        };
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/AbstractRedisSinkFunction.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/AbstractRedisSinkFunction.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.concurrent.GuardedBy;
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.redis.common.container.InlongRedisCommandsContainer;
+import org.apache.inlong.sort.redis.common.container.RedisCommandsContainerBuilder;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Flink Redis Producer.
+ */
+public abstract class AbstractRedisSinkFunction<OUT>
+        extends
+            RichSinkFunction<RowData>
+        implements
+            CheckpointedFunction {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractRedisSinkFunction.class);
+
+    /**
+     * The output type info.
+     */
+    private final TypeInformation<OUT> outputType;
+
+    /**
+     * The serializer for values.
+     */
+    protected final SerializationSchema<RowData> serializationSchema;
+
+    protected final FlinkJedisConfigBase flinkJedisConfigBase;
+
+    /**
+     * The redis record expired time.
+     */
+    protected transient Integer expireTime;
+
+    /**
+     * The flag indicating whether the main thread need flush.
+     */
+    private transient boolean forceFlush;
+
+    private ListState<OUT> listState;
+
+    private transient Object lock;
+
+    private final long batchSize;
+
+    private final long flushIntervalInMillis;
+
+    private static final String DEFAULT_OUTPUT_FLUSH_THREAD_NAME = "OutputFlusher";
+
+    private final List<OUT> rows;
+
+    private transient ScheduledExecutorService executorService;
+
+    /**
+     * The container for all available Redis commands.
+     */
+    protected InlongRedisCommandsContainer redisCommandsContainer;
+
+    /**
+     * The stop watch to measure time duration.
+     */
+    @GuardedBy("lock")
+    protected transient StopWatch stopWatch;
+
+    protected StateEncoder<OUT> stateEncoder;
+
+    public AbstractRedisSinkFunction(
+            TypeInformation<OUT> outputType,
+            SerializationSchema<RowData> serializationSchema,
+            StateEncoder<OUT> stateEncoder,
+            long batchSize,
+            Duration flushInterval,
+            Duration configuration,
+            FlinkJedisConfigBase flinkJedisConfigBase) {
+        checkNotNull(configuration, "The configuration must not be null.");
+
+        this.stateEncoder = stateEncoder;
+        this.outputType = outputType;
+        this.serializationSchema = serializationSchema;
+
+        this.batchSize = batchSize;
+        this.flushIntervalInMillis = flushInterval.toMillis();
+        this.forceFlush = false;
+        this.rows = new ArrayList<>();
+        this.flinkJedisConfigBase = flinkJedisConfigBase;
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        LOG.info("Opening redis sink with address");
+
+        lock = new Object();
+
+        stopWatch = new StopWatch();
+
+        try {
+            this.redisCommandsContainer = RedisCommandsContainerBuilder.build(this.flinkJedisConfigBase);
+            this.redisCommandsContainer.open();
+        } catch (Exception e) {
+            LOG.error("Redis has not been properly initialized: ", e);
+            throw new RuntimeException(e);
+        }
+
+        Optional<OutputFlusher> outputFlusher;
+        if (this.batchSize == 1 || this.flushIntervalInMillis == 0) {
+            LOG.info("Flush records immediately.");
+            outputFlusher = Optional.empty();
+        } else {
+            String threadName = DEFAULT_OUTPUT_FLUSH_THREAD_NAME + " for "
+                    + getRuntimeContext().getTaskNameWithSubtasks();
+            outputFlusher = Optional.of(new OutputFlusher(threadName, flushIntervalInMillis));
+            outputFlusher.get().start();
+        }
+
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        final ListStateDescriptor<OUT> stateDescriptor = new ListStateDescriptor<>(
+                "rowState", outputType);
+        this.listState = context.getOperatorStateStore().getListState(stateDescriptor);
+        if (context.isRestored()) {
+            if (listState != null) {
+                listState.get().forEach(rows::add);
+            }
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
+        LOG.info("redis start snapshotState, id: {}", functionSnapshotContext.getCheckpointId());
+        synchronized (lock) {
+            listState.clear();
+            listState.addAll(rows);
+        }
+        LOG.info("redis end snapshotState, id: {}", functionSnapshotContext.getCheckpointId());
+    }
+
+    protected List<OUT> serialize(RowData in) {
+        try {
+            return stateEncoder.serialize(in, serializationSchema);
+        } catch (Exception e) {
+            LOG.error("Error when serializing data: " + in);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void invoke(RowData in, Context context) {
+
+        List<OUT> redisOutputs = serialize(in);
+        synchronized (lock) {
+            rows.addAll(redisOutputs);
+            if (forceFlush || rows.size() >= batchSize) {
+                flush();
+            }
+        }
+
+    }
+
+    @Override
+    public void close() throws Exception {
+        closeClient();
+
+        if (executorService != null) {
+            try {
+                executorService.shutdown();
+            } catch (Throwable t) {
+                LOG.warn("Could not properly shut down ScheduledExecutorService.", t);
+            }
+        }
+
+        super.close();
+
+        LOG.info("Closed redis sink.");
+    }
+
+    private void closeClient() {
+        synchronized (lock) {
+            if (redisCommandsContainer != null) {
+                flush();
+                try {
+                    redisCommandsContainer.close();
+                    redisCommandsContainer = null;
+                } catch (Throwable t) {
+                    LOG.warn("Could not properly close the redis client.", t);
+                }
+            }
+        }
+    }
+
+    private class OutputFlusher extends Thread {
+
+        private final long timeoutInMillis;
+        private volatile boolean running = true;
+
+        OutputFlusher(String name, long timeoutInMillis) {
+            super(name);
+            setDaemon(true);
+            this.timeoutInMillis = timeoutInMillis;
+        }
+
+        public void terminate() {
+            running = false;
+            interrupt();
+        }
+
+        @Override
+        public void run() {
+            while (running) {
+
+                try {
+                    try {
+                        Thread.sleep(timeoutInMillis);
+                    } catch (InterruptedException e) {
+                        if (running) {
+                            throw new Exception(e);
+                        }
+                    }
+                    if (rows.size() > 0) {
+                        flush();
+                    }
+                } catch (Throwable t) {
+                    LOG.error("An exception happened while flushing the outputs", t);
+                    // There is no need to handle exceptions in asynchronous threads.
+                    // When the number of rows exceeds the batchSize, it will fail directly in the next write.
+                    // But there is a possibility of data delay.
+                    forceFlush = true;
+                    LOG.error("Set the forceFlush to true, it will retry in the main thread.");
+                }
+
+            }
+        }
+    }
+
+    protected abstract void flushInternal(List<OUT> rows);
+
+    private void flush() {
+        synchronized (lock) {
+            try {
+                if (rows != null && rows.size() > 0) {
+                    LOG.debug("Flushing {} records to redis...", rows.size());
+                    flushInternal(rows);
+                    LOG.debug("Flushed {} records to redis...", rows.size());
+                    rows.clear();
+                }
+            } finally {
+                forceFlush = false;
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisBitmapSinkFunction.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisBitmapSinkFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Flink Redis Producer.
+ */
+public class RedisBitmapSinkFunction
+        extends
+            AbstractRedisSinkFunction<Tuple4<Boolean, String, Long, Boolean>> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(RedisBitmapSinkFunction.class);
+
+    public RedisBitmapSinkFunction(
+            SerializationSchema<RowData> serializationSchema,
+            StateEncoder<Tuple4<Boolean, String, Long, Boolean>> stateEncoder,
+            long batchSize,
+            Duration flushInterval,
+            Duration configuration,
+            FlinkJedisConfigBase flinkJedisConfigBase) {
+        super(TypeInformation.of(new TypeHint<Tuple4<Boolean, String, Long, Boolean>>() {
+        }),
+                serializationSchema,
+                stateEncoder,
+                batchSize,
+                flushInterval,
+                configuration,
+                flinkJedisConfigBase);
+        LOG.info("Creating RedisBitmapStaticKvPairSinkFunction ...");
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        super.open(parameters);
+        LOG.info("Opening RedisBitmapStaticKvPairSinkFunction ...");
+    }
+
+    @Override
+    protected void flushInternal(List<Tuple4<Boolean, String, Long, Boolean>> rows) {
+        for (Tuple4<Boolean, String, Long, Boolean> row : rows) {
+            Boolean rowKind = row.f0;
+            String key = row.f1;
+            Long offset = row.f2;
+            Boolean value = row.f3;
+            if (rowKind) {
+                redisCommandsContainer.setBit(key, offset, value);
+            } else {
+                redisCommandsContainer.del(key);
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisDynamicTableSink.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import static org.apache.flink.util.TimeUtils.parseDuration;
+import static org.apache.inlong.sort.redis.common.config.RedisOptions.EXPIRE_TIME;
+import static org.apache.inlong.sort.redis.common.config.RedisOptions.SINK_BATCH_SIZE;
+import static org.apache.inlong.sort.redis.common.config.RedisOptions.SINK_FLUSH_INTERVAL;
+import static org.apache.inlong.sort.redis.common.config.SchemaMappingMode.DYNAMIC;
+import static org.apache.inlong.sort.redis.common.config.SchemaMappingMode.STATIC_KV_PAIR;
+import static org.apache.inlong.sort.redis.common.config.SchemaMappingMode.STATIC_PREFIX_MATCH;
+
+import java.time.Duration;
+import java.util.Map;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.streaming.connectors.redis.common.hanlder.RedisHandlerServices;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.redis.common.config.RedisDataType;
+import org.apache.inlong.sort.redis.common.config.SchemaMappingMode;
+import org.apache.inlong.sort.redis.common.handler.InlongJedisConfigHandler;
+import org.apache.inlong.sort.redis.common.schema.RedisSchema;
+import org.apache.inlong.sort.redis.common.schema.RedisSchemaFactory;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+public class RedisDynamicTableSink implements DynamicTableSink {
+
+    private final FlinkJedisConfigBase flinkJedisConfigBase;
+
+    private final ResolvedSchema resolvedSchema;
+
+    private final EncodingFormat<SerializationSchema<RowData>> format;
+
+    private final RedisDataType dataType;
+    private final SchemaMappingMode mappingMode;
+    private final ReadableConfig config;
+    private final Map<String, String> properties;
+
+    public RedisDynamicTableSink(
+            EncodingFormat<SerializationSchema<RowData>> format,
+            ResolvedSchema resolvedSchema,
+            RedisDataType dataType,
+            SchemaMappingMode schemaMappingMode,
+            ReadableConfig config,
+            Map<String, String> properties) {
+        this.format = format;
+        this.resolvedSchema = resolvedSchema;
+        this.dataType = dataType;
+        this.mappingMode = schemaMappingMode;
+        this.config = config;
+        this.properties = properties;
+
+        flinkJedisConfigBase = RedisHandlerServices
+                .findRedisHandler(InlongJedisConfigHandler.class, properties)
+                .createFlinkJedisConfig(config);
+
+        batchSize = config.get(SINK_BATCH_SIZE);
+        flushInterval = parseDuration(config.get(SINK_FLUSH_INTERVAL));
+        expireTime = parseDuration(config.get(EXPIRE_TIME));
+    }
+
+    private final Duration expireTime;
+    private final Long batchSize;
+    private final Duration flushInterval;
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        // UPSERT mode
+        ChangelogMode.Builder builder = ChangelogMode.newBuilder();
+        for (RowKind kind : requestedMode.getContainedKinds()) {
+            if (kind != RowKind.UPDATE_BEFORE) {
+                builder.addContainedKind(kind);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+
+        RedisSchema redisSchema = RedisSchemaFactory.createRedisSchema(dataType, mappingMode, resolvedSchema);
+        redisSchema.validate(resolvedSchema);
+
+        SerializationSchema serializationSchema =
+                mappingMode == DYNAMIC ? null : redisSchema.getSerializationSchema(context, format);
+        StateEncoder stateEncoder = redisSchema.getStateEncoder();
+
+        RichSinkFunction<RowData> redisSinkFunction;
+        switch (dataType) {
+            case HASH:
+                redisSinkFunction = new RedisHashSinkFunction(
+                        serializationSchema,
+                        stateEncoder,
+                        batchSize,
+                        flushInterval,
+                        expireTime,
+                        flinkJedisConfigBase);
+                break;
+            case PLAIN:
+                redisSinkFunction = new RedisPlainSinkFunction(
+                        serializationSchema,
+                        stateEncoder,
+                        batchSize,
+                        flushInterval,
+                        expireTime,
+                        flinkJedisConfigBase);
+                break;
+            case BITMAP:
+                redisSinkFunction = new RedisBitmapSinkFunction(
+                        serializationSchema,
+                        stateEncoder,
+                        batchSize,
+                        flushInterval,
+                        expireTime,
+                        flinkJedisConfigBase);
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
+        return SinkFunctionProvider.of(redisSinkFunction);
+    }
+
+    private int getValueStartIndexInSchema(
+            RedisDataType dataType,
+            SchemaMappingMode mappingMode) {
+        switch (dataType) {
+            case PLAIN:
+                return 1;
+            case HASH:
+                if (mappingMode == STATIC_PREFIX_MATCH) {
+                    return 2;
+                } else if (mappingMode == STATIC_KV_PAIR) {
+                    // Serialize data without using schema
+                    return 0;
+                } else {
+                    return 1;
+                }
+            case BITMAP:
+                if (mappingMode == STATIC_KV_PAIR) {
+                    // Serialize data without using schema
+                    return 0;
+                }
+                return 0;
+            default:
+                throw new UnsupportedOperationException("The dataType '" + dataType + "' is not supported.");
+        }
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new RedisDynamicTableSink(
+                format,
+                resolvedSchema,
+                dataType,
+                mappingMode,
+                config,
+                properties);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "Redis";
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisHashSinkFunction.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisHashSinkFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple4;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Flink Redis Producer.
+ */
+public class RedisHashSinkFunction
+        extends
+            AbstractRedisSinkFunction<Tuple4<Boolean, String, String, String>> {
+
+    public static final Logger LOG = LoggerFactory.getLogger(RedisHashSinkFunction.class);
+
+    public RedisHashSinkFunction(
+            SerializationSchema<RowData> serializationSchema,
+            StateEncoder<Tuple4<Boolean, String, String, String>> stateEncoder,
+            long batchSize,
+            Duration flushInterval,
+            Duration expireTime,
+            FlinkJedisConfigBase flinkJedisConfigBase) {
+        super(TypeInformation.of(new TypeHint<Tuple4<Boolean, String, String, String>>() {
+        }),
+                serializationSchema,
+                stateEncoder,
+                batchSize,
+                flushInterval,
+                expireTime,
+                flinkJedisConfigBase);
+        LOG.info("Creating RedisHashSinkFunction ...");
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        super.open(parameters);
+        LOG.info("Open RedisHashSinkFunction ...");
+    }
+
+    @Override
+    protected void flushInternal(List<Tuple4<Boolean, String, String, String>> rows) {
+        for (Tuple4<Boolean, String, String, String> row : rows) {
+            LOG.info("Flush new row: {}.", row);
+            Boolean rowKind = row.f0;
+            String key = row.f1;
+            String field = row.f2;
+            String value = row.f3;
+            if (rowKind) {
+                redisCommandsContainer.hset(key, field, value, expireTime);
+            } else {
+                redisCommandsContainer.del(key);
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisPlainSinkFunction.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisPlainSinkFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import static org.apache.flink.api.java.ClosureCleaner.ensureSerializable;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+/**
+ * The Flink Redis Producer.
+ */
+public class RedisPlainSinkFunction
+        extends
+            AbstractRedisSinkFunction<Tuple3<Boolean, String, String>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public RedisPlainSinkFunction(
+            SerializationSchema<RowData> serializationSchema,
+            StateEncoder<Tuple3<Boolean, String, String>> stateEncoder,
+            long batchSize,
+            Duration flushInterval,
+            Duration configuration,
+            FlinkJedisConfigBase flinkJedisConfigBase) {
+        super(TypeInformation.of(new TypeHint<Tuple3<Boolean, String, String>>() {
+        }),
+                serializationSchema,
+                stateEncoder,
+                batchSize,
+                flushInterval,
+                configuration,
+                flinkJedisConfigBase);
+        checkNotNull(serializationSchema, "The serialization schema must not be null.");
+        ensureSerializable(serializationSchema);
+    }
+
+    @Override
+    protected void flushInternal(List<Tuple3<Boolean, String, String>> rows) {
+        for (Tuple3<Boolean, String, String> row : rows) {
+            String key = row.f1;
+            String value = row.f2;
+            if (row.f0) {
+                if (expireTime != null) {
+                    redisCommandsContainer.setex(key, value, expireTime);
+                } else {
+                    redisCommandsContainer.set(key, value);
+                }
+            } else {
+                redisCommandsContainer.del(key);
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisSinkFunction.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/sink/RedisSinkFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis.sink;
+
+import static org.apache.flink.api.java.ClosureCleaner.ensureSerializable;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.time.Duration;
+import java.util.List;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.streaming.connectors.redis.common.config.FlinkJedisConfigBase;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.redis.common.schema.StateEncoder;
+
+/**
+ * The Flink Redis Producer.
+ */
+public class RedisSinkFunction
+        extends
+            AbstractRedisSinkFunction<Tuple3<Boolean, String, String>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public RedisSinkFunction(
+            SerializationSchema<RowData> serializationSchema,
+            StateEncoder<Tuple3<Boolean, String, String>> stateEncoder,
+            long batchSize,
+            Duration flushInterval,
+            Duration configuration,
+            FlinkJedisConfigBase flinkJedisConfigBase) {
+        super(TypeInformation.of(new TypeHint<Tuple3<Boolean, String, String>>() {
+        }),
+                serializationSchema,
+                stateEncoder,
+                batchSize,
+                flushInterval,
+                configuration,
+                flinkJedisConfigBase);
+        checkNotNull(serializationSchema, "The serialization schema must not be null.");
+        ensureSerializable(serializationSchema);
+    }
+
+    @Override
+    protected void flushInternal(List<Tuple3<Boolean, String, String>> rows) {
+        for (Tuple3<Boolean, String, String> row : rows) {
+            String key = row.f1;
+            String value = row.f2;
+            if (row.f0) {
+                if (expireTime != null) {
+                    redisCommandsContainer.setex(key, value, expireTime);
+                } else {
+                    redisCommandsContainer.set(key, value);
+                }
+            } else {
+                redisCommandsContainer.del(key);
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/table/RedisDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/table/RedisDynamicTableFactory.java
@@ -17,35 +17,52 @@
 
 package org.apache.inlong.sort.redis.table;
 
-import org.apache.flink.configuration.ConfigOption;
-import org.apache.flink.configuration.ReadableConfig;
-import org.apache.flink.streaming.connectors.redis.descriptor.RedisValidator;
-import org.apache.flink.table.connector.source.DynamicTableSource;
-import org.apache.flink.table.factories.DynamicTableSourceFactory;
-import org.apache.flink.table.factories.FactoryUtil;
-import org.apache.flink.util.Preconditions;
-import org.apache.flink.util.StringUtils;
-import org.apache.inlong.sort.redis.common.config.RedisLookupOptions;
-import org.apache.inlong.sort.redis.common.config.RedisOptions;
-import org.apache.inlong.sort.redis.common.descriptor.InlongRedisValidator;
-import org.apache.inlong.sort.redis.common.mapper.RedisCommand;
-import org.apache.inlong.sort.redis.source.RedisDynamicTableSource;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.redis.common.config.RedisOptions.DATA_TYPE;
 import static org.apache.inlong.sort.redis.common.config.RedisOptions.LOOKUP_ASYNC;
 import static org.apache.inlong.sort.redis.common.config.RedisOptions.LOOKUP_CACHE_MAX_ROWS;
 import static org.apache.inlong.sort.redis.common.config.RedisOptions.LOOKUP_CACHE_TTL;
 import static org.apache.inlong.sort.redis.common.config.RedisOptions.LOOKUP_MAX_RETRIES;
+import static org.apache.inlong.sort.redis.common.config.RedisOptions.SCHEMA_MAPPING_MODE;
+import static org.apache.inlong.sort.redis.common.config.SchemaMappingMode.STATIC_KV_PAIR;
+import static org.apache.inlong.sort.redis.common.config.SchemaMappingMode.STATIC_PREFIX_MATCH;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.connectors.redis.descriptor.RedisValidator;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.format.EncodingFormat;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.SerializationFormatFactory;
+import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.StringUtils;
+import org.apache.inlong.sort.redis.common.config.RedisDataType;
+import org.apache.inlong.sort.redis.common.config.RedisLookupOptions;
+import org.apache.inlong.sort.redis.common.config.RedisOptions;
+import org.apache.inlong.sort.redis.common.config.SchemaMappingMode;
+import org.apache.inlong.sort.redis.common.descriptor.InlongRedisValidator;
+import org.apache.inlong.sort.redis.common.mapper.RedisCommand;
+import org.apache.inlong.sort.redis.sink.RedisDynamicTableSink;
+import org.apache.inlong.sort.redis.source.RedisDynamicTableSource;
 
 /**
  * Redis dynamic table factory
  */
-public class RedisDynamicTableFactory implements DynamicTableSourceFactory {
+public class RedisDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
     /**
      * The identifier of Redis Connector
@@ -89,6 +106,31 @@ public class RedisDynamicTableFactory implements DynamicTableSourceFactory {
                 context.getCatalogTable().getResolvedSchema(), config, getJdbcLookupOptions(config));
     }
 
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        Map<String, String> properties = context.getCatalogTable().getOptions();
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        ReadableConfig config = helper.getOptions();
+        RedisDataType dataType = config.get(DATA_TYPE);
+        SchemaMappingMode schemaMappingMode = config.get(SCHEMA_MAPPING_MODE);
+
+        validateDataTypeAndSchemaMappingMode(dataType, schemaMappingMode);
+        String inlongMetric = config.getOptional(INLONG_METRIC).orElse(INLONG_METRIC.defaultValue());
+        String auditHostAndPorts = config.getOptional(INLONG_AUDIT).orElse(INLONG_AUDIT.defaultValue());
+
+        ResolvedSchema resolvedSchema = context.getCatalogTable().getResolvedSchema();
+        EncodingFormat<SerializationSchema<RowData>> encodingFormat = helper
+                .discoverEncodingFormat(SerializationFormatFactory.class, FactoryUtil.FORMAT);
+
+        return new RedisDynamicTableSink(
+                encodingFormat,
+                resolvedSchema,
+                dataType,
+                schemaMappingMode,
+                config,
+                properties);
+    }
+
     private RedisLookupOptions getJdbcLookupOptions(ReadableConfig readableConfig) {
         return new RedisLookupOptions(readableConfig.get(LOOKUP_CACHE_MAX_ROWS),
                 readableConfig.get(LOOKUP_CACHE_TTL),
@@ -105,6 +147,44 @@ public class RedisDynamicTableFactory implements DynamicTableSourceFactory {
         final Set<ConfigOption<?>> requiredOptions = new HashSet<>();
         requiredOptions.add(RedisOptions.COMMAND);
         return requiredOptions;
+    }
+
+    private void validateConfigOptions(ReadableConfig config, Set<String> supportCommands) {
+        String redisMode = config.get(RedisOptions.REDIS_MODE);
+        List<String> matchRedisMode = SUPPORT_REDIS_MODE.stream().filter(e -> e.equals(redisMode.toLowerCase().trim()))
+                .collect(Collectors.toList());
+        checkState(!matchRedisMode.isEmpty(),
+                "Unsupported redis-mode " + redisMode + ". The supported redis-mode " + Arrays
+                        .deepToString(SUPPORT_REDIS_MODE.toArray()));
+        String command = config.get(RedisOptions.COMMAND);
+        Preconditions.checkState(!StringUtils.isNullOrWhitespaceOnly(command),
+                "Command can not be empty. The supported command are " + Arrays
+                        .deepToString(supportCommands.toArray()));
+        List<String> matchCommand = supportCommands
+                .stream().filter(e -> e.equals(command.toUpperCase().trim())).collect(Collectors.toList());
+        checkState(!matchCommand.isEmpty(), "Unsupported command " + command + ". The supported command " + Arrays
+                .deepToString(supportCommands.toArray()));
+    }
+
+    private void validateDataTypeAndSchemaMappingMode(
+            RedisDataType dataType,
+            SchemaMappingMode mappingMode) {
+        switch (dataType) {
+            case HASH:
+                break;
+            case PLAIN:
+                org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkState(
+                        mappingMode == STATIC_PREFIX_MATCH,
+                        "Only support STATIC_PREFIX_MATCH mode in PLAIN dataType !");
+                break;
+            case BITMAP:
+                org.apache.flink.shaded.guava18.com.google.common.base.Preconditions.checkState(
+                        mappingMode == STATIC_KV_PAIR,
+                        "Only support STATIC_KV_PAIR mode in BITMAP dataType !");
+                break;
+            default:
+                throw new UnsupportedOperationException("The dataType '" + dataType + "' is not supported.");
+        }
     }
 
     @Override
@@ -131,20 +211,4 @@ public class RedisDynamicTableFactory implements DynamicTableSourceFactory {
         return options;
     }
 
-    private void validateConfigOptions(ReadableConfig config, Set<String> supportCommands) {
-        String redisMode = config.get(RedisOptions.REDIS_MODE);
-        List<String> matchRedisMode = SUPPORT_REDIS_MODE.stream().filter(e -> e.equals(redisMode.toLowerCase().trim()))
-                .collect(Collectors.toList());
-        checkState(!matchRedisMode.isEmpty(),
-                "Unsupported redis-mode " + redisMode + ". The supported redis-mode " + Arrays
-                        .deepToString(SUPPORT_REDIS_MODE.toArray()));
-        String command = config.get(RedisOptions.COMMAND);
-        Preconditions.checkState(!StringUtils.isNullOrWhitespaceOnly(command),
-                "Command can not be empty. The supported command are " + Arrays
-                        .deepToString(supportCommands.toArray()));
-        List<String> matchCommand = supportCommands
-                .stream().filter(e -> e.equals(command.toUpperCase().trim())).collect(Collectors.toList());
-        checkState(!matchCommand.isEmpty(), "Unsupported command " + command + ". The supported command " + Arrays
-                .deepToString(supportCommands.toArray()));
-    }
 }

--- a/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisDynamicTableFactoryTest.java
+++ b/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisDynamicTableFactoryTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis;
+
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
+import org.apache.inlong.sort.redis.sink.RedisBitmapSinkFunction;
+import org.apache.inlong.sort.redis.sink.RedisDynamicTableSink;
+import org.apache.inlong.sort.redis.sink.RedisHashSinkFunction;
+import org.apache.inlong.sort.redis.sink.RedisPlainSinkFunction;
+import org.junit.Test;
+
+public class RedisDynamicTableFactoryTest {
+
+    private static final ResolvedSchema TEST_SCHEMA = ResolvedSchema.of(
+            Column.physical("key", DataTypes.STRING()),
+            Column.physical("f1", DataTypes.BIGINT()),
+            Column.physical("f2", DataTypes.INT()),
+            Column.physical("f3", DataTypes.FLOAT()),
+            Column.physical("f4", DataTypes.DOUBLE()),
+            Column.physical("f5", DataTypes.BOOLEAN()));
+
+    private Map<String, String> getProperties() {
+        Map<String, String> properties = new HashMap<>();
+
+        properties.put("connector", "redis-inlong");
+
+        properties.put("schema.0.name", "key");
+        properties.put("schema.0.type", "STRING");
+        properties.put("schema.1.name", "f1");
+        properties.put("schema.1.type", "BIGINT");
+        properties.put("schema.2.name", "f2");
+        properties.put("schema.2.type", "INT");
+        properties.put("schema.3.name", "f3");
+        properties.put("schema.3.type", "FLOAT");
+        properties.put("schema.4.name", "f4");
+        properties.put("schema.4.type", "DOUBLE");
+        properties.put("schema.5.name", "f5");
+        properties.put("schema.5.type", "BOOLEAN");
+
+        properties.put("format", "csv");
+        properties.put("format.property-version", "1");
+        properties.put("format.derive-schema", "true");
+
+        // cluster mode redis
+        properties.put("redis-mode", "cluster");
+        properties.put("cluster-nodes", "127.0.0.1:6379,127.0.0.1:6378");
+        properties.put("password", "password");
+        properties.put("maxIdle", "8");
+        properties.put("minIdle", "1");
+        properties.put("maxTotal", "2");
+        properties.put("timeout", "2000");
+
+        return properties;
+    }
+
+    @Test
+    public void testCreateTableSink() {
+        Map<String, String> properties = getProperties();
+
+        DynamicTableSink tableSink = createTableSink(TEST_SCHEMA, properties);
+        assertTrue(tableSink instanceof RedisDynamicTableSink);
+    }
+
+    @Test
+    public void testCreateHashSinkFunction() {
+        Map<String, String> properties = getProperties();
+        properties.put("data-type", "HASH");
+        DynamicTableSink tableSink = createTableSink(TEST_SCHEMA, properties);
+
+        DynamicTableSink.SinkRuntimeProvider sinkRuntimeProvider =
+                tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+        assertTrue(sinkRuntimeProvider instanceof SinkFunctionProvider);
+
+        SinkFunction<RowData> sinkFunction = ((SinkFunctionProvider) sinkRuntimeProvider).createSinkFunction();
+        assertTrue(sinkFunction instanceof RedisHashSinkFunction);
+    }
+
+    @Test
+    public void testCreateBitmapSinkFunction() {
+
+        ResolvedSchema TEST_SCHEMA = ResolvedSchema.of(
+                Column.physical("key", DataTypes.STRING()),
+                Column.physical("f1", DataTypes.BIGINT()),
+                Column.physical("f2", DataTypes.BOOLEAN()),
+                Column.physical("f3", DataTypes.BIGINT()),
+                Column.physical("f4", DataTypes.BOOLEAN()),
+                Column.physical("f5", DataTypes.BIGINT()),
+                Column.physical("f6", DataTypes.BOOLEAN()));
+
+        Map<String, String> properties = getProperties();
+        properties.put("data-type", "BITMAP");
+        properties.put("schema-mapping-mode", "STATIC_KV_PAIR");
+
+        DynamicTableSink tableSink = createTableSink(TEST_SCHEMA, properties);
+
+        DynamicTableSink.SinkRuntimeProvider sinkRuntimeProvider =
+                tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+        assertTrue(sinkRuntimeProvider instanceof SinkFunctionProvider);
+
+        SinkFunction<RowData> sinkFunction = ((SinkFunctionProvider) sinkRuntimeProvider).createSinkFunction();
+        assertTrue(sinkFunction instanceof RedisBitmapSinkFunction);
+    }
+
+    @Test
+    public void testCreatePlainSinkFunction() {
+        Map<String, String> properties = getProperties();
+        properties.put("data-type", "PLAIN");
+        properties.put("schema-mapping-mode", "STATIC_PREFIX_MATCH");
+        DynamicTableSink tableSink = createTableSink(TEST_SCHEMA, properties);
+
+        DynamicTableSink.SinkRuntimeProvider sinkRuntimeProvider =
+                tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(false));
+        assertTrue(sinkRuntimeProvider instanceof SinkFunctionProvider);
+
+        SinkFunction<RowData> sinkFunction = ((SinkFunctionProvider) sinkRuntimeProvider).createSinkFunction();
+        assertTrue(sinkFunction instanceof RedisPlainSinkFunction);
+    }
+}

--- a/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
+++ b/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
@@ -1,0 +1,355 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.redis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.NetUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.embedded.RedisServer;
+
+public class RedisTableTest {
+
+    private static int redisPort;
+
+    private static RedisServer redisServer;
+
+    @BeforeClass
+    public static void setup() {
+        redisPort = NetUtils.getAvailablePort();
+        redisServer = RedisServer.builder().setting("maxmemory 128m").port(redisPort).build();
+        redisServer.start();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (redisServer != null) {
+            redisServer.stop();
+        }
+    }
+
+    @Before
+    public void prepare() {
+        Jedis jedis = new Jedis("localhost", redisPort);
+        // Deletes all keys from all databases.
+        jedis.flushAll();
+    }
+
+    @Test
+    public void testSinkWithPlain() throws Exception {
+        StreamExecutionEnvironment executionEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv =
+                StreamTableEnvironment.create(executionEnv);
+
+        executionEnv.setParallelism(1);
+
+        String address = "localhost:" + redisPort;
+
+        DataStream<Row> source =
+                executionEnv.fromCollection(
+                        Arrays.asList(
+                                Row.of("1", "r12", 1.2, 1),
+                                Row.of("2", "r22", 2.2, 2),
+                                Row.of("3", "r32", 3.2, 3)));
+        tableEnv.registerDataStream("source", source, "aaa, bbb, ccc, ddd");
+
+        tableEnv.executeSql("CREATE TABLE sink (" +
+                "    key STRING," +
+                "    aaa STRING," +
+                "    bbb DOUBLE," +
+                "    ccc BIGINT," +
+                "    PRIMARY KEY (`key`) NOT ENFORCED" +
+                ") WITH (" +
+                "  'connector' = 'redis-inlong'," +
+                "  'sink.batch-size' = '1'," +
+                "  'format' = 'csv'," +
+                "  'data-type' = 'PLAIN'," +
+                "  'redis-mode' = 'standalone'," +
+                "  'host' = 'localhost'," +
+                "  'port' = '" + redisPort + "'," +
+                "  'maxIdle' = '8'," +
+                "  'minIdle' = '1'," +
+                "  'maxTotal' = '2'," +
+                "  'timeout' = '2000'" +
+                ")");
+        Jedis jedis = new Jedis("localhost", redisPort);
+        assertNull(jedis.get("1"));
+        assertNull(jedis.get("2"));
+        assertNull(jedis.get("3"));
+
+        String query = "INSERT INTO sink SELECT * FROM source";
+        tableEnv.executeSql(query);
+
+        Thread.sleep(4000);
+
+        assertEquals("r12,1.2,1", jedis.get("1"));
+        assertEquals("r22,2.2,2", jedis.get("2"));
+        assertEquals("r32,3.2,3", jedis.get("3"));
+    }
+
+    @Test
+    public void testSinkWithHashPrefixMatch() throws Exception {
+        StreamExecutionEnvironment executionEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv =
+                StreamTableEnvironment.create(executionEnv);
+
+        executionEnv.setParallelism(1);
+
+        String address = "localhost:" + redisPort;
+
+        DataStream<Row> source =
+                executionEnv.fromCollection(
+                        Arrays.asList(
+                                Row.of("1", "r12", 1.2, 1),
+                                Row.of("2", "r22", 2.2, 2),
+                                Row.of("3", "r32", 3.2, 3)));
+        tableEnv.registerDataStream("source", source, "aaa, bbb, ccc, ddd");
+
+        tableEnv.executeSql("CREATE TABLE sink (" +
+                "    key STRING," +
+                "    aaa STRING," +
+                "    bbb DOUBLE," +
+                "    ccc BIGINT," +
+                "    PRIMARY KEY (`key`) NOT ENFORCED" +
+                ") WITH (" +
+                "  'connector' = 'redis-inlong'," +
+                "  'sink.batch-size' = '1'," +
+                "  'format' = 'csv'," +
+                "  'data-type' = 'HASH'," +
+                "  'redis-mode' = 'standalone'," +
+                "  'host' = 'localhost'," +
+                "  'port' = '" + redisPort + "'," +
+                "  'maxIdle' = '8'," +
+                "  'minIdle' = '1'," +
+                "  'maxTotal' = '2'," +
+                "  'timeout' = '2000'" +
+                ")");
+        Jedis jedis = new Jedis("localhost", redisPort);
+        assertNull(jedis.get("1"));
+        assertNull(jedis.get("2"));
+        assertNull(jedis.get("3"));
+
+        String query = "INSERT INTO sink SELECT * FROM source";
+        tableEnv.executeSql(query);
+
+        Thread.sleep(4000);
+
+        assertEquals("1.2,1", jedis.hget("1", "r12"));
+        assertEquals("2.2,2", jedis.hget("2", "r22"));
+        assertEquals("3.2,3", jedis.hget("3", "r32"));
+    }
+
+    @Test
+    public void testSinkWithHashKvPair() throws Exception {
+        StreamExecutionEnvironment executionEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv =
+                StreamTableEnvironment.create(executionEnv);
+
+        executionEnv.setParallelism(1);
+
+        String address = "localhost:" + redisPort;
+
+        DataStream<Row> source =
+                executionEnv.fromCollection(
+                        Arrays.asList(
+                                Row.of("1", "r12", 1.2, "r14", 1),
+                                Row.of("2", "r22", 2.2, "r24", 2),
+                                Row.of("3", "r32", 3.2, "r34", 3)));
+        tableEnv.registerDataStream("source", source, "aaa, bbb, ccc, ddd,eee");
+
+        tableEnv.executeSql("CREATE TABLE sink (" +
+                "    key STRING," +
+                "    aaa STRING," +
+                "    bbb STRING," +
+                "    ccc STRING," +
+                "    ddd STRING," +
+                "    PRIMARY KEY (`key`) NOT ENFORCED" +
+                ") WITH (" +
+                "  'connector' = 'redis-inlong'," +
+                "  'sink.batch-size' = '1'," +
+                "  'format' = 'csv'," +
+                "  'data-type' = 'HASH'," +
+                "  'schema-mapping-mode' = 'STATIC_KV_PAIR'," +
+                "  'redis-mode' = 'standalone'," +
+                "  'host' = 'localhost'," +
+                "  'port' = '" + redisPort + "'," +
+                "  'maxIdle' = '8'," +
+                "  'minIdle' = '1'," +
+                "  'maxTotal' = '2'," +
+                "  'timeout' = '2000'" +
+                ")");
+        Jedis jedis = new Jedis("localhost", redisPort);
+        assertNull(jedis.get("1"));
+        assertNull(jedis.get("2"));
+        assertNull(jedis.get("3"));
+
+        String query = "INSERT INTO sink SELECT aaa,bbb,cast(ccc as STRING),ddd, cast(eee as STRING) FROM source";
+        tableEnv.executeSql(query);
+
+        Thread.sleep(4000);
+
+        assertEquals("1.2", jedis.hget("1", "r12"));
+        assertEquals("2.2", jedis.hget("2", "r22"));
+        assertEquals("3.2", jedis.hget("3", "r32"));
+        assertEquals("1", jedis.hget("1", "r14"));
+        assertEquals("2", jedis.hget("2", "r24"));
+        assertEquals("3", jedis.hget("3", "r34"));
+    }
+
+    @Test
+    public void testSinkWithDynamic() throws Exception {
+        StreamExecutionEnvironment executionEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv =
+                StreamTableEnvironment.create(executionEnv);
+
+        executionEnv.setParallelism(1);
+
+        String address = "localhost:" + redisPort;
+
+        DataStream<Row> source =
+                executionEnv.fromCollection(
+                        Arrays.asList(
+                                Row.of("1", "r12", 1.2, "r14", 1),
+                                Row.of("2", "r22", 2.2, "r24", 2),
+                                Row.of("3", "r32", 3.2, "r34", 3)));
+        tableEnv.registerDataStream("source", source, "aaa, bbb, ccc, ddd,eee");
+
+        tableEnv.executeSql("CREATE TABLE sink (" +
+                "    key STRING," +
+                "    aaa MAP<STRING,STRING>," +
+                "    PRIMARY KEY (`key`) NOT ENFORCED" +
+                ") WITH (" +
+                "  'connector' = 'redis-inlong'," +
+                "  'sink.batch-size' = '1'," +
+                "  'format' = 'csv'," +
+                "  'data-type' = 'HASH'," +
+                "  'schema-mapping-mode' = 'DYNAMIC'," +
+                "  'redis-mode' = 'standalone'," +
+                "  'host' = 'localhost'," +
+                "  'port' = '" + redisPort + "'," +
+                "  'maxIdle' = '8'," +
+                "  'minIdle' = '1'," +
+                "  'maxTotal' = '2'," +
+                "  'timeout' = '2000'" +
+                ")");
+        Jedis jedis = new Jedis("localhost", redisPort);
+        assertNull(jedis.get("1"));
+        assertNull(jedis.get("2"));
+        assertNull(jedis.get("3"));
+
+        String query = "INSERT INTO sink "
+                + "SELECT "
+                + "aaa as key, "
+                + "MAP[bbb,cast(ccc as STRING),ddd,cast(eee as STRING)] as fv "
+                + "FROM source";
+        tableEnv.executeSql(query);
+
+        Thread.sleep(4000);
+
+        assertEquals("1.2", jedis.hget("1", "r12"));
+        assertEquals("2.2", jedis.hget("2", "r22"));
+        assertEquals("3.2", jedis.hget("3", "r32"));
+        assertEquals("1", jedis.hget("1", "r14"));
+        assertEquals("2", jedis.hget("2", "r24"));
+        assertEquals("3", jedis.hget("3", "r34"));
+    }
+
+    @Test
+    public void testSinkWithBitmap() throws Exception {
+        StreamExecutionEnvironment executionEnv =
+                StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tableEnv =
+                StreamTableEnvironment.create(executionEnv);
+
+        executionEnv.setParallelism(1);
+
+        String address = "localhost:" + redisPort;
+
+        DataStream<Row> source =
+                executionEnv.fromCollection(
+                        Arrays.asList(
+                                Row.of("1", 2, 1.2, 4, 1),
+                                Row.of("2", 2, 2.2, 4, 2),
+                                Row.of("3", 2, 3.2, 4, 3)));
+        tableEnv.registerDataStream("source", source, "aaa, bbb, ccc, ddd,eee");
+
+        tableEnv.executeSql("CREATE TABLE sink (" +
+                "    key STRING," +
+                "    aaa BIGINT," +
+                "    bbb BOOLEAN," +
+                "    ccc BIGINT," +
+                "    ddd BOOLEAN," +
+                "    PRIMARY KEY (`key`) NOT ENFORCED" +
+                ") WITH (" +
+                "  'connector' = 'redis-inlong'," +
+                "  'sink.batch-size' = '1'," +
+                "  'format' = 'csv'," +
+                "  'data-type' = 'BITMAP'," +
+                "  'schema-mapping-mode' = 'STATIC_KV_PAIR'," +
+                "  'redis-mode' = 'standalone'," +
+                "  'host' = 'localhost'," +
+                "  'port' = '" + redisPort + "'," +
+                "  'maxIdle' = '8'," +
+                "  'minIdle' = '1'," +
+                "  'maxTotal' = '2'," +
+                "  'timeout' = '2000'" +
+                ")");
+        Jedis jedis = new Jedis("localhost", redisPort);
+        assertNull(jedis.get("1"));
+        assertNull(jedis.get("2"));
+        assertNull(jedis.get("3"));
+
+        String query = "INSERT INTO sink "
+                + "SELECT "
+                + "aaa as key, "
+                + "bbb,"
+                + "ccc<'2' as cccc,"
+                + "ddd,"
+                + "eee<'2' as eeee "
+                + "FROM source";
+        tableEnv.executeSql(query);
+
+        Thread.sleep(4000);
+
+        assertTrue(jedis.getbit("1", 2));
+        assertTrue(jedis.getbit("1", 4));
+
+        assertFalse(jedis.getbit("2", 2));
+        assertFalse(jedis.getbit("2", 4));
+
+        assertFalse(jedis.getbit("3", 2));
+        assertFalse(jedis.getbit("3", 4));
+    }
+
+}

--- a/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
+++ b/inlong-sort/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
@@ -334,9 +334,9 @@ public class RedisTableTest {
                 + "SELECT "
                 + "aaa as key, "
                 + "bbb,"
-                + "ccc<'2' as cccc,"
+                + "ccc = cast(1.2 as double) as cccc,"
                 + "ddd,"
-                + "eee<'2' as eeee "
+                + "eee = cast(1 as bigint) as eeee "
                 + "FROM source";
         tableEnv.executeSql(query);
 


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7060][Sort] Support write redis in sort-connector-redis 



- Fixes #7060 

### Motivation

1. Support write different redis-modes: cluster / standalone
2. Support data-types: plain / bitmap / hash
3. Support different schema mapping mode: dynamic / prefix-match / kv-pair


> Dirty data and metrics stat will be added in approaching PR.



### Modifications

#### data-type

See detail:  <a href="https://redis.io/topics/data-types-intro">redis data type</a>

##### PLAIN
Redis strings commands are used for managing string values in Redis

##### HASH

* A Redis hash is a data type that represents a mapping between a string field and a string value.<br/>
* There are two members in hash DataType: <br/>
* the first member is Redis hash field.<br/>
* the second member is Redis hash value.

##### SET

* Redis Lists are simply lists of strings, sorted by insertion order.
* You can add elements in Redis lists in the head or the tail of the list.

##### BITMAP

* Bitmaps are not an actual data type, but a set of bit-oriented operations defined on the String type. <br/>
* Since strings are binary safe blobs and their maximum length is 512 MB, <br/>
* they are suitable to set up to 2^32 different bits.

#### SchemaMappingMode

##### DYNAMIC

* The DYNAMIC mode witch mapping a {@link java.util.Map} to {@link RedisDataType}.
* There are two members in DYNAMIC mode: <br/>
* the first member is Redis key. <br/>
* the second member is a {@link java.util.Map} object, witch will be iterated, <br/>
* the entry key is redis key, and the entry value is redis value.

##### STATIC_PREFIX_MATCH

* The are at least two fields, the first member is redis key, <br/>
* and each field from the second field represents a redis value.<br/>
* ex: <br/>

```shell
key, field, value1, value2, value3, [value]...
```

##### STATIC_KV_PAIR;

* There are two fields, the first field is key, <br/>
* and the other fields are pairs of field and value. <br/>
* ex:<br/>
```shell
 key, field1, value1,field2,value2,field3,value3,[field,value]...
```

#### SQL demo

##### PLAIN

> Plain only support STATIC_PREFIX_MATCH schema mapping mode

```sql
CREATE TABLE sink (
    key STRING,
    aaa STRING,
    bbb DOUBLE,    
    ccc BIGINT,    
    PRIMARY KEY (`key`) NOT ENFORCED
) WITH (  
    'connector' = 'redis-inlong',  
    'sink.batch-size' = '1',  
    'format' = 'csv',  
    'data-type' = 'PLAIN',  
    'redis-mode' = 'standalone',  
    'host' = 'localhost',  
    'port' = '56615',  
    'maxIdle' = '8',  
    'minIdle' = '1',  
    'maxTotal' = '2',  
    'timeout' = '2000'
);
```

##### HASH with PREFIX_MATCH

| c1     | c2            | c3  | c4  | c5  | c6  | c7  | 
|--------|---------------|-----|-----|-----|-----|-----|
| rowKey | field: String |     |     |     |     |     |

The first element is Redis row key, must be string type.
The second element is Redis field name in Hash DataType.
The remaining fields(`c2`~`c6`) will be serialized into one value and put into redis

```sql
CREATE TABLE sink (
    KEY STRING, 
    field_name STRING, 
    value_1 DOUBLE,
    value_2 BIGINT, 
    PRIMARY KEY (`key`) NOT ENFORCED
) WITH (
   'connector' = 'redis-inlong',
   'sink.batch-size' = '1',
   'format' = 'csv',
   'data-type' = 'HASH',
   'redis-mode' = 'standalone',
   'host' = 'localhost',
   'port' = '56869',
   'maxIdle' = '8',
   'minIdle' = '1',
   'maxTotal' = '2',
   'timeout' = '2000'
);
```

##### HASH with STATIC_KV_PAIR

| c1     | c2             | c3             | c4              | c5             | c6              | c7             | 
|--------|----------------|----------------|-----------------|----------------|-----------------|----------------|
| rowKey | field1: String | value 1:String | field 2: String | value 2:String | field 3: String | value 3:String |

The first element is Redis row key, must be string type.
The odd elements(`c2` /`c4` /`c6`) are Redis field names in Hash DataType, must be String type.
The even elements(`c3` / `c5` / `c7`) are Redis field values in Hash DataType, must be String type.

```sql
CREATE TABLE sink (
    key STRING,
    field1 STRING,
    value1 STRING,
    field2 STRING,
    value2 STRING,
    PRIMARY KEY (`key`) NOT ENFORCED
) WITH (
  'connector' = 'redis-inlong',
  'sink.batch-size' = '1',
  'format' = 'csv',
  'data-type' = 'HASH',
  'schema-mapping-mode' = 'STATIC_KV_PAIR',
  'redis-mode' = 'standalone',
  'host' = 'localhost',
  'port' = '6379',
  'maxIdle' = '8',
  'minIdle' = '1',
  'maxTotal' = '2',
  'timeout' = '2000'
);
```

##### HASH with DYNAMIC

| c1     | c2            | 
|--------|---------------|
| rowKey | fieldValueMap |

The first element is Redis row key, must be string type.
The second element is must be `Map<String,String>` type: key is fieldName, value is fieldValue.

```sql
CREATE TABLE sink (
    key STRING,
    fieldValueMap MAP<STRING,STRING>,
    PRIMARY KEY (`key`) NOT ENFORCED
) WITH (
  'connector' = 'redis-inlong',
  'sink.batch-size' = '1',
  'format' = 'csv',
  'data-type' = 'HASH',
  'schema-mapping-mode' = 'DYNAMIC',
  'redis-mode' = 'standalone',
  'host' = 'localhost',
  'port' = '6379',
  'maxIdle' = '8',
  'minIdle' = '1',
  'maxTotal' = '2',
  'timeout' = '2000'
)"
```

##### BITMAP with STATIC_KV_PAIR

| c1     | c2           | c3              | c4            | c5              | c6            | c7              | 
|--------|--------------|-----------------|---------------|-----------------|---------------|-----------------|
| rowKey | field1: Long | value 1:Boolean | field 2: Long | value 2:Boolean | field 3: Long | value 3:Boolean |

The first element is Redis row key, must be string type.
The odd elements(`c2` /`c4` /`c6` ) are Redis offsets in Bitmap DataType, must be Long type.
The even elements(`c3` / `c5` / `c7`) are Redis values in Bitmap DataType, must be Boolean type.

```sql
CREATE TABLE sink (
    key STRING,
    offset_1 BIGINT,
    value_1 BOOLEAN,
    offset_2 BIGINT,
    value_2 BOOLEAN,
    PRIMARY KEY (`key`) NOT ENFORCED
) WITH (
  'connector' = 'redis-inlong',
  'sink.batch-size' = '1',
  'format' = 'csv',
  'data-type' = 'BITMAP',
  'schema-mapping-mode' = 'STATIC_KV_PAIR',
  'redis-mode' = 'standalone',
  'host' = 'localhost',
  'port' = '6379',
  'maxIdle' = '8',
  'minIdle' = '1',
  'maxTotal' = '2',
  'timeout' = '2000'
)
```

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
