### PR TITLE
[INLONG-7349][SDK] Fix init failure when a single SortTask create multiple SortClients

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
@@ -25,7 +25,6 @@ import org.apache.inlong.sdk.sort.metrics.SortSdkMetricItemSet;
 import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 
 public abstract class ClientContext implements Cleanable {
 

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
@@ -24,6 +24,7 @@ import org.apache.inlong.sdk.sort.metrics.SortSdkMetricItemSet;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 
 public abstract class ClientContext implements Cleanable {
 
@@ -36,7 +37,7 @@ public abstract class ClientContext implements Cleanable {
     public ClientContext(SortClientConfig config) {
         this.config = config;
         this.sortTaskId = config.getSortTaskId();
-        this.metricItemSet = new SortSdkMetricItemSet(config.getSortTaskId());
+        this.metricItemSet = new SortSdkMetricItemSet(config.getSortTaskId() + new Random().nextInt());
         MetricRegister.register(this.metricItemSet);
     }
 

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/api/ClientContext.java
@@ -22,6 +22,7 @@ import org.apache.inlong.sdk.sort.entity.InLongTopic;
 import org.apache.inlong.sdk.sort.metrics.SortSdkMetricItem;
 import org.apache.inlong.sdk.sort.metrics.SortSdkMetricItemSet;
 
+import java.security.SecureRandom;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -37,7 +38,7 @@ public abstract class ClientContext implements Cleanable {
     public ClientContext(SortClientConfig config) {
         this.config = config;
         this.sortTaskId = config.getSortTaskId();
-        this.metricItemSet = new SortSdkMetricItemSet(config.getSortTaskId() + new Random().nextInt());
+        this.metricItemSet = new SortSdkMetricItemSet(config.getSortTaskId() + new SecureRandom().nextInt());
         MetricRegister.register(this.metricItemSet);
     }
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7349 

### Motivation

Each SortClients creates a SortSdkMetricItemSet with same name (taskId), which leads to a register failure when register this bean as MetricItemSet.

### Modifications

Add a random value in the name of SortSdkMetricItemSet

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? no
