### PR TITLE
[INLONG-7392][Sort] Refactor Doris single table to solve performance issues 

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/DorisOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/DorisOutputFormat.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.doris.internal;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+
+import java.io.IOException;
+
+public interface DorisOutputFormat<T> {
+
+    void open(int taskNumber, int numTasks) throws IOException;
+
+    void initializeState(FunctionInitializationContext context) throws Exception;
+
+    void snapshotState(FunctionSnapshotContext context) throws Exception;
+
+    void close() throws IOException;
+
+    void writeRecord(T var1) throws IOException;
+
+    void setRuntimeContext(RuntimeContext ctx);
+    void flush();
+}

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.util.Preconditions;
-import org.apache.inlong.sort.doris.table.DorisDynamicSchemaOutputFormat;
 
 import javax.annotation.Nonnull;
 import java.io.IOException;

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
@@ -42,7 +42,7 @@ public class GenericDorisSinkFunction<T> extends RichSinkFunction<T>
 
     private final DorisOutputFormat outputFormat;
 
-    public GenericDorisSinkFunction(@Nonnull DorisDynamicSchemaOutputFormat<T> outputFormat) {
+    public GenericDorisSinkFunction(@Nonnull DorisOutputFormat<T> outputFormat) {
         this.outputFormat = Preconditions.checkNotNull(outputFormat);
     }
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/internal/GenericDorisSinkFunction.java
@@ -40,7 +40,7 @@ public class GenericDorisSinkFunction<T> extends RichSinkFunction<T>
         implements
             CheckpointedFunction {
 
-    private final DorisDynamicSchemaOutputFormat<T> outputFormat;
+    private final DorisOutputFormat outputFormat;
 
     public GenericDorisSinkFunction(@Nonnull DorisDynamicSchemaOutputFormat<T> outputFormat) {
         this.outputFormat = Preconditions.checkNotNull(outputFormat);

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicTableSink.java
@@ -96,7 +96,7 @@ public class DorisDynamicTableSink implements DynamicTableSink {
     @Override
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         DorisOutputFormat dorisOutputFormat;
-        if(multipleSink) {
+        if (multipleSink) {
             dorisOutputFormat = buildMultipleFormat();
         } else {
             dorisOutputFormat = buildSingleFormat();

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisSingleOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisSingleOutputFormat.java
@@ -47,7 +47,6 @@ import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.doris.internal.DorisOutputFormat;
 import org.apache.inlong.sort.doris.model.RespContent;
-import org.apache.inlong.sort.doris.table.DorisDynamicSchemaOutputFormat.Builder;
 import org.apache.inlong.sort.doris.util.DorisParseUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -306,7 +305,7 @@ public class DorisSingleOutputFormat<T> extends RichOutputFormat<T> implements D
         RespContent respContent = null;
         for (int i = 0; i <= executionOptions.getMaxRetries(); i++) {
             try {
-                String[] identifiers = tableIdentifier.split(".");
+                String[] identifiers = tableIdentifier.split("\\.");
                 respContent = dorisStreamLoad.load(identifiers[0], identifiers[1], result);
                 try {
                     if (null != metricData && null != respContent) {
@@ -503,6 +502,7 @@ public class DorisSingleOutputFormat<T> extends RichOutputFormat<T> implements D
         }
 
         public DorisSingleOutputFormat.Builder setTableIdentifier(String tableIdentifier) {
+            this.tableIdentifier = tableIdentifier;
             this.optionsBuilder.setTableIdentifier(tableIdentifier);
             return this;
         }


### PR DESCRIPTION
- Fixes #7392

### Motivation

Currently, Doris single table has low throughput (1700 records/s, where it should be 50000). I need to ensure that its performance is good enough.

The cause of the issue is because Doris multiple logic and single table logic are not actually compatible. Instead of doing a huge modification on the base class, I choose to make them into two separate classes, so the logic is simpler in each of the two classes.

### Modifications
To fix this issue, I am isolating single and multiple logic for Doris, and refactor the internal logic for doris single table. DirtyHelper, Inlong metric and etc. are still being kept.

1) create DorisSingleOutputFormat to handle single table logic without repeated access to the single identifier in batchmap
2) create relevant interfaces and builders based on multipleSink, so that DorisSingleOutputFormat is used instead of DorisDynamicSchemaOutputFormat when handling single table logics
3) remove single table logic processing from DorisDynamicSchemaOutputFormat*
