### PR TITLE
[INLONG-7546][Sort] Fix dirty data not archived for iceberg connector

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -147,6 +147,14 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
             sinkMetricData = new SinkTableMetricData(metricOption, runtimeContext.getMetricGroup());
             sinkMetricData.registerSubMetricsGroup(metricState);
         }
+
+        if (dirtySink != null) {
+            try {
+                dirtySink.open(new Configuration());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     @Override

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -123,6 +123,14 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
             if (metricOption != null) {
                 metricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
             }
+
+            if (dirtySink != null) {
+                try {
+                    dirtySink.open(new Configuration());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes  https://github.com/apache/inlong/issues/7546

### Motivation

The S3DirtySink#open method is not called in IcebergSingleStreamWriter and IcebergMultipleStreamWriter, resulting in dirty data that may never be flushed and archived:

https://github.com/apache/inlong/blob/12ee6c42c8e7e4869c170ae97656ff79c323e881/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java#L108-L113

### Modifications

In the open method of IcebergSingleStreamWriter and IcebergMultipleStreamWriter, call the DirtySink#open method

