### PR TITLE
[INLONG-7733][Manager] Support set the rate limit for the mark-delete operation of pulsar namespace

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupApproveRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupApproveRequest.java
@@ -77,6 +77,9 @@ public class InlongGroupApproveRequest {
     @ApiModelProperty(value = "The unit of message size")
     private String retentionSizeUnit;
 
+    @ApiModelProperty(value = "The limit rate of the mark-delete operation")
+    private Double maxMarkDeleteRate;
+
     @ApiModelProperty(value = "Data report type, default is 0.\n"
             + " 0: report to DataProxy and respond when the DataProxy received data.\n"
             + " 1: report to DataProxy and respond after DataProxy sends data.\n"

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarDTO.java
@@ -80,6 +80,9 @@ public class InlongPulsarDTO extends BaseInlongGroup {
     @ApiModelProperty(value = "The unit of message size")
     private String retentionSizeUnit;
 
+    @ApiModelProperty(value = "The limit rate of the mark-delete operation")
+    private Double maxMarkDeleteRate;
+
     /**
      * Get the dto instance from the request
      */

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarInfo.java
@@ -76,6 +76,9 @@ public class InlongPulsarInfo extends InlongGroupInfo {
     @ApiModelProperty(value = "The unit of message size")
     private String retentionSizeUnit = "MB";
 
+    @ApiModelProperty(value = "The limit rate of the mark-delete operation")
+    private Double maxMarkDeleteRate = 0.0;
+
     public InlongPulsarInfo() {
         this.setMqType(MQType.PULSAR);
     }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/pulsar/InlongPulsarRequest.java
@@ -77,6 +77,9 @@ public class InlongPulsarRequest extends InlongGroupRequest {
     @ApiModelProperty(value = "The unit of message size")
     private String retentionSizeUnit = "MB";
 
+    @ApiModelProperty(value = "The limit rate of the mark-delete operation")
+    private Double maxMarkDeleteRate = 0.0;
+
     public InlongPulsarRequest() {
         this.setMqType(MQType.PULSAR);
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarOperator.java
@@ -133,7 +133,7 @@ public class PulsarOperator {
 
             // Configure persistence policies
             PersistencePolicies persistencePolicies = new PersistencePolicies(pulsarInfo.getEnsemble(),
-                    pulsarInfo.getWriteQuorum(), pulsarInfo.getAckQuorum(), 0);
+                    pulsarInfo.getWriteQuorum(), pulsarInfo.getAckQuorum(), pulsarInfo.getMaxMarkDeleteRate());
             namespaces.setPersistence(namespaceName, persistencePolicies);
             LOGGER.info("success to create namespace={}", namespaceName);
         } catch (PulsarAdminException e) {


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7733 

### Motivation

Support set the rate limit for the mark-delete operation of pulsar namespace.

If the rate limit for the mark-delete operation of pulsar namespace  is not setted, the ack persistence rate increases, resulting in FGC.

### Modifications

Support set the rate limit for the mark-delete operation of pulsar namespace.

