### PR TITLE
[INLONG-7379][Manager] Add a database name for MySQLSink

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/mysql/MySQLDataNodeDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/mysql/MySQLDataNodeDTO.java
@@ -23,6 +23,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.JsonUtils;
@@ -42,6 +43,7 @@ import javax.validation.constraints.NotNull;
 public class MySQLDataNodeDTO {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySQLDataNodeDTO.class);
+    private static final String MYSQL_JDBC_PREFIX = "jdbc:mysql://";
 
     @ApiModelProperty("URL of backup DB server")
     private String backupUrl;
@@ -65,5 +67,16 @@ public class MySQLDataNodeDTO {
             throw new BusinessException(ErrorCodeEnum.CLUSTER_INFO_INCORRECT,
                     String.format("Failed to parse extParams for MySQL node: %s", e.getMessage()));
         }
+    }
+
+    /**
+     * Convert ip:post to jdbcurl.
+     */
+    public static String convertToJdbcurl(String url) {
+        String jdbcUrl = url;
+        if (StringUtils.isNotBlank(jdbcUrl) && !jdbcUrl.startsWith(MYSQL_JDBC_PREFIX)) {
+            jdbcUrl = MYSQL_JDBC_PREFIX + jdbcUrl;
+        }
+        return jdbcUrl;
     }
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSink.java
@@ -42,7 +42,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @JsonTypeDefine(value = SinkType.MYSQL)
 public class MySQLSink extends StreamSink {
 
-    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port/database")
+    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")
@@ -50,6 +50,9 @@ public class MySQLSink extends StreamSink {
 
     @ApiModelProperty("User password")
     private String password;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
 
     @ApiModelProperty("Target table name")
     private String tableName;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -37,6 +37,8 @@ import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * MySQL sink info
@@ -61,8 +63,9 @@ public class MySQLSinkDTO {
     };
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MySQLSinkDTO.class);
+    private static final String MYSQL_JDBC_PREFIX = "jdbc:mysql://";
 
-    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port/database")
+    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")
@@ -70,6 +73,9 @@ public class MySQLSinkDTO {
 
     @ApiModelProperty("User password")
     private String password;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
 
     @ApiModelProperty("Target table name")
     private String tableName;
@@ -89,11 +95,13 @@ public class MySQLSinkDTO {
      */
     public static MySQLSinkDTO getFromRequest(MySQLSinkRequest request) {
         String url = filterSensitive(request.getJdbcUrl());
+        url = checkJdbcUrl(url);
         return MySQLSinkDTO.builder()
                 .jdbcUrl(url)
                 .username(request.getUsername())
                 .password(request.getPassword())
                 .primaryKey(request.getPrimaryKey())
+                .databaseName(request.getDatabaseName())
                 .tableName(request.getTableName())
                 .properties(request.getProperties())
                 .build();
@@ -123,8 +131,7 @@ public class MySQLSinkDTO {
      */
     public static MySQLTableInfo getTableInfo(MySQLSinkDTO mySQLSink, List<MySQLColumnInfo> columnList) {
         MySQLTableInfo tableInfo = new MySQLTableInfo();
-        String dbName = getDbNameFromUrl(mySQLSink.getJdbcUrl());
-        tableInfo.setDbName(dbName);
+        tableInfo.setDbName(mySQLSink.getDatabaseName());
         tableInfo.setTableName(mySQLSink.getTableName());
         tableInfo.setPrimaryKey(mySQLSink.getPrimaryKey());
         tableInfo.setColumns(columnList);
@@ -176,6 +183,23 @@ public class MySQLSinkDTO {
             database = database.substring(0, database.indexOf(";"));
         }
         return database;
+    }
+
+    private static String checkJdbcUrl(String jdbcUrl) {
+        if (StringUtils.isBlank(jdbcUrl)) {
+            return jdbcUrl;
+        }
+        String pattern = "jdbc:mysql://(?<host>[a-zA-Z0-9-//.]+):(?<port>[0-9]+)?";
+        Pattern namePattern = Pattern.compile(pattern);
+        Matcher dateMatcher = namePattern.matcher(jdbcUrl);
+        if (dateMatcher.find()) {
+            String host = dateMatcher.group("host");
+            String port = dateMatcher.group("port");
+            return MYSQL_JDBC_PREFIX + host + ":" + port;
+        } else {
+            throw new BusinessException(ErrorCodeEnum.SINK_INFO_INCORRECT,
+                    "MySQL JDBC URL was invalid, it should like jdbc:mysql://host:port");
+        }
     }
 
     /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkRequest.java
@@ -36,7 +36,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 @JsonTypeDefine(value = SinkType.MYSQL)
 public class MySQLSinkRequest extends SinkRequest {
 
-    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port/database")
+    @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")
@@ -44,6 +44,9 @@ public class MySQLSinkRequest extends SinkRequest {
 
     @ApiModelProperty("User password")
     private String password;
+
+    @ApiModelProperty("Target database name")
+    private String databaseName;
 
     @ApiModelProperty("Target table name")
     private String tableName;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -21,7 +21,6 @@ import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.enums.DataTypeEnum;
-import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.FieldType;
@@ -40,6 +39,7 @@ import org.apache.inlong.manager.pojo.sink.hudi.HudiSink;
 import org.apache.inlong.manager.pojo.sink.iceberg.IcebergSink;
 import org.apache.inlong.manager.pojo.sink.kafka.KafkaSink;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSink;
+import org.apache.inlong.manager.pojo.sink.mysql.MySQLSinkDTO;
 import org.apache.inlong.manager.pojo.sink.oracle.OracleSink;
 import org.apache.inlong.manager.pojo.sink.postgresql.PostgreSQLSink;
 import org.apache.inlong.manager.pojo.sink.redis.RedisSink;
@@ -350,7 +350,7 @@ public class LoadNodeUtils {
         Format format = null;
         if (starRocksSink.getSinkMultipleEnable() != null && starRocksSink.getSinkMultipleEnable()
                 && StringUtils.isNotBlank(
-                        starRocksSink.getSinkMultipleFormat())) {
+                starRocksSink.getSinkMultipleFormat())) {
             DataTypeEnum dataType = DataTypeEnum.forType(starRocksSink.getSinkMultipleFormat());
             switch (dataType) {
                 case CANAL:
@@ -601,7 +601,7 @@ public class LoadNodeUtils {
                 null,
                 null,
                 properties,
-                mysqlSink.getJdbcUrl() + InlongConstants.SLASH + mysqlSink.getDatabaseName(),
+                MySQLSinkDTO.setDbNameToUrl(mysqlSink.getJdbcUrl(), mysqlSink.getDatabaseName()),
                 mysqlSink.getUsername(),
                 mysqlSink.getPassword(),
                 mysqlSink.getTableName(),

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.enums.DataTypeEnum;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.FieldType;
@@ -349,7 +350,7 @@ public class LoadNodeUtils {
         Format format = null;
         if (starRocksSink.getSinkMultipleEnable() != null && starRocksSink.getSinkMultipleEnable()
                 && StringUtils.isNotBlank(
-                        starRocksSink.getSinkMultipleFormat())) {
+                starRocksSink.getSinkMultipleFormat())) {
             DataTypeEnum dataType = DataTypeEnum.forType(starRocksSink.getSinkMultipleFormat());
             switch (dataType) {
                 case CANAL:
@@ -600,7 +601,7 @@ public class LoadNodeUtils {
                 null,
                 null,
                 properties,
-                mysqlSink.getJdbcUrl(),
+                mysqlSink.getJdbcUrl() + InlongConstants.SLASH + mysqlSink.getDatabaseName(),
                 mysqlSink.getUsername(),
                 mysqlSink.getPassword(),
                 mysqlSink.getTableName(),
@@ -717,9 +718,9 @@ public class LoadNodeUtils {
     /**
      * Parse format
      *
-     * @param formatName        data serialization, support: csv, json, canal, avro, etc
+     * @param formatName data serialization, support: csv, json, canal, avro, etc
      * @param wrapWithInlongMsg whether wrap content with {@link InLongMsgFormat}
-     * @param separatorStr      the separator of data content
+     * @param separatorStr the separator of data content
      * @param ignoreParseErrors whether ignore deserialization error data
      * @return the format for serialized content
      */

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -350,7 +350,7 @@ public class LoadNodeUtils {
         Format format = null;
         if (starRocksSink.getSinkMultipleEnable() != null && starRocksSink.getSinkMultipleEnable()
                 && StringUtils.isNotBlank(
-                starRocksSink.getSinkMultipleFormat())) {
+                        starRocksSink.getSinkMultipleFormat())) {
             DataTypeEnum dataType = DataTypeEnum.forType(starRocksSink.getSinkMultipleFormat());
             switch (dataType) {
                 case CANAL:

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
@@ -74,4 +74,18 @@ public class MySQLSinkDTOTest {
                 originUrl);
     }
 
+    @Test
+    public void testSetDbNameToUrl() {
+        String originUrl = MySQLSinkDTO.setDbNameToUrl(
+                "jdbc:mysql://127.0.0.1:3306?autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                "test_db");
+        Assertions.assertEquals(
+                "jdbc:mysql://127.0.0.1:3306/test_db?autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                originUrl);
+        originUrl = MySQLSinkDTO.setDbNameToUrl("jdbc:mysql://127.0.0.1:3306", "test_db");
+        Assertions.assertEquals("jdbc:mysql://127.0.0.1:3306/test_db", originUrl);
+        originUrl = MySQLSinkDTO.setDbNameToUrl("jdbc:mysql://127.0.0.1:3306/", "test_db");
+        Assertions.assertEquals("jdbc:mysql://127.0.0.1:3306/test_db", originUrl);
+    }
+
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/mysql/MySQLDataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/mysql/MySQLDataNodeOperator.java
@@ -90,7 +90,7 @@ public class MySQLDataNodeOperator extends AbstractDataNodeOperator {
 
     @Override
     public Boolean testConnection(DataNodeRequest request) {
-        String jdbcUrl = request.getUrl();
+        String jdbcUrl = MySQLDataNodeDTO.convertToJdbcurl(request.getUrl());
         String username = request.getUsername();
         String password = request.getToken();
         Preconditions.expectNotBlank(jdbcUrl, ErrorCodeEnum.INVALID_PARAMETER, "connection jdbcUrl cannot be empty");

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/mysql/MySQLResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/mysql/MySQLResourceOperator.java
@@ -29,6 +29,7 @@ import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.dao.entity.StreamSinkFieldEntity;
 import org.apache.inlong.manager.dao.mapper.StreamSinkFieldEntityMapper;
 import org.apache.inlong.manager.pojo.node.DataNodeInfo;
+import org.apache.inlong.manager.pojo.node.mysql.MySQLDataNodeDTO;
 import org.apache.inlong.manager.pojo.sink.SinkInfo;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLColumnInfo;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSinkDTO;
@@ -132,7 +133,7 @@ public class MySQLResourceOperator implements SinkResourceOperator {
                     "mysql jdbc url not specified and data node is empty");
             DataNodeInfo dataNodeInfo = dataNodeHelper.getDataNodeInfo(dataNodeName, sinkInfo.getSinkType());
             CommonBeanUtils.copyProperties(dataNodeInfo, mysqlInfo);
-            mysqlInfo.setJdbcUrl(dataNodeInfo.getUrl());
+            mysqlInfo.setJdbcUrl(MySQLDataNodeDTO.convertToJdbcurl(dataNodeInfo.getUrl()));
             mysqlInfo.setPassword(dataNodeInfo.getToken());
         }
         return mysqlInfo;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/mysql/MySQLSinkOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/sink/mysql/MySQLSinkOperator.java
@@ -19,18 +19,19 @@ package org.apache.inlong.manager.service.sink.mysql;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.pojo.node.DataNodeInfo;
+import org.apache.inlong.manager.pojo.node.mysql.MySQLDataNodeDTO;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSink;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSinkDTO;
 import org.apache.inlong.manager.pojo.sink.mysql.MySQLSinkRequest;
-import org.apache.inlong.manager.common.util.CommonBeanUtils;
-import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.service.sink.AbstractSinkOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +93,7 @@ public class MySQLSinkOperator extends AbstractSinkOperator {
             DataNodeInfo dataNodeInfo = dataNodeHelper.getDataNodeInfo(
                     entity.getDataNodeName(), entity.getSinkType());
             CommonBeanUtils.copyProperties(dataNodeInfo, dto, true);
-            dto.setJdbcUrl(dataNodeInfo.getUrl());
+            dto.setJdbcUrl(MySQLDataNodeDTO.convertToJdbcurl(dataNodeInfo.getUrl()));
             dto.setPassword(dataNodeInfo.getToken());
         }
         CommonBeanUtils.copyProperties(entity, sink, true);


### PR DESCRIPTION
- Fixes #7379 

### Motivation

Add a database name for MySQLSink.

The databaseName is currently included in mysql  jdbcUrl.
In fact, the user only needs to focus on `ip:post` when save mysql DataNode.
And select database when saving sink information.
So add a database to MySQLSink.

### Modifications

Add a database name for MySQLSink

