### PR TITLE
[INLONG-7231][DataProxy] Add selector policy of cache cluster list

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/AllCacheClusterSelector.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/AllCacheClusterSelector.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.mq;
+
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+
+import java.util.List;
+
+/**
+ * AllCacheClusterSelector
+ */
+public class AllCacheClusterSelector implements CacheClusterSelector {
+
+    /**
+     * select
+     * @param allClusterList
+     * @return
+     */
+    @Override
+    public List<CacheClusterConfig> select(List<CacheClusterConfig> allClusterList) {
+        return allClusterList;
+    }
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackManager.java
@@ -156,7 +156,7 @@ public class BatchPackManager {
         if (!needOutputOvertimeData.getAndSet(false)) {
             return;
         }
-        LOG.debug("start to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{}",
+        LOG.info("start to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{}",
                 profileCache.size(), dispatchQueue.size());
         long currentTime = System.currentTimeMillis();
         long createThreshold = currentTime - dispatchTimeout;
@@ -179,7 +179,7 @@ public class BatchPackManager {
                 outCounter.addAndGet(dispatchProfile.getCount());
             }
         });
-        LOG.debug("end to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{},eventCount:{},"
+        LOG.info("end to outputOvertimeData profileCacheSize:{},dispatchQueueSize:{},eventCount:{},"
                 + "inCounter:{},outCounter:{}",
                 profileCache.size(), dispatchQueue.size(), eventCount,
                 inCounter.getAndSet(0), outCounter.getAndSet(0));

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/CacheClusterSelector.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/CacheClusterSelector.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.mq;
+
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+
+import java.util.List;
+
+/**
+ * CacheClusterSelector
+ */
+public interface CacheClusterSelector {
+
+    /**
+     * select
+     */
+    List<CacheClusterConfig> select(List<CacheClusterConfig> allClusterList);
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
@@ -56,6 +56,8 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable {
     // dispatch
     private ScheduledExecutorService scheduledPool;
 
+    private MessageQueueZoneProducer zoneProducer;
+
     /**
      * configure
      * 
@@ -89,9 +91,12 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable {
                 }
             }, this.dispatchManager.getDispatchTimeout(), this.dispatchManager.getDispatchTimeout(),
                     TimeUnit.MILLISECONDS);
+            // create producer
+            this.zoneProducer = new MessageQueueZoneProducer(this.getName(), this.context);
+            this.zoneProducer.start();
             // create worker
             for (int i = 0; i < context.getMaxThreads(); i++) {
-                MessageQueueZoneWorker worker = new MessageQueueZoneWorker(this.getName(), i, context);
+                MessageQueueZoneWorker worker = new MessageQueueZoneWorker(this.getName(), i, context, zoneProducer);
                 worker.start();
                 this.workers.add(worker);
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneWorker.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneWorker.java
@@ -36,16 +36,13 @@ public class MessageQueueZoneWorker extends Thread {
 
     /**
      * Constructor
-     * 
-     * @param sinkName
-     * @param workerIndex
-     * @param context
      */
-    public MessageQueueZoneWorker(String sinkName, int workerIndex, MessageQueueZoneSinkContext context) {
+    public MessageQueueZoneWorker(String sinkName, int workerIndex, MessageQueueZoneSinkContext context,
+            MessageQueueZoneProducer zoneProducer) {
         super();
         this.workerName = sinkName + "-worker-" + workerIndex;
         this.context = context;
-        this.zoneProducer = new MessageQueueZoneProducer(workerName, this.context);
+        this.zoneProducer = zoneProducer;
         this.status = LifecycleState.IDLE;
     }
 
@@ -54,7 +51,6 @@ public class MessageQueueZoneWorker extends Thread {
      */
     @Override
     public void start() {
-        this.zoneProducer.start();
         this.status = LifecycleState.START;
         super.start();
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/RandomCacheClusterSelector.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/RandomCacheClusterSelector.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.sink.mq;
+
+import org.apache.flume.Context;
+import org.apache.flume.conf.Configurable;
+import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.pulsar.shade.org.apache.commons.lang.math.NumberUtils;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * RandomCacheClusterSelector
+ */
+public class RandomCacheClusterSelector implements CacheClusterSelector, Configurable {
+
+    public static final String KEY_CACHE_CLUSTER_PRODUCER_SIZE = "cacheClusterProducerSize";
+    public static final int DEFAULT_CACHE_CLUSTER_PRODUCER_SIZE = 1;
+    public static final String KEY_CACHE_CLUSTER_RESELECT_INTERVAL_MINUTES = "cacheClusterReselectIntervalMinutes";
+    public static final int DEFAULT_CACHE_CLUSTER_RESELECT_INTERVAL_MINUTES = 10;
+
+    private Context context;
+    private long lastCacheClusterSelectTime = 0;
+    private HashSet<String> currentClusterNames = new HashSet<>();
+
+    /**
+     * select
+     * @param allClusterList
+     * @return
+     */
+    @Override
+    public List<CacheClusterConfig> select(List<CacheClusterConfig> allConfigList) {
+        List<CacheClusterConfig> newConfigList = new ArrayList<>();
+        HashSet<String> newClusterNames = new HashSet<>();
+        allConfigList.forEach(v -> newClusterNames.add(v.getClusterName()));
+        int cacheClusterReselectIntervalMinutes = NumberUtils.toInt(
+                context.getString(KEY_CACHE_CLUSTER_RESELECT_INTERVAL_MINUTES),
+                DEFAULT_CACHE_CLUSTER_RESELECT_INTERVAL_MINUTES);
+        long cacheClusterReselectIntervalMs = cacheClusterReselectIntervalMinutes * 60 * 1000;
+        boolean needReselectCacheCluster = (System.currentTimeMillis()
+                - lastCacheClusterSelectTime) > cacheClusterReselectIntervalMs;
+        if (newClusterNames.equals(currentClusterNames)
+                && !needReselectCacheCluster) {
+            return newConfigList;
+        }
+        this.lastCacheClusterSelectTime = System.currentTimeMillis();
+        this.currentClusterNames = newClusterNames;
+
+        // update cluster list
+        SecureRandom rand = new SecureRandom();
+        int cacheClusterProducerSize = NumberUtils.toInt(
+                context.getString(KEY_CACHE_CLUSTER_PRODUCER_SIZE),
+                DEFAULT_CACHE_CLUSTER_PRODUCER_SIZE);
+        int maxClusterSize = Math.min(cacheClusterProducerSize, allConfigList.size());
+        List<CacheClusterConfig> randomList = new ArrayList<>(allConfigList);
+        for (int i = 0; i < maxClusterSize; i++) {
+            // random select
+            int index = rand.nextInt(randomList.size());
+            CacheClusterConfig config = randomList.remove(index);
+            newConfigList.add(config);
+        }
+        return newConfigList;
+    }
+
+    @Override
+    public void configure(Context context) {
+        this.context = context;
+    }
+
+}


### PR DESCRIPTION
- Title: [INLONG-7231][DataProxy] DataProxy add selector policy of cache cluster list
- Fixes #7231 

### Motivation

- When DataProxy send data to all cache clusters, if the number of Pulsar topic is enough, Zookeeper of Pulsar will go to OutOfMemory because the metadata of PulsarProducer is too big.
- DataProxy will only create one Pulsar client for a cache cluster, and only create one PulsarProducer for a Pulsar topic.
- DataProxy can send data to subset of cache cluster list.
- The selector policy can be configurable and extensibility.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
