### PR TITLE
[INLONG-7433][Docker] Recover the zookeeper 3.4 to be compatible with JDK 1.8

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # tubemq depend on zookeeper
-FROM zookeeper:3.8.1
+FROM zookeeper:3.4
 # install tools for debug
 RUN apt-get update \
     && apt-get install -y net-tools vim curl procps \


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7433

### Motivation

![image](https://user-images.githubusercontent.com/18047329/221351277-cc1d5b45-30a3-4eef-a240-45593f67f3bc.png)

### Modifications

Recover the zookeeper 3.4 to be compatible with JDK 1.8, TubeMQ needs JDK 1.8
