### PR TITLE
[INLONG-7488][Sort] Fix the issue of only being able to read one record during the incremental snapshot

### DIFF
--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/external/IncrementalSourceScanFetcher.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/external/IncrementalSourceScanFetcher.java
@@ -122,6 +122,7 @@ public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, Sour
             SourceRecord lowWatermark = null;
             SourceRecord highWatermark = null;
             Map<Struct, SourceRecord> outputBuffer = new HashMap<>();
+            List<SourceRecord> snapshotRecordsWithoutKey = new ArrayList<>();
             while (!reachChangeLogEnd) {
                 checkReadException();
                 List<DataChangeEvent> batch = queue.poll();
@@ -147,7 +148,11 @@ public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, Sour
                     }
 
                     if (!reachChangeLogStart) {
-                        outputBuffer.put((Struct) record.key(), record);
+                        if (record.key() == null) {
+                            snapshotRecordsWithoutKey.add(record);
+                        } else {
+                            outputBuffer.put((Struct) record.key(), record);
+                        }
                     } else {
                         if (isChangeRecordInChunkRange(record)) {
                             // rewrite overlapping snapshot records through the record key
@@ -162,7 +167,11 @@ public class IncrementalSourceScanFetcher implements Fetcher<SourceRecords, Sour
             // split
             final List<SourceRecord> normalizedRecords = new ArrayList<>();
             normalizedRecords.add(lowWatermark);
-            normalizedRecords.addAll(taskContext.formatMessageTimestamp(outputBuffer.values()));
+            if (snapshotRecordsWithoutKey.isEmpty()) {
+                normalizedRecords.addAll(taskContext.formatMessageTimestamp(outputBuffer.values()));
+            } else {
+                normalizedRecords.addAll(taskContext.formatMessageTimestamp(snapshotRecordsWithoutKey));
+            }
             normalizedRecords.add(highWatermark);
 
             final List<SourceRecords> sourceRecordsSet = new ArrayList<>();

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/reader/external/IncrementalSourceStreamFetcher.java
@@ -165,7 +165,7 @@ public class IncrementalSourceStreamFetcher implements Fetcher<SourceRecords, So
             TableId tableId = taskContext.getTableId(sourceRecord);
             Offset position = taskContext.getStreamOffset(sourceRecord);
             // source record has no primary need no comparing for binlog position
-            if (hasEnterPureStreamPhase(tableId, position)) {
+            if (hasEnterPureStreamPhase(tableId, position) || sourceRecord.key() == null) {
                 return true;
             }
             // only the table who captured snapshot splits need to filter


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7488][Sort] Fix the issue of only being able to read one record during the incremental snapshot

- Fixes #7488 

### Motivation

Open  incremental snapshot, Oracle tables need to have primary keys in order to read all data. For tables without primary keys, you can refer to the current PR for a fix.

### Modifications

In the snapshot, `record.key()` is null, so it will overwrite the previous record. So we can to add record without primary key into list.

```java
  if (!reachChangeLogStart) {
      if (record.key() == null) {
          snapshotRecordsWithoutKey.add(record);
      } else {
          outputBuffer.put((Struct) record.key(), record);
      }
  }
```