### PR TITLE
[INLONG-7411][Sort] Fix the invalid of kafka source meitric due to inlongMetric being null

### DIFF
--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -217,6 +217,7 @@ public class UpsertKafkaDynamicTableFactory
         // Build the dirty data side-output
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(tableOptions);
         final DirtySink<String> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
+        final String inlongMetric = tableOptions.getOptional(INLONG_METRIC).orElse(null);
         return new KafkaDynamicSource(
                 schema.toPhysicalRowDataType(),
                 keyDecodingFormat,
@@ -231,7 +232,7 @@ public class UpsertKafkaDynamicTableFactory
                 Collections.emptyMap(),
                 0,
                 true,
-                null,
+                inlongMetric,
                 null,
                 dirtyOptions,
                 dirtySink);

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -218,6 +218,7 @@ public class UpsertKafkaDynamicTableFactory
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(tableOptions);
         final DirtySink<String> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
         final String inlongMetric = tableOptions.getOptional(INLONG_METRIC).orElse(null);
+        final String auditHostAndPorts = tableOptions.getOptional(INLONG_AUDIT).orElse(null);
         return new KafkaDynamicSource(
                 schema.toPhysicalRowDataType(),
                 keyDecodingFormat,
@@ -233,7 +234,7 @@ public class UpsertKafkaDynamicTableFactory
                 0,
                 true,
                 inlongMetric,
-                null,
+                auditHostAndPorts,
                 dirtyOptions,
                 dirtySink);
     }


### PR DESCRIPTION
- Fixes: https://github.com/apache/inlong/issues/7411

### Motivation
Fix the invalid of kafka source meitric due to inlongMetric being null

### Modifications
In the createDynamicTableSource method of the UpsertKafkaDynamicTableFactory class, when building a KafkaDynamicSource object, you need to pass in the INLONG_METRIC configuration
