### PR TITLE
[INLONG-7742][Tool] Add only support for MacOS and Linux prompts to inlong-dev-toolkit

### DIFF
--- a/inlong-tools/dev/inlong-dev-toolkit.sh
+++ b/inlong-tools/dev/inlong-dev-toolkit.sh
@@ -115,6 +115,11 @@ function manager() {
 }
 
 function main() {
+  if [[ "$OSTYPE" != "darwin"* ]] && [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    echo "This script only supports macOS or Linux, current OS is $OSTYPE"
+    exit 1
+  fi
+
   action=$1
 
   if [ ! -n "$action" ]; then


### PR DESCRIPTION
- Fixes #7742 
