### PR TITLE
[INLONG-7413][Audit] Audit get MQ config from Manager

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
@@ -66,4 +66,8 @@ public class ConfigConstants {
     public static final long DEFAULT_SESSION_MAX_ALLOWED_DELAYED_MSG_COUNT = 4000000L;
 
     public static final long DEFAULT_NETTY_WRITE_BUFFER_HIGH_WATER_MARK = 15 * 1024 * 1024L;
+
+    public static final String MANAGER_PATH = "/inlong/manager/openapi";
+
+    public static final String MANAGER_GET_CONFIG_PATH = "/audit/getConfig";
 }

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
@@ -51,7 +51,7 @@ public class ConfigManager {
 
     private static ConfigManager instance = null;
 
-    private static String DEFAULT_CONFIG_PROPERTIES = "server.properties";
+    private static String DEFAULT_CONFIG_PROPERTIES = "application.properties";
 
     static {
         instance = getInstance(DEFAULT_CONFIG_PROPERTIES, true);

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
@@ -22,14 +22,19 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.apache.inlong.audit.file.holder.PropertiesConfigHolder;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigRequest;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -41,6 +46,8 @@ public class ConfigManager {
 
     private static final Map<String, ConfigHolder> holderMap =
             new ConcurrentHashMap<>();
+
+    public static List<MQClusterInfo> mqClusterInfoList = new ArrayList<>();
 
     private static ConfigManager instance = null;
 
@@ -123,6 +130,10 @@ public class ConfigManager {
         }
     }
 
+    public List<MQClusterInfo> getMQConfigList() {
+        return mqClusterInfoList;
+    }
+
     public ConfigHolder getDefaultConfigHolder() {
         return holderMap.get(DEFAULT_CONFIG_PROPERTIES);
     }
@@ -189,33 +200,42 @@ public class ConfigManager {
             }
         }
 
-        private boolean checkWithManager(String host) {
-            HttpGet httpGet = null;
+        private boolean checkWithManager(String host, String clusterName, String clusterTag) {
+            HttpPost httpPost = null;
             try {
-                String url = "http://" + host + "/inlong/manager/openapi/audit/getConfig";
+                String url = "http://" + host + "/inlong/manager/openapi/dataproxy/getConfig";
                 LOG.info("start to request {} to get config info", url);
-                httpGet = new HttpGet(url);
-                httpGet.addHeader(HttpHeaders.CONNECTION, "close");
+                httpPost = new HttpPost(url);
+                httpPost.addHeader(HttpHeaders.CONNECTION, "close");
+
+                // request body
+                DataProxyConfigRequest request = new DataProxyConfigRequest();
+                request.setClusterName(clusterName);
+                request.setClusterTag(clusterTag);
+                StringEntity stringEntity = new StringEntity(gson.toJson(request));
+                stringEntity.setContentType("application/json");
+                httpPost.setEntity(stringEntity);
 
                 // request with post
-                CloseableHttpResponse response = httpClient.execute(httpGet);
+                LOG.info("start to request {} to get config info with params {}", url, request);
+                CloseableHttpResponse response = httpClient.execute(httpPost);
                 String returnStr = EntityUtils.toString(response.getEntity());
                 // get groupId <-> topic and m value.
 
-                Map<String, String> configJsonMap = gson.fromJson(returnStr, Map.class);
-                if (configJsonMap != null && configJsonMap.size() > 0) {
-                    for (Entry<String, String> entry : configJsonMap.entrySet()) {
-                        Map<String, String> valueMap = gson.fromJson(entry.getValue(), Map.class);
-                        configManager.updatePropertiesHolder(valueMap,
-                                entry.getKey(), true);
+                RemoteConfigJson configJson = gson.fromJson(returnStr, RemoteConfigJson.class);
+                if (configJson.isSuccess() && configJson.getData() != null) {
+                    mqClusterInfoList = configJson.getData().getMqClusterList();
+                    if (mqClusterInfoList == null || mqClusterInfoList.isEmpty()) {
+                        LOG.error("getConfig from manager: no available mq config");
+                        return false;
                     }
                 }
             } catch (Exception ex) {
                 LOG.error("exception caught", ex);
                 return false;
             } finally {
-                if (httpGet != null) {
-                    httpGet.releaseConnection();
+                if (httpPost != null) {
+                    httpPost.releaseConnection();
                 }
             }
             return true;
@@ -224,10 +244,15 @@ public class ConfigManager {
         private void checkRemoteConfig() {
 
             try {
-                String managerHosts = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES).get("manager_hosts");
+                String managerHosts = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES).get("manager.hosts");
+                String proxyClusterName = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES)
+                        .get("proxy.cluster.name");
+                String proxyClusterTag = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES)
+                        .get("proxy.cluster.tag");
+                LOG.info("manager url: {}", managerHosts);
                 String[] hostList = StringUtils.split(managerHosts, ",");
                 for (String host : hostList) {
-                    if (checkWithManager(host)) {
+                    if (checkWithManager(host, proxyClusterName, proxyClusterTag)) {
                         break;
                     }
                 }
@@ -242,7 +267,6 @@ public class ConfigManager {
             while (isRunning) {
 
                 long sleepTimeInMs = getSleepTime();
-                count += 1;
                 try {
                     checkLocalFile();
                     // wait for 30 seconds to update remote config
@@ -254,6 +278,7 @@ public class ConfigManager {
                 } catch (Exception ex) {
                     LOG.error("exception caught", ex);
                 }
+                count += 1;
             }
         }
     }

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/RemoteConfigJson.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/RemoteConfigJson.java
@@ -17,38 +17,23 @@
 
 package org.apache.inlong.audit.file;
 
-import java.util.List;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
 
 public class RemoteConfigJson {
 
-    private boolean result;
-    private List<DataItem> data;
-    private int errCode;
+    private boolean success;
+    private String errMsg;
+    private DataProxyConfig data;
 
-    public List<DataItem> getData() {
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public String getErrMsg() {
+        return errMsg;
+    }
+
+    public DataProxyConfig getData() {
         return data;
-    }
-
-    public int getErrCode() {
-        return errCode;
-    }
-
-    public static class DataItem {
-
-        private String groupId;
-        private String topic;
-        private String m;
-
-        public String getGroupId() {
-            return groupId;
-        }
-
-        public String getTopic() {
-            return topic;
-        }
-
-        public String getM() {
-            return m;
-        }
     }
 }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/node/Application.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/node/Application.java
@@ -21,15 +21,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
@@ -52,8 +43,19 @@ import org.apache.flume.node.MaterializedConfiguration;
 import org.apache.flume.node.PollingPropertiesFileConfigurationProvider;
 import org.apache.flume.node.PropertiesFileConfigurationProvider;
 import org.apache.flume.util.SSLUtil;
+import org.apache.inlong.audit.file.ConfigManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * 
@@ -293,6 +295,8 @@ public class Application {
             boolean reload = !commandLine.hasOption("no-reload-conf");
 
             Application application;
+
+            ConfigManager.getInstance();
 
             File configurationFile = new File(commandLine.getOptionValue('f'));
 

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
@@ -31,7 +31,7 @@ import org.apache.inlong.audit.base.HighPriorityThreadFactory;
 import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.utils.FailoverChannelProcessorHolder;
 import org.apache.inlong.common.constant.MQType;
-import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
+import org.apache.inlong.common.pojo.audit.MQInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -261,8 +261,8 @@ public class KafkaSink extends AbstractSink implements Configurable {
 
     private void initTopicProducer(String topic) {
         ConfigManager configManager = ConfigManager.getInstance();
-        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
-        mqConfigList.forEach(mqClusterInfo -> {
+        List<MQInfo> mqInfoList = configManager.getMqInfoList();
+        mqInfoList.forEach(mqClusterInfo -> {
             if (MQType.KAFKA.equals(mqClusterInfo.getMqType())) {
                 kafkaServerUrl = mqClusterInfo.getUrl();
             }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
@@ -28,7 +28,10 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.flume.sink.AbstractSink;
 import org.apache.inlong.audit.base.HighPriorityThreadFactory;
+import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.utils.FailoverChannelProcessorHolder;
+import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -40,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executors;
@@ -54,6 +58,7 @@ public class KafkaSink extends AbstractSink implements Configurable {
 
     // for kafka producer
     private static Properties properties = new Properties();
+    private String kafkaServerUrl;
     private static final String BOOTSTRAP_SERVER = "bootstrap_servers";
     private static final String TOPIC = "topic";
     private static final String RETRIES = "retries";
@@ -247,7 +252,6 @@ public class KafkaSink extends AbstractSink implements Configurable {
         localIp = NetworkUtils.getLocalIp();
 
         properties = new Properties();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, context.getString(BOOTSTRAP_SERVER));
         properties.put(ProducerConfig.ACKS_CONFIG, defaultAcks);
         properties.put(ProducerConfig.RETRIES_CONFIG, context.getString(RETRIES, defaultRetries));
         properties.put(ProducerConfig.BATCH_SIZE_CONFIG, context.getString(BATCH_SIZE, defaultBatchSize));
@@ -256,6 +260,15 @@ public class KafkaSink extends AbstractSink implements Configurable {
     }
 
     private void initTopicProducer(String topic) {
+        ConfigManager configManager = ConfigManager.getInstance();
+        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
+        mqConfigList.forEach(mqClusterInfo -> {
+            if(MQType.KAFKA.equals(mqClusterInfo.getMqType())) {
+                kafkaServerUrl = mqClusterInfo.getUrl();
+            }
+        });
+        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaServerUrl);
+
         if (StringUtils.isEmpty(topic)) {
             logger.error("topic is empty");
         }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/KafkaSink.java
@@ -263,7 +263,7 @@ public class KafkaSink extends AbstractSink implements Configurable {
         ConfigManager configManager = ConfigManager.getInstance();
         List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
         mqConfigList.forEach(mqClusterInfo -> {
-            if(MQType.KAFKA.equals(mqClusterInfo.getMqType())) {
+            if (MQType.KAFKA.equals(mqClusterInfo.getMqType())) {
                 kafkaServerUrl = mqClusterInfo.getUrl();
             }
         });

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/PulsarSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/PulsarSink.java
@@ -148,6 +148,8 @@ public class PulsarSink extends AbstractSink
 
     private String topic;
 
+    private Context context;
+
     static {
         /*
          * stat pulsar performance
@@ -168,6 +170,7 @@ public class PulsarSink extends AbstractSink
      */
     public void configure(Context context) {
         logger.info("PulsarSink started and context = {}", context.toString());
+        this.context = context;
         /*
          * topic config
          */
@@ -188,7 +191,6 @@ public class PulsarSink extends AbstractSink
         if (diskIORatePerSec != 0) {
             diskRateLimiter = RateLimiter.create(diskIORatePerSec);
         }
-        pulsarClientService = new PulsarClientService(context);
 
         if (sinkCounter == null) {
             sinkCounter = new SinkCounter(getName());
@@ -208,6 +210,7 @@ public class PulsarSink extends AbstractSink
     public void start() {
         logger.info("pulsar sink starting");
         sinkCounter.start();
+        pulsarClientService = new PulsarClientService(context);
         pulsarClientService.initCreateConnection(this);
 
         super.start();

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
@@ -34,7 +34,7 @@ import org.apache.inlong.audit.consts.ConfigConstants;
 import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.utils.FailoverChannelProcessorHolder;
 import org.apache.inlong.common.constant.MQType;
-import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
+import org.apache.inlong.common.pojo.audit.MQInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.inlong.tubemq.client.config.TubeClientConfig;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
@@ -388,8 +388,8 @@ public class TubeSink extends AbstractSink implements Configurable {
 
     private TubeClientConfig initTubeConfig() throws Exception {
         ConfigManager configManager = ConfigManager.getInstance();
-        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
-        mqConfigList.forEach(mqClusterInfo -> {
+        List<MQInfo> mqInfoList = configManager.getMqInfoList();
+        mqInfoList.forEach(mqClusterInfo -> {
             if (MQType.TUBEMQ.equals(mqClusterInfo.getMqType())) {
                 masterHostAndPortList = mqClusterInfo.getUrl();
             }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
@@ -325,7 +325,7 @@ public class TubeSink extends AbstractSink implements Configurable {
             lastSuccessSendCnt.set(nowCnt);
             t2 = System.currentTimeMillis();
             logger.info("tubesink {}, succ put {} events to tube,"
-                            + " in the past {} millsec",
+                    + " in the past {} millsec",
                     new Object[]{
                             getName(), (nowCnt - oldCnt), (t2 - t1)
                     });

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
@@ -325,7 +325,7 @@ public class TubeSink extends AbstractSink implements Configurable {
             lastSuccessSendCnt.set(nowCnt);
             t2 = System.currentTimeMillis();
             logger.info("tubesink {}, succ put {} events to tube,"
-                    + " in the past {} millsec",
+                            + " in the past {} millsec",
                     new Object[]{
                             getName(), (nowCnt - oldCnt), (t2 - t1)
                     });
@@ -390,7 +390,7 @@ public class TubeSink extends AbstractSink implements Configurable {
         ConfigManager configManager = ConfigManager.getInstance();
         List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
         mqConfigList.forEach(mqClusterInfo -> {
-            if(MQType.TUBEMQ.equals(mqClusterInfo.getMqType())) {
+            if (MQType.TUBEMQ.equals(mqClusterInfo.getMqType())) {
                 masterHostAndPortList = mqClusterInfo.getUrl();
             }
         });

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/TubeSink.java
@@ -31,7 +31,10 @@ import org.apache.flume.instrumentation.SinkCounter;
 import org.apache.flume.sink.AbstractSink;
 import org.apache.inlong.audit.base.HighPriorityThreadFactory;
 import org.apache.inlong.audit.consts.ConfigConstants;
+import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.utils.FailoverChannelProcessorHolder;
+import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.inlong.tubemq.client.config.TubeClientConfig;
 import org.apache.inlong.tubemq.client.exception.TubeClientException;
@@ -46,6 +49,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -256,7 +260,6 @@ public class TubeSink extends AbstractSink implements Configurable {
         topic = context.getString(TOPIC);
         Preconditions.checkState(StringUtils.isNotEmpty(topic), "No topic specified");
 
-        masterHostAndPortList = context.getString(MASTER_HOST_PORT_LIST);
         Preconditions.checkState(masterHostAndPortList != null,
                 "No master and port list specified");
 
@@ -363,7 +366,7 @@ public class TubeSink extends AbstractSink implements Configurable {
         }
 
         try {
-            TubeClientConfig conf = initTubeConfig(masterHostAndPortList);
+            TubeClientConfig conf = initTubeConfig();
             sessionFactory = new TubeMultiSessionFactory(conf);
             logger.info("create tube connection successfully");
         } catch (TubeClientException e) {
@@ -383,7 +386,15 @@ public class TubeSink extends AbstractSink implements Configurable {
         }
     }
 
-    private TubeClientConfig initTubeConfig(String masterHostAndPortList) throws Exception {
+    private TubeClientConfig initTubeConfig() throws Exception {
+        ConfigManager configManager = ConfigManager.getInstance();
+        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
+        mqConfigList.forEach(mqClusterInfo -> {
+            if(MQType.TUBEMQ.equals(mqClusterInfo.getMqType())) {
+                masterHostAndPortList = mqClusterInfo.getUrl();
+            }
+        });
+
         final TubeClientConfig tubeClientConfig = new TubeClientConfig(masterHostAndPortList);
         tubeClientConfig.setLinkMaxAllowedDelayedMsgCount(linkMaxAllowedDelayedMsgCount);
         tubeClientConfig.setSessionWarnDelayedMsgCount(sessionWarnDelayedMsgCount);

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
@@ -101,7 +101,7 @@ public class PulsarClientService {
         ConfigManager configManager = ConfigManager.getInstance();
         List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
         mqConfigList.forEach(mqClusterInfo -> {
-            if(MQType.PULSAR.equals(mqClusterInfo.getMqType())) {
+            if (MQType.PULSAR.equals(mqClusterInfo.getMqType())) {
                 pulsarServerUrl = mqClusterInfo.getUrl();
             }
         });
@@ -203,14 +203,14 @@ public class PulsarClientService {
         } catch (PulsarClientException e) {
             callBack.handleCreateClientException(pulsarServerUrl);
             logger.error("create connnection error in metasink, "
-                    + "maybe pulsar master set error, please re-check.url{}, ex1 {}",
+                            + "maybe pulsar master set error, please re-check.url{}, ex1 {}",
                     pulsarServerUrl,
                     e.getMessage());
         } catch (Throwable e) {
             callBack.handleCreateClientException(pulsarServerUrl);
             logger.error("create connnection error in metasink, "
-                    + "maybe pulsar master set error/shutdown in progress, please "
-                    + "re-check. url{}, ex2 {}",
+                            + "maybe pulsar master set error/shutdown in progress, please "
+                            + "re-check. url{}, ex2 {}",
                     pulsarServerUrl,
                     e.getMessage());
         }
@@ -233,7 +233,7 @@ public class PulsarClientService {
         Producer producer = null;
         try {
             producer = pulsarClient.newProducer().sendTimeout(sendTimeout,
-                    TimeUnit.MILLISECONDS)
+                            TimeUnit.MILLISECONDS)
                     .topic(topic)
                     .enableBatching(enableBatch)
                     .blockIfQueueFull(blockIfQueueFull)

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
@@ -27,7 +27,7 @@ import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.sink.EventStat;
 import org.apache.inlong.audit.utils.LogCounter;
 import org.apache.inlong.common.constant.MQType;
-import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
+import org.apache.inlong.common.pojo.audit.MQInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -99,8 +99,8 @@ public class PulsarClientService {
      */
     public PulsarClientService(Context context) {
         ConfigManager configManager = ConfigManager.getInstance();
-        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
-        mqConfigList.forEach(mqClusterInfo -> {
+        List<MQInfo> mqInfoList = configManager.getMqInfoList();
+        mqInfoList.forEach(mqClusterInfo -> {
             if (MQType.PULSAR.equals(mqClusterInfo.getMqType())) {
                 pulsarServerUrl = mqClusterInfo.getUrl();
             }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
@@ -23,8 +23,11 @@ import org.apache.flume.Context;
 import org.apache.flume.Event;
 import org.apache.flume.FlumeException;
 import org.apache.inlong.audit.consts.AttributeConstants;
+import org.apache.inlong.audit.file.ConfigManager;
 import org.apache.inlong.audit.sink.EventStat;
 import org.apache.inlong.audit.utils.LogCounter;
+import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientBuilder;
@@ -36,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -94,8 +98,13 @@ public class PulsarClientService {
      * @param context
      */
     public PulsarClientService(Context context) {
-
-        pulsarServerUrl = context.getString(PULSAR_SERVER_URL);
+        ConfigManager configManager = ConfigManager.getInstance();
+        List<MQClusterInfo> mqConfigList = configManager.getMQConfigList();
+        mqConfigList.forEach(mqClusterInfo -> {
+            if(MQType.PULSAR.equals(mqClusterInfo.getMqType())) {
+                pulsarServerUrl = mqClusterInfo.getUrl();
+            }
+        });
         Preconditions.checkState(pulsarServerUrl != null, "No pulsar server url specified");
 
         sendTimeout = context.getInteger(SEND_TIMEOUT, DEFAULT_SEND_TIMEOUT_MILL);

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/sink/pulsar/PulsarClientService.java
@@ -203,14 +203,14 @@ public class PulsarClientService {
         } catch (PulsarClientException e) {
             callBack.handleCreateClientException(pulsarServerUrl);
             logger.error("create connnection error in metasink, "
-                            + "maybe pulsar master set error, please re-check.url{}, ex1 {}",
+                    + "maybe pulsar master set error, please re-check.url{}, ex1 {}",
                     pulsarServerUrl,
                     e.getMessage());
         } catch (Throwable e) {
             callBack.handleCreateClientException(pulsarServerUrl);
             logger.error("create connnection error in metasink, "
-                            + "maybe pulsar master set error/shutdown in progress, please "
-                            + "re-check. url{}, ex2 {}",
+                    + "maybe pulsar master set error/shutdown in progress, please "
+                    + "re-check. url{}, ex2 {}",
                     pulsarServerUrl,
                     e.getMessage());
         }
@@ -233,7 +233,7 @@ public class PulsarClientService {
         Producer producer = null;
         try {
             producer = pulsarClient.newProducer().sendTimeout(sendTimeout,
-                            TimeUnit.MILLISECONDS)
+                    TimeUnit.MILLISECONDS)
                     .topic(topic)
                     .enableBatching(enableBatch)
                     .blockIfQueueFull(blockIfQueueFull)

--- a/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/KafkaSinkTest.java
+++ b/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/KafkaSinkTest.java
@@ -49,7 +49,6 @@ public class KafkaSinkTest {
         context = new Context();
 
         context.put("topic", "inlong-audit");
-        context.put("master-host-port-list", "127.0.0.1:8080");
 
         kafkaSink.setChannel(channel);
         Configurables.configure(kafkaSink, context);

--- a/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/PulsarSinkTest.java
+++ b/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/PulsarSinkTest.java
@@ -21,7 +21,6 @@ import com.google.common.base.Charsets;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.Event;
-import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Sink;
 import org.apache.flume.Transaction;
 import org.apache.flume.channel.MemoryChannel;
@@ -32,6 +31,7 @@ import org.apache.flume.lifecycle.LifecycleState;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,16 +47,19 @@ public class PulsarSinkTest {
 
     private PulsarSink sink;
     private Channel channel;
+    private Context context;
 
     @Before
-    public void setUp() {
-        sink = new PulsarSink();
+    public void setUp() throws Exception {
+        sink = PowerMockito.mock(PulsarSink.class);
+        PowerMockito.doNothing().when(sink, "start");
+        PowerMockito.when(sink.process()).thenReturn(Sink.Status.READY);
+        PowerMockito.when(sink.getLifecycleState()).thenReturn(LifecycleState.ERROR);
         channel = new MemoryChannel();
 
-        Context context = new Context();
+        context = new Context();
 
         context.put("type", "org.apache.inlong.dataproxy.sink.PulsarSink");
-        context.put("pulsar_server_url", "pulsar://127.0.0.1:6650");
 
         sink.setChannel(channel);
 
@@ -65,7 +68,7 @@ public class PulsarSinkTest {
     }
 
     @Test
-    public void testProcess() throws InterruptedException, EventDeliveryException {
+    public void testProcess() throws Exception {
         setUp();
         Event event = EventBuilder.withBody("test event 1", Charsets.UTF_8);
         sink.start();

--- a/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/TubeSinkTest.java
+++ b/inlong-audit/audit-proxy/src/test/java/org/apache/inlong/audit/sink/TubeSinkTest.java
@@ -50,7 +50,6 @@ public class TubeSinkTest {
         context = new Context();
 
         context.put("topic", "inlong-audit");
-        context.put("master-host-port-list", "127.0.0.1:8080");
 
         tubeSink.setChannel(channel);
         Configurables.configure(tubeSink, context);

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
@@ -67,7 +67,7 @@ public class AuditMsgConsumerServer implements InitializingBean {
     // ClickHouseService
     private ClickHouseService ckService;
 
-    private static final String DEFAULT_CONFIG_PROPERTIES = "server.properties";
+    private static final String DEFAULT_CONFIG_PROPERTIES = "application.properties";
 
     private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
 

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
@@ -17,22 +17,38 @@
 
 package org.apache.inlong.audit.service;
 
+import com.google.gson.Gson;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
 import org.apache.inlong.audit.config.ClickHouseConfig;
 import org.apache.inlong.audit.config.MessageQueueConfig;
 import org.apache.inlong.audit.config.StoreConfig;
 import org.apache.inlong.audit.db.dao.AuditDataDao;
+import org.apache.inlong.audit.file.RemoteConfigJson;
 import org.apache.inlong.audit.service.consume.BaseConsume;
 import org.apache.inlong.audit.service.consume.KafkaConsume;
 import org.apache.inlong.audit.service.consume.PulsarConsume;
 import org.apache.inlong.audit.service.consume.TubeConsume;
+import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigRequest;
+import org.apache.inlong.common.pojo.dataproxy.MQClusterInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 @Service
 public class AuditMsgConsumerServer implements InitializingBean {
@@ -51,21 +67,35 @@ public class AuditMsgConsumerServer implements InitializingBean {
     // ClickHouseService
     private ClickHouseService ckService;
 
+    private static final String DEFAULT_CONFIG_PROPERTIES = "server.properties";
+
+    private final CloseableHttpClient httpClient = HttpClientBuilder.create().build();
+
     /**
      * Initializing bean
      */
     public void afterPropertiesSet() {
+        List<MQClusterInfo> mqConfigList = getConfigManager();
         BaseConsume mqConsume = null;
         List<InsertData> insertServiceList = this.getInsertServiceList();
-        if (mqConfig.isPulsar()) {
-            mqConsume = new PulsarConsume(insertServiceList, storeConfig, mqConfig);
-        } else if (mqConfig.isTube()) {
-            mqConsume = new TubeConsume(insertServiceList, storeConfig, mqConfig);
-        } else if (mqConfig.isKafka()) {
-            mqConsume = new KafkaConsume(insertServiceList, storeConfig, mqConfig);
-        } else {
-            LOG.error("unknown MessageQueue {}", mqConfig.getMqType());
-            return;
+
+        for (MQClusterInfo mqClusterInfo : mqConfigList) {
+            if (mqConfig.isPulsar()) {
+                mqConfig.setPulsarServerUrl(mqClusterInfo.getUrl());
+                mqConsume = new PulsarConsume(insertServiceList, storeConfig, mqConfig);
+                break;
+            } else if (mqConfig.isTube()) {
+                mqConfig.setTubeMasterList(mqClusterInfo.getUrl());
+                mqConsume = new TubeConsume(insertServiceList, storeConfig, mqConfig);
+                break;
+            } else if (mqConfig.isKafka()) {
+                mqConfig.setKafkaServerUrl(mqClusterInfo.getUrl());
+                mqConsume = new KafkaConsume(insertServiceList, storeConfig, mqConfig);
+                break;
+            } else {
+                LOG.error("Unknown MessageQueue {}", mqConfig.getMqType());
+                return;
+            }
         }
 
         if (storeConfig.isElasticsearchStore()) {
@@ -79,6 +109,7 @@ public class AuditMsgConsumerServer implements InitializingBean {
 
     /**
      * getInsertServiceList
+     *
      * @return
      */
     private List<InsertData> getInsertServiceList() {
@@ -95,5 +126,67 @@ public class AuditMsgConsumerServer implements InitializingBean {
             insertServiceList.add(ckService);
         }
         return insertServiceList;
+    }
+
+    private List<MQClusterInfo> getConfigManager() {
+        Properties properties = new Properties();
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_PROPERTIES)) {
+            properties.load(inputStream);
+            String managerHosts = properties.getProperty("manager.hosts");
+            String clusterName = properties.getProperty("proxy.cluster.name");
+            String clusterTag = properties.getProperty("proxy.cluster.tag");
+            String[] hostList = StringUtils.split(managerHosts, ",");
+            for (String host : hostList) {
+                List<MQClusterInfo> mqConfig = getMQConfig(host, clusterName, clusterTag);
+                if (ObjectUtils.isNotEmpty(mqConfig)) {
+                    return mqConfig;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return null;
+    }
+
+    private List<MQClusterInfo> getMQConfig(String host, String clusterName, String clusterTag) {
+        HttpPost httpPost = null;
+        Gson gson = new Gson();
+        try {
+            String url = "http://" + host + "/inlong/manager/openapi/dataproxy/getConfig";
+            LOG.info("start to request {} to get config info", url);
+            httpPost = new HttpPost(url);
+            httpPost.addHeader(HttpHeaders.CONNECTION, "close");
+
+            // request body
+            DataProxyConfigRequest request = new DataProxyConfigRequest();
+            request.setClusterName(clusterName);
+            request.setClusterTag(clusterTag);
+            StringEntity stringEntity = new StringEntity(gson.toJson(request));
+            stringEntity.setContentType("application/json");
+            httpPost.setEntity(stringEntity);
+
+            // request with post
+            LOG.info("start to request {} to get config info with params {}", url, request);
+            CloseableHttpResponse response = httpClient.execute(httpPost);
+            String returnStr = EntityUtils.toString(response.getEntity());
+            // get groupId <-> topic and m value.
+
+            RemoteConfigJson configJson = gson.fromJson(returnStr, RemoteConfigJson.class);
+            if (configJson.isSuccess() && configJson.getData() != null) {
+                LOG.info("getConfig result: {}", configJson);
+                List<MQClusterInfo> mqClusterInfoList = configJson.getData().getMqClusterList();
+                if (mqClusterInfoList != null && !mqClusterInfoList.isEmpty()) {
+                    return mqClusterInfoList;
+                }
+            }
+        } catch (Exception ex) {
+            LOG.error("exception caught", ex);
+            return null;
+        } finally {
+            if (httpPost != null) {
+                httpPost.releaseConnection();
+            }
+        }
+        return null;
     }
 }

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -48,20 +48,22 @@ audit.config.proxy.type=pulsar
 # store.server: mysql / clickhouse / elasticsearch
 audit.config.store.mode=mysql
 
+# manger config
+manager.hosts=127.0.0.1:8083
+proxy.cluster.name=default_dataproxy
+proxy.cluster.tag=default_cluster
+
 # pulsar config
-audit.pulsar.server.url=pulsar://127.0.0.1:6650
 audit.pulsar.topic=persistent://public/default/inlong-audit
 audit.pulsar.consumer.sub.name=inlong-audit-subscription
 audit.pulsar.token=
 audit.pulsar.enable.auth=false
 
 # tube config
-audit.tube.masterlist=127.0.0.1:8715
 audit.tube.topic=inlong-audit
 audit.tube.consumer.group.name=inlong-audit-consumer
 
 # kafka config
-audit.kafka.server.url=127.0.0.1:9092
 audit.kafka.topic=inlong-audit
 audit.kafka.consumer.name=inlong-audit-consumer
 audit.kafka.group.id=audit-consumer-group

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -50,7 +50,6 @@ audit.config.store.mode=mysql
 
 # manger config
 manager.hosts=127.0.0.1:8083
-proxy.cluster.name=default_dataproxy
 proxy.cluster.tag=default_cluster
 
 # pulsar config

--- a/inlong-audit/conf/audit-proxy-kafka.conf
+++ b/inlong-audit/conf/audit-proxy-kafka.conf
@@ -58,7 +58,6 @@ agent1.channels.ch-msg2.fsyncInterval = 10
 
 agent1.sinks.kafka-sink-msg1.channel = ch-msg1
 agent1.sinks.kafka-sink-msg1.type =  org.apache.inlong.audit.sink.KafkaSink
-agent1.sinks.kafka-sink-msg1.bootstrap_servers = localhost:9092
 agent1.sinks.kafka-sink-msg1.topic = inlong-audit
 agent1.sinks.kafka-sink-msg1.retries = 0
 agent1.sinks.kafka-sink-msg1.batch_size = 16384
@@ -67,7 +66,6 @@ agent1.sinks.kafka-sink-msg1.buffer_memory = 33554432
 
 agent1.sinks.kafka-sink-msg2.channel = ch-msg1
 agent1.sinks.kafka-sink-msg2.type =  org.apache.inlong.audit.sink.KafkaSink
-agent1.sinks.kafka-sink-msg2.bootstrap_servers = localhost:9092
 agent1.sinks.kafka-sink-msg2.topic = inlong-audit
 agent1.sinks.kafka-sink-msg2.retries = 0
 agent1.sinks.kafka-sink-msg2.batch_size = 16384

--- a/inlong-audit/conf/audit-proxy-pulsar.conf
+++ b/inlong-audit/conf/audit-proxy-pulsar.conf
@@ -59,7 +59,6 @@ agent1.channels.ch-msg2.fsyncInterval = 10
 
 agent1.sinks.pulsar-sink-msg1.channel = ch-msg1
 agent1.sinks.pulsar-sink-msg1.type = org.apache.inlong.audit.sink.PulsarSink
-agent1.sinks.pulsar-sink-msg1.pulsar_server_url = pulsar://localhost:6650
 agent1.sinks.pulsar-sink-msg1.topic = persistent://public/default/inlong-audit
 agent1.sinks.pulsar-sink-msg1.enable_token_auth = false
 agent1.sinks.pulsar-sink-msg1.auth_token =
@@ -77,7 +76,6 @@ agent1.sinks.pulsar-sink-msg1.disk_io_rate_per_sec= 20000000
 
 agent1.sinks.pulsar-sink-msg2.channel = ch-msg2
 agent1.sinks.pulsar-sink-msg2.type = org.apache.inlong.audit.sink.PulsarSink
-agent1.sinks.pulsar-sink-msg2.pulsar_server_url = pulsar://localhost:6650
 agent1.sinks.pulsar-sink-msg2.topic = persistent://public/default/inlong-audit
 agent1.sinks.pulsar-sink-msg1.enable_token_auth = false
 agent1.sinks.pulsar-sink-msg1.auth_token =

--- a/inlong-audit/conf/audit-proxy-tubemq.conf
+++ b/inlong-audit/conf/audit-proxy-tubemq.conf
@@ -61,7 +61,6 @@ agent1.channels.ch-msg2.fsyncInterval = 10
 
 agent1.sinks.tube-sink-msg1.channel = ch-msg1
 agent1.sinks.tube-sink-msg1.type =  org.apache.inlong.audit.sink.TubeSink
-agent1.sinks.tube-sink-msg1.master-host-port-list = localhost:8715
 agent1.sinks.tube-sink-msg1.topic = inlong-audit
 agent1.sinks.tube-sink-msg1.send_timeout = 30000
 agent1.sinks.tube-sink-msg1.stat-interval-sec = 60
@@ -75,7 +74,6 @@ agent1.sinks.tube-sink-msg1.set=10
 
 agent1.sinks.tube-sink-msg2.channel = ch-msg2
 agent1.sinks.tube-sink-msg2.type = org.apache.inlong.audit.sink.TubeSink
-agent1.sinks.tube-sink-msg2.master-host-port-list = localhost:8715
 agent1.sinks.tube-sink-msg2.topic = inlong-audit
 agent1.sinks.tube-sink-msg2.send_timeout = 30000
 agent1.sinks.tube-sink-msg2.stat-interval-sec = 60

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/AuditConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/AuditConfig.java
@@ -15,25 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.audit.file;
+package org.apache.inlong.common.pojo.audit;
 
-import org.apache.inlong.common.pojo.audit.AuditConfig;
+import lombok.Data;
 
-public class RemoteConfigJson {
+import java.util.ArrayList;
+import java.util.List;
 
-    private boolean success;
-    private String errMsg;
-    private AuditConfig data;
+/**
+ * Audit config, includes MQ server URL and other params.
+ */
+@Data
+public class AuditConfig {
 
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public String getErrMsg() {
-        return errMsg;
-    }
-
-    public AuditConfig getData() {
-        return data;
-    }
+    private List<MQInfo> mqInfoList = new ArrayList<>();
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/AuditConfigRequest.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/AuditConfigRequest.java
@@ -15,25 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.audit.file;
+package org.apache.inlong.common.pojo.audit;
 
-import org.apache.inlong.common.pojo.audit.AuditConfig;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public class RemoteConfigJson {
+/**
+ * Audit MQ config request info.
+ */
+@Data
+@NoArgsConstructor
+public class AuditConfigRequest {
 
-    private boolean success;
-    private String errMsg;
-    private AuditConfig data;
-
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public String getErrMsg() {
-        return errMsg;
-    }
-
-    public AuditConfig getData() {
-        return data;
-    }
+    private String clusterTag;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/MQInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/audit/MQInfo.java
@@ -15,25 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.audit.file;
+package org.apache.inlong.common.pojo.audit;
 
-import org.apache.inlong.common.pojo.audit.AuditConfig;
+import lombok.Data;
 
-public class RemoteConfigJson {
+import java.util.HashMap;
+import java.util.Map;
 
-    private boolean success;
-    private String errMsg;
-    private AuditConfig data;
+/**
+ * MQ info
+ */
+@Data
+public class MQInfo {
 
-    public boolean isSuccess() {
-        return success;
-    }
-
-    public String getErrMsg() {
-        return errMsg;
-    }
-
-    public AuditConfig getData() {
-        return data;
-    }
+    private String url;
+    private String mqType;
+    private Map<String, String> params = new HashMap<>();
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.service.cluster;
 
+import org.apache.inlong.common.pojo.audit.AuditConfig;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyNodeResponse;
 import org.apache.inlong.manager.pojo.cluster.BindTagRequest;
@@ -418,6 +419,14 @@ public interface InlongClusterService {
      * @return data proxy config
      */
     String getAllConfig(String clusterName, String md5);
+
+    /**
+     * Get the MQ info by cluster tag for Audit
+     *
+     * @param clusterTag cluster tag
+     * @return MQ info
+     */
+    AuditConfig getAuditConfig(String clusterTag);
 
     /**
      * Test whether the connection can be successfully established.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -26,6 +26,8 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.constant.Constants;
 import org.apache.inlong.common.constant.MQType;
+import org.apache.inlong.common.pojo.audit.AuditConfig;
+import org.apache.inlong.common.pojo.audit.MQInfo;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyCluster;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfig;
 import org.apache.inlong.common.pojo.dataproxy.DataProxyConfigResponse;
@@ -1327,6 +1329,27 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         }
 
         return configJson;
+    }
+
+    @Override
+    public AuditConfig getAuditConfig(String clusterTag) {
+        AuditConfig auditConfig = new AuditConfig();
+        ClusterPageRequest request = ClusterPageRequest.builder()
+                .clusterTag(clusterTag)
+                .typeList(Arrays.asList(ClusterType.TUBEMQ, ClusterType.PULSAR, ClusterType.KAFKA))
+                .build();
+        List<InlongClusterEntity> clusterEntityList = clusterMapper.selectByCondition(request);
+        LOGGER.info("clusterEntityList {}", clusterEntityList);
+        List<MQInfo> mqInfoList = new ArrayList<>();
+        for (InlongClusterEntity entity : clusterEntityList) {
+            MQInfo info = new MQInfo();
+            info.setUrl(entity.getUrl());
+            info.setMqType(entity.getType());
+            info.setParams(GSON.fromJson(entity.getExtParams(), Map.class));
+            mqInfoList.add(info);
+        }
+        auditConfig.setMqInfoList(mqInfoList);
+        return auditConfig;
     }
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/AuditController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/AuditController.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.controller.openapi;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.inlong.common.pojo.audit.AuditConfig;
+import org.apache.inlong.common.pojo.audit.AuditConfigRequest;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.service.cluster.InlongClusterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Audit controller.
+ */
+@RestController("OpenAuditController")
+@RequestMapping("/openapi")
+@Api(tags = "Open-Audit-API")
+public class AuditController {
+
+    @Autowired
+    private InlongClusterService clusterService;
+
+    @PostMapping("/audit/getConfig")
+    @ApiOperation(value = "Get mq config list")
+    public Response<AuditConfig> getConfig(@RequestBody AuditConfigRequest request) {
+        AuditConfig auditConfig = clusterService.getAuditConfig(request.getClusterTag());
+        if (CollectionUtils.isEmpty(auditConfig.getMqInfoList())) {
+            return Response.fail("Failed to get MQ config of cluster tag: " + request.getClusterTag());
+        }
+        return Response.success(auditConfig);
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7413 

### Motivation

Get the MQ cluster address from the manager.

### Modifications

1. Fix `httpGet` to `httpPost`
2. Add managerHosts and cluster params in `server.properties`
3. Add open API in the manager

### Verifying this change

![企业微信截图_16789503041096](https://user-images.githubusercontent.com/58519431/225800442-076fb690-a9ee-4814-b777-77c77b895dfd.png)

