### PR TITLE
[INLONG-7787][Sort] Fix cannot output drop statement

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -136,6 +136,8 @@ public final class Constants {
 
     public static final String DDL_FIELD_NAME = "ddl";
 
+    public static final String DDL_OP_DROP = "DROP";
+
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
                     .stringType()

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -124,7 +124,9 @@ public final class MySqlRecordEmitter<T>
                 if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
                     String tableName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTableName(element);
                     String dbName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getDbName(element);
-                    TableId tableId = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTabelId(dbName, tableName);
+                    TableId tableId = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTabelId(
+                            dbName,
+                            tableName);
                     // If this table is one of the captured tables, output the ddl element.
                     if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
                         outputDdlElement(element, output, splitState, null);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -23,6 +23,7 @@ import io.debezium.data.Envelope;
 import io.debezium.document.Array;
 import io.debezium.relational.TableId;
 import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.HistoryRecord.Fields;
 import io.debezium.relational.history.TableChanges;
 import io.debezium.relational.history.TableChanges.TableChange;
 import org.apache.flink.api.connector.source.SourceOutput;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
+import static org.apache.inlong.sort.base.Constants.DDL_OP_DROP;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getBinlogPosition;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getFetchTimestamp;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getHistoryRecord;
@@ -113,6 +115,20 @@ public final class MySqlRecordEmitter<T>
                 splitState.asBinlogSplitState().recordSchema(tableChange.getId(), tableChange);
                 if (includeSchemaChanges) {
                     outputDdlElement(element, output, splitState, tableChange);
+                }
+            }
+
+            // For drop table ddl, there's no table change events.
+            if (tableChanges.isEmpty()) {
+                String ddl = historyRecord.document().getString(Fields.DDL_STATEMENTS);
+                if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
+                    String tableName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTableName(element);
+                    String dbName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getDbName(element);
+                    TableId tableId = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTabelId(dbName, tableName);
+                    // If this table is one of the captured tables, output the ddl element.
+                    if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
+                        outputDdlElement(element, output, splitState, null);
+                    }
                 }
             }
 

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -118,12 +118,12 @@ public final class MySqlRecordEmitter<T>
                 }
             }
 
-            // For drop table ddl, there's no table change events.
+            // for drop table ddl, there's no table change events
             if (tableChanges.isEmpty()) {
                 String ddl = historyRecord.document().getString(Fields.DDL_STATEMENTS);
                 if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
                     TableId tableId = RecordUtils.getTableId(element);
-                    // If this table is one of the captured tables, output the ddl element.
+                    // if this table is one of the captured tables, output the ddl element
                     if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
                         outputDdlElement(element, output, splitState, null);
                     }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -122,11 +122,7 @@ public final class MySqlRecordEmitter<T>
             if (tableChanges.isEmpty()) {
                 String ddl = historyRecord.document().getString(Fields.DDL_STATEMENTS);
                 if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
-                    String tableName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTableName(element);
-                    String dbName = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getDbName(element);
-                    TableId tableId = org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getTabelId(
-                            dbName,
-                            tableName);
+                    TableId tableId = RecordUtils.getTableId(element);
                     // If this table is one of the captured tables, output the ddl element.
                     if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
                         outputDdlElement(element, output, splitState, null);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
@@ -49,8 +49,10 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.EventDispatcherImpl.HISTORY_RECORD_FIELD;
+import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.DATABASE_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.SIGNAL_EVENT_VALUE_SCHEMA_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.SPLIT_ID_KEY;
+import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.TABLE_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.WATERMARK_KIND;
 
 /**
@@ -466,5 +468,21 @@ public class RecordUtils {
             return Optional.of(SignalEventDispatcher.WatermarkKind.valueOf(value.getString(WATERMARK_KIND)));
         }
         return Optional.empty();
+    }
+
+    public static String getTableName(SourceRecord element) {
+        Struct value = (Struct) element.value();
+        Struct source = value.getStruct(FieldName.SOURCE);
+        return source.getString(TABLE_NAME);
+    }
+
+    public static String getDbName(SourceRecord element) {
+        Struct value = (Struct) element.value();
+        Struct source = value.getStruct(FieldName.SOURCE);
+        return source.getString(DATABASE_NAME);
+    }
+
+    public static TableId getTabelId(String dbName, String tableName) {
+        return new TableId(dbName, null, tableName);
     }
 }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
@@ -49,10 +49,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.EventDispatcherImpl.HISTORY_RECORD_FIELD;
-import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.DATABASE_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.SIGNAL_EVENT_VALUE_SCHEMA_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.SPLIT_ID_KEY;
-import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.TABLE_NAME;
 import static org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher.WATERMARK_KIND;
 
 /**
@@ -470,19 +468,4 @@ public class RecordUtils {
         return Optional.empty();
     }
 
-    public static String getTableName(SourceRecord element) {
-        Struct value = (Struct) element.value();
-        Struct source = value.getStruct(FieldName.SOURCE);
-        return source.getString(TABLE_NAME);
-    }
-
-    public static String getDbName(SourceRecord element) {
-        Struct value = (Struct) element.value();
-        Struct source = value.getStruct(FieldName.SOURCE);
-        return source.getString(DATABASE_NAME);
-    }
-
-    public static TableId getTabelId(String dbName, String tableName) {
-        return new TableId(dbName, null, tableName);
-    }
 }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/utils/RecordUtils.java
@@ -467,5 +467,4 @@ public class RecordUtils {
         }
         return Optional.empty();
     }
-
 }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7787][Sort] Fix cannot output drop statement

- Fixes #7787 

### Motivation

The `tableChanges` of the drop ddl statement is empty, so it cannot enter the `outputDdlElement()` method. We need to check below whether the drop ddl statement belongs to the currently captured table. If so, output the DDL element.

<img width="1816" alt="image" src="https://user-images.githubusercontent.com/111486498/230014752-bf50e20b-37d2-4726-a4c2-7df3b96095de.png">

### Modifications

1. Get the ddl statement from `historyRecord` and determine if it is a drop statement.
2. Obtain its `tableId` and query in the state to check if it belongs to the captured tables.

```java
// For drop table ddl, there's no table change events.
 if (tableChanges.isEmpty()) {
     String ddl = historyRecord.document().getString(Fields.DDL_STATEMENTS);
     if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
         TableId tableId = RecordUtils.getTableId(element);
         // If this table is one of the captured tables, output the ddl element.
         if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
             outputDdlElement(element, output, splitState, null);
         }
     }
 }
```