### PR TITLE
[INLONG-7391][Sort] Support CSV format and dirty data collecting for StarRocks connector all db migrating

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -18,17 +18,12 @@
 package org.apache.inlong.sort.base.dirty;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Preconditions;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
-import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
-import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/DirtySinkHelper.java
@@ -46,7 +46,10 @@ public class DirtySinkHelper<T> implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(DirtySinkHelper.class);
     static final Pattern REGEX_PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
-
+    private static final String DIRTY_TYPE_KEY = "DIRTY_TYPE";
+    private static final String DIRTY_MESSAGE_KEY = "DIRTY_MESSAGE";
+    private static final String SYSTEM_TIME_KEY = "SYSTEM_TIME";
+    private static final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private DirtyOptions dirtyOptions;
     private final @Nullable DirtySink<T> dirtySink;
 
@@ -72,11 +75,27 @@ public class DirtySinkHelper<T> implements Serializable {
 
     /**
      * Dirty data sink
+     *
      * @param dirtyData The dirty data
      * @param dirtyType The dirty type {@link DirtyType}
      * @param e The cause of dirty data
      */
     public void invoke(T dirtyData, DirtyType dirtyType, Throwable e) {
+        invoke(dirtyData, dirtyType, dirtyOptions.getLabels(), dirtyOptions.getLogTag(), dirtyOptions.getIdentifier(),
+                e);
+    }
+
+    /**
+     * Dirty data sink
+     *
+     * @param dirtyData The dirty data
+     * @param dirtyType The dirty type {@link DirtyType}
+     * @param label The dirty label
+     * @param logTag The dirty logTag
+     * @param identifier The dirty identifier
+     * @param e The cause of dirty data
+     */
+    public void invoke(T dirtyData, DirtyType dirtyType, String label, String logTag, String identifier, Throwable e) {
         if (!dirtyOptions.ignoreDirty()) {
             RuntimeException ex;
             if (e instanceof RuntimeException) {
@@ -91,10 +110,10 @@ public class DirtySinkHelper<T> implements Serializable {
             try {
                 builder.setData(dirtyData)
                         .setDirtyType(dirtyType)
-                        .setLabels(dirtyOptions.getLabels())
-                        .setLogTag(dirtyOptions.getLogTag())
+                        .setLabels(label)
+                        .setLogTag(logTag)
                         .setDirtyMessage(e.getMessage())
-                        .setIdentifier(dirtyOptions.getIdentifier());
+                        .setIdentifier(identifier);
                 dirtySink.invoke(builder.build());
             } catch (Exception ex) {
                 if (!dirtyOptions.ignoreSideOutputErrors()) {
@@ -105,116 +124,59 @@ public class DirtySinkHelper<T> implements Serializable {
         }
     }
 
-    public void invokeMultiple(String tableIdentifier, T dirtyData, DirtyType dirtyType, Throwable e,
-            String sinkMultipleFormat) {
-        if (!dirtyOptions.ignoreDirty()) {
-            RuntimeException ex;
-            if (e instanceof RuntimeException) {
-                ex = (RuntimeException) e;
-            } else {
-                ex = new RuntimeException(e);
-            }
-            throw ex;
-        }
-
-        JsonDynamicSchemaFormat jsonDynamicSchemaFormat =
-                (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
-        JsonNode rootNode = null;
-        String[] actualIdentifier = tableIdentifier.split("\\.");;
-
-        try {
-            // for rowdata where identifier is not the first element, append identifier and SEPARATOR before it.
-            if (dirtyData instanceof RowData) {
-                rootNode = jsonDynamicSchemaFormat.deserialize(((RowData) dirtyData).getBinary(0));
-                handleDirty(dirtyType, e, null, rootNode, jsonDynamicSchemaFormat, dirtyData);
-            } else if (dirtyData instanceof JsonNode) {
-                rootNode = (JsonNode) dirtyData;
-                handleDirty(dirtyType, e, null, rootNode, jsonDynamicSchemaFormat, dirtyData);
-            } else if (dirtyData instanceof String) {
-                handleDirty(dirtyType, e, actualIdentifier, null, jsonDynamicSchemaFormat, dirtyData);
-            } else {
-                throw new Exception("unidentified dirty data " + dirtyData);
-            }
-        } catch (Exception ex) {
-            LOGGER.warn("parse dirty data {} of class {} failed", dirtyData, dirtyData.getClass());
-            invoke(dirtyData, DirtyType.DESERIALIZE_ERROR, e);
-        }
-    }
-
-    private void handleDirty(DirtyType dirtyType, Throwable e,
-            String[] actualIdentifier, JsonNode rootNode, JsonDynamicSchemaFormat jsonDynamicSchemaFormat,
-            T dirtyData) {
-        if (dirtySink != null) {
-            DirtyData.Builder<T> builder = DirtyData.builder();
-            try {
-                if (rootNode != null) {
-                    String labels = regexReplace(dirtyOptions.getLabels(), dirtyType, e.getMessage(), null);
-                    String logTag = regexReplace(dirtyOptions.getLogTag(), dirtyType, e.getMessage(), null);
-                    String identifier = regexReplace(dirtyOptions.getIdentifier(), dirtyType, e.getMessage(), null);
-                    builder.setData(dirtyData)
-                            .setDirtyType(dirtyType)
-                            .setLabels(jsonDynamicSchemaFormat.parse(rootNode, labels))
-                            .setLogTag(jsonDynamicSchemaFormat.parse(rootNode, logTag))
-                            .setDirtyMessage(e.getMessage())
-                            .setIdentifier(jsonDynamicSchemaFormat.parse(rootNode, identifier));
-                } else {
-                    // for dirty data without proper rootnode, parse completely into string literals
-                    String labels = regexReplace(dirtyOptions.getLabels(), dirtyType, e.getMessage(), actualIdentifier);
-                    String logTag = regexReplace(dirtyOptions.getLogTag(), dirtyType, e.getMessage(), actualIdentifier);
-                    String identifier =
-                            regexReplace(dirtyOptions.getIdentifier(), dirtyType, e.getMessage(), actualIdentifier);
-                    builder.setData(dirtyData)
-                            .setDirtyType(dirtyType)
-                            .setLabels(labels)
-                            .setLogTag(logTag)
-                            .setDirtyMessage(e.getMessage())
-                            .setIdentifier(identifier);
-                }
-                dirtySink.invoke(builder.build());
-            } catch (Exception ex) {
-                if (!dirtyOptions.ignoreSideOutputErrors()) {
-                    throw new RuntimeException(ex);
-                }
-                LOGGER.warn("Dirty sink failed", ex);
-            }
-        }
-    }
-
-    public static String regexReplace(String pattern, DirtyType dirtyType,
-            String dirtyMessage, String[] actualIdentifier) throws IOException {
-
+    /**
+     * replace ${SYSTEM_TIME} with real time
+     *
+     * @param pattern
+     * @return
+     */
+    public static String regexReplace(String pattern, DirtyType dirtyType, String dirtyMessage) {
         if (pattern == null) {
             return null;
         }
 
-        final String DIRTY_TYPE_KEY = "DIRTY_TYPE";
-        final String DIRTY_MESSAGE_KEY = "DIRTY_MESSAGE";
-        final String SYSTEM_TIME_KEY = "SYSTEM_TIME";
-        final DateTimeFormatter DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-
-        Map<String, String> paramMap = new HashMap<>();
+        Map<String, String> paramMap = new HashMap<>(6);
         paramMap.put(SYSTEM_TIME_KEY, DATE_TIME_FORMAT.format(LocalDateTime.now()));
         paramMap.put(DIRTY_TYPE_KEY, dirtyType.format());
         paramMap.put(DIRTY_MESSAGE_KEY, dirtyMessage);
 
         Matcher matcher = REGEX_PATTERN.matcher(pattern);
-
-        // if RootNode is not available, generate a complete paramMap with {database} {table},etc.
-        if (actualIdentifier != null) {
-            int i = 0;
-            while (matcher.find()) {
-                try {
-                    String keyText = matcher.group(1);
-                    int finalI = i;
-                    paramMap.computeIfAbsent(keyText, k -> actualIdentifier[finalI]);
-                } catch (Exception e) {
-                    throw new IOException("param map replacement failed", e);
-                }
-                i++;
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            String keyText = matcher.group(1);
+            String replacement = paramMap.get(keyText);
+            if (replacement == null) {
+                continue;
             }
+            matcher.appendReplacement(sb, replacement);
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
+    }
+
+    /**
+     * replace ${database} ${table} etc. Used in cases where jsonDynamicFormat.parse() is not usable.
+     */
+    public static String regexReplace(String pattern, DirtyType dirtyType, String dirtyMessage, String database,
+            String table, String schema) {
+        if (pattern == null) {
+            return null;
         }
 
-        matcher = REGEX_PATTERN.matcher(pattern);
+        Map<String, String> paramMap = new HashMap<>(6);
+        paramMap.put(SYSTEM_TIME_KEY, DATE_TIME_FORMAT.format(LocalDateTime.now()));
+        paramMap.put(DIRTY_TYPE_KEY, dirtyType.format());
+        paramMap.put(DIRTY_MESSAGE_KEY, dirtyMessage);
+        paramMap.put("source.database", database);
+        paramMap.put("database", database);
+        paramMap.put("source.table", table);
+        paramMap.put("table", table);
+        if (schema != null) {
+            paramMap.put("source.schema", schema);
+            paramMap.put("schema", schema);
+        }
+
+        Matcher matcher = REGEX_PATTERN.matcher(pattern);
         StringBuffer sb = new StringBuffer();
         while (matcher.find()) {
             String keyText = matcher.group(1);

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -197,10 +197,36 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     }
 
     /**
+     * output metrics
+     *
+     * @param database the database name of record
+     * @param table the table name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputMetrics(String database, String table, long rowCount,
+            long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            invoke(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, null, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invoke(rowCount, rowSize);
+        subSinkMetricData.invoke(rowCount, rowSize);
+    }
+
+    /**
      * output dirty metrics with estimate
      *
      * @param database the database name of record
-     * @param schema the schema name of record
      * @param table the table name of record
      * @param rowCount the row count of records
      * @param rowSize the row size of records
@@ -217,6 +243,34 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
             subSinkMetricData = subSinkMetricMap.get(identify);
         } else {
             subSinkMetricData = buildSubSinkMetricData(new String[]{database, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invokeDirty(rowCount, rowSize);
+        subSinkMetricData.invokeDirty(rowCount, rowSize);
+    }
+
+    /**
+     * output dirty metrics with estimate
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputDirtyMetricsWithEstimate(String database, String schema, String table, long rowCount,
+            long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(schema) || StringUtils.isBlank(table)) {
+            invokeDirty(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, schema, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, schema, table}, this);
             subSinkMetricMap.put(identify, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
@@ -257,6 +311,32 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     }
 
     /**
+     * output dirty metrics
+     *
+     * @param database the database name of record
+     * @param table the table name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputDirtyMetrics(String database, String table, long rowCount, long rowSize) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            invokeDirty(rowCount, rowSize);
+            return;
+        }
+        String identify = buildSchemaIdentify(database, null, table);
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(identify)) {
+            subSinkMetricData = subSinkMetricMap.get(identify);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{database, table}, this);
+            subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invokeDirty(rowCount, rowSize);
+        subSinkMetricData.invokeDirty(rowCount, rowSize);
+    }
+
+    /**
      * output dirty metrics with estimate
      *
      * @param database the database name of record
@@ -267,6 +347,18 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     public void outputDirtyMetricsWithEstimate(String database, String schema, String table, Object data) {
         long size = data == null ? 0L : data.toString().getBytes(StandardCharsets.UTF_8).length;
         outputDirtyMetrics(database, schema, table, 1, size);
+    }
+
+    /**
+     * output dirty metrics with estimate
+     *
+     * @param database the database name of record
+     * @param table the table name of record
+     * @param data the dirty data
+     */
+    public void outputDirtyMetricsWithEstimate(String database, String table, Object data) {
+        long size = data == null ? 0L : data.toString().getBytes(StandardCharsets.UTF_8).length;
+        outputDirtyMetrics(database, table, 1, size);
     }
 
     public void outputDirtyMetricsWithEstimate(Object data) {

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
@@ -32,7 +32,7 @@ public class RegexReplaceTest {
         identifier[0] = "yizhouyang";
         identifier[1] = "table2";
         String pattern = "${database}-${table}-${DIRTY_MESSAGE}";
-        String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message", identifier);
+        String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message");
         Assert.assertEquals("yizhouyang-table2-mock message", answer);
     }
 }

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
@@ -32,7 +32,8 @@ public class RegexReplaceTest {
         identifier[0] = "yizhouyang";
         identifier[1] = "table2";
         String pattern = "${database}-${table}-${DIRTY_MESSAGE}";
-        String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message");
-        Assert.assertEquals("${database}-${table}-mock message", answer);
+        String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message", identifier[0],
+                identifier[1], null);
+        Assert.assertEquals("yizhouyang-table2-mock message", answer);
     }
 }

--- a/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
+++ b/inlong-sort/sort-connectors/base/src/test/java/org/apache/inlong/sort/base/dirty/RegexReplaceTest.java
@@ -33,6 +33,6 @@ public class RegexReplaceTest {
         identifier[1] = "table2";
         String pattern = "${database}-${table}-${DIRTY_MESSAGE}";
         String answer = DirtySinkHelper.regexReplace(pattern, DirtyType.BATCH_LOAD_ERROR, "mock message");
-        Assert.assertEquals("yizhouyang-table2-mock message", answer);
+        Assert.assertEquals("${database}-${table}-mock message", answer);
     }
 }

--- a/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -44,7 +44,6 @@ import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
-import org.apache.inlong.sort.base.dirty.DirtyType;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.apache.inlong.sort.base.metric.MetricOption;
@@ -569,13 +568,10 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
                     if (!flushFlag && null != tableException) {
                         LOG.info("Put tableIdentifier:{} exception:{}",
                                 tableIdentifier, tableException.getMessage());
-                        outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
-                                1L, true);
-                        if (!schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
-                            dirtySinkHelper.invokeMultiple(
-                                    tableIdentifier, record.toString(),
-                                    DirtyType.RETRY_LOAD_ERROR, tableException,
-                                    sinkMultipleFormat);
+                        if (dirtySinkHelper.getDirtySink() == null &&
+                                !schemaUpdateExceptionPolicy.equals(SchemaUpdateExceptionPolicy.THROW_WITH_STOP)) {
+                            outputMetrics(tableIdentifier, Long.valueOf(tableIdRecordList.size()),
+                                    1L, true);
                         }
                         tableExceptionMap.put(tableIdentifier, tableException);
                         if (stopWritingWhenTableException) {

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/SinkBufferEntity.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/SinkBufferEntity.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.starrocks.manager;
+
+import com.starrocks.connector.flink.manager.StarRocksSinkBufferEntity;
+
+/**
+ * StarRocks data buffer
+ */
+public class SinkBufferEntity extends StarRocksSinkBufferEntity {
+
+    private String dirtyLogTag;
+    private String dirtyLabel;
+    private String dirtyIdentify;
+    private String columns;
+
+    public SinkBufferEntity(String database, String table, String labelPrefix) {
+        super(database, table, labelPrefix);
+    }
+
+    public String getColumns() {
+        return columns;
+    }
+
+    public void setColumns(String columns) {
+        this.columns = columns;
+    }
+
+    public String getDirtyLogTag() {
+        return dirtyLogTag;
+    }
+
+    public void setDirtyLogTag(String dirtyLogTag) {
+        this.dirtyLogTag = dirtyLogTag;
+    }
+
+    public String getDirtyLabel() {
+        return dirtyLabel;
+    }
+
+    public void setDirtyLabel(String dirtyLabel) {
+        this.dirtyLabel = dirtyLabel;
+    }
+
+    public String getDirtyIdentify() {
+        return dirtyIdentify;
+    }
+
+    public void setDirtyIdentify(String dirtyIdentify) {
+        this.dirtyIdentify = dirtyIdentify;
+    }
+
+    @Override
+    public SinkBufferEntity asEOF() {
+        super.asEOF();
+        return this;
+    }
+}

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sort.starrocks.manager;
 
-import com.starrocks.connector.flink.manager.StarRocksSinkBufferEntity;
 import com.starrocks.connector.flink.manager.StarRocksStreamLoadFailedException;
 import com.starrocks.connector.flink.row.sink.StarRocksDelimiterParser;
 import com.starrocks.connector.flink.row.sink.StarRocksSinkOP;
@@ -70,14 +69,15 @@ public class StarRocksStreamLoadVisitor implements Serializable {
     private static final String RESULT_LABEL_ABORTED = "ABORTED";
     private static final String RESULT_LABEL_UNKNOWN = "UNKNOWN";
 
-    public StarRocksStreamLoadVisitor(StarRocksSinkOptions sinkOptions, String[] fieldNames,
+    public StarRocksStreamLoadVisitor(StarRocksSinkOptions sinkOptions,
+            String[] fieldNames,
             boolean opAutoProjectionInJson) {
         this.fieldNames = fieldNames;
         this.sinkOptions = sinkOptions;
         this.opAutoProjectionInJson = opAutoProjectionInJson;
     }
 
-    public Map<String, Object> doStreamLoad(StarRocksSinkBufferEntity bufferEntity) throws IOException {
+    public Map<String, Object> doStreamLoad(SinkBufferEntity bufferEntity) throws IOException {
         String host = getAvailableHost();
         if (null == host) {
             throw new IOException("None of the hosts in `load_url` could be connected.");


### PR DESCRIPTION

### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7391

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

When migrating the whole db, the records are composed with JSON format to submit to StarRocks Server. JSON data may cause StarRocks Server high CPU loads. Data with CSV format will reduce CPU loads.

Records will be lost if an exception threw by StarRocks Server. We may upload the records to S3 bucket as dirty data. This is useful when auditing and checking.


### Modifications

*Describe the modifications you've done.*

1. DirtySinkHelper in base module has new `regexReplace` method. It can replace the meta field with real data, such as DIRTY_TYPE、DIRTY_MESSAGE and SYSTEM_TIME.
2. SinkTableMetricData in base module has new `outputDirtyMetrics` method. 
3. SinkBufferEntity overwrites `StarRocksSinkBufferEntity`. Each batches carry dirty meta data and columns header. When composing the CSV data, columns will be used as http header. Dirty meta data will be used to upload dirty data when the server threw an exception.
4. StarRocksSinkManager has new `writeRecords` method. It will compose data with CSV or JSON format by `sink.properties.format` configuration.


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
