### PR TITLE
[INLONG-7577][Manager] Fix high CPU usage when the number of StreamSource is too large

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
@@ -41,7 +41,14 @@ public interface StreamSourceEntityMapper {
      */
     StreamSourceEntity selectForAgentTask(Integer id);
 
-    StreamSourceEntity selectExistsByTemplateIdAndIp(@Param("templateId") Integer templateId,
+    /**
+     * Select one sub source by template id and agent ip.
+     *
+     * @param templateId template id
+     * @param agentIp agent ip
+     * @return stream source info
+     */
+    StreamSourceEntity selectOneByTemplatedIdAndAgentIp(@Param("templateId") Integer templateId,
             @Param("agentIp") String agentIp);
 
     /**

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/StreamSourceEntityMapper.java
@@ -41,6 +41,9 @@ public interface StreamSourceEntityMapper {
      */
     StreamSourceEntity selectForAgentTask(Integer id);
 
+    StreamSourceEntity selectExistsByTemplateIdAndIp(@Param("templateId") Integer templateId,
+            @Param("agentIp") String agentIp);
+
     /**
      * Query un-deleted sources by the given agentIp.
      */

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -97,6 +97,15 @@
         where id = #{id,jdbcType=INTEGER}
         for update
     </select>
+    <select id="selectExistsByTemplateIdAndIp" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
+        select
+        <include refid="Base_Column_List"/>
+        from stream_source
+        where template_id = #{templateId,jdbcType=INTEGER}
+        and agent_ip = #{agentIp, jdbcType=VARCHAR}
+        and is_deleted = 0
+        limit 1
+    </select>
     <select id="selectCount" resultType="java.lang.Integer">
         select count(1)
         from stream_source

--- a/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/StreamSourceEntityMapper.xml
@@ -97,7 +97,7 @@
         where id = #{id,jdbcType=INTEGER}
         for update
     </select>
-    <select id="selectExistsByTemplateIdAndIp" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
+    <select id="selectOneByTemplatedIdAndAgentIp" resultType="org.apache.inlong.manager.dao.entity.StreamSourceEntity">
         select
         <include refid="Base_Column_List"/>
         from stream_source

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -335,7 +335,7 @@ public class AgentServiceImpl implements AgentService {
         List<StreamSourceEntity> sourceEntities = sourceMapper.selectTemplateSourceByCluster(needCopiedStatusList,
                 Lists.newArrayList(SourceType.FILE), agentClusterName);
         sourceEntities.forEach(sourceEntity -> {
-            StreamSourceEntity subSource = sourceMapper.selectExistsByTemplateIdAndIp(sourceEntity.getId(),
+            StreamSourceEntity subSource = sourceMapper.selectOneByTemplatedIdAndAgentIp(sourceEntity.getId(),
                     agentIp);
             if (subSource == null) {
                 // if not, clone a subtask for this Agent.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -23,7 +23,6 @@ import com.google.gson.Gson;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.inlong.common.constant.Constants;
 import org.apache.inlong.common.constant.MQType;
 import org.apache.inlong.common.db.CommandEntity;
@@ -81,7 +80,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -337,24 +335,24 @@ public class AgentServiceImpl implements AgentService {
         List<StreamSourceEntity> sourceEntities = sourceMapper.selectTemplateSourceByCluster(needCopiedStatusList,
                 Lists.newArrayList(SourceType.FILE), agentClusterName);
         sourceEntities.forEach(sourceEntity -> {
-                    StreamSourceEntity subSource = sourceMapper.selectExistsByTemplateIdAndIp(sourceEntity.getId(),
-                            agentIp);
-                    if (subSource == null) {
-                        // if not, clone a subtask for this Agent.
-                        // note: a new source name with random suffix is generated to adhere to the unique constraint
-                        StreamSourceEntity fileEntity =
-                                CommonBeanUtils.copyProperties(sourceEntity, StreamSourceEntity::new);
-                        fileEntity.setSourceName(fileEntity.getSourceName() + "-"
-                                + RandomStringUtils.randomAlphanumeric(10).toLowerCase(Locale.ROOT));
-                        fileEntity.setTemplateId(sourceEntity.getId());
-                        fileEntity.setAgentIp(agentIp);
-                        fileEntity.setStatus(SourceStatus.TO_BE_ISSUED_ADD.getCode());
-                        // create new sub source task
-                        sourceMapper.insert(fileEntity);
-                        LOGGER.info("Transform new template task({}) for agent({}) in cluster({}).",
-                                fileEntity.getId(), taskRequest.getAgentIp(), taskRequest.getClusterName());
-                    }
-                });
+            StreamSourceEntity subSource = sourceMapper.selectExistsByTemplateIdAndIp(sourceEntity.getId(),
+                    agentIp);
+            if (subSource == null) {
+                // if not, clone a subtask for this Agent.
+                // note: a new source name with random suffix is generated to adhere to the unique constraint
+                StreamSourceEntity fileEntity =
+                        CommonBeanUtils.copyProperties(sourceEntity, StreamSourceEntity::new);
+                fileEntity.setSourceName(fileEntity.getSourceName() + "-"
+                        + RandomStringUtils.randomAlphanumeric(10).toLowerCase(Locale.ROOT));
+                fileEntity.setTemplateId(sourceEntity.getId());
+                fileEntity.setAgentIp(agentIp);
+                fileEntity.setStatus(SourceStatus.TO_BE_ISSUED_ADD.getCode());
+                // create new sub source task
+                sourceMapper.insert(fileEntity);
+                LOGGER.info("Transform new template task({}) for agent({}) in cluster({}).",
+                        fileEntity.getId(), taskRequest.getAgentIp(), taskRequest.getClusterName());
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7577 

### Motivation

Fix the manager generate too many streamSource instances when pulling tasks.
### Modifications
The previous query was to pull out all Streamsources in the templateId and filter them.
If there were 200 agents, this method would generate 500 + streamSource instances each time, leading to a large amount of gc.
Filtering is now done directly in the mysql layer to avoid generating too many instances and causing gc.
