### PR TITLE
[INLONG-7683][Sort] Fix errors in Oracle UT

### DIFF
--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/OracleExtractSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/OracleExtractSqlParseTest.java
@@ -73,7 +73,7 @@ public class OracleExtractSqlParseTest extends AbstractTestBase {
         return new OracleExtractNode("1", "oracle_input", fields,
                 null, properties, "ID", "localhost",
                 "flinkuser", "flinkpw", "xE",
-                "flinkuser", "table", 1521, null);
+                "flinkuser", "flinkuser.table", 1521, null);
     }
 
     private Node buildKafkaLoadNode() {


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7683][Sort] Fix errors in Oracle UT

- Fixes #7683 

### Motivation

In Flink SQL, the Oracle table should be in the format of `schemaName.tableName`, not just `tableName`. For more details, please refer to the documentation at https://inlong.apache.org/zh-CN/docs/next/data_node/extract_node/oracle-cdc.


### Modifications

Modify `tableName` to `schemaName.tableName`