### PR TITLE
[INLONG-7468][Manager] Fix re-executing the workflow fails to load the new configuration information

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/QueueResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/QueueResourceListener.java
@@ -33,6 +33,7 @@ import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProces
 import org.apache.inlong.manager.service.group.InlongGroupService;
 import org.apache.inlong.manager.service.resource.queue.QueueResourceOperator;
 import org.apache.inlong.manager.service.resource.queue.QueueResourceOperatorFactory;
+import org.apache.inlong.manager.service.stream.InlongStreamService;
 import org.apache.inlong.manager.service.workflow.WorkflowService;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
@@ -77,6 +78,8 @@ public class QueueResourceListener implements QueueOperateListener {
     @Autowired
     private InlongGroupService groupService;
     @Autowired
+    private InlongStreamService streamService;
+    @Autowired
     private WorkflowService workflowService;
     @Autowired
     private QueueResourceOperatorFactory queueOperatorFactory;
@@ -106,6 +109,9 @@ public class QueueResourceListener implements QueueOperateListener {
             log.error(msg);
             throw new WorkflowListenerException(msg);
         }
+        // Read the current information
+        groupProcessForm.setGroupInfo(groupInfo);
+        groupProcessForm.setStreamInfos(streamService.list(groupId));
 
         if (InlongConstants.DISABLE_CREATE_RESOURCE.equals(groupInfo.getEnableCreateResource())) {
             log.warn("skip to execute QueueResourceListener as disable create resource for groupId={}", groupId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/StreamQueueResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/StreamQueueResourceListener.java
@@ -29,6 +29,7 @@ import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProces
 import org.apache.inlong.manager.service.group.InlongGroupService;
 import org.apache.inlong.manager.service.resource.queue.QueueResourceOperator;
 import org.apache.inlong.manager.service.resource.queue.QueueResourceOperatorFactory;
+import org.apache.inlong.manager.service.stream.InlongStreamService;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
 import org.apache.inlong.manager.workflow.event.task.QueueOperateListener;
@@ -44,6 +45,8 @@ public class StreamQueueResourceListener implements QueueOperateListener {
 
     @Autowired
     private InlongGroupService groupService;
+    @Autowired
+    private InlongStreamService streamService;
     @Autowired
     private QueueResourceOperatorFactory queueOperatorFactory;
 
@@ -80,6 +83,10 @@ public class StreamQueueResourceListener implements QueueOperateListener {
             log.error(msg);
             throw new WorkflowListenerException(msg);
         }
+        final String streamId = streamInfo.getInlongStreamId();
+        // Read the current information
+        streamProcessForm.setGroupInfo(groupInfo);
+        streamProcessForm.setStreamInfo(streamService.get(groupId, streamId));
 
         if (InlongConstants.DISABLE_CREATE_RESOURCE.equals(groupInfo.getEnableCreateResource())) {
             log.warn("skip to execute StreamQueueResourceListener as disable create resource for groupId={}", groupId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sink/SinkResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sink/SinkResourceListener.java
@@ -27,6 +27,7 @@ import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm;
 import org.apache.inlong.manager.service.resource.sink.SinkResourceOperator;
 import org.apache.inlong.manager.service.resource.sink.SinkResourceOperatorFactory;
+import org.apache.inlong.manager.service.stream.InlongStreamService;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
 import org.apache.inlong.manager.workflow.event.task.SinkOperateListener;
@@ -48,6 +49,8 @@ public class SinkResourceListener implements SinkOperateListener {
     @Autowired
     private StreamSinkEntityMapper sinkMapper;
     @Autowired
+    private InlongStreamService streamService;
+    @Autowired
     private SinkResourceOperatorFactory sinkOperatorFactory;
 
     @Override
@@ -62,7 +65,7 @@ public class SinkResourceListener implements SinkOperateListener {
         log.info("begin to create sink resources for groupId={}", groupId);
 
         List<String> streamIdList = new ArrayList<>();
-        List<InlongStreamInfo> streamList = form.getStreamInfos();
+        List<InlongStreamInfo> streamList = streamService.list(groupId);
         if (CollectionUtils.isNotEmpty(streamList)) {
             streamIdList = streamList.stream().map(InlongStreamInfo::getInlongStreamId).collect(Collectors.toList());
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/StreamSortConfigListener.java
@@ -26,8 +26,10 @@ import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
 import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
+import org.apache.inlong.manager.service.group.InlongGroupService;
 import org.apache.inlong.manager.service.resource.sort.SortConfigOperator;
 import org.apache.inlong.manager.service.resource.sort.SortConfigOperatorFactory;
+import org.apache.inlong.manager.service.stream.InlongStreamService;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
 import org.apache.inlong.manager.workflow.event.task.SortOperateListener;
@@ -50,6 +52,10 @@ public class StreamSortConfigListener implements SortOperateListener {
 
     @Autowired
     private SortConfigOperatorFactory operatorFactory;
+    @Autowired
+    private InlongGroupService groupService;
+    @Autowired
+    private InlongStreamService streamService;
 
     @Override
     public TaskEvent event() {
@@ -85,12 +91,15 @@ public class StreamSortConfigListener implements SortOperateListener {
             return ListenerResult.success();
         }
 
-        InlongGroupInfo groupInfo = form.getGroupInfo();
+        InlongGroupInfo groupInfo = groupService.get(groupId);
         List<StreamSink> streamSinks = streamInfo.getSinkList();
         if (CollectionUtils.isEmpty(streamSinks)) {
             LOGGER.warn("not build sort config for groupId={}, streamId={}, as not found any sinks", groupId, streamId);
             return ListenerResult.success();
         }
+        // Read the current information
+        form.setGroupInfo(groupInfo);
+        form.setStreamInfo(streamService.get(groupId, streamId));
 
         List<InlongStreamInfo> streamInfos = Collections.singletonList(streamInfo);
         try {


### PR DESCRIPTION


### Prepare a Pull Request
- Fixes #7468 

### Motivation

Fix re-executing the workflow fails to load the new configuration information.

### Modifications
Fix re-executing the workflow fails to load the new configuration information.
Obtain the current configuration in real time.
