### PR TITLE
[INLONG-7550][Sort] Optimize the log printing level of dirty data to avoid generating a large number of logs

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/log/LogDirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/log/LogDirtySink.java
@@ -46,11 +46,10 @@ public class LogDirtySink<T> implements DirtySink<T> {
     private static final long serialVersionUID = 1L;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LogDirtySink.class);
-
-    private RowData.FieldGetter[] fieldGetters;
     private final String format;
     private final String fieldDelimiter;
     private final DataType physicalRowDataType;
+    private RowData.FieldGetter[] fieldGetters;
     private RowDataToJsonConverter converter;
 
     public LogDirtySink(String format, String fieldDelimiter, DataType physicalRowDataType) {
@@ -79,7 +78,7 @@ public class LogDirtySink<T> implements DirtySink<T> {
             // Only support csv format when the row is not a 'RowData' and 'JsonNode'
             value = FormatUtils.csvFormat(data, labelMap, fieldDelimiter);
         }
-        LOGGER.info("[{}] {}", dirtyData.getLogTag(), value);
+        LOGGER.debug("[{}] {}", dirtyData.getLogTag(), value);
     }
 
     private String format(RowData data, LogicalType rowType,

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/s3/S3DirtySink.java
@@ -161,7 +161,7 @@ public class S3DirtySink<T> implements DirtySink<T> {
             value = FormatUtils.csvFormat(data, labelMap, s3Options.getFieldDelimiter());
         }
         if (s3Options.enableDirtyLog()) {
-            LOGGER.info("[{}] {}", dirtyData.getLogTag(), value);
+            LOGGER.debug("[{}] {}", dirtyData.getLogTag(), value);
         }
         batchBytes += value.getBytes(UTF_8).length;
         size++;


### PR DESCRIPTION
### Prepare a Pull Request

- Title: [INLONG-7550][Sort] Optimize the log printing level of dirty data to avoid generating a large number of logs

- Fixes #7550 

### Motivation

Optimize the log printing level of dirty data to avoid generating a large number of logs

### Modifications

Set the level of dirty data log to debug for 'LogDirtySink' and 'S3DirtySink'

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
