### PR TITLE
[INLONG-7595][Sort] Mongo read phase metrics need to update when no incremental data

### DIFF
--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/DebeziumSourceFunction.java
@@ -502,12 +502,6 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                         sourceContext,
                         new DebeziumDeserializationSchema<T>() {
 
-                            /**
-                             * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
-                             *
-                             * @param record
-                             * @param out
-                             */
                             @Override
                             public void deserialize(SourceRecord record, Collector<T> out) throws Exception {
                                 // do nothing

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/DebeziumSourceFunction.java
@@ -19,8 +19,10 @@ package org.apache.inlong.sort.cdc.mongodb;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope;
+import com.ververica.cdc.connectors.mongodb.source.utils.MongoRecordUtils;
 import com.ververica.cdc.debezium.Validator;
-import io.debezium.connector.SnapshotRecord;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
 import io.debezium.document.DocumentReader;
 import io.debezium.document.DocumentWriter;
 import io.debezium.embedded.Connect;
@@ -50,6 +52,7 @@ import org.apache.flink.util.Collector;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.inlong.sort.base.Constants;
+import org.apache.inlong.sort.base.enums.ReadPhase;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
@@ -499,19 +502,38 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                         sourceContext,
                         new DebeziumDeserializationSchema<T>() {
 
+                            /**
+                             * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
+                             *
+                             * @param record
+                             * @param out
+                             */
                             @Override
                             public void deserialize(SourceRecord record, Collector<T> out) throws Exception {
+                                // do nothing
+                            }
+
+                            @Override
+                            public void deserialize(SourceRecord record, Collector<T> out, Boolean isStreamingPhase)
+                                    throws Exception {
+                                if (record != null && MongoRecordUtils.isHeartbeatEvent(record)) {
+                                    if (sourceMetricData != null && isStreamingPhase) {
+                                        sourceMetricData.outputReadPhaseMetrics(ReadPhase.INCREASE_PHASE);
+                                    }
+                                    return;
+                                }
                                 if (sourceMetricData != null && record != null && migrateAll) {
                                     Struct value = (Struct) record.value();
-                                    Struct source = value.getStruct(MongoDBEnvelope.NAMESPACE_FIELD);
-                                    if (null == source) {
-                                        source = value.getStruct(RecordUtils.DOCUMENT_TO_FIELD);
+                                    Struct ns = value.getStruct(MongoDBEnvelope.NAMESPACE_FIELD);
+                                    if (null == ns) {
+                                        ns = value.getStruct(RecordUtils.DOCUMENT_TO_FIELD);
                                     }
-                                    String dbName = source.getString(MongoDBEnvelope.NAMESPACE_DATABASE_FIELD);
+                                    String dbName = ns.getString(MongoDBEnvelope.NAMESPACE_DATABASE_FIELD);
                                     String collectionName =
-                                            source.getString(MongoDBEnvelope.NAMESPACE_COLLECTION_FIELD);
-                                    SnapshotRecord snapshotRecord = SnapshotRecord.fromSource(source);
-                                    boolean isSnapshotRecord = (SnapshotRecord.TRUE == snapshotRecord);
+                                            ns.getString(MongoDBEnvelope.NAMESPACE_COLLECTION_FIELD);
+                                    Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                                    String snapshotRecord = source.getString(AbstractSourceInfo.SNAPSHOT_KEY);
+                                    boolean isSnapshotRecord = Boolean.parseBoolean(snapshotRecord);
                                     sourceMetricData
                                             .outputMetricsWithEstimate(new String[]{dbName, collectionName},
                                                     isSnapshotRecord, value);

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/DebeziumDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/DebeziumDeserializationSchema.java
@@ -17,11 +17,12 @@
 
 package org.apache.inlong.sort.cdc.mongodb.debezium;
 
-import java.io.Serializable;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.util.Collector;
 import org.apache.kafka.connect.source.SourceRecord;
+
+import java.io.Serializable;
 
 /**
  * The deserialization schema describes how to turn the Debezium SourceRecord into data types
@@ -36,5 +37,10 @@ public interface DebeziumDeserializationSchema<T> extends Serializable, ResultTy
      * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
      */
     void deserialize(SourceRecord record, Collector<T> out) throws Exception;
+
+    /**
+     * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
+     */
+    void deserialize(SourceRecord record, Collector<T> out, Boolean isStreamingPhase) throws Exception;
 
 }

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
@@ -222,6 +222,18 @@ public class MongoDBConnectorDeserializationSchema
         }
     }
 
+    /**
+     * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
+     *
+     * @param record
+     * @param out
+     * @param isStreamingPhase
+     */
+    @Override
+    public void deserialize(SourceRecord record, Collector<RowData> out, Boolean isStreamingPhase) throws Exception {
+        this.deserialize(record, out);
+    }
+
     private GenericRowData extractMongoDMLData(Struct value, String keyFiled, String ddlType) {
         Struct documentTo = (Struct) value.get(keyFiled);
         String newDb = documentTo.getString(MongoDBEnvelope.NAMESPACE_DATABASE_FIELD);

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
@@ -222,13 +222,6 @@ public class MongoDBConnectorDeserializationSchema
         }
     }
 
-    /**
-     * Deserialize the Debezium record, it is represented in Kafka {@link SourceRecord}.
-     *
-     * @param record
-     * @param out
-     * @param isStreamingPhase
-     */
     @Override
     public void deserialize(SourceRecord record, Collector<RowData> out, Boolean isStreamingPhase) throws Exception {
         this.deserialize(record, out);


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-7595][Sort] Mongo read phase metrics need to update when no incremental data

- Fixes #7595 

### Motivation
It won't report incremental read phase metrics when i use single parallel logic and no incremental data.
Mongo read phase metrics need to update when no incremental data.

### Modifications

* `DebeziumDeserializationSchema` add overload `deserialize` for jugde read phase
*  `DebeziumSourceFunction` fix error logic for get read phase

