### PR TITLE
[INLONG-7327][Dashboard] Support using different env variable

### DIFF
--- a/inlong-dashboard/craco.config.ts
+++ b/inlong-dashboard/craco.config.ts
@@ -21,6 +21,9 @@ import CracoLess from 'craco-less';
 import { CracoAliasPlugin } from 'react-app-alias';
 import AntdDayjsWebpackPlugin from 'antd-dayjs-webpack-plugin';
 import type { CracoConfig } from 'craco__craco';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const config: CracoConfig = {
   plugins: [
@@ -49,6 +52,13 @@ const config: CracoConfig = {
   webpack: {
     plugins: {
       add: [new AntdDayjsWebpackPlugin()],
+    },
+    configure: webpackConfig => {
+      if (webpackConfig.resolve?.extensions && process.env.INLONG_ENV) {
+        const tsIndex = webpackConfig.resolve.extensions.findIndex(item => item === '.ts');
+        webpackConfig.resolve.extensions.splice(tsIndex, 0, `.${process.env.INLONG_ENV}.ts`);
+      }
+      return webpackConfig;
     },
   },
   babel: {

--- a/inlong-dashboard/package-lock.json
+++ b/inlong-dashboard/package-lock.json
@@ -5961,9 +5961,9 @@
       }
     },
     "dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
       "dev": true
     },
     "dotenv-expand": {
@@ -13182,6 +13182,12 @@
         "workbox-webpack-plugin": "^6.4.1"
       },
       "dependencies": {
+        "dotenv": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+          "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+          "dev": true
+        },
         "react-refresh": {
           "version": "0.11.0",
           "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",

--- a/inlong-dashboard/package.json
+++ b/inlong-dashboard/package.json
@@ -76,6 +76,7 @@
     "antd-dayjs-webpack-plugin": "^1.0.6",
     "babel-plugin-import": "^1.13.5",
     "craco-less": "^2.1.0-alpha.0",
+    "dotenv": "^16.0.3",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",

--- a/inlong-dashboard/src/configs/default/conf.ts
+++ b/inlong-dashboard/src/configs/default/conf.ts
@@ -21,7 +21,7 @@ import i18n from '@/i18n';
 import Provider from '@/components/Provider';
 import Layout from '@/components/Layout';
 
-export const config = {
+const conf = {
   title: '',
   logo: '/logo.svg',
   loginUrl: `${window.location.origin}/#/${i18n?.language || ''}/login`,
@@ -29,3 +29,5 @@ export const config = {
   AppLoading: PageLoading,
   AppLayout: Layout,
 };
+
+export default conf;

--- a/inlong-dashboard/src/configs/default/index.ts
+++ b/inlong-dashboard/src/configs/default/index.ts
@@ -17,4 +17,6 @@
  * under the License.
  */
 
-export { config } from './conf';
+import conf from './conf';
+
+export const config = conf;

--- a/inlong-dashboard/src/configs/locales/conf.ts
+++ b/inlong-dashboard/src/configs/locales/conf.ts
@@ -19,7 +19,7 @@
 
 import type { LocalesType } from '.';
 
-const localesConf: LocalesType = {
+const conf: LocalesType = {
   cn: {
     label: '简体中文',
     uiComponentPath: 'zh_CN',
@@ -32,4 +32,4 @@ const localesConf: LocalesType = {
   },
 };
 
-export default localesConf;
+export default conf;

--- a/inlong-dashboard/src/configs/menus/conf.ts
+++ b/inlong-dashboard/src/configs/menus/conf.ts
@@ -20,7 +20,7 @@
 import i18n from '@/i18n';
 import type { MenuItemType } from '.';
 
-const menusTree: MenuItemType[] = [
+const conf: MenuItemType[] = [
   {
     path: '/group',
     name: i18n.t('configs.menus.Groups'),
@@ -66,4 +66,4 @@ const menusTree: MenuItemType[] = [
   },
 ];
 
-export default menusTree;
+export default conf;

--- a/inlong-dashboard/src/configs/routes/conf.ts
+++ b/inlong-dashboard/src/configs/routes/conf.ts
@@ -19,7 +19,7 @@
 
 import type { RouteProps } from '.';
 
-const routes: RouteProps[] = [
+const conf: RouteProps[] = [
   {
     path: '/login',
     component: () => import('@/pages/Login'),
@@ -102,4 +102,4 @@ const routes: RouteProps[] = [
   },
 ];
 
-export default routes;
+export default conf;

--- a/inlong-dashboard/vite.config.ts
+++ b/inlong-dashboard/vite.config.ts
@@ -25,6 +25,10 @@ import vitePluginImp from 'vite-plugin-imp';
 import dynamicImport from 'vite-plugin-dynamic-import';
 import svgr from 'vite-plugin-svgr';
 import eslintPlugin from 'vite-plugin-eslint';
+import ResolveEnvPlugin from './scripts/vite-plugin-resolve-env';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 export default defineConfig({
   resolve: {
@@ -43,6 +47,9 @@ export default defineConfig({
     },
   },
   plugins: [
+    ResolveEnvPlugin({
+      env: process.env.INLONG_ENV || undefined,
+    }),
     react(),
     tsConfigPaths(),
     vitePluginImp({


### PR DESCRIPTION
- Fixes #7327

Supports the use of different environment variable configurations, including `.env`, `.env.local`, etc. For example, users can declare `INLONG_ENV=mytest` in the configuration file, and the system will automatically use the corresponding configuration file under mytest: `src/configs/menus/conf.mytest.ts`