### PR TITLE
[INLONG-7504][Sort] Fix NPE when dirty ignore is false

### DIFF
--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/manager/StarRocksStreamLoadVisitor.java
@@ -95,9 +95,8 @@ public class StarRocksStreamLoadVisitor implements Serializable {
                             + "2.Wrong column_separator or row_delimiter. "
                             + "3.Column count exceeded the limitation.");
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(String.format("Stream Load response: \n%s\n", JSON.toJSONString(loadResult)));
-        }
+        LOG.info(String.format("Stream Load response: \n%s\n", JSON.toJSONString(loadResult)));
+
         if (RESULT_FAILED.equals(loadResult.get(keyStatus))) {
             Map<String, String> logMap = new HashMap<>();
             if (loadResult.containsKey("ErrorURL")) {

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
@@ -279,42 +279,25 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
                 LOG.warn("Parse dirty options failed. {}", ExceptionUtils.stringifyException(e));
             }
 
-            List<RowKind> rowKinds = jsonDynamicSchemaFormat.opType2RowKind(
-                    jsonDynamicSchemaFormat.getOpType(rootNode));
+            RowKind rowKind = rowData.getRowKind();
             List<Map<String, String>> physicalDataList = jsonDynamicSchemaFormat.jsonNode2Map(
                     jsonDynamicSchemaFormat.getPhysicalData(rootNode));
-            JsonNode updateBeforeNode = jsonDynamicSchemaFormat.getUpdateBefore(rootNode);
-            List<Map<String, String>> updateBeforeList = null;
-            if (updateBeforeNode != null) {
-                updateBeforeList = jsonDynamicSchemaFormat.jsonNode2Map(updateBeforeNode);
-            }
             List<Map<String, String>> records = new ArrayList<>();
             for (int i = 0; i < physicalDataList.size(); i++) {
-                for (RowKind rowKind : rowKinds) {
-                    Map<String, String> record = null;
-                    switch (rowKind) {
-                        case INSERT:
-                        case UPDATE_AFTER:
-                            record = physicalDataList.get(i);
-                            record.put("__op", String.valueOf(StarRocksSinkOP.UPSERT.ordinal()));
-                            break;
-                        case DELETE:
-                            record = physicalDataList.get(i);
-                            record.put("__op", String.valueOf(StarRocksSinkOP.DELETE.ordinal()));
-                            break;
-                        case UPDATE_BEFORE:
-                            if (updateBeforeList != null && updateBeforeList.size() > i) {
-                                record = updateBeforeList.get(i);
-                                record.put("__op", String.valueOf(StarRocksSinkOP.DELETE.ordinal()));
-                            }
-                            break;
-                        default:
-                            throw new RuntimeException("Unrecognized row kind:" + rowKind);
-                    }
-                    if (record != null) {
-                        records.add(record);
-                    }
+                Map<String, String> record = physicalDataList.get(i);
+                switch (rowKind) {
+                    case INSERT:
+                    case UPDATE_AFTER:
+                        record.put("__op", String.valueOf(StarRocksSinkOP.UPSERT.ordinal()));
+                        break;
+                    case DELETE:
+                    case UPDATE_BEFORE:
+                        record.put("__op", String.valueOf(StarRocksSinkOP.DELETE.ordinal()));
+                        break;
+                    default:
+                        throw new RuntimeException("Unrecognized row kind:" + rowKind);
                 }
+                records.add(record);
             }
             sinkManager.writeRecords(databaseName, tableName, records, dirtyLogTag, dirtyIdentify, dirtyLabel);
         } else {

--- a/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
+++ b/inlong-sort/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
@@ -226,7 +226,7 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
             }
         }
         if (value instanceof RowData) {
-            if (RowKind.UPDATE_BEFORE.equals(((RowData) value).getRowKind())) {
+            if (!multipleSink && RowKind.UPDATE_BEFORE.equals(((RowData) value).getRowKind())) {
                 // do not need update_before, cauz an update action happened on the primary keys will be separated into
                 // `delete` and `create`
                 return;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7504

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

StarRocks will throw NullPointerException when dirty.ignore is false.

![image](https://user-images.githubusercontent.com/2731242/222482393-8092061f-1a68-47a4-8273-a6d04c7c2fd8.png)


### Modifications

*Describe the modifications you've done.*

Check if null when parsing dirty.label, dirty.logtag and dirty.identifier in class `StarRocksDynamicSinkFunction`.


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
