### PR TITLE
[INLONG-7254][Manager] Fix config error when InlongGroupId is in the process of switching

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.service.core.impl;
 
-import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -29,6 +28,7 @@ import org.apache.inlong.common.pojo.sdk.Topic;
 import org.apache.inlong.common.constant.MQType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.dao.entity.InlongGroupExtEntity;
 import org.apache.inlong.manager.dao.entity.InlongStreamExtEntity;
 import org.apache.inlong.manager.pojo.sort.standalone.SortSourceClusterInfo;
@@ -293,7 +293,7 @@ public class SortSourceServiceImpl implements SortSourceService {
             String clusterName,
             List<SortSourceStreamSinkInfo> sinkList) {
 
-        Preconditions.checkNotNull(sortClusters.get(clusterName));
+        Preconditions.checkNotNull(sortClusters.get(clusterName), "sort cluster should not be NULL");
         String sortClusterTag = sortClusters.get(clusterName).getClusterTags();
 
         // get group infos

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -305,11 +305,12 @@ public class SortSourceServiceImpl implements SortSourceService {
 
         // group them by cluster tag.
         Map<String, List<SortSourceStreamSinkInfo>> tag2SinkInfos = sinkInfoList.stream()
+                .filter(sink -> Objects.nonNull(groupInfos.get(sink.getGroupId())))
                 .filter(sink -> {
                     if (StringUtils.isBlank(sortClusterTag)) {
                         return true;
                     }
-                    return groupInfos.get(sink.getGroupId()).getClusterTag().equals(sortClusterTag);
+                    return sortClusterTag.equals(groupInfos.get(sink.getGroupId()).getClusterTag());
                 })
                 .collect(Collectors.groupingBy(sink -> {
                     SortSourceGroupInfo groupInfo = groupInfos.get(sink.getGroupId());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortSourceServiceImpl.java
@@ -45,7 +45,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.PostConstruct;
-import javax.swing.text.html.Option;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,7 +52,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -73,6 +71,7 @@ public class SortSourceServiceImpl implements SortSourceService {
 
     private static final Gson GSON = new Gson();
     private static final Set<String> SUPPORTED_MQ_TYPE = new HashSet<String>() {
+
         {
             add(MQType.KAFKA);
             add(MQType.TUBEMQ);
@@ -370,7 +369,8 @@ public class SortSourceServiceImpl implements SortSourceService {
             SortSourceClusterInfo cluster,
             boolean isBackupTag) {
         switch (cluster.getType()) {
-            case ClusterType.PULSAR: return parsePulsarZone(sinks, cluster, isBackupTag);
+            case ClusterType.PULSAR:
+                return parsePulsarZone(sinks, cluster, isBackupTag);
             default:
                 throw new BusinessException(String.format("do not support cluster type=%s of cluster=%s",
                         cluster.getType(), cluster));

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
@@ -228,7 +228,6 @@ public class SortServiceImplTest extends ServiceBaseTest {
         Assertions.assertEquals("testPulsar", zone.getZoneName());
         Assertions.assertEquals(1, zone.getTopics().size());
 
-
         response = sortService.getSourceConfig(TEST_CLUSTER_3, TEST_TASK_3, "");
         jo = new JSONObject(response);
         System.out.println(jo);

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/sort/SortServiceImplTest.java
@@ -18,6 +18,8 @@
 package org.apache.inlong.manager.service.sort;
 
 import org.apache.inlong.common.constant.ClusterSwitch;
+import org.apache.inlong.common.pojo.sdk.CacheZone;
+import org.apache.inlong.common.pojo.sdk.CacheZoneConfig;
 import org.apache.inlong.common.pojo.sdk.SortSourceConfigResponse;
 import org.apache.inlong.common.pojo.sortstandalone.SortClusterResponse;
 import org.apache.inlong.manager.common.consts.DataNodeType;
@@ -67,8 +69,12 @@ import java.util.Map;
 public class SortServiceImplTest extends ServiceBaseTest {
 
     private static final String TEST_GROUP = "test-group";
-    private static final String TEST_CLUSTER = "test-cluster";
-    private static final String TEST_TASK = "test-task";
+    private static final String TEST_CLUSTER_1 = "test-cluster-1";
+    private static final String TEST_CLUSTER_2 = "test-cluster-2";
+    private static final String TEST_CLUSTER_3 = "test-cluster-3";
+    private static final String TEST_TASK_1 = "test-task-1";
+    private static final String TEST_TASK_2 = "test-task-2";
+    private static final String TEST_TASK_3 = "test-task-3";
     private static final String TEST_STREAM_1 = "1";
     private static final String TEST_STREAM_2 = "2";
     private static final String TEST_TAG = "testTag";
@@ -114,8 +120,8 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Test
     @Order(2)
     @Transactional
-    public void testSourceCorrectParams() {
-        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
+    public void testSourceCorrectParamsOfNoTagSortCluster() {
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER_1, TEST_TASK_1, "");
         JSONObject jo = new JSONObject(response);
         System.out.println(jo);
         Assertions.assertEquals(0, response.getCode());
@@ -128,9 +134,9 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Order(3)
     @Transactional
     public void testSourceSameMd5() {
-        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, "");
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER_1, TEST_TASK_1, "");
         String md5 = response.getMd5();
-        response = sortService.getSourceConfig(TEST_CLUSTER, TEST_TASK, md5);
+        response = sortService.getSourceConfig(TEST_CLUSTER_1, TEST_TASK_1, md5);
         System.out.println(response);
         Assertions.assertEquals(1, response.getCode());
         Assertions.assertEquals(md5, response.getMd5());
@@ -167,7 +173,7 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Order(6)
     @Transactional
     public void testClusterCorrectParams() {
-        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER, "");
+        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER_1, "");
         JSONObject jo = new JSONObject(response);
         System.out.println(jo);
         Assertions.assertEquals(0, response.getCode());
@@ -180,9 +186,9 @@ public class SortServiceImplTest extends ServiceBaseTest {
     @Order(7)
     @Transactional
     public void testClusterSameMd5() {
-        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER, "");
+        SortClusterResponse response = sortService.getClusterConfig(TEST_CLUSTER_1, "");
         String md5 = response.getMd5();
-        response = sortService.getClusterConfig(TEST_CLUSTER, md5);
+        response = sortService.getClusterConfig(TEST_CLUSTER_1, md5);
         System.out.println(response);
         Assertions.assertEquals(1, response.getCode());
         Assertions.assertEquals(md5, response.getMd5());
@@ -202,17 +208,61 @@ public class SortServiceImplTest extends ServiceBaseTest {
         Assertions.assertNotNull(response.getMsg());
     }
 
+    @Test
+    @Order(9)
+    @Transactional
+    public void testSourceCorrectParamsOfTaggedSortCluster() {
+        SortSourceConfigResponse response = sortService.getSourceConfig(TEST_CLUSTER_2, TEST_TASK_2, "");
+        JSONObject jo = new JSONObject(response);
+        System.out.println(jo);
+        Assertions.assertEquals(0, response.getCode());
+        Assertions.assertNotNull(response.getMd5());
+        Assertions.assertNotNull(response.getMsg());
+        CacheZoneConfig config = response.getData();
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals(TEST_CLUSTER_2, config.getSortClusterName());
+        Assertions.assertEquals(TEST_TASK_2, config.getSortTaskId());
+        Assertions.assertEquals(1, config.getCacheZones().size());
+        CacheZone zone = config.getCacheZones().get("testPulsar");
+        Assertions.assertNotNull(zone);
+        Assertions.assertEquals("testPulsar", zone.getZoneName());
+        Assertions.assertEquals(1, zone.getTopics().size());
+
+
+        response = sortService.getSourceConfig(TEST_CLUSTER_3, TEST_TASK_3, "");
+        jo = new JSONObject(response);
+        System.out.println(jo);
+        Assertions.assertEquals(0, response.getCode());
+        Assertions.assertNotNull(response.getMd5());
+        Assertions.assertNotNull(response.getMsg());
+        config = response.getData();
+        Assertions.assertNotNull(config);
+        Assertions.assertEquals(TEST_CLUSTER_3, config.getSortClusterName());
+        Assertions.assertEquals(TEST_TASK_3, config.getSortTaskId());
+        Assertions.assertEquals(1, config.getCacheZones().size());
+        zone = config.getCacheZones().get("backupPulsar");
+        Assertions.assertNotNull(zone);
+        Assertions.assertEquals("backupPulsar", zone.getZoneName());
+        Assertions.assertEquals(1, zone.getTopics().size());
+    }
+
     @BeforeEach
     private void prepareAll() {
-        this.prepareCluster(TEST_CLUSTER);
+        this.prepareCluster(TEST_CLUSTER_1, null);
+        this.prepareCluster(TEST_CLUSTER_2, TEST_TAG);
+        this.prepareCluster(TEST_CLUSTER_3, BACK_UP_TAG);
         this.preparePulsar("testPulsar", true, TEST_TAG);
         this.preparePulsar("backupPulsar", true, BACK_UP_TAG);
-        this.prepareDataNode(TEST_TASK);
+        this.prepareDataNode(TEST_TASK_1);
+        this.prepareDataNode(TEST_TASK_2);
+        this.prepareDataNode(TEST_TASK_3);
         this.prepareGroupId(TEST_GROUP);
         this.prepareStreamId(TEST_GROUP, TEST_STREAM_1, TEST_TOPIC_1);
         this.prepareStreamId(TEST_GROUP, TEST_STREAM_2, TEST_TOPIC_2);
-        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER, TEST_STREAM_1);
-        this.prepareTask(TEST_TASK, TEST_GROUP, TEST_CLUSTER, TEST_STREAM_2);
+        this.prepareTask(TEST_TASK_1, TEST_GROUP, TEST_CLUSTER_1, TEST_STREAM_1);
+        this.prepareTask(TEST_TASK_1, TEST_GROUP, TEST_CLUSTER_1, TEST_STREAM_2);
+        this.prepareTask(TEST_TASK_2, TEST_GROUP, TEST_CLUSTER_2, TEST_STREAM_1);
+        this.prepareTask(TEST_TASK_3, TEST_GROUP, TEST_CLUSTER_3, TEST_STREAM_2);
     }
 
     private void prepareDataNode(String taskName) {
@@ -277,13 +327,14 @@ public class SortServiceImplTest extends ServiceBaseTest {
         streamService.save(request, "test_operator");
     }
 
-    private void prepareCluster(String clusterName) {
+    private void prepareCluster(String clusterName, String clusterTag) {
         InlongClusterEntity entity = new InlongClusterEntity();
         entity.setName(clusterName);
         entity.setType(DataNodeType.HIVE);
         entity.setExtParams("{}");
         entity.setCreator(TEST_CREATOR);
         entity.setInCharges(TEST_CREATOR);
+        entity.setClusterTags(clusterTag);
         Date now = new Date();
         entity.setCreateTime(now);
         entity.setModifyTime(now);


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7254 

### Motivation

When a InlongGroupId is in the process of switching, the config of source cluster and target cluster will be mixed up.
Which doubles the data consuming from MQ.

The solution is to check if the target sort cluster is tagged. If so, fiter the MQs under this tag; otherwise, get all MQs of both source and target MQs.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change added tests and can be verified as follows: Swiching in tagged/untagged cluster.


### Documentation

  - Does this pull request introduce a new feature? yes 
