### PR TITLE
[INLONG-7271][Manager] Support comma separation for primary key and partition key of Hudi table

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
@@ -18,9 +18,13 @@
 package org.apache.inlong.manager.service.sink.hudi;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -77,20 +81,22 @@ public class HudiSinkOperator extends AbstractSinkOperator {
 
         String partitionKey = sinkRequest.getPartitionKey();
         String primaryKey = sinkRequest.getPrimaryKey();
-        boolean primaryKeyExist = StringUtils.isNotEmpty(partitionKey);
-        boolean partitionKeyExist = StringUtils.isNotEmpty(primaryKey);
+        boolean primaryKeyExist = StringUtils.isNotBlank(partitionKey);
+        boolean partitionKeyExist = StringUtils.isNotBlank(primaryKey);
         if (primaryKeyExist || partitionKeyExist) {
             Set<String> fieldNames = sinkRequest.getSinkFieldList().stream().map(SinkField::getFieldName)
                     .collect(Collectors.toSet());
-            if (primaryKeyExist) {
-                if (!fieldNames.contains(partitionKey)) {
+            if (partitionKeyExist) {
+                List<String> partitionKeys = Arrays.asList(partitionKey.split(","));
+                if (!CollectionUtils.isSubCollection(partitionKeys, fieldNames)) {
                     throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED,
                             String.format("The partitionKey(%s) must be included in the sinkFieldList(%s)",
                                     partitionKey, fieldNames));
                 }
             }
-            if (partitionKeyExist) {
-                if (!fieldNames.contains(primaryKey)) {
+            if (primaryKeyExist) {
+                List<String> primaryKeys = Arrays.asList(primaryKey.split(","));
+                if (!CollectionUtils.isSubCollection(primaryKeys, fieldNames)) {
                     throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED,
                             String.format("The primaryKey(%s) must be included in the sinkFieldList(%s)",
                                     primaryKey, fieldNames));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
@@ -82,8 +82,8 @@ public class HudiSinkOperator extends AbstractSinkOperator {
 
         String partitionKey = sinkRequest.getPartitionKey();
         String primaryKey = sinkRequest.getPrimaryKey();
-        boolean primaryKeyExist = StringUtils.isNotBlank(partitionKey);
-        boolean partitionKeyExist = StringUtils.isNotBlank(primaryKey);
+        boolean primaryKeyExist = StringUtils.isNotBlank(primaryKey);
+        boolean partitionKeyExist = StringUtils.isNotBlank(partitionKey);
         if (primaryKeyExist || partitionKeyExist) {
             Set<String> fieldNames = sinkRequest.getSinkFieldList().stream().map(SinkField::getFieldName)
                     .collect(Collectors.toSet());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/hudi/HudiSinkOperator.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.FieldType;
@@ -87,7 +88,7 @@ public class HudiSinkOperator extends AbstractSinkOperator {
             Set<String> fieldNames = sinkRequest.getSinkFieldList().stream().map(SinkField::getFieldName)
                     .collect(Collectors.toSet());
             if (partitionKeyExist) {
-                List<String> partitionKeys = Arrays.asList(partitionKey.split(","));
+                List<String> partitionKeys = Arrays.asList(partitionKey.split(InlongConstants.COMMA));
                 if (!CollectionUtils.isSubCollection(partitionKeys, fieldNames)) {
                     throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED,
                             String.format("The partitionKey(%s) must be included in the sinkFieldList(%s)",
@@ -95,7 +96,7 @@ public class HudiSinkOperator extends AbstractSinkOperator {
                 }
             }
             if (primaryKeyExist) {
-                List<String> primaryKeys = Arrays.asList(primaryKey.split(","));
+                List<String> primaryKeys = Arrays.asList(primaryKey.split(InlongConstants.COMMA));
                 if (!CollectionUtils.isSubCollection(primaryKeys, fieldNames)) {
                     throw new BusinessException(ErrorCodeEnum.SINK_SAVE_FAILED,
                             String.format("The primaryKey(%s) must be included in the sinkFieldList(%s)",


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7271][Manager] The primary key and partition key of the hudi table support comma separation

- Fixes #7271 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
