### PR TITLE
[INLONG-7299][Sort] Optimize the options check for the Kafka connector

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -18,8 +18,6 @@
 package org.apache.inlong.sort.protocol.node.extract;
 
 import com.google.common.base.Preconditions;
-import java.util.HashMap;
-import java.util.Map.Entry;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
@@ -35,14 +33,7 @@ import org.apache.inlong.sort.protocol.Metadata;
 import org.apache.inlong.sort.protocol.constant.KafkaConstant;
 import org.apache.inlong.sort.protocol.enums.KafkaScanStartupMode;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
-import org.apache.inlong.sort.protocol.node.format.AvroFormat;
-import org.apache.inlong.sort.protocol.node.format.CanalJsonFormat;
-import org.apache.inlong.sort.protocol.node.format.CsvFormat;
-import org.apache.inlong.sort.protocol.node.format.DebeziumJsonFormat;
 import org.apache.inlong.sort.protocol.node.format.Format;
-import org.apache.inlong.sort.protocol.node.format.InLongMsgFormat;
-import org.apache.inlong.sort.protocol.node.format.JsonFormat;
-import org.apache.inlong.sort.protocol.node.format.RawFormat;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
 
 import javax.annotation.Nonnull;
@@ -155,63 +146,22 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
         Map<String, String> options = super.tableOptions();
         options.put(KafkaConstant.TOPIC, topic);
         options.put(KafkaConstant.PROPERTIES_BOOTSTRAP_SERVERS, bootstrapServers);
-
-        boolean wrapWithInlongMsg = format instanceof InLongMsgFormat;
-        Format realFormat = wrapWithInlongMsg ? ((InLongMsgFormat) format).getInnerFormat() : format;
-        if (realFormat instanceof JsonFormat
-                || realFormat instanceof AvroFormat
-                || realFormat instanceof CsvFormat) {
-            if (StringUtils.isEmpty(this.primaryKey)) {
-                options.put(KafkaConstant.CONNECTOR, KafkaConstant.KAFKA);
-                options.put(KafkaConstant.SCAN_STARTUP_MODE, kafkaScanStartupMode.getValue());
-                if (StringUtils.isNotEmpty(scanSpecificOffsets)) {
-                    options.put(KafkaConstant.SCAN_STARTUP_SPECIFIC_OFFSETS, scanSpecificOffsets);
-                }
-                if (StringUtils.isNotBlank(scanTimestampMillis)) {
-                    options.put(KafkaConstant.SCAN_STARTUP_TIMESTAMP_MILLIS, scanTimestampMillis);
-                }
-                options.putAll(delegateInlongFormat(realFormat.generateOptions(false), wrapWithInlongMsg));
-            } else {
-                options.put(KafkaConstant.CONNECTOR, KafkaConstant.UPSERT_KAFKA);
-                options.putAll(delegateInlongFormat(realFormat.generateOptions(true), wrapWithInlongMsg));
-            }
-        } else if (realFormat instanceof CanalJsonFormat
-                || realFormat instanceof DebeziumJsonFormat
-                || realFormat instanceof RawFormat) {
+        options.put(KafkaConstant.SCAN_STARTUP_MODE, kafkaScanStartupMode.getValue());
+        if (StringUtils.isEmpty(this.primaryKey)) {
             options.put(KafkaConstant.CONNECTOR, KafkaConstant.KAFKA);
-            options.put(KafkaConstant.SCAN_STARTUP_MODE, kafkaScanStartupMode.getValue());
-            if (StringUtils.isNotEmpty(scanSpecificOffsets)) {
-                options.put(KafkaConstant.SCAN_STARTUP_SPECIFIC_OFFSETS, scanSpecificOffsets);
-            }
-            if (StringUtils.isNotBlank(scanTimestampMillis)) {
-                options.put(KafkaConstant.SCAN_STARTUP_TIMESTAMP_MILLIS, scanTimestampMillis);
-            }
-            options.putAll(delegateInlongFormat(realFormat.generateOptions(false), wrapWithInlongMsg));
+            options.putAll(format.generateOptions(false));
         } else {
-            throw new IllegalArgumentException("kafka extract node format is IllegalArgument");
+            options.put(KafkaConstant.CONNECTOR, KafkaConstant.UPSERT_KAFKA);
+            options.putAll(format.generateOptions(true));
+        }
+        if (StringUtils.isNotEmpty(scanSpecificOffsets)) {
+            options.put(KafkaConstant.SCAN_STARTUP_SPECIFIC_OFFSETS, scanSpecificOffsets);
+        }
+        if (StringUtils.isNotBlank(scanTimestampMillis)) {
+            options.put(KafkaConstant.SCAN_STARTUP_TIMESTAMP_MILLIS, scanTimestampMillis);
         }
         if (StringUtils.isNotEmpty(groupId)) {
             options.put(KafkaConstant.PROPERTIES_GROUP_ID, groupId);
-        }
-        return options;
-    }
-
-    private Map<String, String> delegateInlongFormat(
-            Map<String, String> realOptions,
-            boolean wrapWithInlongMsg) {
-        if (!wrapWithInlongMsg) {
-            return realOptions;
-        }
-        Map<String, String> options = new HashMap<>();
-        for (Entry<String, String> entry : realOptions.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            if ("format".equals(key)) {
-                options.put("format", "inlong-msg");
-                options.put("inlong-msg.inner.format", value);
-            } else {
-                options.put("inlong-msg." + key, value);
-            }
         }
         return options;
     }

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -326,10 +326,13 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
         final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
                 getValueDecodingFormat(helper);
 
-        helper.validateExcept(PROPERTIES_PREFIX, DIRTY_PREFIX);
+        final String valueFormatPrefix = tableOptions.getOptional(FORMAT)
+                .orElse(tableOptions.get(VALUE_FORMAT));
 
+        // Validate the option data type.
+        helper.validateExcept(PROPERTIES_PREFIX, DIRTY_PREFIX, valueFormatPrefix);
+        // Validate the option values.
         validateTableSourceOptions(tableOptions);
-
         validatePKConstraints(
                 context.getObjectIdentifier(), context.getCatalogTable(), valueDecodingFormat);
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7299

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

- All supported formats are checked in `ExtractNodeUtils.parsingFormat()`, so it does not need to check again for Kafka ExtractNode.
- Add `valueFormatPrefix` check for `inlong-msg.' prefix options.
![image](https://user-images.githubusercontent.com/18047329/222050659-17ddb0bd-d6bc-477b-91b5-901f471c55a3.png)

