### PR TITLE
[INLONG-7767][Sort]Doris connector does not real delete record because of columns header losing

### DIFF
--- a/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
+++ b/inlong-sort/sort-connectors/doris/src/main/java/org/apache/inlong/sort/doris/table/DorisDynamicSchemaOutputFormat.java
@@ -688,7 +688,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
         try {
             // support csv and json format
             String format = executionOptions.getStreamLoadProp().getProperty(FORMAT_KEY, FORMAT_JSON_VALUE);
-            loadValue = serialize(values, format);
+            loadValue = serialize(tableIdentifier, values, format);
             respContent = load(tableIdentifier, loadValue);
             try {
                 if (null != metricData && null != respContent) {
@@ -785,7 +785,7 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
      * @return string
      * @throws JsonProcessingException
      */
-    private String serialize(List values, String format) throws JsonProcessingException {
+    private String serialize(String tableIdentifier, List values, String format) throws JsonProcessingException {
         if (FORMAT_CSV_VALUE.equalsIgnoreCase(format)) {
             LOG.info("doris data format: {}", format);
             // set columns, and format json data to csv
@@ -822,6 +822,10 @@ public class DorisDynamicSchemaOutputFormat<T> extends RichOutputFormat<T> {
             }
             return csvData.toString();
         } else {
+            // Dynamic set COLUMNS_KEY for tableIdentifier every time for multiple sink scenario
+            if (multipleSink) {
+                executionOptions.getStreamLoadProp().put(COLUMNS_KEY, columnsMap.get(tableIdentifier));
+            }
             return OBJECT_MAPPER.writeValueAsString(values);
         }
     }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7767

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

When source cdc delete one record, Doris connector should invoke SystemLoad api with columns header which contains __DORIS_DELETE_SIGN__ flag.

If columns header is lost, Doris server will not delete the record.

### Modifications

*Describe the modifications you've done.*

`serialize` method of `DorisDynamicSchemaOutputFormat.java` class appends system load `columns` when json format and multiple sink enabled.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
