### PR TITLE
[INLONG-7591][Manager] Support updating related streamSources after updating DataNode

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/AbstractDataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/AbstractDataNodeOperator.java
@@ -72,6 +72,7 @@ public abstract class AbstractDataNodeOperator implements DataNodeOperator {
         DataNodeEntity entity = CommonBeanUtils.copyProperties(request, DataNodeEntity::new);
         // set the ext params
         this.setTargetEntity(request, entity);
+        this.updateRelatedStreamSource(request);
         entity.setModifier(operator);
         int rowCount = dataNodeEntityMapper.updateByIdSelective(entity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
@@ -91,5 +92,10 @@ public abstract class AbstractDataNodeOperator implements DataNodeOperator {
     public Boolean testConnection(DataNodeRequest request) {
         throw new BusinessException(
                 String.format(ErrorCodeEnum.DATA_NODE_TYPE_NOT_SUPPORTED.getMessage(), request.getType()));
+    }
+
+    @Override
+    public void updateRelatedStreamSource(DataNodeRequest request) {
+        LOGGER.info("do nothing for the data node type ={}", request.getType());
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeOperator.java
@@ -79,4 +79,11 @@ public interface DataNodeOperator {
      */
     Boolean testConnection(DataNodeRequest request);
 
+    /**
+     * Update related stream source.
+     *
+     * @param request data node request
+     */
+    void updateRelatedStreamSource(DataNodeRequest request);
+
 }


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7591 

### Motivation

Support updating related streamSources after updating DataNode.
Currently, no streamSource uses Datanodes, It will be gradually supported later.
Therefore, nothing is done in the `updateRelatedStreamSource` method.
### Modifications

Support updating related streamSources after updating DataNode.

