### PR TITLE
[INLONG-7762][Sort] Fix capturing unrelated tables when open DDL change detection

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -116,12 +116,6 @@ public final class MySqlRecordEmitter<T>
                 }
             }
 
-            // for create table ddl, there's no table change events
-            // still we need to generate a ddl message
-            if (tableChanges.isEmpty()) {
-                outputDdlElement(element, output, splitState, null);
-            }
-
         } else if (isDataChangeRecord(element)) {
             if (splitState.isBinlogSplitState()) {
                 BinlogOffset position = getBinlogPosition(element);


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7762][Sort] Fix capturing unrelated tables when open DDL change detection

- Fixes #7762 

### Motivation

Fix capturing unrelated tables when open DDL change detection

### Modifications

Remove the following code.

```java
            // for create table ddl, there's no table change events
            // still we need to generate a ddl message
            if (tableChanges.isEmpty()) {
                outputDdlElement(element, output, splitState, null);
            }
```