### PR TITLE
[INLONG-7715][Sort] Fix single table metric invalid

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -184,11 +184,12 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
             LOGGER.error(String.format("Deserialize error, raw data: %s",
                     new String(element.getValue().getBinary(0))), e);
             if (SchemaUpdateExceptionPolicy.LOG_WITH_IGNORE == multipleSinkOption.getSchemaUpdatePolicy()) {
-                // If the table name and library name are "unkonw",
+                // If the table name and library name are "unknown",
                 // it will not conflict with the table and library names in the IcebergMultipleStreamWriter operator,
                 // so it can be counted here
                 handleDirtyData(new String(element.getValue().getBinary(0)),
-                        null, DirtyType.DESERIALIZE_ERROR, e, TableIdentifier.of("unknow", "unknow"));
+                        null, DirtyType.DESERIALIZE_ERROR, e,
+                        TableIdentifier.of("unknown", "unknown"));
             }
             return;
         }
@@ -199,7 +200,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
             LOGGER.error(String.format("Table identifier parse error, raw data: %s", jsonNode), e);
             if (SchemaUpdateExceptionPolicy.LOG_WITH_IGNORE == multipleSinkOption.getSchemaUpdatePolicy()) {
                 handleDirtyData(jsonNode, jsonNode, DirtyType.TABLE_IDENTIFIER_PARSE_ERROR, e,
-                        TableIdentifier.of("unknow", "unknow"));
+                        TableIdentifier.of("unknown", "unknown"));
             }
         }
         if (blacklist.contains(tableId)) {

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -184,6 +184,9 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
             LOGGER.error(String.format("Deserialize error, raw data: %s",
                     new String(element.getValue().getBinary(0))), e);
             if (SchemaUpdateExceptionPolicy.LOG_WITH_IGNORE == multipleSinkOption.getSchemaUpdatePolicy()) {
+                // If the table name and library name are "unkonw",
+                // it will not conflict with the table and library names in the IcebergMultipleStreamWriter operator,
+                // so it can be counted here
                 handleDirtyData(new String(element.getValue().getBinary(0)),
                         null, DirtyType.DESERIALIZE_ERROR, e, TableIdentifier.of("unknow", "unknow"));
             }
@@ -225,7 +228,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
             if (!dirtyOptions.ignoreDirty()) {
                 if (metricData != null) {
                     metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString(),
-                            null, tableId.name(), rowData.toString());
+                            tableId.name(), rowData.toString());
                 }
             } else {
                 handleDirtyData(rowData.toString(), jsonNode, DirtyType.EXTRACT_ROWDATA_ERROR, e, tableId,
@@ -266,7 +269,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
                     dirtyOptions.getIdentifier(), e);
         }
         if (metricData != null && needDirtyMetric) {
-            metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString(), null, tableId.name(), dirtyData);
+            metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString(), tableId.name(), dirtyData);
         }
     }
 
@@ -378,8 +381,8 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
                                         DirtyOptions dirtyOptions = dirtySinkHelper.getDirtyOptions();
                                         if (!dirtyOptions.ignoreDirty()) {
                                             if (metricData != null) {
-                                                metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString(),
-                                                        null, tableId.name(), rowData.toString());
+                                                metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString()
+                                                        , tableId.name(), rowData.toString());
                                             }
                                         } else {
                                             handleDirtyData(rowData.toString(), jsonNode,

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -238,10 +238,10 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
     }
 
     private void handleDirtyData(Object dirtyData,
-                                 JsonNode rootNode,
-                                 DirtyType dirtyType,
-                                 Exception e,
-                                 TableIdentifier tableId) {
+            JsonNode rootNode,
+            DirtyType dirtyType,
+            Exception e,
+            TableIdentifier tableId) {
         handleDirtyData(dirtyData, rootNode, dirtyType, e, tableId, true);
     }
 
@@ -381,8 +381,9 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
                                         DirtyOptions dirtyOptions = dirtySinkHelper.getDirtyOptions();
                                         if (!dirtyOptions.ignoreDirty()) {
                                             if (metricData != null) {
-                                                metricData.outputDirtyMetricsWithEstimate(tableId.namespace().toString()
-                                                        , tableId.name(), rowData.toString());
+                                                metricData.outputDirtyMetricsWithEstimate(
+                                                        tableId.namespace().toString(), tableId.name(),
+                                                        rowData.toString());
                                             }
                                         } else {
                                             handleDirtyData(rowData.toString(), jsonNode,

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/RecordWithSchema.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/RecordWithSchema.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.iceberg.sink.multiple;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
@@ -55,6 +57,16 @@ public class RecordWithSchema {
         this.tableId = tableId;
         this.primaryKeys = primaryKeys;
     }
+
+    @Setter
+    @Getter
+    private boolean isDirty;
+    @Setter
+    @Getter
+    private long rowCount;
+    @Setter
+    @Getter
+    private long rowSize;
 
     private transient JsonNode originalData;
 

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/RecordWithSchema.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/RecordWithSchema.java
@@ -17,8 +17,7 @@
 
 package org.apache.inlong.sort.iceberg.sink.multiple;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import org.apache.flink.table.data.RowData;
 import org.apache.iceberg.Schema;
@@ -45,6 +44,7 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+@Data
 public class RecordWithSchema {
 
     public RecordWithSchema(
@@ -58,14 +58,8 @@ public class RecordWithSchema {
         this.primaryKeys = primaryKeys;
     }
 
-    @Setter
-    @Getter
     private boolean isDirty;
-    @Setter
-    @Getter
     private long rowCount;
-    @Setter
-    @Getter
     private long rowSize;
 
     private transient JsonNode originalData;


### PR DESCRIPTION
- Fixes https://github.com/apache/inlong/issues/7715

### Motivation
When mysql synchronizes iceberg, it is found that the dirty data index of the single table dimension is lost.
Since DynamicSchemaHandleOperator also registers the metric index of a single table, it overlaps with the dirty data index in IcebergMultipleStreamWriter, resulting in the loss of the index;

### Modifications
By adding the dirty data flag bit in RecordWithSchema, pass it to IcebergMultipleStreamWriter, count the number of dirty data in IcebergMultipleStreamWriter, and temporarily not count in DynamicSchemaHandleOperator

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*
