### PR TITLE
[INLONG-7453][Sort] Fix the blacklist of Iceberg connector will lose the metric and archiving of dirty data

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -65,12 +65,10 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.Set;
 
 import static org.apache.inlong.sort.base.Constants.DIRTY_BYTES_OUT;
 import static org.apache.inlong.sort.base.Constants.DIRTY_RECORDS_OUT;


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes https://github.com/apache/inlong/issues/7453

### Motivation

In the Iceberg Connector, the blacklist feature will cause metric and archiving of dirty data to be invalid.


### Modifications

In the Iceberg connector, blacklisting will cause metric and archiving dirtiness to be ineffective, so the blacklisting feature needs to be removed.


