### PR TITLE
[INLONG-7358][Manager] Fix the ungraceful util tool import classes of Lists/Maps

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/greenplum/GreenplumSqlBuilder.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/greenplum/GreenplumSqlBuilder.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.manager.service.resource.sink.greenplum;
 
-import org.apache.commons.compress.utils.Lists;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.pojo.sink.greenplum.GreenplumColumnInfo;
 import org.apache.inlong.manager.pojo.sink.greenplum.GreenplumTableInfo;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/postgresql/PostgreSQLSqlBuilder.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/postgresql/PostgreSQLSqlBuilder.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.manager.service.resource.sink.postgresql;
 
-import org.apache.commons.compress.utils.Lists;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.pojo.sink.postgresql.PostgreSQLColumnInfo;
 import org.apache.inlong.manager.pojo.sink.postgresql.PostgreSQLTableInfo;

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/StreamSourceServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/StreamSourceServiceTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.manager.service.source;
 
-import org.apache.curator.shaded.com.google.common.collect.Maps;
+import com.google.common.collect.Maps;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.pojo.source.StreamSource;


### PR DESCRIPTION
Fix the ungraceful util tool import classes of Lists/Maps

### Prepare a Pull Request

- Fixes https://github.com/apache/inlong/issues/7358

### Motivation

Use gracefull util tool class import for the full project

### Modifications

- Use com.google.common.collect.Lists import for GreenplumSqlBuilder instead of org.apache.commons.compress.utils.Lists
- Use com.google.common.collect.Lists import for PostgreSQLSqlBuilder instead of org.apache.commons.compress.utils.Lists
- Use com.google.common.collect.Maps import for StreamSourceServiceTest instead of org.apache.curator.shaded.com.google.common.collect.Maps

