### PR TITLE
[INLONG-7695][Sort] Fix NPE when running Oracle all database migration jobs

### DIFF
--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/meta/split/SourceSplitState.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/meta/split/SourceSplitState.java
@@ -53,7 +53,7 @@ public abstract class SourceSplitState {
     /** Use the current split state to create a new SourceSplit. */
     public abstract SourceSplitBase toSourceSplit();
 
-    /** Get the current MySQLSplit. */
+    /** Get the current split. */
     @Internal
     public SourceSplitBase getSourceSplitBase() {
         return split;

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/meta/split/SourceSplitState.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/source/meta/split/SourceSplitState.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.cdc.base.source.meta.split;
 
+import org.apache.flink.annotation.Internal;
+
 /** State of the reader, essentially a mutable version of the {@link SourceSplitBase}.
  * Copy from com.ververica:flink-cdc-base:2.3.0.
  * */
@@ -50,4 +52,10 @@ public abstract class SourceSplitState {
 
     /** Use the current split state to create a new SourceSplit. */
     public abstract SourceSplitBase toSourceSplit();
+
+    /** Get the current MySQLSplit. */
+    @Internal
+    public SourceSplitBase getSourceSplitBase() {
+        return split;
+    }
 }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7695][Sort] Fix the error of enabling incremental snapshots when Oracle run all database migration job

- Fixes #7695

### Motivation

When running an all database migration job, we need to obtain its `tableSchema`, otherwise a null pointer error will be reported.


### Modifications

Get `tableSchema` from `splitState`.