### PR TITLE
[INLONG-7410][Sort] Support open incremental snapshot in oracle cdc connector

### DIFF
--- a/inlong-sort/sort-connectors/cdc-base/pom.xml
+++ b/inlong-sort/sort-connectors/cdc-base/pom.xml
@@ -42,6 +42,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-cdc-base</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.base.source;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.ververica.cdc.connectors.base.config.SourceConfig;
+import com.ververica.cdc.connectors.base.dialect.DataSourceDialect;
+import com.ververica.cdc.connectors.base.options.StartupMode;
+import com.ververica.cdc.connectors.base.source.assigner.HybridSplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.SplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.StreamSplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.state.HybridPendingSplitsState;
+import com.ververica.cdc.connectors.base.source.assigner.state.PendingSplitsState;
+import com.ververica.cdc.connectors.base.source.assigner.state.PendingSplitsStateSerializer;
+import com.ververica.cdc.connectors.base.source.assigner.state.StreamPendingSplitsState;
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitSerializer;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
+import io.debezium.relational.TableId;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.source.reader.IncrementalSourceRecordEmitter;
+
+/**
+ * The basic source of Incremental Snapshot framework for datasource, it is based on FLIP-27 and
+ * Watermark Signal Algorithm which supports parallel reading snapshot of table and then continue to
+ * capture data change by streaming reading.
+ */
+@Experimental
+public class IncrementalSource<T, C extends SourceConfig>
+        implements
+            Source<T, SourceSplitBase, PendingSplitsState>,
+            ResultTypeQueryable<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final SourceConfig.Factory<C> configFactory;
+    protected final DataSourceDialect<C> dataSourceDialect;
+    protected final OffsetFactory offsetFactory;
+    protected final DebeziumDeserializationSchema<T> deserializationSchema;
+    protected final SourceSplitSerializer sourceSplitSerializer;
+
+    public IncrementalSource(
+            SourceConfig.Factory<C> configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema,
+            OffsetFactory offsetFactory,
+            DataSourceDialect<C> dataSourceDialect) {
+        this.configFactory = configFactory;
+        this.deserializationSchema = deserializationSchema;
+        this.offsetFactory = offsetFactory;
+        this.dataSourceDialect = dataSourceDialect;
+        this.sourceSplitSerializer =
+                new SourceSplitSerializer() {
+
+                    @Override
+                    public OffsetFactory getOffsetFactory() {
+                        return offsetFactory;
+                    }
+                };
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public IncrementalSourceReader<T, C> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        // create source config for the given subtask (e.g. unique server id)
+        C sourceConfig = configFactory.create(readerContext.getIndexOfSubtask());
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
+                new FutureCompletingBlockingQueue<>();
+
+        // Forward compatible with flink 1.13
+        final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
+        metricGroupMethod.setAccessible(true);
+        final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
+        final SourceReaderMetrics sourceReaderMetrics = new SourceReaderMetrics(metricGroup);
+
+        sourceReaderMetrics.registerMetrics();
+        Supplier<IncrementalSourceSplitReader<C>> splitReaderSupplier =
+                () -> new IncrementalSourceSplitReader<>(
+                        readerContext.getIndexOfSubtask(), dataSourceDialect, sourceConfig);
+        return new IncrementalSourceReader<>(
+                elementsQueue,
+                splitReaderSupplier,
+                createRecordEmitter(sourceConfig, sourceReaderMetrics),
+                readerContext.getConfiguration(),
+                readerContext,
+                sourceConfig,
+                sourceSplitSerializer,
+                dataSourceDialect);
+    }
+
+    @Override
+    public SplitEnumerator<SourceSplitBase, PendingSplitsState> createEnumerator(
+            SplitEnumeratorContext<SourceSplitBase> enumContext) {
+        C sourceConfig = configFactory.create(0);
+        final SplitAssigner splitAssigner;
+        if (sourceConfig.getStartupOptions().startupMode == StartupMode.INITIAL) {
+            try {
+                final List<TableId> remainingTables =
+                        dataSourceDialect.discoverDataCollections(sourceConfig);
+                boolean isTableIdCaseSensitive =
+                        dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                splitAssigner =
+                        new HybridSplitAssigner<>(
+                                sourceConfig,
+                                enumContext.currentParallelism(),
+                                remainingTables,
+                                isTableIdCaseSensitive,
+                                dataSourceDialect,
+                                offsetFactory);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(
+                        "Failed to discover captured tables for enumerator", e);
+            }
+        } else {
+            splitAssigner = new StreamSplitAssigner(sourceConfig, dataSourceDialect, offsetFactory);
+        }
+
+        return new IncrementalSourceEnumerator(enumContext, sourceConfig, splitAssigner);
+    }
+
+    @Override
+    public SplitEnumerator<SourceSplitBase, PendingSplitsState> restoreEnumerator(
+            SplitEnumeratorContext<SourceSplitBase> enumContext, PendingSplitsState checkpoint) {
+        C sourceConfig = configFactory.create(0);
+
+        final SplitAssigner splitAssigner;
+        if (checkpoint instanceof HybridPendingSplitsState) {
+            splitAssigner =
+                    new HybridSplitAssigner<>(
+                            sourceConfig,
+                            enumContext.currentParallelism(),
+                            (HybridPendingSplitsState) checkpoint,
+                            dataSourceDialect,
+                            offsetFactory);
+        } else if (checkpoint instanceof StreamPendingSplitsState) {
+            splitAssigner =
+                    new StreamSplitAssigner(
+                            sourceConfig,
+                            (StreamPendingSplitsState) checkpoint,
+                            dataSourceDialect,
+                            offsetFactory);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported restored PendingSplitsState: " + checkpoint);
+        }
+        return new IncrementalSourceEnumerator(enumContext, sourceConfig, splitAssigner);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<SourceSplitBase> getSplitSerializer() {
+        return sourceSplitSerializer;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<PendingSplitsState> getEnumeratorCheckpointSerializer() {
+        SourceSplitSerializer sourceSplitSerializer = (SourceSplitSerializer) getSplitSerializer();
+        return new PendingSplitsStateSerializer(sourceSplitSerializer);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+
+    protected RecordEmitter<SourceRecords, T, SourceSplitState> createRecordEmitter(
+            SourceConfig sourceConfig, SourceReaderMetrics sourceReaderMetrics) {
+        return new IncrementalSourceRecordEmitter<>(
+                deserializationSchema,
+                sourceReaderMetrics,
+                sourceConfig.isIncludeSchemaChanges(),
+                offsetFactory);
+    }
+}

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
@@ -63,6 +63,7 @@ import org.apache.inlong.sort.cdc.base.source.reader.IncrementalSourceRecordEmit
  * The basic source of Incremental Snapshot framework for datasource, it is based on FLIP-27 and
  * Watermark Signal Algorithm which supports parallel reading snapshot of table and then continue to
  * capture data change by streaming reading.
+ * Copy from com.ververica:flink-cdc-base:2.3.0
  */
 @Experimental
 public class IncrementalSource<T, C extends SourceConfig>

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/jdbc/JdbcIncrementalSource.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/jdbc/JdbcIncrementalSource.java
@@ -28,6 +28,7 @@ import org.apache.inlong.sort.cdc.base.source.IncrementalSource;
  * The basic source of Incremental Snapshot framework for JDBC datasource, it is based on FLIP-27
  * and Watermark Signal Algorithm which supports parallel reading snapshot of table and then
  * continue to capture data change by streaming reading.
+ * Copy from com.ververica:flink-cdc-base:2.3.0
  */
 public class JdbcIncrementalSource<T> extends IncrementalSource<T, JdbcSourceConfig> {
 

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/jdbc/JdbcIncrementalSource.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/jdbc/JdbcIncrementalSource.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.base.source.jdbc;
+
+import com.ververica.cdc.connectors.base.config.JdbcSourceConfig;
+import com.ververica.cdc.connectors.base.config.JdbcSourceConfigFactory;
+import com.ververica.cdc.connectors.base.dialect.JdbcDataSourceDialect;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.source.IncrementalSource;
+
+/**
+ * The basic source of Incremental Snapshot framework for JDBC datasource, it is based on FLIP-27
+ * and Watermark Signal Algorithm which supports parallel reading snapshot of table and then
+ * continue to capture data change by streaming reading.
+ */
+public class JdbcIncrementalSource<T> extends IncrementalSource<T, JdbcSourceConfig> {
+
+    public JdbcIncrementalSource(
+            JdbcSourceConfigFactory configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema,
+            OffsetFactory offsetFactory,
+            JdbcDataSourceDialect dataSourceDialect) {
+        super(configFactory, deserializationSchema, offsetFactory, dataSourceDialect);
+    }
+}

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
  * emit records rather than emit the records directly.
+ * Copy from com.ververica:flink-cdc-base:2.3.0
  */
 public class IncrementalSourceRecordEmitter<T>
         implements

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.base.source.reader;
+
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isWatermarkEvent;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getFetchTimestamp;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getHistoryRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getMessageTimestamp;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+
+import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import io.debezium.document.Array;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.TableChanges;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.debezium.history.FlinkJsonTableChangeSerializer;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link IncrementalSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
+ * emit records rather than emit the records directly.
+ */
+public class IncrementalSourceRecordEmitter<T>
+        implements
+            RecordEmitter<SourceRecords, T, SourceSplitState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementalSourceRecordEmitter.class);
+    private static final FlinkJsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
+            new FlinkJsonTableChangeSerializer();
+
+    protected final DebeziumDeserializationSchema<T> debeziumDeserializationSchema;
+    protected final SourceReaderMetrics sourceReaderMetrics;
+    protected final boolean includeSchemaChanges;
+    protected final OutputCollector<T> outputCollector;
+    protected final OffsetFactory offsetFactory;
+
+    public IncrementalSourceRecordEmitter(
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
+            SourceReaderMetrics sourceReaderMetrics,
+            boolean includeSchemaChanges,
+            OffsetFactory offsetFactory) {
+        this.debeziumDeserializationSchema = debeziumDeserializationSchema;
+        this.sourceReaderMetrics = sourceReaderMetrics;
+        this.includeSchemaChanges = includeSchemaChanges;
+        this.outputCollector = new OutputCollector<>();
+        this.offsetFactory = offsetFactory;
+    }
+
+    @Override
+    public void emitRecord(
+            SourceRecords sourceRecords, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        final Iterator<SourceRecord> elementIterator = sourceRecords.iterator();
+        while (elementIterator.hasNext()) {
+            processElement(elementIterator.next(), output, splitState);
+        }
+    }
+
+    protected void processElement(
+            SourceRecord element, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        if (isWatermarkEvent(element)) {
+            Offset watermark = getWatermark(element);
+            if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            }
+        } else if (isSchemaChangeEvent(element) && splitState.isStreamSplitState()) {
+            HistoryRecord historyRecord = getHistoryRecord(element);
+            Array tableChanges =
+                    historyRecord.document().getArray(HistoryRecord.Fields.TABLE_CHANGES);
+            TableChanges changes = TABLE_CHANGE_SERIALIZER.deserialize(tableChanges, true);
+            for (TableChanges.TableChange tableChange : changes) {
+                splitState.asStreamSplitState().recordSchema(tableChange.getId(), tableChange);
+            }
+            if (includeSchemaChanges) {
+                emitElement(element, output);
+            }
+        } else if (isDataChangeRecord(element)) {
+            if (splitState.isStreamSplitState()) {
+                Offset position = getOffsetPosition(element);
+                splitState.asStreamSplitState().setStartingOffset(position);
+            }
+            reportMetrics(element);
+            emitElement(element, output);
+        } else {
+            // unknown element
+            LOG.info("Meet unknown element {}, just skip.", element);
+        }
+    }
+
+    private Offset getWatermark(SourceRecord watermarkEvent) {
+        return getOffsetPosition(watermarkEvent.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(SourceRecord dataRecord) {
+        return getOffsetPosition(dataRecord.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(Map<String, ?> offset) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offset.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+        return offsetFactory.newOffset(offsetStrMap);
+    }
+
+    protected void emitElement(SourceRecord element, SourceOutput<T> output) throws Exception {
+        outputCollector.output = output;
+        debeziumDeserializationSchema.deserialize(element, outputCollector);
+    }
+
+    protected void reportMetrics(SourceRecord element) {
+        long now = System.currentTimeMillis();
+        // record the latest process time
+        sourceReaderMetrics.recordProcessTime(now);
+        Long messageTimestamp = getMessageTimestamp(element);
+
+        if (messageTimestamp != null && messageTimestamp > 0L) {
+            // report fetch delay
+            Long fetchTimestamp = getFetchTimestamp(element);
+            if (fetchTimestamp != null) {
+                sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
+            }
+            // report emit delay
+            sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
+        }
+    }
+
+    private static class OutputCollector<T> implements Collector<T> {
+
+        private SourceOutput<T> output;
+
+        @Override
+        public void collect(T record) {
+            output.collect(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleSourceBuilder.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleSourceBuilder.java
@@ -36,6 +36,7 @@ import org.apache.inlong.sort.cdc.base.source.jdbc.JdbcIncrementalSource;
  *
  * <p>Check the Java docs of each individual method to learn more about the settings to build a
  * {@link OracleIncrementalSource}.
+ * Copy from com.ververica:flink-connector-oracle-cdc:2.3.0
  */
 @Internal
 public class OracleSourceBuilder<T> {

--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleSourceBuilder.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleSourceBuilder.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.oracle.source;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.connectors.oracle.source.OracleDialect;
+import com.ververica.cdc.connectors.oracle.source.config.OracleSourceConfigFactory;
+import com.ververica.cdc.connectors.oracle.source.meta.offset.RedoLogOffsetFactory;
+import java.time.Duration;
+import java.util.Properties;
+import javax.annotation.Nullable;
+import org.apache.flink.annotation.Internal;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.source.jdbc.JdbcIncrementalSource;
+
+/**
+ * The builder class for {@link OracleIncrementalSource} to make it easier for the users to
+ * construct a {@link OracleIncrementalSource}.
+ *
+ * <p>Check the Java docs of each individual method to learn more about the settings to build a
+ * {@link OracleIncrementalSource}.
+ */
+@Internal
+public class OracleSourceBuilder<T> {
+
+    private final OracleSourceConfigFactory configFactory = new OracleSourceConfigFactory();
+    private RedoLogOffsetFactory offsetFactory;
+    private OracleDialect dialect;
+    private DebeziumDeserializationSchema<T> deserializer;
+
+    public OracleSourceBuilder<T> hostname(String hostname) {
+        this.configFactory.hostname(hostname);
+        return this;
+    }
+
+    /** Url to use when connecting to the Oracle database server. */
+    public OracleSourceBuilder<T> url(@Nullable String url) {
+        this.configFactory.url(url);
+        return this;
+    }
+
+    /** Integer port number of the Oracle database server. */
+    public OracleSourceBuilder<T> port(int port) {
+        this.configFactory.port(port);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match database names to be monitored; any
+     * database name not included in the whitelist will be excluded from monitoring.
+     */
+    public OracleSourceBuilder<T> databaseList(String... databaseList) {
+        this.configFactory.databaseList(databaseList);
+        return this;
+    }
+
+    /**
+     * An optional list of regular expressions that match schema names to be monitored; any schema
+     * name not included in the whitelist will be excluded from monitoring. By default all
+     * non-system schemas will be monitored.
+     */
+    public OracleSourceBuilder<T> schemaList(String... schemaList) {
+        this.configFactory.schemaList(schemaList);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored; any table not included in the list will be excluded from monitoring.
+     * Each identifier is of the form {@code <databaseName>.<tableName>}.
+     */
+    public OracleSourceBuilder<T> tableList(String... tableList) {
+        this.configFactory.tableList(tableList);
+        return this;
+    }
+
+    /** Name of the Oracle database to use when connecting to the Oracle database server. */
+    public OracleSourceBuilder<T> username(String username) {
+        this.configFactory.username(username);
+        return this;
+    }
+
+    /** Password to use when connecting to the Oracle database server. */
+    public OracleSourceBuilder<T> password(String password) {
+        this.configFactory.password(password);
+        return this;
+    }
+
+    /**
+     * The session time zone in database server, e.g. "America/Los_Angeles". It controls how the
+     * TIMESTAMP type in Oracle converted to STRING. See more
+     * https://debezium.io/documentation/reference/1.5/connectors/Oracle.html#Oracle-temporal-types
+     */
+    public OracleSourceBuilder<T> serverTimeZone(String timeZone) {
+        this.configFactory.serverTimeZone(timeZone);
+        return this;
+    }
+
+    /**
+     * The split size (number of rows) of table snapshot, captured tables are split into multiple
+     * splits when read the snapshot of table.
+     */
+    public OracleSourceBuilder<T> splitSize(int splitSize) {
+        this.configFactory.splitSize(splitSize);
+        return this;
+    }
+
+    /**
+     * The group size of split meta, if the meta size exceeds the group size, the meta will be will
+     * be divided into multiple groups.
+     */
+    public OracleSourceBuilder<T> splitMetaGroupSize(int splitMetaGroupSize) {
+        this.configFactory.splitMetaGroupSize(splitMetaGroupSize);
+        return this;
+    }
+
+    /**
+     * The upper bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public OracleSourceBuilder<T> distributionFactorUpper(double distributionFactorUpper) {
+        this.configFactory.distributionFactorUpper(distributionFactorUpper);
+        return this;
+    }
+
+    /**
+     * The lower bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public OracleSourceBuilder<T> distributionFactorLower(double distributionFactorLower) {
+        this.configFactory.distributionFactorLower(distributionFactorLower);
+        return this;
+    }
+
+    /** The maximum fetch size for per poll when read table snapshot. */
+    public OracleSourceBuilder<T> fetchSize(int fetchSize) {
+        this.configFactory.fetchSize(fetchSize);
+        return this;
+    }
+
+    /**
+     * The maximum time that the connector should wait after trying to connect to the Oracle
+     * database server before timing out.
+     */
+    public OracleSourceBuilder<T> connectTimeout(Duration connectTimeout) {
+        this.configFactory.connectTimeout(connectTimeout);
+        return this;
+    }
+
+    /** The max retry times to get connection. */
+    public OracleSourceBuilder<T> connectMaxRetries(int connectMaxRetries) {
+        this.configFactory.connectMaxRetries(connectMaxRetries);
+        return this;
+    }
+
+    /** The connection pool size. */
+    public OracleSourceBuilder<T> connectionPoolSize(int connectionPoolSize) {
+        this.configFactory.connectionPoolSize(connectionPoolSize);
+        return this;
+    }
+
+    /** Whether the {@link OracleIncrementalSource} should output the schema changes or not. */
+    public OracleSourceBuilder<T> includeSchemaChanges(boolean includeSchemaChanges) {
+        this.configFactory.includeSchemaChanges(includeSchemaChanges);
+        return this;
+    }
+
+    /** Specifies the startup options. */
+    public OracleSourceBuilder<T> startupOptions(StartupOptions startupOptions) {
+        this.configFactory.startupOptions(startupOptions);
+        return this;
+    }
+
+    /**
+     * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
+     * key column when read the snapshot of table.
+     */
+    public OracleSourceBuilder<T> chunkKeyColumn(String chunkKeyColumn) {
+        this.configFactory.chunkKeyColumn(chunkKeyColumn);
+        return this;
+    }
+
+    /** The Debezium Oracle connector properties. For example, "snapshot.mode". */
+    public OracleSourceBuilder<T> debeziumProperties(Properties properties) {
+        this.configFactory.debeziumProperties(properties);
+        return this;
+    }
+
+    /**
+     * The deserializer used to convert from consumed {@link
+     * org.apache.kafka.connect.source.SourceRecord}.
+     */
+    public OracleSourceBuilder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
+        this.deserializer = deserializer;
+        return this;
+    }
+
+    /**
+     * Build the {@link OracleIncrementalSource}.
+     *
+     * @return a OracleParallelSource with the settings made for this builder.
+     */
+    public OracleIncrementalSource<T> build() {
+        this.offsetFactory = new RedoLogOffsetFactory();
+        this.dialect = new OracleDialect(configFactory);
+        return new OracleIncrementalSource<T>(
+                configFactory, checkNotNull(deserializer), offsetFactory, dialect);
+    }
+
+    /** The {@link JdbcIncrementalSource} implementation for Oracle. */
+    public static class OracleIncrementalSource<T> extends JdbcIncrementalSource<T> {
+
+        public OracleIncrementalSource(
+                OracleSourceConfigFactory configFactory,
+                DebeziumDeserializationSchema<T> deserializationSchema,
+                RedoLogOffsetFactory offsetFactory,
+                OracleDialect dataSourceDialect) {
+            super(configFactory, deserializationSchema, offsetFactory, dataSourceDialect);
+        }
+
+        public static <T> OracleSourceBuilder<T> builder() {
+            return new OracleSourceBuilder<>();
+        }
+
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/OracleExtractSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/OracleExtractSqlParseTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.parser;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -66,8 +68,10 @@ public class OracleExtractSqlParseTest extends AbstractTestBase {
                 new MetaFieldInfo("table_name", MetaField.TABLE_NAME),
                 new MetaFieldInfo("op_ts", MetaField.OP_TS),
                 new MetaFieldInfo("schema_name", MetaField.SCHEMA_NAME));
+        Map<String, String> properties = new HashMap<>();
+        properties.put("scan.incremental.snapshot.enabled", "true");
         return new OracleExtractNode("1", "oracle_input", fields,
-                null, null, "ID", "localhost",
+                null, properties, "ID", "localhost",
                 "flinkuser", "flinkpw", "xE",
                 "flinkuser", "table", 1521, null);
     }

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -459,7 +459,7 @@
 
  Source  : flink-cdc-connectors 2.2.1 (Please note that the software have been modified.)
  License : https://github.com/ververica/flink-cdc-connectors/blob/master/LICENSE
- 
+
 1.3.2 inlong-sort/sort-connectors/sort-hive/src/main/java/org/apache/inlong/sort/hive/HiveValidator.java
       inlong-sort/sort-connectors/sort-hive/src/main/java/org/apache/inlong/sort/hive/HiveTableSink.java
       inlong-sort/sort-connectors/sort-hive/src/main/java/org/apache/inlong/sort/hive/HiveTableMetaStoreFactory.java
@@ -597,6 +597,13 @@
   Source  : com.starrocks:flink-connector-starrocks:1.2.3_flink-1.13_2.11 (Please note that the software have been modified.)
   License : https://www.apache.org/licenses/LICENSE-2.0.txt
 
+1.3.14 inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/jdbc/JdbcIncrementalSource.java
+       inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/IncrementalSourceRecordEmitter.java
+       inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
+       inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleSourceBuilder.java
+
+ Source  : flink-cdc-connectors 2.3.0 (Please note that the software have been modified.)
+ License : https://github.com/ververica/flink-cdc-connectors/blob/master/LICENSE
 
 =======================================================================
 Apache InLong Subcomponents:

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
         <flink.connector.oracle.cdc.version>2.3.0</flink.connector.oracle.cdc.version>
         <flink.connector.doris.version>1.0.3</flink.connector.doris.version>
         <flink.connector.redis>1.1.0</flink.connector.redis>
+        <flink.cdc.base.version>2.3.0</flink.cdc.base.version>
 
         <curator.version>2.12.0</curator.version>
 
@@ -1045,6 +1046,12 @@
                 <groupId>com.ververica</groupId>
                 <artifactId>flink-connector-sqlserver-cdc</artifactId>
                 <version>${flink.connector.sqlserver.cdc.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.ververica</groupId>
+                <artifactId>flink-cdc-base</artifactId>
+                <version>${flink.cdc.base.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Support open incremental snapshot in oracle cdc connector

- Fixes #7410

### Motivation

Support open incremental snapshot in oracle cdc connector and Improve the efficiency of reading records.

### How to enable incremental snapshot

Add `scan.incremental.snapshot.enabled=true` to the option of the Flink Sql, for example:

```sql
CREATE TABLE products (
     ID INT NOT NULL,
     NAME STRING,
     DESCRIPTION STRING,
     WEIGHT DECIMAL(10, 3),
     PRIMARY KEY(id) NOT ENFORCED
     ) WITH (
     'connector' = 'oracle-cdc-inlong',
     'hostname' = 'localhost',
     'port' = '1521',
     'username' = 'flinkuser',
     'password' = 'flinkpw',
     'database-name' = 'XE',
     'schema-name' = 'inlong',
     'table-name' = 'user',
     'scan.incremental.snapshot.enabled' = 'true');
```

### Modifications

Add some options:

```java
enableParallelRead
splitSize
splitMetaGroupSize
fetchSize
connectTimeout
connectMaxRetries
connectionPoolSize
distributionFactorUpper
distributionFactorLower
chunkKeyColumn
```

### Verifying this change

Run `OracleExtractSqlParseTest.java`

### Documentation

  - Does this pull request introduce a new feature? (yes)

New options desciption:

|Option | Required | Default | Type | Description
-- | -- | -- | -- | --
scan.incremental.snapshot.enabled | optional | true | Boolean | Incremental snapshot is a new mechanism to read snapshot of a table. Compared to the old snapshot mechanism, the incremental snapshot has many advantages, including: (1) source can be parallel during snapshot reading, (2) source can perform checkpoints in the chunk granularity during snapshot reading, (3) source doesn't need to acquire ROW SHARE MODE lock before snapshot reading.
scan.incremental.snapshot.chunk.size | optional | 8096 | Integer | The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.
scan.snapshot.fetch.size | optional | 1024 | Integer | The maximum fetch size for per poll when read table snapshot.
connect.max-retries | optional | 3 | Integer | The max retry times that the connector should retry to build MySQL database server connection.
chunk-meta.group.size | optional | 1000 | Integer | The group size of chunk meta, if the meta size exceeds the group size, the meta will be divided into multiple groups.
connect.timeout | optional | 30s | Duration | The maximum time that the connector should wait after trying to connect to the Oracle database server before timing out.
chunk-key.even-distribution.factor.lower-bound | optional | 0.05d | Double | The lower bound of chunk key distribution factor. The distribution factor is used to determine whether the table is evenly distribution or not. The table chunks would use evenly calculation optimization when the data distribution is even, and the query for splitting would happen when it is uneven. The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.
chunk-key.even-distribution.factor.upper-bound | optional | 1000.0d | Double | The upper bound of chunk key distribution factor. The distribution factor is used to determine whether the table is evenly distribution or not. The table chunks would use evenly calculation optimization when the data distribution is even, and the query for splitting would happen when it is uneven. The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.
connection.pool.size | optional | 20 | Integer | The connection pool size.





