### PR TITLE
[INLONG-7543][Sort] Fix PostgreSQL connector output two data with the same UPDATE operation

### DIFF
--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
@@ -435,8 +435,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert debezium operation to canal-json operation type
      *
-     * @param record
-     * @return
+     * @param record: source record
+     * @return: source table DML operation type
      */
     private static String getOpType(SourceRecord record) {
         String opType;
@@ -454,8 +454,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get primary key names
      *
-     * @param tableSchema
-     * @return
+     * @param tableSchema: table schema
+     * @return: primary key column names
      */
     private static List<String> getPkNames(@Nullable TableChange tableSchema) {
         if (tableSchema == null) {
@@ -467,8 +467,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get a map about column name and type
      *
-     * @param tableSchema
-     * @return
+     * @param tableSchema: table schema
+     * @return: map of field name and field type
      */
     public static Map<String, Integer> getSqlType(@Nullable TableChange tableSchema) {
         if (tableSchema == null) {
@@ -485,8 +485,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert canal operation to canal-json operation type
      *
-     * @param record
-     * @return
+     * @param record: raw data with canal json format
+     * @return source table DML operation type
      */
     private static String getCanalOpType(GenericRowData record) {
         String opType;
@@ -509,8 +509,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert debezium operation to debezium-json operation type
      *
-     * @param record
-     * @return
+     * @param record: raw data with debezium json format
+     * @return source table DML operation type
      */
     private static String getDebeziumOpType(GenericRowData record) {
         String opType;
@@ -533,9 +533,9 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get meta info from debezium-json data stream
      *
-     * @param record
-     * @param tableNameKey
-     * @return
+     * @param record: source record
+     * @param tableNameKey: key in the source record
+     * @return value of the key in the source record
      */
     private static String getMetaData(SourceRecord record, String tableNameKey) {
         Struct messageStruct = (Struct) record.value();

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
@@ -455,7 +455,7 @@ public enum PostgreSQLReadableMetaData {
      * get primary key names
      *
      * @param tableSchema table schema
-     * @return: primary key column names
+     * @return primary key column names
      */
     private static List<String> getPkNames(@Nullable TableChange tableSchema) {
         if (tableSchema == null) {
@@ -468,7 +468,7 @@ public enum PostgreSQLReadableMetaData {
      * get a map about column name and type
      *
      * @param tableSchema table schema
-     * @return: map of field name and field type
+     * @return map of field name and field type
      */
     public static Map<String, Integer> getSqlType(@Nullable TableChange tableSchema) {
         if (tableSchema == null) {

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLReadableMetaData.java
@@ -373,9 +373,9 @@ public enum PostgreSQLReadableMetaData {
     /**
      * Generate a canal json message
      *
-     * @param record
-     * @param tableSchema
-     * @param rowData
+     * @param record source record
+     * @param tableSchema table schema
+     * @param rowData row data with canal json or debezium json
      * @return
      */
     private static StringData getCanalData(SourceRecord record, TableChange tableSchema, GenericRowData rowData) {
@@ -435,8 +435,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert debezium operation to canal-json operation type
      *
-     * @param record: source record
-     * @return: source table DML operation type
+     * @param record source record
+     * @return source table DML operation type
      */
     private static String getOpType(SourceRecord record) {
         String opType;
@@ -454,7 +454,7 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get primary key names
      *
-     * @param tableSchema: table schema
+     * @param tableSchema table schema
      * @return: primary key column names
      */
     private static List<String> getPkNames(@Nullable TableChange tableSchema) {
@@ -467,7 +467,7 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get a map about column name and type
      *
-     * @param tableSchema: table schema
+     * @param tableSchema table schema
      * @return: map of field name and field type
      */
     public static Map<String, Integer> getSqlType(@Nullable TableChange tableSchema) {
@@ -485,7 +485,7 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert canal operation to canal-json operation type
      *
-     * @param record: raw data with canal json format
+     * @param record raw data with canal json format
      * @return source table DML operation type
      */
     private static String getCanalOpType(GenericRowData record) {
@@ -509,7 +509,7 @@ public enum PostgreSQLReadableMetaData {
     /**
      * convert debezium operation to debezium-json operation type
      *
-     * @param record: raw data with debezium json format
+     * @param record raw data with debezium json format
      * @return source table DML operation type
      */
     private static String getDebeziumOpType(GenericRowData record) {
@@ -533,8 +533,8 @@ public enum PostgreSQLReadableMetaData {
     /**
      * get meta info from debezium-json data stream
      *
-     * @param record: source record
-     * @param tableNameKey: key in the source record
+     * @param record source record
+     * @param tableNameKey key in the source record
      * @return value of the key in the source record
      */
     private static String getMetaData(SourceRecord record, String tableNameKey) {


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7543

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

Refer issue https://github.com/apache/inlong/issues/7397 , postgres cdc connector also sends two data with the same UPDATE operation.

Postgres cdc connector also should fix the type in canal-json or debezium-json when UPDATE operation.

### Modifications

*Describe the modifications you've done.*

For UPDATE_BEFORE output DELETE
For UPDATE_AFTER output INSERT

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
