### PR TITLE
[INLONG-7537][Sort] Enable incremental snapshot for MongoDB CDC

### DIFF
--- a/inlong-sort/sort-connectors/mongodb-cdc/pom.xml
+++ b/inlong-sort/sort-connectors/mongodb-cdc/pom.xml
@@ -69,6 +69,11 @@
             <artifactId>debezium-core</artifactId>
             <version>${debezium.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-cdc-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -104,6 +109,7 @@
                                     <!--  Include fixed version 18.0-13.0 of flink shaded guava  -->
                                     <include>org.apache.flink:flink-shaded-guava</include>
                                     <include>com.google.protobuf:*</include>
+                                    <include>com.ververica:flink-cdc-base</include>
                                 </includes>
                             </artifactSet>
                             <filters>

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/IncrementalSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/IncrementalSource.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mongodb.source;
+
+import com.ververica.cdc.connectors.base.config.SourceConfig;
+import com.ververica.cdc.connectors.base.dialect.DataSourceDialect;
+import com.ververica.cdc.connectors.base.options.StartupMode;
+import com.ververica.cdc.connectors.base.source.assigner.HybridSplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.SplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.StreamSplitAssigner;
+import com.ververica.cdc.connectors.base.source.assigner.state.HybridPendingSplitsState;
+import com.ververica.cdc.connectors.base.source.assigner.state.PendingSplitsState;
+import com.ververica.cdc.connectors.base.source.assigner.state.PendingSplitsStateSerializer;
+import com.ververica.cdc.connectors.base.source.assigner.state.StreamPendingSplitsState;
+import com.ververica.cdc.connectors.base.source.enumerator.IncrementalSourceEnumerator;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitBase;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitSerializer;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceSplitReader;
+import io.debezium.relational.TableId;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Supplier;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.mongodb.source.reader.IncrementalSourceRecordEmitter;
+
+/**
+ * The basic source of Incremental Snapshot framework for datasource, it is based on FLIP-27 and
+ * Watermark Signal Algorithm which supports parallel reading snapshot of table and then continue to
+ * capture data change by streaming reading.
+ */
+@Experimental
+public class IncrementalSource<T, C extends SourceConfig>
+        implements
+            Source<T, SourceSplitBase, PendingSplitsState>,
+            ResultTypeQueryable<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    protected final SourceConfig.Factory<C> configFactory;
+    protected final DataSourceDialect<C> dataSourceDialect;
+    protected final OffsetFactory offsetFactory;
+    protected final DebeziumDeserializationSchema<T> deserializationSchema;
+    protected final SourceSplitSerializer sourceSplitSerializer;
+
+    public IncrementalSource(
+            SourceConfig.Factory<C> configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema,
+            OffsetFactory offsetFactory,
+            DataSourceDialect<C> dataSourceDialect) {
+        this.configFactory = configFactory;
+        this.deserializationSchema = deserializationSchema;
+        this.offsetFactory = offsetFactory;
+        this.dataSourceDialect = dataSourceDialect;
+        this.sourceSplitSerializer =
+                new SourceSplitSerializer() {
+
+                    @Override
+                    public OffsetFactory getOffsetFactory() {
+                        return offsetFactory;
+                    }
+                };
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.CONTINUOUS_UNBOUNDED;
+    }
+
+    @Override
+    public IncrementalSourceReader<T, C> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        // create source config for the given subtask (e.g. unique server id)
+        C sourceConfig = configFactory.create(readerContext.getIndexOfSubtask());
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<SourceRecords>> elementsQueue =
+                new FutureCompletingBlockingQueue<>();
+
+        // Forward compatible with flink 1.13
+        final Method metricGroupMethod = readerContext.getClass().getMethod("metricGroup");
+        metricGroupMethod.setAccessible(true);
+        final MetricGroup metricGroup = (MetricGroup) metricGroupMethod.invoke(readerContext);
+        final SourceReaderMetrics sourceReaderMetrics = new SourceReaderMetrics(metricGroup);
+
+        sourceReaderMetrics.registerMetrics();
+        Supplier<IncrementalSourceSplitReader<C>> splitReaderSupplier =
+                () -> new IncrementalSourceSplitReader<>(
+                        readerContext.getIndexOfSubtask(), dataSourceDialect, sourceConfig);
+        return new IncrementalSourceReader<>(
+                elementsQueue,
+                splitReaderSupplier,
+                createRecordEmitter(sourceConfig, sourceReaderMetrics),
+                readerContext.getConfiguration(),
+                readerContext,
+                sourceConfig,
+                sourceSplitSerializer,
+                dataSourceDialect);
+    }
+
+    @Override
+    public SplitEnumerator<SourceSplitBase, PendingSplitsState> createEnumerator(
+            SplitEnumeratorContext<SourceSplitBase> enumContext) {
+        C sourceConfig = configFactory.create(0);
+        final SplitAssigner splitAssigner;
+        if (sourceConfig.getStartupOptions().startupMode == StartupMode.INITIAL) {
+            try {
+                final List<TableId> remainingTables =
+                        dataSourceDialect.discoverDataCollections(sourceConfig);
+                boolean isTableIdCaseSensitive =
+                        dataSourceDialect.isDataCollectionIdCaseSensitive(sourceConfig);
+                splitAssigner =
+                        new HybridSplitAssigner<>(
+                                sourceConfig,
+                                enumContext.currentParallelism(),
+                                remainingTables,
+                                isTableIdCaseSensitive,
+                                dataSourceDialect,
+                                offsetFactory);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(
+                        "Failed to discover captured tables for enumerator", e);
+            }
+        } else {
+            splitAssigner = new StreamSplitAssigner(sourceConfig, dataSourceDialect, offsetFactory);
+        }
+
+        return new IncrementalSourceEnumerator(enumContext, sourceConfig, splitAssigner);
+    }
+
+    @Override
+    public SplitEnumerator<SourceSplitBase, PendingSplitsState> restoreEnumerator(
+            SplitEnumeratorContext<SourceSplitBase> enumContext, PendingSplitsState checkpoint) {
+        C sourceConfig = configFactory.create(0);
+
+        final SplitAssigner splitAssigner;
+        if (checkpoint instanceof HybridPendingSplitsState) {
+            splitAssigner =
+                    new HybridSplitAssigner<>(
+                            sourceConfig,
+                            enumContext.currentParallelism(),
+                            (HybridPendingSplitsState) checkpoint,
+                            dataSourceDialect,
+                            offsetFactory);
+        } else if (checkpoint instanceof StreamPendingSplitsState) {
+            splitAssigner =
+                    new StreamSplitAssigner(
+                            sourceConfig,
+                            (StreamPendingSplitsState) checkpoint,
+                            dataSourceDialect,
+                            offsetFactory);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported restored PendingSplitsState: " + checkpoint);
+        }
+        return new IncrementalSourceEnumerator(enumContext, sourceConfig, splitAssigner);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<SourceSplitBase> getSplitSerializer() {
+        return sourceSplitSerializer;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<PendingSplitsState> getEnumeratorCheckpointSerializer() {
+        SourceSplitSerializer sourceSplitSerializer = (SourceSplitSerializer) getSplitSerializer();
+        return new PendingSplitsStateSerializer(sourceSplitSerializer);
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+
+    protected RecordEmitter<SourceRecords, T, SourceSplitState> createRecordEmitter(
+            SourceConfig sourceConfig, SourceReaderMetrics sourceReaderMetrics) {
+        return new IncrementalSourceRecordEmitter<>(
+                deserializationSchema,
+                sourceReaderMetrics,
+                sourceConfig.isIncludeSchemaChanges(),
+                offsetFactory);
+    }
+}

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/IncrementalSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/IncrementalSource.java
@@ -61,6 +61,7 @@ import org.apache.inlong.sort.cdc.mongodb.source.reader.IncrementalSourceRecordE
  * The basic source of Incremental Snapshot framework for datasource, it is based on FLIP-27 and
  * Watermark Signal Algorithm which supports parallel reading snapshot of table and then continue to
  * capture data change by streaming reading.
+ * Copy from com.ververica:flink-cdc-base:2.3.0.
  */
 @Experimental
 public class IncrementalSource<T, C extends SourceConfig>

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSource.java
@@ -57,6 +57,7 @@ import org.apache.inlong.sort.cdc.mongodb.source.reader.MongoDBRecordEmitter;
  * <p>See {@link MongoDBSourceBuilder} for more details.
  *
  * @param <T> the output type of the source.
+ * Copy from com.ververica:flink-connector-mongodb-cdc:2.3.0.
  */
 @Internal
 @Experimental

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSource.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mongodb.source;
+
+import com.ververica.cdc.connectors.base.config.SourceConfig;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfig;
+import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
+import com.ververica.cdc.connectors.mongodb.source.dialect.MongoDBDialect;
+import com.ververica.cdc.connectors.mongodb.source.offset.ChangeStreamOffsetFactory;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.mongodb.source.reader.MongoDBRecordEmitter;
+
+/**
+ * The MongoDB CDC Source based on FLIP-27 which supports parallel reading snapshot of collection
+ * and then continue to capture data change from change stream.
+ *
+ * <pre>
+ *     1. The source supports parallel capturing database(s) or collection(s) change.
+ *     2. The source supports checkpoint in split level when read snapshot data.
+ *     3. The source doesn't need apply any lock of MongoDB.
+ * </pre>
+ *
+ * <pre>{@code
+ * MongoDBSource
+ *     .<String>builder()
+ *     .hosts("localhost:27017")
+ *     .databaseList("mydb")
+ *     .collectionList("mydb.users")
+ *     .username(username)
+ *     .password(password)
+ *     .deserializer(new JsonDebeziumDeserializationSchema())
+ *     .build();
+ * }</pre>
+ *
+ * <p>See {@link MongoDBSourceBuilder} for more details.
+ *
+ * @param <T> the output type of the source.
+ */
+@Internal
+@Experimental
+public class MongoDBSource<T> extends IncrementalSource<T, MongoDBSourceConfig> {
+
+    private static final long serialVersionUID = 1L;
+
+    MongoDBSource(
+            MongoDBSourceConfigFactory configFactory,
+            DebeziumDeserializationSchema<T> deserializationSchema) {
+        super(
+                configFactory,
+                deserializationSchema,
+                new ChangeStreamOffsetFactory(),
+                new MongoDBDialect());
+    }
+
+    /**
+     * Get a MongoDBSourceBuilder to build a {@link MongoDBSource}.
+     *
+     * @return a MongoDB parallel source builder.
+     */
+    @PublicEvolving
+    public static <T> MongoDBSourceBuilder<T> builder() {
+        return new MongoDBSourceBuilder<>();
+    }
+
+    @Override
+    protected RecordEmitter<SourceRecords, T, SourceSplitState> createRecordEmitter(
+            SourceConfig sourceConfig, SourceReaderMetrics sourceReaderMetrics) {
+        return new MongoDBRecordEmitter<>(
+                deserializationSchema, sourceReaderMetrics, offsetFactory);
+    }
+}

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSourceBuilder.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSourceBuilder.java
@@ -43,7 +43,8 @@ import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema
  * }</pre>
  *
  * <p>Check the Java docs of each individual method to learn more about the settings to build a
- * {@link com.ververica.cdc.connectors.mongodb.source.MongoDBSource}.
+ * {@link MongoDBSource}.
+ * Copy from com.ververica:flink-connector-mongodb-cdc:2.3.0.
  */
 @Experimental
 @PublicEvolving

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSourceBuilder.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSourceBuilder.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mongodb.source;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceConfigFactory;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema;
+
+/**
+ * The builder class for {@link MongoDBSource} to make it easier for the users to construct a {@link
+ * MongoDBSource}.
+ *
+ * <pre>{@code
+ * MongoDBSource
+ *     .<String>builder()
+ *     .hosts("localhost:27017")
+ *     .databaseList("mydb")
+ *     .collectionList("mydb.users")
+ *     .username(username)
+ *     .password(password)
+ *     .deserializer(new JsonDebeziumDeserializationSchema())
+ *     .build();
+ * }</pre>
+ *
+ * <p>Check the Java docs of each individual method to learn more about the settings to build a
+ * {@link com.ververica.cdc.connectors.mongodb.source.MongoDBSource}.
+ */
+@Experimental
+@PublicEvolving
+public class MongoDBSourceBuilder<T> {
+
+    private final MongoDBSourceConfigFactory configFactory = new MongoDBSourceConfigFactory();
+    private DebeziumDeserializationSchema<T> deserializer;
+
+    /** The comma-separated list of hostname and port pairs of mongodb servers. */
+    public MongoDBSourceBuilder<T> hosts(String hosts) {
+        this.configFactory.hosts(hosts);
+        return this;
+    }
+
+    /**
+     * Ampersand (i.e. &) separated MongoDB connection options eg
+     * replicaSet=test&connectTimeoutMS=300000
+     * https://docs.mongodb.com/manual/reference/connection-string/#std-label-connections-connection-options
+     */
+    public MongoDBSourceBuilder<T> connectionOptions(String connectionOptions) {
+        this.configFactory.connectionOptions(connectionOptions);
+        return this;
+    }
+
+    /** Name of the database user to be used when connecting to MongoDB. */
+    public MongoDBSourceBuilder<T> username(String username) {
+        this.configFactory.username(username);
+        return this;
+    }
+
+    /** Password to be used when connecting to MongoDB. */
+    public MongoDBSourceBuilder<T> password(String password) {
+        this.configFactory.password(password);
+        return this;
+    }
+
+    /** Regular expressions list that match database names to be monitored. */
+    public MongoDBSourceBuilder<T> databaseList(String... databases) {
+        this.configFactory.databaseList(databases);
+        return this;
+    }
+
+    /**
+     * Regular expressions that match fully-qualified collection identifiers for collections to be
+     * monitored. Each identifier is of the form {@code <databaseName>.<collectionName>}.
+     */
+    public MongoDBSourceBuilder<T> collectionList(String... collections) {
+        this.configFactory.collectionList(collections);
+        return this;
+    }
+
+    /**
+     * batch.size
+     *
+     * <p>The cursor batch size. Default: 1024
+     */
+    public MongoDBSourceBuilder<T> batchSize(int batchSize) {
+        this.configFactory.batchSize(batchSize);
+        return this;
+    }
+
+    /**
+     * poll.await.time.ms
+     *
+     * <p>The amount of time to wait before checking for new results on the change stream. Default:
+     * 1000
+     */
+    public MongoDBSourceBuilder<T> pollAwaitTimeMillis(int pollAwaitTimeMillis) {
+        checkArgument(pollAwaitTimeMillis > 0);
+        this.configFactory.pollAwaitTimeMillis(pollAwaitTimeMillis);
+        return this;
+    }
+
+    /**
+     * poll.max.batch.size
+     *
+     * <p>Maximum number of change stream documents to include in a single batch when polling for
+     * new data. This setting can be used to limit the amount of data buffered internally in the
+     * connector. Default: 1024
+     */
+    public MongoDBSourceBuilder<T> pollMaxBatchSize(int pollMaxBatchSize) {
+        this.configFactory.pollMaxBatchSize(pollMaxBatchSize);
+        return this;
+    }
+
+    /**
+     * copy.existing
+     *
+     * <p>Copy existing data from source collections and convert them to Change Stream events on
+     * their respective topics. Any changes to the data that occur during the copy process are
+     * applied once the copy is completed.
+     */
+    public MongoDBSourceBuilder<T> copyExisting(boolean copyExisting) {
+        if (copyExisting) {
+            this.configFactory.startupOptions(StartupOptions.initial());
+        } else {
+            this.configFactory.startupOptions(StartupOptions.latest());
+        }
+        return this;
+    }
+
+    /**
+     * heartbeat.interval.ms
+     *
+     * <p>The length of time in milliseconds between sending heartbeat messages. Heartbeat messages
+     * contain the post batch resume token and are sent when no source records have been published
+     * in the specified interval. This improves the resumability of the connector for low volume
+     * namespaces. Use 0 to disable.
+     */
+    public MongoDBSourceBuilder<T> heartbeatIntervalMillis(int heartbeatIntervalMillis) {
+        this.configFactory.heartbeatIntervalMillis(heartbeatIntervalMillis);
+        return this;
+    }
+
+    /**
+     * scan.incremental.snapshot.chunk.size.mb
+     *
+     * <p>The chunk size mb of incremental snapshot. Default: 64mb.
+     */
+    public MongoDBSourceBuilder<T> splitSizeMB(int splitSizeMB) {
+        this.configFactory.splitSizeMB(splitSizeMB);
+        return this;
+    }
+
+    /**
+     * The group size of split meta, if the meta size exceeds the group size, the meta will be
+     * divided into multiple groups.
+     */
+    public MongoDBSourceBuilder<T> splitMetaGroupSize(int splitMetaGroupSize) {
+        this.configFactory.splitMetaGroupSize(splitMetaGroupSize);
+        return this;
+    }
+
+    /**
+     * The deserializer used to convert from consumed {@link
+     * org.apache.kafka.connect.source.SourceRecord}.
+     */
+    public MongoDBSourceBuilder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
+        this.deserializer = deserializer;
+        return this;
+    }
+
+    /**
+     * Build the {@link MongoDBSource}.
+     *
+     * @return a MongoDBParallelSource with the settings made for this builder.
+     */
+    public MongoDBSource<T> build() {
+        configFactory.validate();
+        return new MongoDBSource<>(configFactory, checkNotNull(deserializer));
+    }
+}

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/IncrementalSourceRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/IncrementalSourceRecordEmitter.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
  * emit records rather than emit the records directly.
+ * Copy from com.ververica:flink-cdc-base:2.3.0.
  */
 public class IncrementalSourceRecordEmitter<T>
         implements

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/IncrementalSourceRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/IncrementalSourceRecordEmitter.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mongodb.source.reader;
+
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isWatermarkEvent;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getFetchTimestamp;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getHistoryRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getMessageTimestamp;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+
+import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceRecords;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import com.ververica.cdc.debezium.history.FlinkJsonTableChangeSerializer;
+import io.debezium.document.Array;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.TableChanges;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link IncrementalSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
+ * emit records rather than emit the records directly.
+ */
+public class IncrementalSourceRecordEmitter<T>
+        implements
+            RecordEmitter<SourceRecords, T, SourceSplitState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementalSourceRecordEmitter.class);
+    private static final FlinkJsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
+            new FlinkJsonTableChangeSerializer();
+
+    protected final DebeziumDeserializationSchema<T> debeziumDeserializationSchema;
+    protected final SourceReaderMetrics sourceReaderMetrics;
+    protected final boolean includeSchemaChanges;
+    protected final OutputCollector<T> outputCollector;
+    protected final OffsetFactory offsetFactory;
+
+    public IncrementalSourceRecordEmitter(
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
+            SourceReaderMetrics sourceReaderMetrics,
+            boolean includeSchemaChanges,
+            OffsetFactory offsetFactory) {
+        this.debeziumDeserializationSchema = debeziumDeserializationSchema;
+        this.sourceReaderMetrics = sourceReaderMetrics;
+        this.includeSchemaChanges = includeSchemaChanges;
+        this.outputCollector = new OutputCollector<>();
+        this.offsetFactory = offsetFactory;
+    }
+
+    @Override
+    public void emitRecord(
+            SourceRecords sourceRecords, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        final Iterator<SourceRecord> elementIterator = sourceRecords.iterator();
+        while (elementIterator.hasNext()) {
+            processElement(elementIterator.next(), output, splitState);
+        }
+    }
+
+    protected void processElement(
+            SourceRecord element, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        if (isWatermarkEvent(element)) {
+            Offset watermark = getWatermark(element);
+            if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            }
+        } else if (isSchemaChangeEvent(element) && splitState.isStreamSplitState()) {
+            HistoryRecord historyRecord = getHistoryRecord(element);
+            Array tableChanges =
+                    historyRecord.document().getArray(HistoryRecord.Fields.TABLE_CHANGES);
+            TableChanges changes = TABLE_CHANGE_SERIALIZER.deserialize(tableChanges, true);
+            for (TableChanges.TableChange tableChange : changes) {
+                splitState.asStreamSplitState().recordSchema(tableChange.getId(), tableChange);
+            }
+            if (includeSchemaChanges) {
+                emitElement(element, output);
+            }
+        } else if (isDataChangeRecord(element)) {
+            if (splitState.isStreamSplitState()) {
+                Offset position = getOffsetPosition(element);
+                splitState.asStreamSplitState().setStartingOffset(position);
+            }
+            reportMetrics(element);
+            emitElement(element, output);
+        } else {
+            // unknown element
+            LOG.info("Meet unknown element {}, just skip.", element);
+        }
+    }
+
+    private Offset getWatermark(SourceRecord watermarkEvent) {
+        return getOffsetPosition(watermarkEvent.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(SourceRecord dataRecord) {
+        return getOffsetPosition(dataRecord.sourceOffset());
+    }
+
+    public Offset getOffsetPosition(Map<String, ?> offset) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offset.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+        return offsetFactory.newOffset(offsetStrMap);
+    }
+
+    protected void emitElement(SourceRecord element, SourceOutput<T> output) throws Exception {
+        outputCollector.output = output;
+        debeziumDeserializationSchema.deserialize(element, outputCollector);
+    }
+
+    protected void reportMetrics(SourceRecord element) {
+        long now = System.currentTimeMillis();
+        // record the latest process time
+        sourceReaderMetrics.recordProcessTime(now);
+        Long messageTimestamp = getMessageTimestamp(element);
+
+        if (messageTimestamp != null && messageTimestamp > 0L) {
+            // report fetch delay
+            Long fetchTimestamp = getFetchTimestamp(element);
+            if (fetchTimestamp != null) {
+                sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
+            }
+            // report emit delay
+            sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
+        }
+    }
+
+    private static class OutputCollector<T> implements Collector<T> {
+
+        private SourceOutput<T> output;
+
+        @Override
+        public void collect(T record) {
+            output.collect(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/MongoDBRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/MongoDBRecordEmitter.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mongodb.source.reader;
+
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isWatermarkEvent;
+import static com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils.getFetchTimestamp;
+import static com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils.getMessageTimestamp;
+import static com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils.getResumeToken;
+import static com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils.isHeartbeatEvent;
+
+import com.ververica.cdc.connectors.base.source.meta.offset.Offset;
+import com.ververica.cdc.connectors.base.source.meta.offset.OffsetFactory;
+import com.ververica.cdc.connectors.base.source.meta.split.SourceSplitState;
+import com.ververica.cdc.connectors.base.source.meta.split.StreamSplitState;
+import com.ververica.cdc.connectors.base.source.metrics.SourceReaderMetrics;
+import com.ververica.cdc.connectors.base.source.reader.IncrementalSourceReader;
+import com.ververica.cdc.connectors.mongodb.source.offset.ChangeStreamOffset;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.inlong.sort.cdc.mongodb.debezium.DebeziumDeserializationSchema;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link IncrementalSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
+ * emit records rather than emit the records directly.
+ */
+public final class MongoDBRecordEmitter<T> extends IncrementalSourceRecordEmitter<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDBRecordEmitter.class);
+
+    public MongoDBRecordEmitter(
+            DebeziumDeserializationSchema<T> deserializationSchema,
+            SourceReaderMetrics sourceReaderMetrics,
+            OffsetFactory offsetFactory) {
+        super(deserializationSchema, sourceReaderMetrics, false, offsetFactory);
+    }
+
+    @Override
+    protected void processElement(
+            SourceRecord element, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        if (isWatermarkEvent(element)) {
+            Offset watermark = getOffsetPosition(element);
+            if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            }
+        } else if (isHeartbeatEvent(element)) {
+            if (splitState.isStreamSplitState()) {
+                updatePositionForStreamSplit(element, splitState);
+            }
+        } else if (isDataChangeRecord(element)) {
+            if (splitState.isStreamSplitState()) {
+                updatePositionForStreamSplit(element, splitState);
+            }
+            reportMetrics(element);
+            emitElement(element, output);
+        } else {
+            // unknown element
+            LOG.info("Meet unknown element {}, just skip.", element);
+        }
+    }
+
+    private void updatePositionForStreamSplit(SourceRecord element, SourceSplitState splitState) {
+        BsonDocument resumeToken = getResumeToken(element);
+        StreamSplitState streamSplitState = splitState.asStreamSplitState();
+        ChangeStreamOffset offset = (ChangeStreamOffset) streamSplitState.getStartingOffset();
+        if (offset != null) {
+            offset.updatePosition(resumeToken);
+        }
+        splitState.asStreamSplitState().setStartingOffset(offset);
+    }
+
+    @Override
+    protected void reportMetrics(SourceRecord element) {
+        long now = System.currentTimeMillis();
+        // record the latest process time
+        sourceReaderMetrics.recordProcessTime(now);
+        Long messageTimestamp = getMessageTimestamp(element);
+
+        if (messageTimestamp != null && messageTimestamp > 0L) {
+            // report fetch delay
+            Long fetchTimestamp = getFetchTimestamp(element);
+            if (fetchTimestamp != null && fetchTimestamp >= messageTimestamp) {
+                sourceReaderMetrics.recordFetchDelay(fetchTimestamp - messageTimestamp);
+            }
+            // report emit delay
+            sourceReaderMetrics.recordEmitDelay(now - messageTimestamp);
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/MongoDBRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/MongoDBRecordEmitter.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
  * emit records rather than emit the records directly.
+ * Copy from com.ververica:flink-connector-mongodb-cdc:2.3.0.
  */
 public final class MongoDBRecordEmitter<T> extends IncrementalSourceRecordEmitter<T> {
 

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -675,6 +675,11 @@
        inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OracleDialect.java
        inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/OraclePooledDataSourceFactory.java
        inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/base/source/IncrementalSource.java
+       inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/IncrementalSourceRecordEmitter.java
+       inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/MongoDBRecordEmitter.java
+       inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/IncrementalSource.java
+       inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSource.java
+       inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/MongoDBSourceBuilder.java
 
  Source  : flink-cdc-connectors 2.3.0 (Please note that the software have been modified.)
  License : https://github.com/ververica/flink-cdc-connectors/blob/master/LICENSE


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7537][Sort] Enable incremental snapshot for MongoDB CDC

- Fixes #7537 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

After enabling incremental snapshots in MongoDB CDC, data can be read in chunks to improve reading efficiency.

### Modifications

*Describe the modifications you've done.*

Add the `MongoDBSource` class to implement incremental snapshot logic.

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( docs )

This feature add some options, details for  https://github.com/apache/inlong-website/pull/710 .

| **Option**                | **Required** | **Default**      | **Type** | **Description**                                              |
| ------------------------- | ------------ | ---------------- | -------- | ------------------------------------------------------------ |
 | batch.size | optional     | 1024            | Integer  | The cursor batch size.          |
 | scan.incremental.snapshot.enabled | optional | false | Boolean | Whether enable incremental snapshot. The incremental snapshot feature only supports after MongoDB 4.0. |
 | scan.incremental.snapshot.chunk.size.mb | optional | 64 | Integer | The chunk size mb of incremental snapshot. |
 | chunk-meta.group.size | optional | 1000 | Integer | The group size of chunk meta, if the meta size exceeds the group size, the meta will be divided into multiple groups. |




