### PR TITLE
[INLONG-7286][Sort] Fix issue of tableidentifier being null when addRow

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -441,7 +441,10 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
 
     @SuppressWarnings({"unchecked"})
     private void addRow(RowKind rowKind, JsonNode rootNode, JsonNode physicalNode, JsonNode updateBeforeNode,
-            Map<String, String> physicalData, Map<String, String> updateBeforeData) {
+            Map<String, String> physicalData, Map<String, String> updateBeforeData) throws IOException {
+        String tableIdentifier = StringUtils.join(
+                jsonDynamicSchemaFormat.parse(rootNode, databasePattern), ".",
+                jsonDynamicSchemaFormat.parse(rootNode, tablePattern));
         switch (rowKind) {
             case INSERT:
             case UPDATE_AFTER:

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -313,7 +313,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     }
 
     @Override
-    public synchronized void writeRecord(T row) {
+    public synchronized void writeRecord(T row) throws IOException {
         addBatch(row);
         boolean valid = (executionOptions.getBatchSize() > 0 && size >= executionOptions.getBatchSize())
                 || batchBytes >= executionOptions.getMaxBatchBytes();
@@ -372,7 +372,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
 
     }
 
-    private void addBatch(T row) {
+    private void addBatch(T row) throws IOException {
         readInNum.incrementAndGet();
         if (!multipleSink) {
             addSingle(row);


### PR DESCRIPTION
https://github.com/apache/inlong/issues/7286

------------------------------------------------
Motivation:
An error stack which is arrayIndexoutofbounds. 
After investigation, it is because the dirtyidentifier is null for multiple sink.
This was okay since we dont need the identifier to process data in multiple sink scenarios, but this is not ok for dirty data log output

Modifications:
generated a precise dirtyidentifier in addrow, so that load() call will have the actual identifier instead of null.