### PR TITLE
[INLONG-7392][Sort] Refactor Doris single table to solve performance issues

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -243,7 +243,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             try {
                 schema = RestService.getSchema(options, readOptions, LOG);
             } catch (DorisException e) {
-                LOG.error("failed to get Doris schema" + e);
+                throw new RuntimeException(e);
             }
         }
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -149,6 +149,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
     private final LogicalType[] logicalTypes;
     private final DirtyOptions dirtyOptions;
     private @Nullable final DirtySink<Object> dirtySink;
+    private transient Schema schema;
 
     public DorisDynamicSchemaOutputFormat(DorisOptions option,
             DorisReadOptions readOptions,
@@ -191,15 +192,6 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         return new DorisDynamicSchemaOutputFormat.Builder();
     }
 
-    private String parseKeysType() {
-        try {
-            Schema schema = RestService.getSchema(options, readOptions, LOG);
-            return schema.getKeysType();
-        } catch (DorisException e) {
-            throw new RuntimeException("Failed fetch doris table schema: " + options.getTableIdentifier());
-        }
-    }
-
     private void handleStreamLoadProp() {
         Properties props = executionOptions.getStreamLoadProp();
         boolean ifEscape = Boolean.parseBoolean(props.getProperty(ESCAPE_DELIMITERS_KEY, ESCAPE_DELIMITERS_DEFAULT));
@@ -230,12 +222,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         if (multipleSink) {
             return executionOptions.getEnableDelete();
         }
-        try {
-            Schema schema = RestService.getSchema(options, readOptions, LOG);
-            return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
-        } catch (DorisException e) {
-            throw new RuntimeException("Failed fetch doris single table schema: " + options.getTableIdentifier(), e);
-        }
+        return executionOptions.getEnableDelete() || UNIQUE_KEYS_TYPE.equals(schema.getKeysType());
     }
 
     @Override
@@ -251,16 +238,12 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             handleStreamLoadProp();
             this.fieldGetters = new RowData.FieldGetter[logicalTypes.length];
             for (int i = 0; i < logicalTypes.length; i++) {
-                fieldGetters[i] = RowData.createFieldGetter(logicalTypes[i], i);
-                if ("DATE".equalsIgnoreCase(logicalTypes[i].toString())) {
-                    int finalI = i;
-                    fieldGetters[i] = row -> {
-                        if (row.isNullAt(finalI)) {
-                            return null;
-                        }
-                        return DorisParseUtils.epochToDate(row.getInt(finalI));
-                    };
-                }
+                fieldGetters[i] = DorisParseUtils.createFieldGetter(logicalTypes[i], i);
+            }
+            try {
+                schema = RestService.getSchema(options, readOptions, LOG);
+            } catch (DorisException e) {
+                LOG.error("failed to get Doris schema" + e);
             }
         }
 

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
@@ -114,8 +114,6 @@ public class DorisParseUtils {
                 "Convert to LocalDate failed from unexpected value '" + obj + "' of type " + obj.getClass().getName());
     }
 
-
-
     private enum LogicalTypeEnum {
         DATE("DATE");
 
@@ -129,4 +127,5 @@ public class DorisParseUtils {
             return logicalType;
         }
     }
+
 }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.sort.doris.util;
 
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.RowData.FieldGetter;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.types.RowKind;
 
 import java.time.LocalDate;
@@ -47,6 +50,21 @@ public class DorisParseUtils {
         } else {
             throw new RuntimeException("Unrecognized row kind: " + rowKind.toString());
         }
+    }
+
+    public static FieldGetter createFieldGetter(LogicalType type, int pos) {
+        FieldGetter getter;
+        if ("DATE".equalsIgnoreCase(type.toString())) {
+            getter = row -> {
+                if (row.isNullAt(pos)) {
+                    return null;
+                }
+                return DorisParseUtils.epochToDate(row.getInt(pos));
+            };
+        } else {
+            getter = RowData.createFieldGetter(type, pos);
+        }
+        return getter;
     }
 
     /**

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
@@ -52,9 +52,16 @@ public class DorisParseUtils {
         }
     }
 
+    /**
+     * A utility function used to handle special fieldGetters for specific
+     *
+     * @param type the logical type of the field getter array
+     * @param pos the index of the corresponding row
+     * @return the fieldGetter created
+     */
     public static FieldGetter createFieldGetter(LogicalType type, int pos) {
         FieldGetter getter;
-        if ("DATE".equalsIgnoreCase(type.toString())) {
+        if (type.toString().equalsIgnoreCase(LogicalTypeEnum.DATE.getType())) {
             getter = row -> {
                 if (row.isNullAt(pos)) {
                     return null;
@@ -105,5 +112,21 @@ public class DorisParseUtils {
         }
         throw new IllegalArgumentException(
                 "Convert to LocalDate failed from unexpected value '" + obj + "' of type " + obj.getClass().getName());
+    }
+
+
+
+    private enum LogicalTypeEnum {
+        DATE("DATE");
+
+        private final String logicalType;
+
+        LogicalTypeEnum(String logicalType) {
+            this.logicalType = logicalType;
+        }
+
+        public String getType() {
+            return logicalType;
+        }
     }
 }

--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/util/DorisParseUtils.java
@@ -115,6 +115,7 @@ public class DorisParseUtils {
     }
 
     private enum LogicalTypeEnum {
+
         DATE("DATE");
 
         private final String logicalType;


### PR DESCRIPTION
- Fixes #7392 

### Motivation
Doris Single table had performance bottlenecks. The throughput was 1700 records/s, and this pr fixes 2 bugs to enhance its performance to 50000 records/s.

### Modifications
1. refactored EnableBatchDelete and related helpers so that the Schema is not calculated by RestService after initialization.
2. Refactored the date bugfix pr into DorisParseUtils so that it will not interfere with single table.

### Verification
<img width="418" alt="image" src="https://user-images.githubusercontent.com/32808678/221462923-2e9b8506-b9b0-440a-be60-c81489e523ec.png">
