### PR TITLE
[INLONG-7252][Sort] Fix Doris connector throw NPE when DATE type data is null

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -254,7 +254,12 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
                 fieldGetters[i] = RowData.createFieldGetter(logicalTypes[i], i);
                 if ("DATE".equalsIgnoreCase(logicalTypes[i].toString())) {
                     int finalI = i;
-                    fieldGetters[i] = row -> DorisParseUtils.epochToDate(row.getInt(finalI));
+                    fieldGetters[i] = row -> {
+                        if (row.isNullAt(finalI)) {
+                            return null;
+                        }
+                        return DorisParseUtils.epochToDate(row.getInt(finalI));
+                    };
                 }
             }
         }


### PR DESCRIPTION

### Prepare a Pull Request

- [INLONG-7252][Sort] Fix Doris connector throw NPE when DATE type data is null

- Fixes #7257 

### Motivation

* Fix Doris connector throw NPE when DATE type data is null

### Modifications

* modify `DorisDynamicSchemaOutputFormat#open()` to judge null


