### PR TITLE
[INLONG-7246][Dashboard] Remove helper info of DataType in Stream configuration

### DIFF
--- a/inlong-dashboard/src/locales/cn.json
+++ b/inlong-dashboard/src/locales/cn.json
@@ -381,7 +381,6 @@
   "meta.Stream.FieldName": "字段名",
   "meta.Stream.FieldNameRule": "以英文字母开头，只能包含英文字母、数字、下划线",
   "meta.Stream.DataType": "数据格式",
-  "meta.Stream.DataTypeHelp": "CSV：消息体为原生 CSV 的 InLong 消息类型",
   "meta.Stream.FieldType": "字段类型",
   "meta.Stream.FieldComment": "字段描述",
   "meta.Stream.DataEncoding": "数据编码",

--- a/inlong-dashboard/src/locales/en.json
+++ b/inlong-dashboard/src/locales/en.json
@@ -381,7 +381,6 @@
   "meta.Stream.FieldName": "Field name",
   "meta.Stream.FieldNameRule": "At the beginning of English letters, only English letters, numbers, and underscores",
   "meta.Stream.DataType": "DataType",
-  "meta.Stream.DataTypeHelp": "CSV: InLong message type whose message body is raw CSV",
   "meta.Stream.FieldType": "FieldType",
   "meta.Stream.FieldComment": "Field comment",
   "meta.Stream.DataEncoding": "Data encoding",

--- a/inlong-dashboard/src/metas/streams/common/StreamDefaultInfo.ts
+++ b/inlong-dashboard/src/metas/streams/common/StreamDefaultInfo.ts
@@ -97,7 +97,6 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
   @FieldDecorator({
     type: 'radio',
     initialValue: 'CSV',
-    tooltip: i18n.t('meta.Stream.DataTypeHelp'),
     props: values => ({
       disabled: [110, 130].includes(values?.status),
       options: [


### PR DESCRIPTION
### Prepare a Pull Request


- [INLONG-7246][INLONG-7246][Dashboard] Remove helper info of DataType in Stream configuration

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7246 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
