### PR TITLE
[INLONG-7673][Manager] Remove whitespace when saving url

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -35,6 +35,8 @@ public class InlongConstants {
      */
     public static final String COMMA = ",";
 
+    public static final String BLANK = " ";
+
     public static final String SLASH = "/";
 
     public static final String COLON = ":";

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterRequest.java
@@ -65,6 +65,7 @@ public abstract class ClusterRequest {
 
     @ApiModelProperty(value = "Cluster url")
     @Length(max = 512, message = "length must be less than or equal to 512")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String url;
 
     @ApiModelProperty(value = "Extension tag")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/pulsar/PulsarClusterRequest.java
@@ -27,6 +27,8 @@ import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * Inlong cluster request for Pulsar
  */
@@ -38,6 +40,7 @@ import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 public class PulsarClusterRequest extends ClusterRequest {
 
     @ApiModelProperty(value = "Pulsar admin URL, such as: http://127.0.0.1:8080", notes = "Pulsar service URL is the 'url' field of the cluster")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String adminUrl;
 
     @ApiModelProperty(value = "Pulsar tenant, default is 'public'")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/tubemq/TubeClusterRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/tubemq/TubeClusterRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * Inlong cluster request for TubeMQ
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.pojo.cluster.ClusterRequest;
 public class TubeClusterRequest extends ClusterRequest {
 
     @ApiModelProperty(value = "Master Web URL http://120.0.0.1:8080", notes = "TubeMQ master RPC URL is the 'url' field of the cluster")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String masterWebUrl;
 
     public TubeClusterRequest() {

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/DataNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/DataNodeRequest.java
@@ -60,6 +60,7 @@ public abstract class DataNodeRequest {
 
     @ApiModelProperty(value = "Data node URL")
     @Length(max = 512, message = "length must be less than or equal to 512")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String url;
 
     @ApiModelProperty(value = "Data node username")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/mysql/MySQLDataNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/node/mysql/MySQLDataNodeRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.DataNodeType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * MySQL data node request
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 public class MySQLDataNodeRequest extends DataNodeRequest {
 
     @ApiModelProperty("URL of backup DB server")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String backupUrl;
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/ck/ClickHouseSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/ck/ClickHouseSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * ClickHouse sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.pojo.sink.SinkRequest;
 public class ClickHouseSinkRequest extends SinkRequest {
 
     @ApiModelProperty("JDBC URL of the ClickHouse server")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username of the ClickHouse server")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/greenplum/GreenplumSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/greenplum/GreenplumSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * Greenplum sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 public class GreenplumSinkRequest extends SinkRequest {
 
     @ApiModelProperty("Greenplum JDBC URL such as:jdbc:postgresql://host:port/database")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/hive/HiveSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/hive/HiveSinkRequest.java
@@ -28,6 +28,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
@@ -42,6 +43,7 @@ import java.util.List;
 public class HiveSinkRequest extends SinkRequest {
 
     @ApiModelProperty("Hive JDBC URL, such as jdbc:hive2://${ip}:${port}")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username of the Hive server")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/hudi/HudiSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/hudi/HudiSinkRequest.java
@@ -28,6 +28,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * Hudi sink request.
  */
@@ -42,6 +44,7 @@ public class HudiSinkRequest extends SinkRequest {
     private String catalogType = "HIVE";
 
     @ApiModelProperty("Catalog uri, such as hive metastore thrift://ip:port")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String catalogUri;
 
     @ApiModelProperty("Hudi data warehouse dir")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -221,10 +221,11 @@ public class MySQLSinkDTO {
             return url;
         }
         try {
-            String resultUrl = url.replaceAll(InlongConstants.BLANK, "");
+            String resultUrl = url;
             while (resultUrl.contains(InlongConstants.PERCENT)) {
                 resultUrl = URLDecoder.decode(resultUrl, "UTF-8");
             }
+            resultUrl = resultUrl.replaceAll(InlongConstants.BLANK, "");
             for (String sensitiveParam : SENSITIVE_PARAM_MAP.keySet()) {
                 if (StringUtils.containsIgnoreCase(resultUrl, sensitiveParam)) {
                     resultUrl = StringUtils.replaceIgnoreCase(resultUrl, sensitiveParam,

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -221,7 +221,7 @@ public class MySQLSinkDTO {
             return url;
         }
         try {
-            String resultUrl = url;
+            String resultUrl = url.replaceAll(InlongConstants.BLANK, "");
             while (resultUrl.contains(InlongConstants.PERCENT)) {
                 resultUrl = URLDecoder.decode(resultUrl, "UTF-8");
             }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * MySQL sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 public class MySQLSinkRequest extends SinkRequest {
 
     @ApiModelProperty("MySQL JDBC URL, such as jdbc:mysql://host:port")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/oracle/OracleSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/oracle/OracleSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * Oracle sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 public class OracleSinkRequest extends SinkRequest {
 
     @ApiModelProperty("Oracle JDBC URL, such as jdbc:oracle:thin://host:port/database")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/postgresql/PostgreSQLSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/postgresql/PostgreSQLSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * PostgreSQL sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 public class PostgreSQLSinkRequest extends SinkRequest {
 
     @ApiModelProperty("JDBC URL of the PostgreSQL server")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/sqlserver/SQLServerSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/sqlserver/SQLServerSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * SQLServer sink request.
  */
@@ -43,6 +45,7 @@ public class SQLServerSinkRequest extends SinkRequest {
     private String password;
 
     @ApiModelProperty("SQLServer meta db URL, etc jdbc:sqlserver://host:port;databaseName=database")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Schema name of the SQLServer")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/starrocks/StarRocksSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * StarRocks sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.pojo.sink.SinkRequest;
 public class StarRocksSinkRequest extends SinkRequest {
 
     @ApiModelProperty("StarRocks jdbc url")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("StarRocks FE http address")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/tdsqlpostgresql/TDSQLPostgreSQLSinkRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/tdsqlpostgresql/TDSQLPostgreSQLSinkRequest.java
@@ -26,6 +26,8 @@ import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.pojo.sink.SinkRequest;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 
+import javax.validation.constraints.Pattern;
+
 /**
  * TDSQLPostgreSQL sink request.
  */
@@ -37,6 +39,7 @@ import org.apache.inlong.manager.common.util.JsonTypeDefine;
 public class TDSQLPostgreSQLSinkRequest extends SinkRequest {
 
     @ApiModelProperty("TDSQLPostgreSQL jdbc url, such as jdbc:postgresql://host:port/database")
+    @Pattern(regexp = "^((?!\\s).)*$", message = "not supports blank in url")
     private String jdbcUrl;
 
     @ApiModelProperty("Username for JDBC URL")

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
@@ -31,19 +31,19 @@ public class MySQLSinkDTOTest {
     public void testFilterSensitive() throws Exception {
         // the sensitive params no use url code
         String originUrl = MySQLSinkDTO.filterSensitive(
-                "autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true");
+                "autoDeserialize=TRue&allowLoadLocalInfile = TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true");
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=&autoReconnect=true",
                 originUrl);
 
         originUrl = MySQLSinkDTO.filterSensitive(
-                "autoReconnect=true&autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
+                "autoReconnect=true&autoDeserialize = TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
         Assertions.assertEquals(
                 "autoReconnect=true&autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
                 originUrl);
 
         originUrl = MySQLSinkDTO.filterSensitive(
-                "autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
+                "autoDeserialize=TRue&allowLoadLocalInfile = TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/");
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
                 originUrl);
@@ -51,7 +51,7 @@ public class MySQLSinkDTOTest {
         // the sensitive params use url code
         originUrl = MySQLSinkDTO.filterSensitive(
                 URLEncoder.encode(
-                        "autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true",
+                        "autoDeserialize=TRue&allowLoadLocalInfile = TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/&autoReconnect=true",
                         "UTF-8"));
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=&autoReconnect=true",
@@ -59,7 +59,7 @@ public class MySQLSinkDTOTest {
 
         originUrl = MySQLSinkDTO.filterSensitive(
                 URLEncoder.encode(
-                        "autoReconnect=true&autoDeserialize=TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                        "autoReconnect=true&autoDeserialize = TRue&allowLoadLocalInfile=TRue&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
                         "UTF-8"));
         Assertions.assertEquals(
                 "autoReconnect=true&autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
@@ -67,7 +67,7 @@ public class MySQLSinkDTOTest {
 
         originUrl = MySQLSinkDTO.filterSensitive(
                 URLEncoder.encode(
-                        "autoDeserialize=TRue&allowLoadLocalInfile=TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
+                        "autoDeserialize=TRue&allowLoadLocalInfile = TRue&autoReconnect=true&allowUrlInLocalInfile=TRue&allowLoadLocalInfileInPath=/",
                         "UTF-8"));
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7673 

### Motivation

Remove whitespace when saving mysql jdbcUrl to avoid circumventing sensitive parameters.
Prohibit users from adding URLs with spaces.

### Modifications

Remove whitespace when saving mysql jdbcUrl.
Prohibit users from adding URLs with spaces

