### PR TITLE
[INLONG-7724][Sort] Add rate limit  to ingest data into iceberg

### DIFF
--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/FlinkDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/FlinkDynamicTableFactory.java
@@ -132,6 +132,13 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
                     .withDescription("Distribute the records from input data stream based "
                             + "on the write.distribution-mode.");
 
+    public static final ConfigOption<Long> WRITE_RATE_LIMIT =
+            ConfigOptions.key("write.rate.limit")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription("Write record rate limit per second to"
+                            + " prevent traffic jitter and improve stability, default 0 (no limit)");
+
     private final FlinkCatalog catalog;
 
     public FlinkDynamicTableFactory() {
@@ -297,6 +304,7 @@ public class FlinkDynamicTableFactory implements DynamicTableSinkFactory, Dynami
         options.add(WRITE_COMPACT_ENABLE);
         options.add(WRITE_COMPACT_INTERVAL);
         options.add(WRITE_DISTRIBUTION_MODE);
+        options.add(WRITE_RATE_LIMIT);
         return options;
     }
 

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RateLimitMapFunction.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RateLimitMapFunction.java
@@ -21,8 +21,14 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.RateLimiter;
 
+/**
+ * Function that limit the rate.
+ */
 public class RateLimitMapFunction<T> extends RichMapFunction<T, T> {
 
+    /**
+     * Rate limit per second for all subtasks added up.
+     */
     private final double totalLimit;
     private transient RateLimiter rateLimiter;
 

--- a/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RateLimitMapFunction.java
+++ b/inlong-sort/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RateLimitMapFunction.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.iceberg.sink;
+
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.RateLimiter;
+
+public class RateLimitMapFunction<T> extends RichMapFunction<T, T> {
+
+    private final double totalLimit;
+    private transient RateLimiter rateLimiter;
+
+    public RateLimitMapFunction(long totalLimit) {
+        this.totalLimit = totalLimit;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+        this.rateLimiter = RateLimiter.create(
+                totalLimit / getRuntimeContext().getNumberOfParallelSubtasks());
+    }
+
+    @Override
+    public T map(T value) throws Exception {
+        rateLimiter.acquire();
+        return value;
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-7724][Sort] Add rate limit  to ingest data into iceberg

- Fixes #7724 

### Motivation

In the existing data synchronization, snapshot data and incremental data are send to kafka first, and then streaming write to Iceberg by Flink. Because the direct consumption of snapshot data will lead to problems such as high throughput and serious disorder (writing partition randomly), which will lead to write performance degradation and throughput glitches. It will always crash beacuse memory limit.e.g.

### Modifications

Rate limit
At this time, the write.rate.limit option can be turned on to ensure smooth writing, it will decrese throughput .

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs

here is the docs：
#7724 