### PR TITLE
[INLONG-7470][Sort] Fix Iceberg's data were duplicated when delete records in upsert mode

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/BaseDeltaTaskWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/BaseDeltaTaskWriter.java
@@ -94,7 +94,11 @@ abstract class BaseDeltaTaskWriter extends BaseTaskWriter<RowData> {
                 writer.delete(row);
                 break;
             case DELETE:
-                writer.delete(row);
+                if (upsert) { // https://github.com/apache/iceberg/pull/6753/files
+                    writer.deleteKey(keyProjection.wrap(row));
+                } else {
+                    writer.delete(row);
+                }
                 break;
 
             default:


### PR DESCRIPTION
Fix iceberg's data were duplicated when delete records in upsert mode, if message has delete record of data in CDC of RDB.
- Fixes #7470 

### Motivation

Keep ACID in the iceberg.

### Modifications

Modify class BaseDeltaTaskWriter in the iceberg

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:
