### PR TITLE
[INLONG-7508][Sort] Carry right RowKind when cdc-base sends RowData to sink

### DIFF
--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/debezium/table/AppendMetadataCollector.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/debezium/table/AppendMetadataCollector.java
@@ -46,14 +46,14 @@ public final class AppendMetadataCollector implements Collector<RowData>, Serial
     }
 
     public void collect(RowData physicalRow, TableChange tableSchema) {
-        GenericRowData metaRow = new GenericRowData(metadataConverters.length);
+        GenericRowData metaRow = new GenericRowData(physicalRow.getRowKind(), metadataConverters.length);
         for (int i = 0; i < metadataConverters.length; i++) {
             Object meta = metadataConverters[i].read(inputRecord, tableSchema, physicalRow);
             metaRow.setField(i, meta);
         }
         if (migrateAll) {
             // all data are put into meta row, set physicalRow to empty
-            physicalRow = new GenericRowData(0);
+            physicalRow = new GenericRowData(physicalRow.getRowKind(), 0);
         }
         RowData outRow = new JoinedRowData(physicalRow.getRowKind(), physicalRow, metaRow);
         outputCollector.collect(outRow);


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7508

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

cdc-base sends RowData to sink, should carry right RowKind

![image](https://user-images.githubusercontent.com/2731242/222632083-f7174ace-62b1-49b4-b152-2a60aae284a0.png)
![image](https://user-images.githubusercontent.com/2731242/222632235-4b1fa8fa-29cf-4898-bceb-1592b75f55ad.png)
![image](https://user-images.githubusercontent.com/2731242/222632253-30b58af7-3770-49e7-8950-a96192ab9970.png)


### Modifications

*Describe the modifications you've done.*

`AppendMetadataCollector` make a new GenericRowData instance, should pass right RowKind.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
