### PR TITLE
[INLONG-7311][Sort] Fix Doris StreamLoad unable to archive dirtydata

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -678,7 +678,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         } catch (Exception e) {
             LOG.error(String.format("Flush table: %s error", tableIdentifier), e);
             // Makesure it is a dirty data
-            if (respContent != null && StringUtils.isNotBlank(respContent.getErrorURL())) {
+            if (respContent == null || StringUtils.isNotBlank(respContent.getErrorURL())) {
                 flushExceptionMap.put(tableIdentifier, e);
                 errorNum.getAndAdd(values.size());
                 for (Object value : values) {


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7311][Sort] Fix Doris StreamLoad unable to archive dirtydata

- Fixes #7311 

### Motivation
When testing dirty data to doris sink, I found that none of the dirty data is archived, and the metric is always 0 for successfully written and 0 for dirty.

<img width="820" alt="image" src="https://user-images.githubusercontent.com/32808678/216253820-9a505577-4af1-4a76-ba77-bd03e063c8f2.png">

I found the cause is that when flush(), the data is written by DorisStreamLoad.load(), and within this method exception will occur.

However, when load() fails, its return value, respContent, will be null since an exception is thrown, and at this time, the current logic will not archive this as dirty data.

### Modifications
Changed the archive strategy so that  when respContent is null (exception during streamload), the unwritten data will be archived as dirtydata if dirtysink is not null.