### PR TITLE
[INLONG-7325][Manager] Format the topic name and data separator for Kafka

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.service.resource.queue.kafka;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.constant.Constants;
 import org.apache.inlong.common.constant.MQType;
 import org.apache.inlong.manager.common.enums.ClusterType;
@@ -135,7 +136,7 @@ public class KafkaResourceOperators implements QueueResourceOperator {
 
         try {
             String topicName = streamInfo.getMqResource();
-            if (topicName == null || topicName.equals(streamId)) {
+            if (StringUtils.isBlank(topicName) || topicName.equals(streamId)) {
                 // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
                 topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
                         groupInfo.getMqResource(), streamInfo.getMqResource());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
@@ -135,7 +135,7 @@ public class KafkaResourceOperators implements QueueResourceOperator {
 
         try {
             String topicName = streamInfo.getMqResource();
-            if (topicName.equals(streamId)) {
+            if (topicName == null || topicName.equals(streamId)) {
                 // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
                 topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
                         groupInfo.getMqResource(), streamInfo.getMqResource());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaResourceOperators.java
@@ -134,7 +134,13 @@ public class KafkaResourceOperators implements QueueResourceOperator {
         log.info("begin to delete kafka resource for groupId={} streamId={}", groupId, streamId);
 
         try {
-            this.deleteKafkaTopic(groupInfo, streamInfo.getMqResource());
+            String topicName = streamInfo.getMqResource();
+            if (topicName.equals(streamId)) {
+                // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
+                topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
+                        groupInfo.getMqResource(), streamInfo.getMqResource());
+            }
+            this.deleteKafkaTopic(groupInfo, topicName);
             log.info("success to delete kafka topic for groupId={}, streamId={}", groupId, streamId);
         } catch (Exception e) {
             String msg = String.format("failed to delete kafka topic for groupId=%s, streamId=%s", groupId, streamId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.common.constant.Constants;
 import org.apache.inlong.common.enums.DataTypeEnum;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ClusterType;
@@ -113,6 +114,13 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setBootstrapServers(bootstrapServers);
             kafkaSource.setTopic(streamInfo.getMqResource());
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+            String topicName = streamInfo.getMqResource();
+            if (topicName.equals(streamId)) {
+                // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
+                topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
+                        groupInfo.getMqResource(), streamInfo.getMqResource());
+            }
+            kafkaSource.setTopic(topicName);
             kafkaSource.setSerializationType(serializationType);
             kafkaSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
@@ -123,6 +131,17 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
                 if (StringUtils.isEmpty(kafkaSource.getSerializationType()) && StringUtils.isNotEmpty(
                         sourceInfo.getSerializationType())) {
                     kafkaSource.setSerializationType(sourceInfo.getSerializationType());
+                }
+            }
+
+            // if the SerializationType is still null, set it to the CSV
+            if (StringUtils.isEmpty(kafkaSource.getSerializationType())) {
+                kafkaSource.setSerializationType(DataTypeEnum.CSV.getType());
+            }
+            if (DataTypeEnum.CSV.getType().equalsIgnoreCase(kafkaSource.getSerializationType())) {
+                kafkaSource.setDataSeparator(streamInfo.getDataSeparator());
+                if (StringUtils.isEmpty(kafkaSource.getDataSeparator())) {
+                    kafkaSource.setDataSeparator(String.valueOf((int) ','));
                 }
             }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -115,7 +115,7 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setTopic(streamInfo.getMqResource());
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             String topicName = streamInfo.getMqResource();
-            if (topicName.equals(streamId)) {
+            if (topicName == null || topicName.equals(streamId)) {
                 // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
                 topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
                         groupInfo.getMqResource(), streamInfo.getMqResource());
@@ -135,12 +135,12 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             }
 
             // if the SerializationType is still null, set it to the CSV
-            if (StringUtils.isEmpty(kafkaSource.getSerializationType())) {
+            if (StringUtils.isBlank(kafkaSource.getSerializationType())) {
                 kafkaSource.setSerializationType(DataTypeEnum.CSV.getType());
             }
             if (DataTypeEnum.CSV.getType().equalsIgnoreCase(kafkaSource.getSerializationType())) {
                 kafkaSource.setDataSeparator(streamInfo.getDataSeparator());
-                if (StringUtils.isEmpty(kafkaSource.getDataSeparator())) {
+                if (StringUtils.isBlank(kafkaSource.getDataSeparator())) {
                     kafkaSource.setDataSeparator(String.valueOf((int) ','));
                 }
             }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -115,7 +115,7 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setTopic(streamInfo.getMqResource());
             String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
             String topicName = streamInfo.getMqResource();
-            if (topicName == null || topicName.equals(streamId)) {
+            if (StringUtils.isBlank(topicName) || topicName.equals(streamId)) {
                 // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
                 topicName = String.format(Constants.DEFAULT_KAFKA_TOPIC_FORMAT,
                         groupInfo.getMqResource(), streamInfo.getMqResource());


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7325 

### Motivation

The Kafka topic naming rules are updated to: `inlongGroupId.inlongStreamId`, but the Flink task submitted by sort is still `inlongstreamId`.

### Modifications

`inlongstreamId` -> `inlongGroupId.inlongStreamId`

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:
