### PR TITLE
[INLONG-7292][Sort] Accurately detect and archive dirty data for Doris/StarRocks/JDBC

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -135,8 +135,6 @@ public final class Constants {
 
     public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
 
-    public static final String DIRTY_IDENTIFIER_SEPARATOR = "%#%#%#";
-
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
                     .stringType()

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -135,7 +135,7 @@ public final class Constants {
 
     public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
 
-    public static final String SEPARATOR = "%#%#%#";
+    public static final String DIRTY_IDENTIFIER_SEPARATOR = "%#%#%#";
 
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -135,6 +135,8 @@ public final class Constants {
 
     public static final String AUTO_DESERIALIZE_FALSE = "autoDeserialize=false";
 
+    public static final String SEPARATOR = "%#%#%#";
+
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
                     .stringType()

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -147,6 +147,12 @@ public class DirtySinkHelper<T> implements Serializable {
             return;
         }
 
+        handleDirty(dirtyType, e, actualIdentifier, rootNode, jsonDynamicSchemaFormat, dirtyData);
+    }
+
+    private void handleDirty(DirtyType dirtyType, Throwable e,
+            List<String> actualIdentifier, JsonNode rootNode, JsonDynamicSchemaFormat jsonDynamicSchemaFormat,
+            T dirtyData) {
         if (dirtySink != null) {
             DirtyData.Builder<T> builder = DirtyData.builder();
             try {

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -40,6 +40,8 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.apache.inlong.sort.base.Constants.SEPARATOR;
+
 /**
  * Dirty sink helper, it helps dirty data sink for {@link DirtySink}
  * @param <T>
@@ -121,7 +123,6 @@ public class DirtySinkHelper<T> implements Serializable {
 
         JsonDynamicSchemaFormat jsonDynamicSchemaFormat =
                 (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
-        final String SEPARATOR = "%#%#%#";
         JsonNode rootNode = null;
         List<String> actualIdentifier = new ArrayList<>();
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -52,7 +52,6 @@ public class DirtySinkHelper<T> implements Serializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(DirtySinkHelper.class);
     static final Pattern REGEX_PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
 
-
     private DirtyOptions dirtyOptions;
     private final @Nullable DirtySink<T> dirtySink;
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -40,7 +40,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.apache.inlong.sort.base.Constants.SEPARATOR;
+import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER_SEPARATOR;
 
 /**
  * Dirty sink helper, it helps dirty data sink for {@link DirtySink}
@@ -135,10 +135,10 @@ public class DirtySinkHelper<T> implements Serializable {
                 rootNode = (JsonNode) dirtyData;
             } else if (dirtyData instanceof String) {
                 // parse and remove the added identifier for string cases
-                String rawIdentifier = ((String) dirtyData).split(SEPARATOR)[0];
+                String rawIdentifier = ((String) dirtyData).split(DIRTY_IDENTIFIER_SEPARATOR)[0];
                 String[] arr = rawIdentifier.split("\\.");
                 actualIdentifier.addAll(Arrays.asList(arr));
-                dirtyData = (T) ((String) dirtyData).split(SEPARATOR)[1];
+                dirtyData = (T) ((String) dirtyData).split(DIRTY_IDENTIFIER_SEPARATOR)[1];
             } else {
                 throw new Exception("unidentified dirty data " + dirtyData);
             }

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -50,6 +50,8 @@ public class DirtySinkHelper<T> implements Serializable {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(DirtySinkHelper.class);
+    static final Pattern REGEX_PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
+
 
     private DirtyOptions dirtyOptions;
     private final @Nullable DirtySink<T> dirtySink;
@@ -192,7 +194,6 @@ public class DirtySinkHelper<T> implements Serializable {
             return null;
         }
 
-        final Pattern REGEX_PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
         final String DIRTY_TYPE_KEY = "DIRTY_TYPE";
         final String DIRTY_MESSAGE_KEY = "DIRTY_MESSAGE";
         final String SYSTEM_TIME_KEY = "SYSTEM_TIME";

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -197,7 +197,6 @@ public class DirtySinkHelper<T> implements Serializable {
         paramMap.put(DIRTY_MESSAGE_KEY, dirtyMessage);
 
         Matcher matcher = REGEX_PATTERN.matcher(pattern);
-
         int i = 0;
         while (matcher.find()) {
             try {
@@ -210,6 +209,7 @@ public class DirtySinkHelper<T> implements Serializable {
             i++;
         }
 
+        matcher = REGEX_PATTERN.matcher(pattern);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String keyText = matcher.group(1);

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.dirty;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+@Slf4j
+public class RegexReplaceTest {
+
+    @Test
+    public void testRegexReplacement() throws IOException {
+        String[] identifier = new String[2];
+        identifier[0] = "yizhouyang";
+        identifier[1] = "table2";
+        String pattern = "${database}-${table}-${DIRTY_MESSAGE}";
+        String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message", identifier);
+        Assert.assertEquals("yizhouyang-table2-mock message", answer);
+    }
+}

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -496,8 +496,12 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         }
 
         if (multipleSink) {
-            handleMultipleDirtyData(dirtyData, dirtyType, e);
-            return;
+            if (dirtyType == DirtyType.DESERIALIZE_ERROR) {
+                LOG.error("database and table can't be identified, will use default ${database}${table}");
+            } else {
+                handleMultipleDirtyData(dirtyData, dirtyType, e);
+                return;
+            }
         }
 
         if (dirtySink != null) {

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -42,7 +42,6 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
-import org.apache.inlong.sort.base.Constants;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.DirtyType;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -42,6 +42,7 @@ import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.base.Constants;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.DirtyType;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
@@ -89,6 +90,7 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
+import static org.apache.inlong.sort.base.Constants.SEPARATOR;
 
 /**
  * A JDBC multi-table outputFormat that supports batching records before writing records to databases.
@@ -566,7 +568,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                         outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
                                 1L, true);
                         if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
-                            dirtySinkHelper.invokeMultiple(tableIdentifier + "%#%#%#" + record.toString(),
+                            dirtySinkHelper.invokeMultiple(tableIdentifier + SEPARATOR + record.toString(),
                                     DirtyType.RETRY_LOAD_ERROR, tableException,
                                     sinkMultipleFormat);
                         }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -566,7 +566,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                         outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
                                 1L, true);
                         if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
-                            dirtySinkHelper.invokeMultiple(record, DirtyType.RETRY_LOAD_ERROR, tableException,
+                            dirtySinkHelper.invokeMultiple(tableIdentifier + "%#%#%#" + record.toString(),
+                                    DirtyType.RETRY_LOAD_ERROR, tableException,
                                     sinkMultipleFormat);
                         }
                         tableExceptionMap.put(tableIdentifier, tableException);

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -567,7 +567,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                         outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
                                 1L, true);
                         if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
-                            dirtySinkHelper.invokeMultiple(tableIdentifier + DIRTY_IDENTIFIER_SEPARATOR + record.toString(),
+                            dirtySinkHelper.invokeMultiple(
+                                    tableIdentifier + DIRTY_IDENTIFIER_SEPARATOR + record.toString(),
                                     DirtyType.RETRY_LOAD_ERROR, tableException,
                                     sinkMultipleFormat);
                         }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -89,7 +89,7 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
-import static org.apache.inlong.sort.base.Constants.SEPARATOR;
+import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER_SEPARATOR;
 
 /**
  * A JDBC multi-table outputFormat that supports batching records before writing records to databases.
@@ -567,7 +567,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                         outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
                                 1L, true);
                         if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
-                            dirtySinkHelper.invokeMultiple(tableIdentifier + SEPARATOR + record.toString(),
+                            dirtySinkHelper.invokeMultiple(tableIdentifier + DIRTY_IDENTIFIER_SEPARATOR + record.toString(),
                                     DirtyType.RETRY_LOAD_ERROR, tableException,
                                     sinkMultipleFormat);
                         }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -89,7 +89,6 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
-import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER_SEPARATOR;
 
 /**
  * A JDBC multi-table outputFormat that supports batching records before writing records to databases.
@@ -568,7 +567,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                                 1L, true);
                         if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
                             dirtySinkHelper.invokeMultiple(
-                                    tableIdentifier + DIRTY_IDENTIFIER_SEPARATOR + record.toString(),
+                                    tableIdentifier, record.toString(),
                                     DirtyType.RETRY_LOAD_ERROR, tableException,
                                     sinkMultipleFormat);
                         }

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -60,8 +60,6 @@ import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER_SEPARATOR;
-
 /**
  * StarRocks sink manager which caches and flushes data.
  */
@@ -454,16 +452,16 @@ public class StarRocksSinkManager implements Serializable {
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + DIRTY_IDENTIFIER_SEPARATOR
-                                + new String(row, StandardCharsets.UTF_8),
+                        flushData.getDatabase() + "." + flushData.getTable(),
+                        new String(row, StandardCharsets.UTF_8),
                         DirtyType.BATCH_LOAD_ERROR, e,
                         sinkMultipleFormat);
             }
         } else if (StarRocksSinkOptions.StreamLoadFormat.JSON.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + DIRTY_IDENTIFIER_SEPARATOR
-                                + OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)).toString(),
+                        flushData.getDatabase() + "." + flushData.getTable(),
+                        OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)).toString(),
                         DirtyType.BATCH_LOAD_ERROR, e, sinkMultipleFormat);
             }
         }

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -451,12 +451,17 @@ public class StarRocksSinkManager implements Serializable {
         // archive dirty data
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
-                dirtySinkHelper.invokeMultiple(new String(row, StandardCharsets.UTF_8), DirtyType.BATCH_LOAD_ERROR, e,
+                dirtySinkHelper.invokeMultiple(
+                        flushData.getDatabase() + "." + flushData.getTable() + "%#%#%#"
+                                + new String(row, StandardCharsets.UTF_8),
+                        DirtyType.BATCH_LOAD_ERROR, e,
                         sinkMultipleFormat);
             }
         } else if (StarRocksSinkOptions.StreamLoadFormat.JSON.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
-                dirtySinkHelper.invokeMultiple(OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)),
+                dirtySinkHelper.invokeMultiple(
+                        flushData.getDatabase() + "." + flushData.getTable() + "%#%#%#"
+                                + OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)).toString(),
                         DirtyType.BATCH_LOAD_ERROR, e, sinkMultipleFormat);
             }
         }

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -60,6 +60,8 @@ import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.inlong.sort.base.Constants.SEPARATOR;
+
 /**
  * StarRocks sink manager which caches and flushes data.
  */
@@ -452,7 +454,7 @@ public class StarRocksSinkManager implements Serializable {
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + "%#%#%#"
+                        flushData.getDatabase() + "." + flushData.getTable() + SEPARATOR
                                 + new String(row, StandardCharsets.UTF_8),
                         DirtyType.BATCH_LOAD_ERROR, e,
                         sinkMultipleFormat);
@@ -460,7 +462,7 @@ public class StarRocksSinkManager implements Serializable {
         } else if (StarRocksSinkOptions.StreamLoadFormat.JSON.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + "%#%#%#"
+                        flushData.getDatabase() + "." + flushData.getTable() + SEPARATOR
                                 + OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)).toString(),
                         DirtyType.BATCH_LOAD_ERROR, e, sinkMultipleFormat);
             }

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksSinkManager.java
@@ -60,7 +60,7 @@ import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.inlong.sort.base.Constants.SEPARATOR;
+import static org.apache.inlong.sort.base.Constants.DIRTY_IDENTIFIER_SEPARATOR;
 
 /**
  * StarRocks sink manager which caches and flushes data.
@@ -454,7 +454,7 @@ public class StarRocksSinkManager implements Serializable {
         if (StarRocksSinkOptions.StreamLoadFormat.CSV.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + SEPARATOR
+                        flushData.getDatabase() + "." + flushData.getTable() + DIRTY_IDENTIFIER_SEPARATOR
                                 + new String(row, StandardCharsets.UTF_8),
                         DirtyType.BATCH_LOAD_ERROR, e,
                         sinkMultipleFormat);
@@ -462,7 +462,7 @@ public class StarRocksSinkManager implements Serializable {
         } else if (StarRocksSinkOptions.StreamLoadFormat.JSON.equals(sinkOptions.getStreamLoadFormat())) {
             for (byte[] row : flushData.getBuffer()) {
                 dirtySinkHelper.invokeMultiple(
-                        flushData.getDatabase() + "." + flushData.getTable() + SEPARATOR
+                        flushData.getDatabase() + "." + flushData.getTable() + DIRTY_IDENTIFIER_SEPARATOR
                                 + OBJECT_MAPPER.readTree(new String(row, StandardCharsets.UTF_8)).toString(),
                         DirtyType.BATCH_LOAD_ERROR, e, sinkMultipleFormat);
             }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7292

### Motivation
There are two different bugs that should be fixed by this.
1) when archiving, the patternreplaceutils and JsonDymanicSchema competes for ${} symbol, and it will throw exceptions.
2) Sometimes, when invoking dirty data, there is no JsonNode. In this case, the dirty data still needs to be archived.

### Modification

This fix does two things:
1) created a regexreplace method which does the regex replacement process all at once, while not interfering (editing) the common process layer.
2) for those cases where jsonnode is not available, manually pass in identifier so that at least the data can be processed in all cases