### PR TITLE
[INLONG-7417][Sort] Use SinkTableMetricData instead of SinkMetricData in IcebergSingleStreamWriter

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
@@ -716,7 +716,7 @@ public class FlinkSink {
                         appendMode);
 
         return new IcebergProcessOperator<>(new IcebergSingleStreamWriter<>(
-                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts, null, dirtyOptions, dirtySink));
+                table.name(), taskWriterFactory,  null));
     }
 
 }

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/FlinkSink.java
@@ -716,7 +716,8 @@ public class FlinkSink {
                         appendMode);
 
         return new IcebergProcessOperator<>(new IcebergSingleStreamWriter<>(
-                table.name(), taskWriterFactory,  null));
+                table.name(), taskWriterFactory, inlongMetric, auditHostAndPorts,
+                null, dirtyOptions, dirtySink, false));
     }
 
 }

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -17,6 +17,11 @@
 
 package org.apache.inlong.sort.iceberg.sink.multiple;
 
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -35,15 +40,21 @@ import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.inlong.sort.base.Constants;
+import org.apache.inlong.sort.base.dirty.DirtyData;
 import org.apache.inlong.sort.base.dirty.DirtyOptions;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.sink.MultipleSinkOption;
+import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.apache.inlong.sort.iceberg.sink.RowDataTaskWriterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -58,6 +69,11 @@ import static org.apache.iceberg.TableProperties.UPSERT_ENABLED_DEFAULT;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES;
 import static org.apache.iceberg.TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT;
 import static org.apache.inlong.sort.base.Constants.DELIMITER;
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
+import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
 
 /**
  * Iceberg writer that can distinguish different sink tables and route and distribute data into different
@@ -86,6 +102,12 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
     private final DirtyOptions dirtyOptions;
     private @Nullable final DirtySink<Object> dirtySink;
 
+    private transient SinkTableMetricData sinkMetricData;
+    private transient MetricState metricState;
+    private transient ListState<MetricState> metricStateListState;
+    private transient RuntimeContext runtimeContext;
+
+
     public IcebergMultipleStreamWriter(
             boolean appendMode,
             CatalogLoader catalogLoader,
@@ -109,6 +131,21 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
         this.multipleWriters = new HashMap<>();
         this.multipleTables = new HashMap<>();
         this.multipleSchemas = new HashMap<>();
+
+        this.runtimeContext = getRuntimeContext();
+        MetricOption metricOption = MetricOption.builder()
+                .withInlongLabels(inlongMetric)
+                .withInlongAudit(auditHostAndPorts)
+                .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
+                .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
+                .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
+                .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
+                .withRegisterMetric(MetricOption.RegisteredMetric.ALL)
+                .build();
+        if (metricOption != null) {
+            sinkMetricData = new SinkTableMetricData(metricOption, runtimeContext.getMetricGroup());
+            sinkMetricData.registerSubMetricsGroup(metricState);
+        }
     }
 
     @Override
@@ -201,7 +238,41 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
 
         if (multipleWriters.get(tableId) != null) {
             for (RowData data : recordWithSchema.getData()) {
-                multipleWriters.get(tableId).processElement(data);
+                try {
+                    multipleWriters.get(tableId).processElement(data);
+                } catch (Exception e) {
+                    LOG.error(String.format("write error, raw data: %s", data), e);
+                    if (!dirtyOptions.ignoreDirty()) {
+                        throw e;
+                    }
+                    if (dirtySink != null) {
+                        DirtyData.Builder<Object> builder = DirtyData.builder();
+                        try {
+                            builder.setData(data)
+                                    .setLabels(dirtyOptions.getLabels())
+                                    .setLogTag(dirtyOptions.getLogTag())
+                                    .setIdentifier(dirtyOptions.getIdentifier())
+                                    .setRowType( multipleWriters.get(tableId).getFlinkRowType())
+                                    .setDirtyMessage(e.getMessage());
+                            dirtySink.invoke(builder.build());
+                            if (sinkMetricData != null) {
+                                sinkMetricData.invokeDirtyWithEstimate(data);
+                            }
+                        } catch (Exception ex) {
+                            if (!dirtyOptions.ignoreSideOutputErrors()) {
+                                throw new RuntimeException(ex);
+                            }
+                            LOG.warn("Dirty sink failed", ex);
+                        }
+                    }
+                }
+
+                if (sinkMetricData != null) {
+                    String dataBaseName = tableId.namespace().toString();
+                    String tableName = tableId.name();
+                    long size = data.toString().getBytes(StandardCharsets.UTF_8).length;
+                    sinkMetricData.outputMetrics(dataBaseName, tableName, 1, size);
+                }
             }
         } else {
             LOG.error("Unregistered table schema for {}.", recordWithSchema.getTableId());
@@ -217,14 +288,26 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        for (Entry<TableIdentifier, IcebergSingleStreamWriter<RowData>> entry : multipleWriters.entrySet()) {
-            entry.getValue().snapshotState(context);
+        if (sinkMetricData != null && metricStateListState != null) {
+            MetricStateUtils.snapshotMetricStateForSinkMetricData(metricStateListState, sinkMetricData,
+                    getRuntimeContext().getIndexOfThisSubtask());
         }
     }
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
         this.functionInitializationContext = context;
+        if (this.inlongMetric != null) {
+            this.metricStateListState = context.getOperatorStateStore().getUnionListState(
+                    new ListStateDescriptor<>(
+                            INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
+                    })));
+
+        }
+        if (context.isRestored()) {
+            metricState = MetricStateUtils.restoreMetricState(metricStateListState,
+                    getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getNumberOfParallelSubtasks());
+        }
     }
 
     private boolean isSchemaUpdate(RecordWithSchema recordWithSchema) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -219,8 +219,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
                         .append(DELIMITER)
                         .append(Constants.TABLE_NAME).append("=").append(tableId.name());
                 IcebergSingleStreamWriter<RowData> writer = new IcebergSingleStreamWriter<>(
-                        tableId.toString(), taskWriterFactory, subWriterInlongMetric.toString(),
-                        auditHostAndPorts, flinkRowType, dirtyOptions, dirtySink);
+                        tableId.toString(), taskWriterFactory, flinkRowType);
                 writer.setup(getRuntimeContext(),
                         new CallbackCollector<>(
                                 writeResult -> collector.collect(new MultipleWriteResult(tableId, writeResult))),

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -282,6 +282,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
                             LOG.warn("Dirty sink failed", ex);
                         }
                     }
+                    return;
                 }
 
                 if (sinkMetricData != null) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -248,11 +248,11 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
                     if (dirtySink != null) {
                         DirtyData.Builder<Object> builder = DirtyData.builder();
                         try {
-                            builder.setData(data)
-                                    .setLabels(dirtyOptions.getLabels())
+                            builder.setData(data).setLabels(dirtyOptions.getLabels())
                                     .setLogTag(dirtyOptions.getLogTag())
                                     .setIdentifier(dirtyOptions.getIdentifier())
-                                    .setRowType( multipleWriters.get(tableId).getFlinkRowType())
+                                    .setRowType(multipleWriters.get(tableId)
+                                    .getFlinkRowType())
                                     .setDirtyMessage(e.getMessage());
                             dirtySink.invoke(builder.build());
                             if (sinkMetricData != null) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -316,7 +316,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
             this.metricStateListState = context.getOperatorStateStore().getUnionListState(
                     new ListStateDescriptor<>(
                             INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
-                    })));
+                            })));
 
         }
         if (context.isRestored()) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -166,6 +166,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
                     LOGGER.warn("Dirty sink failed", ex);
                 }
             }
+            return;
         }
         if (metricData != null) {
             metricData.invokeWithEstimate(value == null ? "" : value);
@@ -181,7 +182,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
         if (this.inlongMetric != null) {
             this.metricStateListState = context.getOperatorStateStore().getUnionListState(
                     new ListStateDescriptor<>(
-                            String.format("Iceberg(%s)-" + INLONG_METRIC_STATE_NAME, fullTableName),
+                            String.format(INLONG_METRIC_STATE_NAME, fullTableName),
                             TypeInformation.of(new TypeHint<MetricState>() {
                             })));
         }

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -17,6 +17,10 @@
 
 package org.apache.inlong.sort.iceberg.sink.multiple;
 
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
@@ -26,13 +30,25 @@ import org.apache.iceberg.flink.sink.TaskWriterFactory;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.inlong.sort.base.dirty.DirtyData;
 import org.apache.inlong.sort.base.dirty.DirtyOptions;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+
+import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
+import static org.apache.inlong.sort.base.Constants.NUM_BYTES_OUT;
+import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_OUT;
 
 public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, WriteResult>
         implements
@@ -44,20 +60,39 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     private static final long serialVersionUID = 1L;
 
     private final String fullTableName;
+    private final String inlongMetric;
+    private final String auditHostAndPorts;
     private TaskWriterFactory<T> taskWriterFactory;
 
     private transient TaskWriter<T> writer;
     private transient int subTaskId;
     private transient int attemptId;
+    private @Nullable transient SinkMetricData metricData;
+    private transient ListState<MetricState> metricStateListState;
+    private transient MetricState metricState;
     private @Nullable RowType flinkRowType;
+    private final DirtyOptions dirtyOptions;
+    private @Nullable final DirtySink<Object> dirtySink;
+
+    private boolean multipleSink;
 
     public IcebergSingleStreamWriter(
             String fullTableName,
             TaskWriterFactory<T> taskWriterFactory,
-            @Nullable RowType flinkRowType) {
+            String inlongMetric,
+            String auditHostAndPorts,
+            @Nullable RowType flinkRowType,
+            DirtyOptions dirtyOptions,
+            @Nullable DirtySink<Object> dirtySink,
+            boolean multipleSink) {
         this.fullTableName = fullTableName;
         this.taskWriterFactory = taskWriterFactory;
+        this.inlongMetric = inlongMetric;
+        this.auditHostAndPorts = auditHostAndPorts;
         this.flinkRowType = flinkRowType;
+        this.dirtyOptions = dirtyOptions;
+        this.dirtySink = dirtySink;
+        this.multipleSink = multipleSink;
     }
 
     public RowType getFlinkRowType() {
@@ -73,6 +108,22 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
         this.taskWriterFactory.initialize(subTaskId, attemptId);
         // Initialize the task writer.
         this.writer = taskWriterFactory.create();
+
+        // Initialize metric
+        if (!multipleSink) {
+            MetricOption metricOption = MetricOption.builder()
+                    .withInlongLabels(inlongMetric)
+                    .withInlongAudit(auditHostAndPorts)
+                    .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
+                    .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
+                    .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
+                    .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
+                    .withRegisterMetric(RegisteredMetric.ALL)
+                    .build();
+            if (metricOption != null) {
+                metricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
+            }
+        }
     }
 
     @Override
@@ -84,11 +135,60 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
 
     @Override
     public void processElement(T value) throws Exception {
-        writer.write(value);
+        try {
+            writer.write(value);
+        } catch (Exception e) {
+            if (multipleSink) {
+                throw e;
+            }
+
+            LOGGER.error(String.format("write error, raw data: %s", value), e);
+            if (!dirtyOptions.ignoreDirty()) {
+                throw e;
+            }
+            if (dirtySink != null) {
+                DirtyData.Builder<Object> builder = DirtyData.builder();
+                try {
+                    builder.setData(value)
+                            .setLabels(dirtyOptions.getLabels())
+                            .setLogTag(dirtyOptions.getLogTag())
+                            .setIdentifier(dirtyOptions.getIdentifier())
+                            .setRowType(flinkRowType)
+                            .setDirtyMessage(e.getMessage());
+                    dirtySink.invoke(builder.build());
+                    if (metricData != null) {
+                        metricData.invokeDirtyWithEstimate(value);
+                    }
+                } catch (Exception ex) {
+                    if (!dirtyOptions.ignoreSideOutputErrors()) {
+                        throw new RuntimeException(ex);
+                    }
+                    LOGGER.warn("Dirty sink failed", ex);
+                }
+            }
+        }
+        if (metricData != null) {
+            metricData.invokeWithEstimate(value == null ? "" : value);
+        }
     }
 
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
+        // init metric state
+        if(multipleSink){
+            return;
+        }
+        if (this.inlongMetric != null) {
+            this.metricStateListState = context.getOperatorStateStore().getUnionListState(
+                    new ListStateDescriptor<>(
+                            String.format("Iceberg(%s)-" + INLONG_METRIC_STATE_NAME, fullTableName),
+                            TypeInformation.of(new TypeHint<MetricState>() {
+                            })));
+        }
+        if (context.isRestored()) {
+            metricState = MetricStateUtils.restoreMetricState(metricStateListState,
+                    getRuntimeContext().getIndexOfThisSubtask(), getRuntimeContext().getNumberOfParallelSubtasks());
+        }
     }
 
     public void setFlinkRowType(@Nullable RowType flinkRowType) {
@@ -97,6 +197,10 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        if (metricData != null && metricStateListState != null) {
+            MetricStateUtils.snapshotMetricStateForSinkMetricData(metricStateListState, metricData,
+                    getRuntimeContext().getIndexOfThisSubtask());
+        }
     }
 
     @Override

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -176,7 +176,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     @Override
     public void initializeState(FunctionInitializationContext context) throws Exception {
         // init metric state
-        if(multipleSink){
+        if (multipleSink) {
             return;
         }
         if (this.inlongMetric != null) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -54,11 +54,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     public IcebergSingleStreamWriter(
             String fullTableName,
             TaskWriterFactory<T> taskWriterFactory,
-            String inlongMetric,
-            String auditHostAndPorts,
-            @Nullable RowType flinkRowType,
-            DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            @Nullable RowType flinkRowType) {
         this.fullTableName = fullTableName;
         this.taskWriterFactory = taskWriterFactory;
         this.flinkRowType = flinkRowType;


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes https://github.com/apache/inlong/issues/7417

### Motivation
Use SinkTableMetricData instead of SinkMetricData in IcebergSingleStreamWriter

### Modifications

Use SinkTableMetricData instead of SinkMetricData in IcebergSingleStreamWriter
