### PR TITLE
[INLONG-7589][Sort] Support multi node relation with same output but different input nodes

### DIFF
--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -226,13 +226,13 @@ public class FlinkSqlParser implements Parser {
                 "relation must have at least one output node");
         relation.getOutputs().forEach(s -> {
             Preconditions.checkNotNull(s, "node id in outputs is null");
-            Node node = nodeMap.get(s);
-            Preconditions.checkNotNull(node, "can not find any node by node id " + s);
+            Node outputNode = nodeMap.get(s);
+            Preconditions.checkNotNull(outputNode, "can not find any node by node id " + s);
             parseInputNodes(relation, nodeMap, relationMap);
-            parseSingleNode(node, relation, nodeMap);
+            parseSingleNode(outputNode, relation, nodeMap);
             // for Load node we need to generate insert sql
-            if (node instanceof LoadNode) {
-                insertSqls.add(genLoadNodeInsertSql((LoadNode) node, relation, nodeMap));
+            if (outputNode instanceof LoadNode) {
+                insertSqls.add(genLoadNodeInsertSql((LoadNode) outputNode, relation, nodeMap));
             }
         });
         log.info("parse node relation success, relation:{}", relation);

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -228,9 +228,32 @@ public class FlinkSqlParser implements Parser {
             Preconditions.checkNotNull(s, "node id in outputs is null");
             Node node = nodeMap.get(s);
             Preconditions.checkNotNull(node, "can not find any node by node id " + s);
-            parseNode(node, relation, nodeMap, relationMap);
+            parseInputNodes(relation, nodeMap, relationMap);
+            parseSingleNode(node, relation, nodeMap);
+            // for Load node we need to generate insert sql
+            if (node instanceof LoadNode) {
+                insertSqls.add(genLoadNodeInsertSql((LoadNode) node, relation, nodeMap));
+            }
         });
         log.info("parse node relation success, relation:{}", relation);
+    }
+
+    /**
+     * parse the input nodes corresponding to the output node
+     * @param relation Define relations between nodes, it also shows the data flow
+     * @param nodeMap Store the mapping relation between node id and node
+     * @param relationMap Store the mapping relation between node id and relation
+     */
+    private void parseInputNodes(NodeRelation relation, Map<String, Node> nodeMap,
+        Map<String, NodeRelation> relationMap) {
+        for (String upstreamNodeId : relation.getInputs()) {
+            if (!hasParsedSet.contains(upstreamNodeId)) {
+                Node upstreamNode = nodeMap.get(upstreamNodeId);
+                Preconditions.checkNotNull(upstreamNode,
+                    "can not find any node by node id " + upstreamNodeId);
+                parseSingleNode(upstreamNode, relationMap.get(upstreamNodeId), nodeMap);
+            }
+        }
     }
 
     private void registerTableSql(Node node, String sql) {
@@ -246,15 +269,13 @@ public class FlinkSqlParser implements Parser {
     }
 
     /**
-     * Parse a node and recursively resolve its dependent nodes
+     * Parse a single node and generate the corresponding sql
      *
      * @param node The abstract of extract, transform, load
      * @param relation Define relations between nodes, it also shows the data flow
      * @param nodeMap store the mapping relation between node id and node
-     * @param relationMap Store the mapping relation between node id and relation
      */
-    private void parseNode(Node node, NodeRelation relation, Map<String, Node> nodeMap,
-            Map<String, NodeRelation> relationMap) {
+    private void parseSingleNode(Node node, NodeRelation relation, Map<String, Node> nodeMap) {
         if (hasParsedSet.contains(node.getId())) {
             log.warn("the node has already been parsed, node id:{}", node.getId());
             return;
@@ -267,22 +288,10 @@ public class FlinkSqlParser implements Parser {
             hasParsedSet.add(node.getId());
         } else {
             Preconditions.checkNotNull(relation, "relation is null");
-            for (String upstreamNodeId : relation.getInputs()) {
-                if (!hasParsedSet.contains(upstreamNodeId)) {
-                    Node upstreamNode = nodeMap.get(upstreamNodeId);
-                    Preconditions.checkNotNull(upstreamNode,
-                            "can not find any node by node id " + upstreamNodeId);
-                    parseNode(upstreamNode, relationMap.get(upstreamNodeId), nodeMap, relationMap);
-                }
-            }
             if (node instanceof LoadNode) {
                 String createSql = genCreateSql(node);
                 log.info("node id:{}, create table sql:\n{}", node.getId(), createSql);
                 registerTableSql(node, createSql);
-                LoadNode loadNode = (LoadNode) node;
-                String insertSql = genLoadNodeInsertSql(loadNode, relation, nodeMap);
-                log.info("node id:{}, insert sql:\n{}", node.getId(), insertSql);
-                insertSqls.add(insertSql);
                 hasParsedSet.add(node.getId());
             } else if (node instanceof TransformNode) {
                 TransformNode transformNode = (TransformNode) node;

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -245,12 +245,12 @@ public class FlinkSqlParser implements Parser {
      * @param relationMap Store the mapping relation between node id and relation
      */
     private void parseInputNodes(NodeRelation relation, Map<String, Node> nodeMap,
-        Map<String, NodeRelation> relationMap) {
+            Map<String, NodeRelation> relationMap) {
         for (String upstreamNodeId : relation.getInputs()) {
             if (!hasParsedSet.contains(upstreamNodeId)) {
                 Node upstreamNode = nodeMap.get(upstreamNodeId);
                 Preconditions.checkNotNull(upstreamNode,
-                    "can not find any node by node id " + upstreamNodeId);
+                        "can not find any node by node id " + upstreamNodeId);
                 parseSingleNode(upstreamNode, relationMap.get(upstreamNodeId), nodeMap);
             }
         }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
@@ -149,7 +149,7 @@ public class AllMigrateTest {
         Node inputNode = buildAllMigrateExtractNode();
         Node outputNode = buildAllMigrateKafkaNode();
         StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, outputNode),
-                        Collections.singletonList(buildNodeRelation(Collections.singletonList(inputNode),
+                Collections.singletonList(buildNodeRelation(Collections.singletonList(inputNode),
                         Collections.singletonList(outputNode))));
         GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
         FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
@@ -165,10 +165,10 @@ public class AllMigrateTest {
     @Test
     public void testAllMigrateMultiRelations() throws Exception {
         EnvironmentSettings settings = EnvironmentSettings
-            .newInstance()
-            .useBlinkPlanner()
-            .inStreamingMode()
-            .build();
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(10000);
@@ -177,9 +177,10 @@ public class AllMigrateTest {
         Node inputNode2 = buildAllMigrateExtractNode2();
         Node outputNode = buildAllMigrateKafkaNode();
         StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, inputNode2, outputNode),
-            Arrays.asList(buildNodeRelation(Collections.singletonList(inputNode),
-                Collections.singletonList(outputNode)),
-                buildNodeRelation(Collections.singletonList(inputNode2), Collections.singletonList(outputNode))));
+                Arrays.asList(buildNodeRelation(Collections.singletonList(inputNode),
+                        Collections.singletonList(outputNode)),
+                        buildNodeRelation(Collections.singletonList(inputNode2),
+                                Collections.singletonList(outputNode))));
         GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
         FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
         ParseResult result = parser.parse();

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/AllMigrateTest.java
@@ -118,7 +118,7 @@ public class AllMigrateTest {
                         new FieldInfo("data", new StringFormatInfo())));
         CsvFormat csvFormat = new CsvFormat();
         csvFormat.setDisableQuoteCharacter(true);
-        return new KafkaLoadNode("2", "kafka_output", fields, relations, null, null,
+        return new KafkaLoadNode("3", "kafka_output", fields, relations, null, null,
                 "topic", "localhost:9092",
                 csvFormat, null,
                 null, null);


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7589 

### Motivation


Now it's not capable for sort to generate multi insert sqls for one output with multiple inputs which is not acceptable for user cases.

For instance, user may want to get data from multiple data sources, they can only use union operation for now. But union operation in flink is too heavy.

We need to support generate sqls from one stream such that:

Insert into sink select * from sourceA;
Insert into sink select * from sourceB;

### Modifications

Change the `parseNode` to `ParseSingleNode` because the recuisive method will be multi branches which is not suitable for reading. And move the input nodes parsing outside of `parseNode` method to make it easy for reading

### Verifying this change

Run `AllmigrateTestMultiRelations`
