### PR TITLE
[INLONG-7626][Docker] Optimize the docker push workflow

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -114,7 +114,7 @@ jobs:
 
       # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'branch-1.4'.
       - name: Push aarch64 Docker images to Docker Hub
-        if: ${{ steps.match.outputs.match_release == 'true' }}
+        # if: ${{ steps.match.outputs.match_release == 'true' }}
         working-directory: docker
         run: |
           bash +x build-docker-images.sh --buildx aarch64

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -101,9 +101,9 @@ jobs:
 
       # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'branch-1.4'.
       - name: Push x86 Docker images to Docker Hub
-        if: |
-          steps.match.outputs.match_master == 'true'
-          || steps.match.outputs.match_release == 'true'
+        # if: |
+        #   steps.match.outputs.match_master == 'true'
+        #   || steps.match.outputs.match_release == 'true'
         working-directory: docker
         run: |
           bash +x publish-by-arch.sh --tag --publish

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -132,7 +132,7 @@ jobs:
           || steps.match.outputs.match_release == 'true'
         working-directory: docker
         run: |
-          bash +x publish-by-arch.sh --tag  --publish
+          bash +x publish-by-arch.sh --tag --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -81,6 +81,21 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Set up environment
+        run: |
+          echo "1"
+          sudo sysctl -w vm.max_map_count=262144
+          echo "2"
+          sudo sysctl -w fs.file-max=65536
+          echo "3"
+          sudo fallocate -l 5G /swapfile
+          echo "4"
+          sudo chmod 600 /swapfile
+          echo "5"
+          sudo mkswap /swapfile
+          echo "6"
+          sudo swapon /swapfile
+
       - name: Remove unnecessary packages
         run: | # stolen from https://github.com/easimon/maximize-build-space
           echo "=== Before pruning ==="
@@ -97,56 +112,35 @@ jobs:
         env:
           CI: false
 
-      - name: test arm
-        working-directory: docker
+      - name: Match branch
+        id: match
+        if: |
+          success()
+          && github.event_name == 'push'
+          && github.repository_owner == 'apache'
         run: |
-          bash +x build-docker-images.sh --buildx aarch64
-          bash +x publish-by-arch.sh --tag --arch aarch64 --publish      
- 
-      - name: Set up environment
-        run: |
-          echo "1"
-          sudo sysctl -w vm.max_map_count=262144
-          echo "2"
-          sudo sysctl -w fs.file-max=65536
-          echo "3"
-          sudo fallocate -l 5G /swapfile
-          echo "4"
-          sudo chmod 600 /swapfile
-          echo "5"
-          sudo mkswap /swapfile
-          echo "6"
-          sudo swapon /swapfile
-
-      # - name: Match branch
-      #  id: match
-      #  if: |
-      #    success()
-      #    && github.event_name == 'push'
-      #    && github.repository_owner == 'apache'
-      #  run: |
-      #    if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-      #      echo "match_master=true" >> $GITHUB_OUTPUT
-      #    elif [[ ${{ github.ref_name }} =~ ^branch-[0-9]+\.[0-9]+$ ]]; then
-      #      echo "match_release=true" >> $GITHUB_OUTPUT
-      #    fi
+          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+            echo "match_master=true" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.ref_name }} =~ ^branch-[0-9]+\.[0-9]+$ ]]; then
+            echo "match_release=true" >> $GITHUB_OUTPUT
+          fi
 
       # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'branch-1.4'.
-      #- name: Push x86 Docker images to Docker Hub
-        # if: |
-        #   steps.match.outputs.match_master == 'true'
-        #   || steps.match.outputs.match_release == 'true'
-      #  working-directory: docker
-      #  run: |
-      #    bash +x publish-by-arch.sh --tag # --publish
-      #  env:
-      #    DOCKER_USER: ${{ secrets.DOCKER_USER }}
-      #    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      #    DOCKER_ORG: inlong
+      - name: Push x86 Docker images to Docker Hub
+        if: |
+          steps.match.outputs.match_master == 'true'
+          || steps.match.outputs.match_release == 'true'
+        working-directory: docker
+        run: |
+          bash +x publish-by-arch.sh --tag # --publish
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_ORG: inlong
 
       # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'branch-1.4'.
       - name: Push aarch64 Docker images to Docker Hub
-        # if: ${{ steps.match.outputs.match_release == 'true' }}
+        if: ${{ steps.match.outputs.match_release == 'true' }}
         working-directory: docker
         run: |
           bash +x build-docker-images.sh --buildx aarch64

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -85,13 +85,26 @@ jobs:
         run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
         env:
           CI: false
+
+      - name: test arm
+         working-directory: docker
+        run: |
+          bash +x build-docker-images.sh --buildx aarch64
+          bash +x publish-by-arch.sh --tag --arch aarch64 --publish      
+ 
       - name: Set up environment
         run: |
+          echo "1"
           sudo sysctl -w vm.max_map_count=262144
+          echo "2"
           sudo sysctl -w fs.file-max=65536
+          echo "3"
           sudo fallocate -l 5G /swapfile
+          echo "4"
           sudo chmod 600 /swapfile
+          echo "5"
           sudo mkswap /swapfile
+          echo "6"
           sudo swapon /swapfile
 
       # - name: Match branch

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Set up environment
         run: |
+          df -h
           echo "1"
           sudo sysctl -w vm.max_map_count=262144
           echo "2"
@@ -95,6 +96,8 @@ jobs:
           sudo mkswap /swapfile
           echo "6"
           sudo swapon /swapfile
+          echo "7"
+          df -h
 
       - name: Remove unnecessary packages
         run: | # stolen from https://github.com/easimon/maximize-build-space

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -86,31 +86,31 @@ jobs:
         env:
           CI: false
 
-      - name: Match branch
-        id: match
-        if: |
-          success()
-          && github.event_name == 'push'
-          && github.repository_owner == 'apache'
-        run: |
-          if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
-            echo "match_master=true" >> $GITHUB_OUTPUT
-          elif [[ ${{ github.ref_name }} =~ ^branch-[0-9]+\.[0-9]+$ ]]; then
-            echo "match_release=true" >> $GITHUB_OUTPUT
-          fi
+      # - name: Match branch
+      #  id: match
+      #  if: |
+      #    success()
+      #    && github.event_name == 'push'
+      #    && github.repository_owner == 'apache'
+      #  run: |
+      #    if [[ ${{ github.ref_name }} == ${{ github.event.repository.default_branch }} ]]; then
+      #      echo "match_master=true" >> $GITHUB_OUTPUT
+      #    elif [[ ${{ github.ref_name }} =~ ^branch-[0-9]+\.[0-9]+$ ]]; then
+      #      echo "match_release=true" >> $GITHUB_OUTPUT
+      #    fi
 
       # Publish x86 Docker images when the changes are being pushed to the master branch or a release branch like 'branch-1.4'.
-      - name: Push x86 Docker images to Docker Hub
+      #- name: Push x86 Docker images to Docker Hub
         # if: |
         #   steps.match.outputs.match_master == 'true'
         #   || steps.match.outputs.match_release == 'true'
-        working-directory: docker
-        run: |
-          bash +x publish-by-arch.sh --tag # --publish
-        env:
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_ORG: inlong
+      #  working-directory: docker
+      #  run: |
+      #    bash +x publish-by-arch.sh --tag # --publish
+      #  env:
+      #    DOCKER_USER: ${{ secrets.DOCKER_USER }}
+      #    DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      #    DOCKER_ORG: inlong
 
       # Publish aarch64 Docker images when the changes are being pushed to a release branch like 'branch-1.4'.
       - name: Push aarch64 Docker images to Docker Hub

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -106,7 +106,7 @@ jobs:
         #   || steps.match.outputs.match_release == 'true'
         working-directory: docker
         run: |
-          bash +x publish-by-arch.sh --tag --publish
+          bash +x publish-by-arch.sh --tag # --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -81,23 +81,14 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Set up environment
+      - name: Set up swapfile path
         run: |
-          df -h
-          echo "1"
           sudo sysctl -w vm.max_map_count=262144
-          echo "2"
           sudo sysctl -w fs.file-max=65536
-          echo "3"
           sudo fallocate -l 5G /swapfile
-          echo "4"
           sudo chmod 600 /swapfile
-          echo "5"
           sudo mkswap /swapfile
-          echo "6"
           sudo swapon /swapfile
-          echo "7"
-          df -h
 
       - name: Remove unnecessary packages
         run: | # stolen from https://github.com/easimon/maximize-build-space

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -85,6 +85,14 @@ jobs:
         run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
         env:
           CI: false
+      - name: Set up environment
+        run: |
+          sudo sysctl -w vm.max_map_count=262144
+          sudo sysctl -w fs.file-max=65536
+          sudo fallocate -l 5G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
 
       # - name: Match branch
       #  id: match

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -91,7 +91,7 @@ jobs:
           sudo swapon /swapfile
 
       - name: Remove unnecessary packages
-        run: | # stolen from https://github.com/easimon/maximize-build-space
+        run: |
           echo "=== Before pruning ==="
           df -h
           sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -81,6 +81,17 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Remove unnecessary packages
+        run: | # stolen from https://github.com/easimon/maximize-build-space
+          echo "=== Before pruning ==="
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          echo
+          echo "=== After pruning ==="
+          df -h
+
       - name: Build Docker images
         run: mvn --batch-mode --update-snapshots -e -V clean package -DskipTests -Pdocker
         env:

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -87,7 +87,7 @@ jobs:
           CI: false
 
       - name: test arm
-         working-directory: docker
+        working-directory: docker
         run: |
           bash +x build-docker-images.sh --buildx aarch64
           bash +x publish-by-arch.sh --tag --arch aarch64 --publish      

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -132,7 +132,7 @@ jobs:
           || steps.match.outputs.match_release == 'true'
         working-directory: docker
         run: |
-          bash +x publish-by-arch.sh --tag # --publish
+          bash +x publish-by-arch.sh --tag  --publish
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -141,7 +141,6 @@ docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/agent:${tag}       
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-all:${tag}     inlong-tubemq/tubemq-docker/tubemq-all/     --build-arg TUBEMQ_TARBALL=${TUBEMQ_TARBALL}
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-manager:${tag} inlong-tubemq/tubemq-docker/tubemq-manager/ --build-arg TUBEMQ_MANAGER_TARBALL=${TUBEMQ_MANAGER_TARBALL}
 if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
-  docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-cpp:${tag}    inlong-tubemq/tubemq-docker/tubemq-cpp/
   docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-build:${tag}  inlong-tubemq/tubemq-docker/tubemq-build/
 fi
 
@@ -159,7 +158,6 @@ docker tag inlong/dashboard:${tag}       inlong/dashboard:latest${POSTFIX}
 docker tag inlong/agent:${tag}           inlong/agent:latest${POSTFIX}
 docker tag inlong/tubemq-all:${tag}      inlong/tubemq-all:latest${POSTFIX}
 if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
-  docker tag inlong/tubemq-cpp:${tag}   inlong/tubemq-cpp:latest${POSTFIX}
   docker tag inlong/tubemq-build:${tag} inlong/tubemq-build:latest${POSTFIX}
 fi
 

--- a/docker/build-docker-images.sh
+++ b/docker/build-docker-images.sh
@@ -138,9 +138,9 @@ docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/dataproxy:${tag}   
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/audit:${tag}          inlong-audit/audit-docker/          --build-arg AUDIT_TARBALL=${AUDIT_TARBALL}
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/dashboard:${tag}      inlong-dashboard/                   --build-arg DASHBOARD_FILE=${DASHBOARD_FILE}
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/agent:${tag}          inlong-agent/agent-docker/          --build-arg AGENT_TARBALL=${AGENT_TARBALL}
-docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-all:${tag}     inlong-tubemq/tubemq-docker/tubemq-all/     --build-arg TUBEMQ_TARBALL=${TUBEMQ_TARBALL}
 docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-manager:${tag} inlong-tubemq/tubemq-docker/tubemq-manager/ --build-arg TUBEMQ_MANAGER_TARBALL=${TUBEMQ_MANAGER_TARBALL}
 if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
+  docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-all:${tag}     inlong-tubemq/tubemq-docker/tubemq-all/     --build-arg TUBEMQ_TARBALL=${TUBEMQ_TARBALL}
   docker ${USE_BUILDX} build ${USE_PLATFORM} ${TYPE} -t inlong/tubemq-build:${tag}  inlong-tubemq/tubemq-docker/tubemq-build/
 fi
 

--- a/docker/publish-by-arch.sh
+++ b/docker/publish-by-arch.sh
@@ -58,7 +58,6 @@ initTagImageForx86() {
   docker tag inlong/tubemq-all:latest${SRC_POSTFIX}      inlong/tubemq-all:latest${DES_POSTFIX}
   docker tag inlong/tubemq-build:latest${SRC_POSTFIX}    inlong/tubemq-build:latest${DES_POSTFIX}
   docker tag inlong/dashboard:latest${SRC_POSTFIX}       inlong/dashboard:latest${DES_POSTFIX}
-  docker tag inlong/tubemq-cpp:latest${SRC_POSTFIX}      inlong/tubemq-cpp:latest${DES_POSTFIX}
   docker tag inlong/audit:latest${SRC_POSTFIX}           inlong/audit:latest${DES_POSTFIX}
 
   docker tag inlong/manager:${MVN_VERSION}${SRC_POSTFIX}         inlong/manager:${MVN_VERSION}${DES_POSTFIX}
@@ -68,7 +67,6 @@ initTagImageForx86() {
   docker tag inlong/tubemq-all:${MVN_VERSION}${SRC_POSTFIX}      inlong/tubemq-all:${MVN_VERSION}${DES_POSTFIX}
   docker tag inlong/tubemq-build:${MVN_VERSION}${SRC_POSTFIX}    inlong/tubemq-build:${MVN_VERSION}${DES_POSTFIX}
   docker tag inlong/dashboard:${MVN_VERSION}${SRC_POSTFIX}       inlong/dashboard:${MVN_VERSION}${DES_POSTFIX}
-  docker tag inlong/tubemq-cpp:${MVN_VERSION}${SRC_POSTFIX}      inlong/tubemq-cpp:${MVN_VERSION}${DES_POSTFIX}
   docker tag inlong/audit:${MVN_VERSION}${SRC_POSTFIX}           inlong/audit:${MVN_VERSION}${DES_POSTFIX}
 }
 
@@ -94,9 +92,8 @@ tagImage() {
   docker tag inlong/tubemq-manager:latest${SRC_POSTFIX}  ${docker_registry_org}/tubemq-manager:latest${DES_POSTFIX}
   docker tag inlong/dashboard:latest${SRC_POSTFIX}       ${docker_registry_org}/dashboard:latest${DES_POSTFIX}
   docker tag inlong/audit:latest${SRC_POSTFIX}           ${docker_registry_org}/audit:latest${DES_POSTFIX}
-  docker tag inlong/tubemq-all:latest${SRC_POSTFIX}      ${docker_registry_org}/tubemq-all:latest${DES_POSTFIX}
   if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
-    docker tag inlong/tubemq-cpp:latest${SRC_POSTFIX}      ${docker_registry_org}/tubemq-cpp:latest${DES_POSTFIX}
+    docker tag inlong/tubemq-all:latest${SRC_POSTFIX}      ${docker_registry_org}/tubemq-all:latest${DES_POSTFIX}
     docker tag inlong/tubemq-build:latest${SRC_POSTFIX}    ${docker_registry_org}/tubemq-build:latest${DES_POSTFIX}
   fi
 
@@ -106,9 +103,8 @@ tagImage() {
   docker tag inlong/tubemq-manager:${MVN_VERSION}${SRC_POSTFIX}  ${docker_registry_org}/tubemq-manager:${MVN_VERSION}${DES_POSTFIX}
   docker tag inlong/dashboard:${MVN_VERSION}${SRC_POSTFIX}       ${docker_registry_org}/dashboard:${MVN_VERSION}${DES_POSTFIX}
   docker tag inlong/audit:${MVN_VERSION}${SRC_POSTFIX}           ${docker_registry_org}/audit:${MVN_VERSION}${DES_POSTFIX}
-  docker tag inlong/tubemq-all:${MVN_VERSION}${SRC_POSTFIX}      ${docker_registry_org}/tubemq-all:${MVN_VERSION}${DES_POSTFIX}
   if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
-    docker tag inlong/tubemq-cpp:${MVN_VERSION}${SRC_POSTFIX}      ${docker_registry_org}/tubemq-cpp:${MVN_VERSION}${DES_POSTFIX}
+    docker tag inlong/tubemq-all:${MVN_VERSION}${SRC_POSTFIX}      ${docker_registry_org}/tubemq-all:${MVN_VERSION}${DES_POSTFIX}
     docker tag inlong/tubemq-build:${MVN_VERSION}${SRC_POSTFIX}    ${docker_registry_org}/tubemq-build:${MVN_VERSION}${DES_POSTFIX}
   fi
   echo "End tagging images"
@@ -148,7 +144,6 @@ pushDefaultImage() {
   docker push inlong/tubemq-all:latest
   docker push inlong/tubemq-build:latest
   docker push inlong/dashboard:latest
-  docker push inlong/tubemq-cpp:latest
   docker push inlong/audit:latest
   docker push inlong/manager:${MVN_VERSION}
   docker push inlong/agent:${MVN_VERSION}
@@ -157,7 +152,6 @@ pushDefaultImage() {
   docker push inlong/tubemq-all:${MVN_VERSION}
   docker push inlong/tubemq-build:${MVN_VERSION}
   docker push inlong/dashboard:${MVN_VERSION}
-  docker push inlong/tubemq-cpp:${MVN_VERSION}
   docker push inlong/audit:${MVN_VERSION}
 }
 
@@ -183,10 +177,9 @@ pushImage() {
   docker push inlong/tubemq-manager:latest${SRC_POSTFIX}
   docker push inlong/dashboard:latest${SRC_POSTFIX}
   docker push inlong/audit:latest${SRC_POSTFIX}
-  docker push inlong/tubemq-all:latest${SRC_POSTFIX}
   if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
     docker push inlong/tubemq-build:latest${SRC_POSTFIX}
-    docker push inlong/tubemq-cpp:latest${SRC_POSTFIX}
+    docker push inlong/tubemq-all:latest${SRC_POSTFIX}
   fi
 
   docker push inlong/manager:${MVN_VERSION}${SRC_POSTFIX}
@@ -195,10 +188,9 @@ pushImage() {
   docker push inlong/tubemq-manager:${MVN_VERSION}${SRC_POSTFIX}
   docker push inlong/dashboard:${MVN_VERSION}${SRC_POSTFIX}
   docker push inlong/audit:${MVN_VERSION}${SRC_POSTFIX}
-  docker push inlong/tubemq-all:${MVN_VERSION}${SRC_POSTFIX}
   if [ "$BUILD_ARCH" = "$ARCH_X86" ]; then
     docker push inlong/tubemq-build:${MVN_VERSION}${SRC_POSTFIX}
-    docker push inlong/tubemq-cpp:${MVN_VERSION}${SRC_POSTFIX}
+    docker push inlong/tubemq-all:${MVN_VERSION}${SRC_POSTFIX}
   fi
 
   echo "Finished pushing images to inlong"
@@ -211,9 +203,8 @@ pushManifest() {
   docker manifest create --insecure --amend inlong/dataproxy:latest      inlong/dataproxy:latest-aarch64      inlong/dataproxy:latest-x86
   docker manifest create --insecure --amend inlong/dashboard:latest      inlong/dashboard:latest-aarch64      inlong/dashboard:latest-x86
   docker manifest create --insecure --amend inlong/audit:latest          inlong/audit:latest-aarch64          inlong/audit:latest-x86
-  docker manifest create --insecure --amend inlong/tubemq-all:latest     inlong/tubemq-all:latest-aarch64     inlong/tubemq-all:latest-x86
+  docker manifest create --insecure --amend inlong/tubemq-all:latest     inlong/tubemq-all:latest-x86
   docker manifest create --insecure --amend inlong/tubemq-manager:latest inlong/tubemq-manager:latest-aarch64 inlong/tubemq-manager:latest-x86
-  docker manifest create --insecure --amend inlong/tubemq-cpp:latest     inlong/tubemq-cpp:latest-x86
   docker manifest create --insecure --amend inlong/tubemq-build:latest   inlong/tubemq-build:latest-x86
 
   docker manifest push inlong/manager:latest
@@ -223,7 +214,6 @@ pushManifest() {
   docker manifest push inlong/tubemq-all:latest
   docker manifest push inlong/tubemq-build:latest
   docker manifest push inlong/dashboard:latest
-  docker manifest push inlong/tubemq-cpp:latest
   docker manifest push inlong/audit:latest
 
   docker manifest create --insecure --amend inlong/manager:${MVN_VERSION}        inlong/manager:${MVN_VERSION}-aarch64        inlong/manager:${MVN_VERSION}-x86
@@ -232,9 +222,8 @@ pushManifest() {
   docker manifest create --insecure --amend inlong/dashboard:${MVN_VERSION}      inlong/dashboard:${MVN_VERSION}-aarch64      inlong/dashboard:${MVN_VERSION}-x86
   docker manifest create --insecure --amend inlong/audit:${MVN_VERSION}          inlong/audit:${MVN_VERSION}-aarch64          inlong/audit:${MVN_VERSION}-x86
   docker manifest create --insecure --amend inlong/tubemq-manager:${MVN_VERSION} inlong/tubemq-manager:${MVN_VERSION}-aarch64 inlong/tubemq-manager:${MVN_VERSION}-x86
-  docker manifest create --insecure --amend inlong/tubemq-all:${MVN_VERSION}     inlong/tubemq-all:${MVN_VERSION}-aarch64     inlong/tubemq-all:${MVN_VERSION}-x86
+  docker manifest create --insecure --amend inlong/tubemq-all:${MVN_VERSION}     inlong/tubemq-all:${MVN_VERSION}-x86
   docker manifest create --insecure --amend inlong/tubemq-build:${MVN_VERSION}   inlong/tubemq-build:${MVN_VERSION}-x86
-  docker manifest create --insecure --amend inlong/tubemq-cpp:${MVN_VERSION}     inlong/tubemq-cpp:${MVN_VERSION}-x86
 
   docker manifest push inlong/manager:${MVN_VERSION}
   docker manifest push inlong/agent:${MVN_VERSION}
@@ -243,7 +232,6 @@ pushManifest() {
   docker manifest push inlong/tubemq-all:${MVN_VERSION}
   docker manifest push inlong/tubemq-build:${MVN_VERSION}
   docker manifest push inlong/dashboard:${MVN_VERSION}
-  docker manifest push inlong/tubemq-cpp:${MVN_VERSION}
   docker manifest push inlong/audit:${MVN_VERSION}
   echo "End pushing manifest"
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-7626][Docker] Delete tubemq-cpp images on x86
- Fixes #7626 

### Motivation

- Delete tubemq-cpp images on x86.
  - Because storage on GitHub workflow is not enough. Sometime agent arm image will be dropped.
- Delete tubemq-all images on arm
  - Now time Zookeeper version is not support arm platform.

### Modifications

- Delete tubemq-cpp images on x86.
  - Because storage on GitHub workflow is not enough. Sometime agent arm image will be dropped.
- Delete tubemq-all images on arm
  - Now time Zookeeper version is not support arm platform.
- Expand swapfile to expand disk space.
- Remove unused dependence, such as dotnet, android and ghc.
