### PR TITLE
[INLONG-7809][Sort]ES multiple sink support dirty data runtime strategies

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SinkTableMetricData.java
@@ -224,6 +224,30 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
     }
 
     /**
+     * output metrics
+     *
+     * @param index the index name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputMetrics(String index, long rowCount, long rowSize) {
+        if (StringUtils.isBlank(index)) {
+            invoke(rowCount, rowSize);
+            return;
+        }
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(index)) {
+            subSinkMetricData = subSinkMetricMap.get(index);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{index}, this);
+            subSinkMetricMap.put(index, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invoke(rowCount, rowSize);
+        subSinkMetricData.invoke(rowCount, rowSize);
+    }
+
+    /**
      * output dirty metrics with estimate
      *
      * @param database the database name of record
@@ -330,6 +354,30 @@ public class SinkTableMetricData extends SinkMetricData implements SinkSubMetric
         } else {
             subSinkMetricData = buildSubSinkMetricData(new String[]{database, table}, this);
             subSinkMetricMap.put(identify, subSinkMetricData);
+        }
+        // sink metric and sub sink metric output metrics
+        this.invokeDirty(rowCount, rowSize);
+        subSinkMetricData.invokeDirty(rowCount, rowSize);
+    }
+
+    /**
+     * output dirty metrics
+     *
+     * @param index the table name of record
+     * @param rowCount the row count of records
+     * @param rowSize the row size of records
+     */
+    public void outputDirtyMetrics(String index, long rowCount, long rowSize) {
+        if (StringUtils.isBlank(index)) {
+            invokeDirty(rowCount, rowSize);
+            return;
+        }
+        SinkMetricData subSinkMetricData;
+        if (subSinkMetricMap.containsKey(index)) {
+            subSinkMetricData = subSinkMetricMap.get(index);
+        } else {
+            subSinkMetricData = buildSubSinkMetricData(new String[]{index}, this);
+            subSinkMetricMap.put(index, subSinkMetricData);
         }
         // sink metric and sub sink metric output metrics
         this.invokeDirty(rowCount, rowSize);

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/ElasticsearchSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/ElasticsearchSink.java
@@ -83,14 +83,16 @@ public class ElasticsearchSink<T>
             RestClientFactory restClientFactory,
             String inlongMetric,
             DirtySinkHelper<Object> dirtySinkHelper,
-            String auditHostAndPorts) {
+            String auditHostAndPorts,
+            boolean multipleSink) {
         super(new Elasticsearch6ApiCallBridge(httpHosts, restClientFactory),
                 bulkRequestsConfig,
                 elasticsearchSinkFunction,
                 failureHandler,
                 inlongMetric,
                 dirtySinkHelper,
-                auditHostAndPorts);
+                auditHostAndPorts,
+                multipleSink);
     }
 
     @Override
@@ -131,6 +133,7 @@ public class ElasticsearchSink<T>
         private String inlongMetric = null;
         private DirtySinkHelper<Object> dirtySinkHelper;
         private String auditHostAndPorts;
+        private boolean multipleSink;
 
         /**
          * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link
@@ -286,6 +289,10 @@ public class ElasticsearchSink<T>
             this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
         }
 
+        public void setMultipleSink(boolean multipleSink) {
+            this.multipleSink = multipleSink;
+        }
+
         /**
          * Creates the Elasticsearch sink.
          * Use {@link DirtySinkFailureHandler} when need sink dirty data
@@ -304,7 +311,8 @@ public class ElasticsearchSink<T>
                     restClientFactory,
                     inlongMetric,
                     dirtySinkHelper,
-                    auditHostAndPorts);
+                    auditHostAndPorts,
+                    multipleSink);
         }
 
         @Override

--- a/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-6/src/main/java/org/apache/inlong/sort/elasticsearch6/table/Elasticsearch6DynamicSink.java
@@ -174,6 +174,7 @@ final class Elasticsearch6DynamicSink implements DynamicTableSink {
                 builder.setRestClientFactory(
                         new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
             }
+            builder.setMultipleSink(multipleSink);
             final ElasticsearchSink<RowData> sink = builder.build();
             if (config.isDisableFlushOnCheckpoint()) {
                 sink.disableFlushOnCheckpoint();

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/ElasticsearchSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/ElasticsearchSink.java
@@ -83,14 +83,16 @@ public class ElasticsearchSink<T>
             RestClientFactory restClientFactory,
             String inlongMetric,
             DirtySinkHelper<Object> dirtySinkHelper,
-            String auditHostAndPorts) {
+            String auditHostAndPorts,
+            boolean multipleSink) {
         super(new Elasticsearch7ApiCallBridge(httpHosts, restClientFactory),
                 bulkRequestsConfig,
                 elasticsearchSinkFunction,
                 failureHandler,
                 inlongMetric,
                 dirtySinkHelper,
-                auditHostAndPorts);
+                auditHostAndPorts,
+                multipleSink);
     }
 
     @Override
@@ -131,6 +133,7 @@ public class ElasticsearchSink<T>
         private String inlongMetric = null;
         private DirtySinkHelper<Object> dirtySinkHelper;
         private String auditHostAndPorts;
+        private boolean multipleSink;
 
         /**
          * Creates a new {@code ElasticsearchSink} that connects to the cluster using a {@link
@@ -286,6 +289,10 @@ public class ElasticsearchSink<T>
             this.restClientFactory = Preconditions.checkNotNull(restClientFactory);
         }
 
+        public void setMultipleSink(boolean multipleSink) {
+            this.multipleSink = multipleSink;
+        }
+
         /**
          * Creates the Elasticsearch sink.
          * Use {@link DirtySinkFailureHandler} when need sink dirty data
@@ -304,7 +311,8 @@ public class ElasticsearchSink<T>
                     restClientFactory,
                     inlongMetric,
                     dirtySinkHelper,
-                    auditHostAndPorts);
+                    auditHostAndPorts,
+                    multipleSink);
         }
 
         @Override

--- a/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
+++ b/inlong-sort/sort-connectors/elasticsearch-7/src/main/java/org/apache/inlong/sort/elasticsearch7/table/Elasticsearch7DynamicSink.java
@@ -207,6 +207,7 @@ final class Elasticsearch7DynamicSink implements DynamicTableSink {
                 builder.setRestClientFactory(
                         new DefaultRestClientFactory(config.getPathPrefix().orElse(null)));
             }
+            builder.setMultipleSink(multipleSink);
             final ElasticsearchSink<RowData> sink = builder.build();
             if (config.isDisableFlushOnCheckpoint()) {
                 sink.disableFlushOnCheckpoint();


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7809 

### Motivation
Support dirtydata, table level metrics and sink runtime strategies.

### Modifications
adjusted es multiple sink and base related classes.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.
Is partially tested in oceanus, should not break single table metrics.