### PR TITLE
[INLONG-7487][Sort] Change changelog mode to capture update_before for ES 

### DIFF
--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
@@ -27,7 +27,6 @@ import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkFunctionProvider;
 import org.apache.flink.table.data.RowData;
-import org.apache.flink.types.RowKind;
 import org.apache.flink.util.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
@@ -110,13 +109,7 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
 
     @Override
     public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-        ChangelogMode.Builder builder = ChangelogMode.newBuilder();
-        for (RowKind kind : requestedMode.getContainedKinds()) {
-            if (kind != RowKind.UPDATE_BEFORE) {
-                builder.addContainedKind(kind);
-            }
-        }
-        return builder.build();
+        return ChangelogMode.all();
     }
 
     // --------------------------------------------------------------

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/RowElasticsearchSinkFunction.java
@@ -164,6 +164,7 @@ public class RowElasticsearchSinkFunction implements ElasticsearchSinkFunction<R
                 }
                 break;
             case UPDATE_BEFORE:
+                sendMetrics(document);
                 break;
             default:
                 LOGGER.error(String.format("The type of element should be 'RowData' only, raw data: %s", element));


### PR DESCRIPTION
- Fixes #7487 

### Motivation

Similar to doris/jdbc/kafka, ES needs to change changelog too, so that read metric and write metric can both be 2 records for upsert changelog. 

### Modifications

1. changed changelogMode for es
2. additionally, calculate metrics for update_before changelog for es7 sink.

### Verifying this change
<img width="771" alt="image" src="https://user-images.githubusercontent.com/32808678/222645176-c87c31c3-c71b-4661-89a9-4fde574b9c4f.png">
