### PR TITLE
[INLONG-7752][Agent] PulsarSink threadPool throw reject exception

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/PulsarSink.java
@@ -196,7 +196,6 @@ public class PulsarSink extends AbstractSink {
             AgentUtils.silenceSleepInMs(batchFlushInterval);
         }
         shutdown = true;
-        EXECUTOR_SERVICE.shutdown();
         if (CollectionUtils.isNotEmpty(pulsarSenders)) {
             for (PulsarTopicSender sender : pulsarSenders) {
                 sender.close();


### PR DESCRIPTION
### Prepare a Pull Request
- Title: [INLONG-7752][Agent] PulsarSink threadPool throw reject exception
- Fixes #7752 

### Motivation

Fix `PulsarSink` threadPool throw reject exception when  delete file data source on dashboard and then add  file data source.

### Modifications

Do not shut down the global thread pool when destroy the `PulsarSink` of one task.
