### PR TITLE
[INLONG-7535][Manager]Optimize the serializationType setting of PulsarSource to prevent Null Pointer Exception.

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -131,8 +131,10 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
             pulsarSource.setAdminUrl(adminUrl);
             pulsarSource.setServiceUrl(serviceUrl);
             pulsarSource.setInlongComponent(true);
-            String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-            pulsarSource.setSerializationType(serializationType);
+            if (StringUtils.isNotBlank(streamInfo.getDataType())) {
+                String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+                pulsarSource.setSerializationType(serializationType);
+            }
             pulsarSource.setWrapWithInlongMsg(streamInfo.getWrapWithInlongMsg());
             pulsarSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 


### PR DESCRIPTION
[INLONG-7535][Manager]Optimize the serializationType setting of PulsarSource to prevent Null Pointer Exception.

- Fixes #7535

### Motivation

When InlongStreamInfo does not set the dataType attribute, a null pointer exception will occur, but dataType is not necessary.
Add judgment to avoid the occurrence of null pointers, fault tolerance.
