### PR TITLE
[INLONG-7292][Sort] S3DirtySink flushes too quickly

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -71,7 +71,7 @@ public class S3DirtySink<T> implements DirtySink<T> {
     private final DataType physicalRowDataType;
     private RowData.FieldGetter[] fieldGetters;
     private RowDataToJsonConverter converter;
-    private long currentTime;
+    private long lastExecutetime;
     private long batchBytes = 0L;
     private int size;
     private transient volatile boolean closed = false;
@@ -125,24 +125,29 @@ public class S3DirtySink<T> implements DirtySink<T> {
                     + "and the dirty data will be throw away in the future"
                     + " because the option 'dirty.side-output.ignore-errors' is 'true'", dirtyData.getIdentifier());
         }
-        if (valid() && !flushing) {
+        if (buffered() && valid() && !flushing) {
             flush();
         }
     }
 
     private boolean valid() {
-        // stash dirty data for at least a minute to avoid flushing too fast
-        if (currentTime == 0) {
-            currentTime = System.currentTimeMillis();
-            return false;
-        }
-        if (System.currentTimeMillis() - currentTime < s3Options.getBatchIntervalMs()) {
-            return false;
-        }
         return (s3Options.getBatchSize() > 0 && (size >= s3Options.getBatchSize()
                 || batchBytes <= s3Options.getMaxBatchBytes()));
     }
 
+
+    private boolean buffered() {
+        // stash dirty data for at least a minute to avoid flushing too fast
+        if (lastExecutetime == 0) {
+            lastExecutetime = System.currentTimeMillis();
+            return false;
+        }
+        if (System.currentTimeMillis() - lastExecutetime < s3Options.getBatchIntervalMs()) {
+            return false;
+        }
+        return true;
+    }
+    
     private void addBatch(DirtyData<T> dirtyData) throws IOException {
         readInNum.incrementAndGet();
         String value;
@@ -227,7 +232,7 @@ public class S3DirtySink<T> implements DirtySink<T> {
      */
     public synchronized void flush() {
         flushing = true;
-        currentTime = System.currentTimeMillis();
+        lastExecutetime = System.currentTimeMillis();
         if (!hasRecords()) {
             flushing = false;
             return;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -131,8 +131,8 @@ public class S3DirtySink<T> implements DirtySink<T> {
     }
 
     private boolean valid() {
-        return (s3Options.getBatchSize() > 0 && (size >= s3Options.getBatchSize()
-                || batchBytes <= s3Options.getMaxBatchBytes()));
+        return (s3Options.getBatchSize() > 0 && size >= s3Options.getBatchSize())
+                || batchBytes >= s3Options.getMaxBatchBytes();
     }
 
 

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -135,7 +135,6 @@ public class S3DirtySink<T> implements DirtySink<T> {
                 || batchBytes >= s3Options.getMaxBatchBytes();
     }
 
-
     private boolean buffered() {
         // stash dirty data for at least a minute to avoid flushing too fast
         if (lastExecutetime == 0) {
@@ -147,7 +146,7 @@ public class S3DirtySink<T> implements DirtySink<T> {
         }
         return true;
     }
-    
+
     private void addBatch(DirtyData<T> dirtyData) throws IOException {
         readInNum.incrementAndGet();
         String value;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -141,8 +141,6 @@ public class S3DirtySink<T> implements DirtySink<T> {
         }
         return (s3Options.getBatchSize() > 0 && (size >= s3Options.getBatchSize()
                 || batchBytes <= s3Options.getMaxBatchBytes()));
-        return (s3Options.getBatchSize() > 0 && size >= s3Options.getBatchSize())
-                || batchBytes >= s3Options.getMaxBatchBytes();
     }
 
     private void addBatch(DirtyData<T> dirtyData) throws IOException {


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7293
 
### Motivation

For JDBC multiple sink, the cos was filled very quickly, with a new file created every second instead of minute.

So I tried to debug, and realized that whenever dirtysink.invoke() is called, dirtysink.flush() will be called as well.

So the record will be flush into cos every second instead of every minute, and this is not how it is supposed to work.

### Modifications

I added a mechanism to prevent the flush() from being triggered in dirtysink too often, so that every two calls to dirtysink.flush() will at least have dirtysink.batchinverval seconds in between, and cos won't flush too quickly.
