### PR TITLE
[INLONG-7513][DataProxy] Delete duplicate definitions

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -282,8 +282,6 @@ public class PulsarHandler implements MessageQueueHandler {
         switch (type) {
             case "LZ4":
                 return CompressionType.LZ4;
-            case "NONE":
-                return CompressionType.NONE;
             case "ZLIB":
                 return CompressionType.ZLIB;
             case "ZSTD":

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -289,7 +289,7 @@ public class PulsarHandler implements MessageQueueHandler {
             case "SNAPPY":
                 return CompressionType.SNAPPY;
             case "NONE":
-                default:
+            default:
                 return CompressionType.NONE;
         }
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -288,7 +288,8 @@ public class PulsarHandler implements MessageQueueHandler {
                 return CompressionType.ZSTD;
             case "SNAPPY":
                 return CompressionType.SNAPPY;
-            default:
+            case "NONE":
+                default:
                 return CompressionType.NONE;
         }
     }


### PR DESCRIPTION
- Fixes #7513

### Motivation

There are duplicate definitions here, so delete the duplicate part.

### Modifications

Delete the duplicate definition part.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.
