### PR TITLE
[INLONG-7581][Sort] Support multiple-sink migration for Elasticsearch

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/es/ElasticsearchSink.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/es/ElasticsearchSink.java
@@ -75,6 +75,15 @@ public class ElasticsearchSink extends StreamSink {
     @ApiModelProperty("Elasticsearch version")
     private Integer esVersion;
 
+    @ApiModelProperty("The multiple enable of sink")
+    private Boolean sinkMultipleEnable = false;
+
+    @ApiModelProperty("The multiple format of sink")
+    private String sinkMultipleFormat;
+
+    @ApiModelProperty("The multiple index-pattern of sink")
+    private String indexPattern;
+
     public ElasticsearchSink() {
         this.setSinkType(SinkType.ELASTICSEARCH);
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -559,7 +559,7 @@ public class LoadNodeUtils {
                     format = new DebeziumJsonFormat();
                     break;
                 default:
-                    throw new IllegalArgumentException(String.format("Unsupported dataType=%s for doris", dataType));
+                    throw new IllegalArgumentException(String.format("Unsupported dataType=%s for elasticsearch", dataType));
             }
         }
         return new ElasticsearchLoadNode(

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -549,7 +549,7 @@ public class LoadNodeUtils {
         Format format = null;
         if (elasticsearchSink.getSinkMultipleEnable() != null && elasticsearchSink.getSinkMultipleEnable()
                 && StringUtils.isNotBlank(
-                elasticsearchSink.getSinkMultipleFormat())) {
+                        elasticsearchSink.getSinkMultipleFormat())) {
             DataTypeEnum dataType = DataTypeEnum.forType(elasticsearchSink.getSinkMultipleFormat());
             switch (dataType) {
                 case CANAL:

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -559,7 +559,8 @@ public class LoadNodeUtils {
                     format = new DebeziumJsonFormat();
                     break;
                 default:
-                    throw new IllegalArgumentException(String.format("Unsupported dataType=%s for elasticsearch", dataType));
+                    throw new IllegalArgumentException(
+                            String.format("Unsupported dataType=%s for elasticsearch", dataType));
             }
         }
         return new ElasticsearchLoadNode(

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -577,7 +577,10 @@ public class LoadNodeUtils {
                 elasticsearchSink.getPassword(),
                 elasticsearchSink.getDocumentType(),
                 elasticsearchSink.getPrimaryKey(),
-                elasticsearchSink.getEsVersion());
+                elasticsearchSink.getEsVersion(),
+                elasticsearchSink.getSinkMultipleEnable(),
+                format,
+                elasticsearchSink.getIndexPattern());
     }
 
     /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/LoadNodeUtils.java
@@ -546,6 +546,22 @@ public class LoadNodeUtils {
      */
     public static ElasticsearchLoadNode createLoadNode(ElasticsearchSink elasticsearchSink,
             List<FieldInfo> fieldInfos, List<FieldRelation> fieldRelations, Map<String, String> properties) {
+        Format format = null;
+        if (elasticsearchSink.getSinkMultipleEnable() != null && elasticsearchSink.getSinkMultipleEnable()
+                && StringUtils.isNotBlank(
+                elasticsearchSink.getSinkMultipleFormat())) {
+            DataTypeEnum dataType = DataTypeEnum.forType(elasticsearchSink.getSinkMultipleFormat());
+            switch (dataType) {
+                case CANAL:
+                    format = new CanalJsonFormat();
+                    break;
+                case DEBEZIUM_JSON:
+                    format = new DebeziumJsonFormat();
+                    break;
+                default:
+                    throw new IllegalArgumentException(String.format("Unsupported dataType=%s for doris", dataType));
+            }
+        }
         return new ElasticsearchLoadNode(
                 elasticsearchSink.getSinkName(),
                 elasticsearchSink.getSinkName(),

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
@@ -28,6 +28,7 @@ import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.InlongMetric;
 import org.apache.inlong.sort.protocol.enums.FilterStrategy;
 import org.apache.inlong.sort.protocol.node.LoadNode;
+import org.apache.inlong.sort.protocol.node.format.Format;
 import org.apache.inlong.sort.protocol.transformation.FieldRelation;
 import org.apache.inlong.sort.protocol.transformation.FilterFunction;
 
@@ -73,6 +74,19 @@ public class ElasticsearchLoadNode extends LoadNode implements InlongMetric, Ser
     @JsonProperty("version")
     private int version;
 
+    @Nullable
+    @JsonProperty("sinkMultipleEnable")
+    private Boolean sinkMultipleEnable = false;
+
+    @Nullable
+    @JsonProperty("sinkMultipleFormat")
+    private Format sinkMultipleFormat;
+
+    @Nullable
+    @JsonProperty("indexPattern")
+    private String indexPattern;
+
+
     @JsonCreator
     public ElasticsearchLoadNode(@JsonProperty("id") String id,
             @JsonProperty("name") String name,
@@ -88,7 +102,10 @@ public class ElasticsearchLoadNode extends LoadNode implements InlongMetric, Ser
             @Nonnull @JsonProperty("password") String password,
             @Nonnull @JsonProperty("documentType") String documentType,
             @Nonnull @JsonProperty("primaryKey") String primaryKey,
-            @JsonProperty("version") int version) {
+            @JsonProperty("version") int version,
+            @Nullable @JsonProperty("sinkMultipleEnable") Boolean sinkMultipleEnable,
+            @Nullable @JsonProperty("sinkMultipleFormat") Format sinkMultipleFormat,
+            @Nullable @JsonProperty("indexPattern") String indexPattern) {
         super(id, name, fields, fieldRelationShips, filters, filterStrategy, sinkParallelism, properties);
         this.password = Preconditions.checkNotNull(password, "password is null");
         this.username = Preconditions.checkNotNull(username, "username is null");
@@ -97,6 +114,10 @@ public class ElasticsearchLoadNode extends LoadNode implements InlongMetric, Ser
         this.documentType = documentType;
         this.primaryKey = primaryKey;
         this.version = version;
+        this.sinkMultipleEnable = sinkMultipleEnable;
+        this.sinkMultipleFormat = sinkMultipleFormat;
+        this.indexPattern = indexPattern;
+
     }
 
     /**

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/ElasticsearchLoadNode.java
@@ -86,7 +86,6 @@ public class ElasticsearchLoadNode extends LoadNode implements InlongMetric, Ser
     @JsonProperty("indexPattern")
     private String indexPattern;
 
-
     @JsonCreator
     public ElasticsearchLoadNode(@JsonProperty("id") String id,
             @JsonProperty("name") String name,

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ElasticSearchNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/ElasticSearchNodeTest.java
@@ -38,6 +38,6 @@ public class ElasticSearchNodeTest extends SerializeBaseTest<Node> {
                                 new FieldInfo("id", new StringFormatInfo()))),
                 null, null, 1, null,
                 "index", "hosts", "username",
-                "password", "documentType", "age", 7);
+                "password", "documentType", "age", 7, false, null, null);
     }
 }

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/MultipleRowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/MultipleRowElasticsearchSinkFunction.java
@@ -31,7 +31,7 @@ import javax.annotation.Nullable;
 import java.util.function.Function;
 
 /**
- * ElasticsearchSinkFunction for elasticsearch7
+ * ElasticsearchSinkFunction for elasticsearch6
  */
 public class MultipleRowElasticsearchSinkFunction
         extends

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/MultipleRowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/MultipleRowElasticsearchSinkFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.elasticsearch6;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
+import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
+import org.apache.inlong.sort.elasticsearch.table.MultipleElasticsearchSinkFunctionBase;
+import org.apache.inlong.sort.elasticsearch.table.RequestFactory;
+import org.apache.inlong.sort.elasticsearch.table.TableSchemaFactory;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+/**
+ * ElasticsearchSinkFunction for elasticsearch7
+ */
+public class MultipleRowElasticsearchSinkFunction
+        extends
+            MultipleElasticsearchSinkFunctionBase<DocWriteRequest<?>, XContentType> {
+
+    private static final long serialVersionUID = 1L;
+
+    public MultipleRowElasticsearchSinkFunction(
+            @Nullable String docType, // this is deprecated in es 7+
+            SerializationSchema<RowData> serializationSchema,
+            XContentType contentType,
+            RequestFactory<DocWriteRequest<?>, XContentType> requestFactory,
+            Function<RowData, String> createKey,
+            @Nullable Function<RowData, String> createRouting,
+            DirtySinkHelper<Object> dirtySinkHelper,
+            TableSchemaFactory schema,
+            String multipleFormat,
+            String indexPattern,
+            SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy) {
+        super(docType, serializationSchema, contentType,
+                requestFactory, createKey, createRouting, dirtySinkHelper,
+                schema, multipleFormat, indexPattern, schemaUpdateExceptionPolicy);
+    }
+
+    @Override
+    public void handleRouting(DocWriteRequest<?> request, String routing) {
+        request.routing(routing);
+    }
+}

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSinkFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSinkFactory.java
@@ -47,6 +47,7 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_SCHEMA_UPDATE_POLICY;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLASH_MAX_SIZE_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_BACKOFF_DELAY_OPTION;
@@ -65,7 +66,6 @@ import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.IN
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.ROUTING_FIELD_NAME;
-import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_FORMAT;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSinkFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSinkFactory.java
@@ -35,6 +35,7 @@ import org.apache.inlong.sort.base.dirty.DirtyOptions;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
+import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.elasticsearch.table.ElasticsearchValidationUtils;
 
 import java.util.Set;
@@ -45,6 +46,8 @@ import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_SCHEMA_UPDATE_POLICY;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLASH_MAX_SIZE_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_BACKOFF_DELAY_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_BACKOFF_MAX_RETRIES_OPTION;
@@ -62,6 +65,8 @@ import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.IN
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.ROUTING_FIELD_NAME;
+import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /**
@@ -91,7 +96,11 @@ public class Elasticsearch6DynamicSinkFactory implements DynamicTableSinkFactory
                     USERNAME_OPTION,
                     INLONG_METRIC,
                     INLONG_AUDIT,
-                    AUDIT_KEYS)
+                    AUDIT_KEYS,
+                    SINK_MULTIPLE_FORMAT,
+                    SINK_MULTIPLE_INDEX_PATTERN,
+                    SINK_MULTIPLE_ENABLE,
+                    SINK_MULTIPLE_SCHEMA_UPDATE_POLICY)
                     .collect(Collectors.toSet());
 
     private static void validate(boolean condition, Supplier<String> message) {
@@ -119,9 +128,15 @@ public class Elasticsearch6DynamicSinkFactory implements DynamicTableSinkFactory
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(helper.getOptions());
         final DirtySink<Object> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
         final DirtySinkHelper<Object> dirtySinkHelper = new DirtySinkHelper<>(dirtyOptions, dirtySink);
+        final boolean multipleSink = helper.getOptions().getOptional(SINK_MULTIPLE_ENABLE).orElse(false);
+        final String indexPattern = helper.getOptions().getOptional(SINK_MULTIPLE_INDEX_PATTERN).orElse(null);
+        final String multipleFormat = helper.getOptions().getOptional(SINK_MULTIPLE_FORMAT).orElse(null);
+        final SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy =
+                helper.getOptions().getOptional(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY).orElse(null);
         return new Elasticsearch6DynamicSink(
                 format, config, TableSchemaUtils.getPhysicalSchema(tableSchema),
-                inlongMetric, auditHostAndPorts, dirtySinkHelper);
+                inlongMetric, auditHostAndPorts, dirtySinkHelper, multipleSink, multipleFormat, indexPattern,
+                schemaUpdateExceptionPolicy);
     }
 
     private void validate(Elasticsearch6Configuration config, Configuration originalConfiguration) {

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/MultipleRowElasticsearchSinkFunction.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/MultipleRowElasticsearchSinkFunction.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.elasticsearch7;
+
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
+import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
+import org.apache.inlong.sort.elasticsearch.table.MultipleElasticsearchSinkFunctionBase;
+import org.apache.inlong.sort.elasticsearch.table.RequestFactory;
+import org.apache.inlong.sort.elasticsearch.table.TableSchemaFactory;
+import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+/**
+ * ElasticsearchSinkFunction for elasticsearch7
+ */
+public class MultipleRowElasticsearchSinkFunction
+        extends
+            MultipleElasticsearchSinkFunctionBase<DocWriteRequest<?>, XContentType> {
+
+    private static final long serialVersionUID = 1L;
+
+    public MultipleRowElasticsearchSinkFunction(
+            @Nullable String docType, // this is deprecated in es 7+
+            SerializationSchema<RowData> serializationSchema,
+            XContentType contentType,
+            RequestFactory<DocWriteRequest<?>, XContentType> requestFactory,
+            Function<RowData, String> createKey,
+            @Nullable Function<RowData, String> createRouting,
+            DirtySinkHelper<Object> dirtySinkHelper,
+            TableSchemaFactory schema,
+            String multipleFormat,
+            String indexPattern,
+            SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy) {
+        super(docType, serializationSchema, contentType,
+                requestFactory, createKey, createRouting, dirtySinkHelper,
+                schema, multipleFormat, indexPattern, schemaUpdateExceptionPolicy);
+    }
+
+    @Override
+    public void handleRouting(DocWriteRequest<?> request, String routing) {
+        request.routing(routing);
+    }
+}

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7Configuration.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7Configuration.java
@@ -31,6 +31,7 @@ import org.elasticsearch.action.DocWriteRequest;
 
 import java.util.List;
 import java.util.stream.Collectors;
+
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.FAILURE_HANDLER_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.HOSTS_OPTION;
 

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
@@ -34,11 +34,12 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
+import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
+import org.apache.inlong.sort.elasticsearch.ElasticsearchSinkFunction;
 import org.apache.inlong.sort.elasticsearch.table.IndexGeneratorFactory;
 import org.apache.inlong.sort.elasticsearch.table.KeyExtractor;
 import org.apache.inlong.sort.elasticsearch.table.RequestFactory;
 import org.apache.inlong.sort.elasticsearch.table.RoutingExtractor;
-import org.apache.inlong.sort.elasticsearch7.ElasticsearchSink;
 import org.apache.inlong.sort.elasticsearch.table.TableSchemaFactory;
 import org.apache.inlong.sort.elasticsearch7.ElasticsearchSink;
 import org.apache.inlong.sort.elasticsearch7.MultipleRowElasticsearchSinkFunction;
@@ -63,7 +64,7 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
 
     @VisibleForTesting
     static final Elasticsearch7RequestFactory REQUEST_FACTORY =
-            new Elasticsearch7DynamicSink.Elasticsearch7RequestFactory();
+            new Elasticsearch7RequestFactory();
 
     private final EncodingFormat<SerializationSchema<RowData>> format;
     private final TableSchema schema;
@@ -72,6 +73,10 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
     private final String auditHostAndPorts;
     private final ElasticSearchBuilderProvider builderProvider;
     private final DirtySinkHelper<Object> dirtySinkHelper;
+    private final boolean multipleSink;
+    private final String multipleFormat;
+    private final String indexPattern;
+    private final SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy;
 
     // --------------------------------------------------------------
     // Hack to make configuration testing possible.
@@ -89,9 +94,14 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
             TableSchema schema,
             String inlongMetric,
             String auditHostAndPorts,
-            DirtySinkHelper<Object> dirtySinkHelper) {
+            DirtySinkHelper<Object> dirtySinkHelper,
+            boolean multipleSink,
+            String multipleFormat,
+            String indexPattern,
+            SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy) {
         this(format, config, schema, (ElasticsearchSink.Builder::new),
-                inlongMetric, auditHostAndPorts, dirtySinkHelper);
+                inlongMetric, auditHostAndPorts, dirtySinkHelper, multipleSink, multipleFormat, indexPattern,
+                schemaUpdateExceptionPolicy);
     }
 
     Elasticsearch7DynamicSink(
@@ -101,7 +111,11 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
             ElasticSearchBuilderProvider builderProvider,
             String inlongMetric,
             String auditHostAndPorts,
-            DirtySinkHelper<Object> dirtySinkHelper) {
+            DirtySinkHelper<Object> dirtySinkHelper,
+            boolean multipleSink,
+            String multipleFormat,
+            String indexPattern,
+            SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy) {
         this.format = format;
         this.schema = schema;
         this.config = config;
@@ -109,6 +123,11 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
         this.dirtySinkHelper = dirtySinkHelper;
+        this.multipleSink = multipleSink;
+        this.multipleFormat = multipleFormat;
+        this.indexPattern = indexPattern;
+        this.schemaUpdateExceptionPolicy = schemaUpdateExceptionPolicy;
+
     }
 
     @Override
@@ -120,11 +139,44 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
     // End of hack to make configuration testing possible
     // --------------------------------------------------------------
 
+    private ElasticsearchSinkFunction<RowData, DocWriteRequest<?>> createSinkFunction(
+            SerializationSchema<RowData> format,
+            Context context) {
+
+        if (multipleSink) {
+            return new MultipleRowElasticsearchSinkFunction(
+                    null, // this is deprecated in es 7+
+                    format,
+                    XContentType.JSON,
+                    REQUEST_FACTORY,
+                    KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()),
+                    RoutingExtractor.createRoutingExtractor(
+                            schema, config.getRoutingField().orElse(null)),
+                    dirtySinkHelper,
+                    new TableSchemaFactory(schema.getFieldNames(), schema.getFieldTypes()),
+                    multipleFormat,
+                    indexPattern,
+                    schemaUpdateExceptionPolicy);
+        }
+
+        return new RowElasticsearchSinkFunction(
+                IndexGeneratorFactory.createIndexGenerator(config.getIndex(), schema),
+                null, // this is deprecated in es 7+
+                format,
+                XContentType.JSON,
+                REQUEST_FACTORY,
+                KeyExtractor.createKeyExtractor(schema, config.getKeyDelimiter()),
+                RoutingExtractor.createRoutingExtractor(
+                        schema, config.getRoutingField().orElse(null)),
+                dirtySinkHelper);
+    }
+
     @Override
     public SinkFunctionProvider getSinkRuntimeProvider(Context context) {
         return () -> {
             SerializationSchema<RowData> format =
                     this.format.createRuntimeEncoder(context, schema.toRowDataType());
+
             final ElasticsearchSinkFunction<RowData, DocWriteRequest<?>> upsertFunction =
                     createSinkFunction(format, context);
             final ElasticsearchSink.Builder<RowData> builder =
@@ -199,7 +251,7 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
     interface ElasticSearchBuilderProvider {
 
         ElasticsearchSink.Builder<RowData> createBuilder(
-                List<HttpHost> httpHosts, RowElasticsearchSinkFunction upsertSinkFunction);
+                List<HttpHost> httpHosts, ElasticsearchSinkFunction<RowData, DocWriteRequest<?>> upsertSinkFunction);
     }
 
     /**

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
@@ -67,7 +67,6 @@ import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.PA
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.ROUTING_FIELD_NAME;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN;
-import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 
 /**
  * A {@link DynamicTableSinkFactory} for discovering {@link Elasticsearch7DynamicSink}.

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
@@ -36,6 +36,8 @@ import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.elasticsearch.table.ElasticsearchValidationUtils;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_SCHEMA_UPDATE_POLICY;
 
 import java.util.Set;
 import java.util.function.Supplier;

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSinkFactory.java
@@ -37,7 +37,6 @@ import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.elasticsearch.table.ElasticsearchValidationUtils;
-
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -48,6 +47,7 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_SCHEMA_UPDATE_POLICY;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLASH_MAX_SIZE_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.BULK_FLUSH_BACKOFF_DELAY_OPTION;
@@ -65,7 +65,7 @@ import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.IN
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.KEY_DELIMITER_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.PASSWORD_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.ROUTING_FIELD_NAME;
-import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN;
 import static org.apache.inlong.sort.elasticsearch.table.ElasticsearchOptions.USERNAME_OPTION;
 

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>1.7.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch-base</artifactId>

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-elasticsearch-base_2.12</artifactId>
-            <version>1.13.5</version>
+            <version>${flink.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -107,7 +107,7 @@
             <artifactId>audit-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <!-- Elasticsearch table sink factory testing -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -102,6 +102,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
         <!-- Elasticsearch table sink factory testing -->
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors</artifactId>
-        <version>1.7.0-SNAPSHOT</version>
+        <version>1.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch-base</artifactId>
@@ -129,6 +129,20 @@
             <groupId>org.apache.inlong</groupId>
             <artifactId>audit-sdk</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-connector-elasticsearch-base_2.12</artifactId>
+            <version>1.13.5</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-json</artifactId>
         </dependency>
     </dependencies>
 

--- a/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-connectors/elasticsearch-base/pom.xml
@@ -126,23 +126,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>audit-sdk</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-elasticsearch-base_2.12</artifactId>
-            <version>${flink.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-json</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchConfiguration.java
@@ -124,6 +124,14 @@ public class ElasticsearchConfiguration {
         return config.getOptional(ElasticsearchOptions.CONNECTION_PATH_PREFIX);
     }
 
+    public Optional<String> getMultipleFormat() {
+        return config.getOptional(ElasticsearchOptions.SINK_MULTIPLE_FORMAT);
+    }
+
+    public Optional<String> getMultipleIndexPattern() {
+        return config.getOptional(ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchConfiguration.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchConfiguration.java
@@ -124,10 +124,6 @@ public class ElasticsearchConfiguration {
         return config.getOptional(ElasticsearchOptions.CONNECTION_PATH_PREFIX);
     }
 
-    public Optional<String> getMultipleFormat() {
-        return config.getOptional(ElasticsearchOptions.SINK_MULTIPLE_FORMAT);
-    }
-
     public Optional<String> getMultipleIndexPattern() {
         return config.getOptional(ElasticsearchOptions.SINK_MULTIPLE_INDEX_PATTERN);
     }

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
@@ -143,6 +143,20 @@ public class ElasticsearchOptions {
                     .withDescription(
                             "The format must produce a valid JSON document. "
                                     + "Please refer to the documentation on formats for more details.");
+    
+    public static final ConfigOption<String> SINK_MULTIPLE_FORMAT =
+            ConfigOptions.key("sink.multiple.format")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The format of multiple sink, it represents the real format of the raw binary data");
+    public static final ConfigOption<String> SINK_MULTIPLE_INDEX_PATTERN =
+            ConfigOptions.key("sink.multiple.index-pattern")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The option 'sink.multiple.table-pattern' "
+                            + "is used extract table name from the raw binary data, "
+                            + "this is only used in the multiple sink writing scenario.");
 
     private ElasticsearchOptions() {
 

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
@@ -143,7 +143,7 @@ public class ElasticsearchOptions {
                     .withDescription(
                             "The format must produce a valid JSON document. "
                                     + "Please refer to the documentation on formats for more details.");
-    
+
     public static final ConfigOption<String> SINK_MULTIPLE_FORMAT =
             ConfigOptions.key("sink.multiple.format")
                     .stringType()

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/ElasticsearchOptions.java
@@ -144,12 +144,6 @@ public class ElasticsearchOptions {
                             "The format must produce a valid JSON document. "
                                     + "Please refer to the documentation on formats for more details.");
 
-    public static final ConfigOption<String> SINK_MULTIPLE_FORMAT =
-            ConfigOptions.key("sink.multiple.format")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription(
-                            "The format of multiple sink, it represents the real format of the raw binary data");
     public static final ConfigOption<String> SINK_MULTIPLE_INDEX_PATTERN =
             ConfigOptions.key("sink.multiple.index-pattern")
                     .stringType()

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
 import java.util.UUID;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
@@ -1,0 +1,346 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.elasticsearch.table;
+
+import org.apache.flink.api.common.functions.RuntimeContext;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.formats.common.TimestampFormat;
+import org.apache.flink.formats.json.JsonOptions.MapNullKeyMode;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
+import java.util.UUID;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
+import org.apache.inlong.sort.base.dirty.DirtyType;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
+import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
+import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
+import org.apache.inlong.sort.elasticsearch.ElasticsearchSinkFunction;
+import org.apache.inlong.sort.elasticsearch.RequestIndexer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Sink function for converting upserts into Elasticsearch ActionRequests.
+ */
+public abstract class MultipleElasticsearchSinkFunctionBase<Request, ContentType>
+        implements
+            ElasticsearchSinkFunction<RowData, Request> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSinkFunctionBase.class);
+
+    private final String docType;
+    private final ContentType contentType;
+    private final RequestFactory<Request, ContentType> requestFactory;
+    private final Function<RowData, String> createKey;
+    private final Function<RowData, String> createRouting;
+    private final DirtySinkHelper<Object> dirtySinkHelper;
+    private final String multipleFormat;
+    private final String indexPattern;
+    private final TableSchemaFactory tableSchemaFactory;
+    // initialized and reserved for a later feature.
+    private final SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy;
+    // open and store an index generator for each new index.
+    private Map<String, IndexGenerator> indexGeneratorMap;
+    // table level metrics
+    private SinkMetricData sinkMetricData;
+    private transient JsonDynamicSchemaFormat jsonDynamicSchemaFormat;
+    private transient SerializationSchema<RowData> serializationSchema;
+
+    public MultipleElasticsearchSinkFunctionBase(
+            @Nullable String docType, // this is deprecated in es 7+
+            SerializationSchema<RowData> serializationSchema,
+            ContentType contentType,
+            RequestFactory<Request, ContentType> requestFactory,
+            Function<RowData, String> createKey,
+            @Nullable Function<RowData, String> createRouting,
+            DirtySinkHelper<Object> dirtySinkHelper,
+            TableSchemaFactory tableSchemaFactory,
+            String multipleFormat,
+            String indexPattern,
+            SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy) {
+        this.docType = docType;
+        this.serializationSchema = Preconditions.checkNotNull(serializationSchema);
+        this.contentType = Preconditions.checkNotNull(contentType);
+        this.requestFactory = Preconditions.checkNotNull(requestFactory);
+        this.createKey = Preconditions.checkNotNull(createKey);
+        this.createRouting = createRouting;
+        this.dirtySinkHelper = dirtySinkHelper;
+        this.tableSchemaFactory = tableSchemaFactory;
+        this.multipleFormat = multipleFormat;
+        this.indexPattern = indexPattern;
+        this.schemaUpdateExceptionPolicy = schemaUpdateExceptionPolicy;
+    }
+
+    @Override
+    public void open(RuntimeContext ctx, SinkMetricData sinkMetricData) {
+        indexGeneratorMap = new HashMap<>();
+        this.sinkMetricData = sinkMetricData;
+    }
+
+    private void sendMetrics(byte[] document) {
+        if (sinkMetricData != null) {
+            sinkMetricData.invoke(1, document.length);
+        }
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) {
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) {
+    }
+
+    // dynamically parse the columns of the schema and deserialize the canal-json element
+    private RowData parseElement(RowData element, JsonNode rootNode) {
+        RowType rowType = jsonDynamicSchemaFormat.extractSchema(rootNode);
+        RowData result = jsonDynamicSchemaFormat.extractRowData(rootNode, rowType).get(0);
+        debugconverter(result, rowType);
+        LOGGER.info("parseElement result, rootNode:{}", rootNode);
+        LOGGER.info("parseElement result, rowType:{}", rowType);
+        LOGGER.info("parseElement result, result:{}", result);
+        return result;
+    }
+
+    private void debugconverter(RowData row, RowType type) {
+        final String[] fieldNames = type.getFieldNames().toArray(new String[0]);
+        for (String fieldname : fieldNames) {
+            LOGGER.info("fieldname:{}", fieldname);
+        }
+        final LogicalType[] fieldTypes =
+                type.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .toArray(LogicalType[]::new);
+        for (LogicalType fieldType : fieldTypes) {
+            LOGGER.info("fieldType:{}", fieldType);
+        }
+        final int fieldCount = type.getFieldCount();
+        final RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[fieldTypes.length];
+        for (int i = 0; i < fieldCount; i++) {
+            fieldGetters[i] = RowData.createFieldGetter(fieldTypes[i], i);
+            LOGGER.info("fieldgetter {}:{}", i, fieldGetters[i]);
+        }
+
+        for (int i = 0; i < fieldCount; i++) {
+            String fieldName = fieldNames[i];
+            Object field = fieldGetters[i].getFieldOrNull(row);
+            LOGGER.info("debugconverter field is {}:{}", fieldName, field);
+        }
+    }
+
+    @Override
+    public void process(RowData element, RuntimeContext ctx, RequestIndexer<Request> indexer) {
+        LOGGER.info("starting to process, rowdata:{}", element);
+        JsonNode rootNode = null;
+        // parse rootnode
+        try {
+            LOGGER.info("multipleFormat:{}", multipleFormat);
+            jsonDynamicSchemaFormat =
+                    (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(multipleFormat);
+            LOGGER.info("jsonDynamicSchemaFormat:{}", jsonDynamicSchemaFormat);
+            rootNode = jsonDynamicSchemaFormat.deserialize(element.getBinary(0));
+            // Ignore ddl change for now
+            boolean isDDL = jsonDynamicSchemaFormat.extractDDLFlag(rootNode);
+            if (isDDL) {
+                LOGGER.error("ddl change unsupported");
+                return;
+            }
+        } catch (Exception e) {
+            LOGGER.error(String.format("deserialize error, raw data: %s", new String(element.getBinary(0))), e);
+        }
+
+        // RowData data = parseElement(element, rootNode);
+
+        RowType rowType = jsonDynamicSchemaFormat.extractSchema(rootNode);
+        RowData data = jsonDynamicSchemaFormat.extractRowData(rootNode, rowType).get(0);
+        LOGGER.info("rowtype:{}", rowType);
+        LOGGER.info("data:{}", data);
+        // generate the serialization schema
+        serializationSchema = new JsonRowDataSerializationSchema(
+                rowType, TimestampFormat.ISO_8601, MapNullKeyMode.LITERAL, "null", true);
+
+        final byte[] document;
+        try {
+            // for multiple sink, need to update runtimeconverter to correct rowtype
+            // for now create custom schema
+            document = serializationSchema.serialize(data);
+        } catch (Exception e) {
+            LOGGER.error(String.format("Serialize error, raw data: %s", data), e);
+            dirtySinkHelper.invoke(data, DirtyType.SERIALIZE_ERROR, e);
+            if (sinkMetricData != null) {
+                sinkMetricData.invokeDirty(1, data.toString().getBytes(StandardCharsets.UTF_8).length);
+            }
+            return;
+        }
+        final String key;
+        try {
+            // use uuid3 as key
+            JsonNode physicalData = jsonDynamicSchemaFormat.getPhysicalData(rootNode);
+            // will this line have performance issues?
+            key = UUID.nameUUIDFromBytes(physicalData.toString().getBytes(StandardCharsets.UTF_8)).toString();
+            LOGGER.info("physical data is:{}, key is:{}", physicalData, key);
+        } catch (Exception e) {
+            LOGGER.error(String.format("Generate index id error, raw data: %s", data), e);
+            dirtySinkHelper.invoke(data, DirtyType.INDEX_ID_GENERATE_ERROR, e);
+            if (sinkMetricData != null) {
+                sinkMetricData.invokeDirty(1, document.length);
+            }
+            return;
+        }
+        final String index;
+        try {
+            index = parseIndex(data, rootNode);
+        } catch (Exception e) {
+            LOGGER.error(String.format("Generate index error, raw data: %s", data), e);
+            dirtySinkHelper.invoke(data, DirtyType.INDEX_GENERATE_ERROR, e);
+            if (sinkMetricData != null) {
+                sinkMetricData.invokeDirty(1, document.length);
+            }
+            return;
+        }
+        addDocument(data, key, index, document, indexer);
+    }
+
+    private String parseIndex(RowData rowData, JsonNode rootNode)
+            throws Exception {
+        String index;
+        // parse the index dynamically, put index generators
+        try {
+            LOGGER.info("indexPattern:{}", indexPattern);
+            String rawIndex = jsonDynamicSchemaFormat.parse(rootNode, indexPattern);
+            if (!indexGeneratorMap.containsKey(rawIndex)) {
+                TableSchema schema = tableSchemaFactory.getSchema();
+                IndexGenerator indexGenerator = IndexGeneratorFactory.createIndexGenerator(rawIndex, schema);
+                indexGeneratorMap.put(rawIndex, indexGenerator);
+                indexGenerator.open();
+            }
+            LOGGER.info("indexGeneratorMap:{}", indexGeneratorMap);
+            index = indexGeneratorMap.get(rawIndex).generate(rowData);
+            LOGGER.info("index:{}", index);
+        } catch (Exception e) {
+            LOGGER.error(String.format("json parse error, raw data: %s", new String(rowData.getBinary(0))), e);
+            throw e;
+        }
+        return index;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addDocument(RowData element, String key, String index, byte[] document,
+            RequestIndexer<Request> indexer) {
+        Request request;
+        switch (element.getRowKind()) {
+            case INSERT:
+            case UPDATE_AFTER:
+                if (key != null) {
+                    request = requestFactory.createUpdateRequest(index, docType, key, contentType, document);
+                    if (addRouting(request, element, document)) {
+                        indexer.add(request);
+                        sendMetrics(document);
+                    }
+                } else {
+                    request = requestFactory.createIndexRequest(index, docType, key, contentType, document);
+                    if (addRouting(request, element, document)) {
+                        indexer.add(request);
+                        sendMetrics(document);
+                    }
+                }
+                break;
+            case DELETE:
+                request = requestFactory.createDeleteRequest(index, docType, key);
+                if (addRouting(request, element, document)) {
+                    indexer.add(request);
+                    sendMetrics(document);
+                }
+                break;
+            case UPDATE_BEFORE:
+                sendMetrics(document);
+                break;
+            default:
+                LOGGER.error(String.format("The type of element should be 'RowData' only, raw data: %s", element));
+                dirtySinkHelper.invoke(element, DirtyType.UNSUPPORTED_DATA_TYPE,
+                        new RuntimeException("The type of element should be 'RowData' only."));
+                if (sinkMetricData != null) {
+                    sinkMetricData.invokeDirty(1, document.length);
+                }
+        }
+    }
+
+    private boolean addRouting(Request request, RowData row, byte[] document) {
+        if (null != createRouting) {
+            try {
+                String routing = createRouting.apply(row);
+                handleRouting(request, routing);
+            } catch (Exception e) {
+                LOGGER.error(String.format("Routing error, raw data: %s", row), e);
+                dirtySinkHelper.invoke(row, DirtyType.INDEX_ROUTING_ERROR, e);
+                if (sinkMetricData != null) {
+                    sinkMetricData.invokeDirty(1, document.length);
+                }
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public abstract void handleRouting(Request request, String routing);
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        @SuppressWarnings("unchecked")
+        MultipleElasticsearchSinkFunctionBase<Request, ContentType> that =
+                (MultipleElasticsearchSinkFunctionBase<Request, ContentType>) o;
+        return Objects.equals(docType, that.docType)
+                && Objects.equals(serializationSchema, that.serializationSchema)
+                && contentType == that.contentType
+                && Objects.equals(requestFactory, that.requestFactory)
+                && Objects.equals(createKey, that.createKey);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                docType,
+                serializationSchema,
+                contentType,
+                requestFactory,
+                createKey);
+    }
+}

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
@@ -28,7 +28,6 @@ import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
 
-import java.io.IOException;
 import java.util.UUID;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/MultipleElasticsearchSinkFunctionBase.java
@@ -27,6 +27,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.formats.json.JsonRowDataSerializationSchema;
+
+import java.io.IOException;
 import java.util.UUID;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.Preconditions;
@@ -138,6 +140,7 @@ public abstract class MultipleElasticsearchSinkFunctionBase<Request, ContentType
             }
         } catch (Exception e) {
             LOGGER.error(String.format("deserialize error, raw data: %s", new String(element.getBinary(0))), e);
+            throw new RuntimeException(e);
         }
 
         RowType rowType = jsonDynamicSchemaFormat.extractSchema(rootNode);
@@ -163,7 +166,6 @@ public abstract class MultipleElasticsearchSinkFunctionBase<Request, ContentType
         try {
             // use uuid3 as key
             JsonNode physicalData = jsonDynamicSchemaFormat.getPhysicalData(rootNode);
-            // will this line have performance issues?
             key = UUID.nameUUIDFromBytes(physicalData.toString().getBytes(StandardCharsets.UTF_8)).toString();
         } catch (Exception e) {
             LOGGER.error(String.format("Generate index id error, raw data: %s", data), e);

--- a/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/TableSchemaFactory.java
+++ b/inlong-sort/sort-connectors/elasticsearch-base/src/main/java/org/apache/inlong/sort/elasticsearch/table/TableSchemaFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.elasticsearch.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.api.TableSchema;
+import java.io.Serializable;
+
+public class TableSchemaFactory implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    String[] fieldNames;
+    TypeInformation<?>[] fieldTypes;
+
+    public TableSchemaFactory(String[] fieldNames, TypeInformation<?>[] fieldTypes) {
+        this.fieldNames = fieldNames;
+        this.fieldTypes = fieldTypes;
+
+    }
+
+    public TableSchema getSchema() {
+        return new TableSchema(fieldNames, fieldTypes);
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
@@ -101,7 +101,7 @@ public class ESMultipleSinkTest {
      * @throws Exception The exception may be thrown when executing
      */
     @Test
-    public void testDorisMultipleSinkParse() throws Exception {
+    public void testESMultipleSinkParse() throws Exception {
         EnvironmentSettings settings = EnvironmentSettings
                 .newInstance()
                 .useBlinkPlanner()

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.inlong.sort.formats.common.VarBinaryFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.enums.KafkaScanStartupMode;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.KafkaExtractNode;
+import org.apache.inlong.sort.protocol.node.format.CanalJsonFormat;
+import org.apache.inlong.sort.protocol.node.format.RawFormat;
+import org.apache.inlong.sort.protocol.node.load.ElasticsearchLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test for {@link ElasticsearchLoadNode}
+ */
+public class ESMultipleSinkTest {
+
+    private KafkaExtractNode buildKafkaExtractNode() {
+        List<FieldInfo> fields = Collections.singletonList(new FieldInfo("raw", new VarBinaryFormatInfo()));
+        return new KafkaExtractNode("1", "kafka_input", fields,
+                null, null, "kafka_raw", "localhost:9092",
+                new RawFormat(), KafkaScanStartupMode.EARLIEST_OFFSET, null,
+                "test_group", null, null);
+    }
+
+    /**
+     * Build node relation
+     *
+     * @param inputs extract node
+     * @param outputs load node
+     * @return node relation
+     */
+    private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    private ElasticsearchLoadNode buildESLoadNodeWithMultipleSink(String indexPattern) {
+        List<FieldInfo> fields = Collections.singletonList(new FieldInfo("raw", new VarBinaryFormatInfo()));
+        List<FieldRelation> relations = Collections
+                .singletonList(new FieldRelation(new FieldInfo("raw", new VarBinaryFormatInfo()),
+                        new FieldInfo("raw", new VarBinaryFormatInfo())));
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=${database}&table=${table}");
+        properties.put("dirty.identifier", "${database}-${table}-${SYSTEM_TIME}");
+        properties.put("dirty.side-output.s3.bucket", "s3-test-bucket");
+        properties.put("dirty.side-output.s3.endpoint", "s3.test.endpoint");
+        properties.put("dirty.side-output.s3.key", "dirty/test");
+        properties.put("dirty.side-output.s3.region", "region");
+        properties.put("dirty.side-output.s3.access-key-id", "access_key_id");
+        properties.put("dirty.side-output.s3.secret-key-id", "secret_key_id");
+        return new ElasticsearchLoadNode("2", "es_output", fields, relations,
+                null, null, 1, properties, "mock",
+                "localhost:8030", "root", "000000", null,
+                null, 1, true, new CanalJsonFormat(), indexPattern);
+    }
+
+    /**
+     * Test kafka to doris with multiple sink enable
+     *
+     * @throws Exception The exception may be thrown when executing
+     */
+    @Test
+    public void testDorisMultipleSinkParse() throws Exception {
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .useBlinkPlanner()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        env.disableOperatorChaining();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode = buildKafkaExtractNode();
+        Node outputNode = buildESLoadNodeWithMultipleSink("${database}_${table}");
+        StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, outputNode),
+                Collections.singletonList(buildNodeRelation(Collections.singletonList(inputNode),
+                        Collections.singletonList(outputNode))));
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        Assert.assertTrue(result.tryExecute());
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ESMultipleSinkTest.java
@@ -96,7 +96,7 @@ public class ESMultipleSinkTest {
     }
 
     /**
-     * Test kafka to doris with multiple sink enable
+     * Test kafka to ES with multiple sink enable
      *
      * @throws Exception The exception may be thrown when executing
      */

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ElasticsearchSqlParseTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/ElasticsearchSqlParseTest.java
@@ -17,13 +17,6 @@
 
 package org.apache.inlong.sort.parser;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -41,6 +34,14 @@ import org.apache.inlong.sort.protocol.node.load.ElasticsearchLoadNode;
 import org.apache.inlong.sort.protocol.transformation.FieldRelation;
 import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
 import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * test elastic search sql parse
@@ -84,7 +85,7 @@ public abstract class ElasticsearchSqlParseTest extends AbstractTestBase {
         return new ElasticsearchLoadNode("2", "kafka_output", fields, relations, null, null,
                 2, properties,
                 "test", "http://localhost:9200",
-                "elastic", "my_password", null, "age", version);
+                "elastic", "my_password", null, "age", version, false, null, null);
     }
 
     private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7581 

### Motivation
Support multiple sink migration for ES sink.

### Modifications
mainly modified multipleElasticRowFunction for 2 key features:
1. support 4 additional options for esloadnode
2. parsing canal-json data

TODO:
1. table-level metric
2. dirty data
4. runtime strategy+other features 

### Verifying this change
<img width="912" alt="image" src="https://user-images.githubusercontent.com/32808678/227854492-fe9f9560-8174-4b9c-9235-992e1de85fee.png">