### PR TITLE
[INLONG-7815][DataProxy] Get authorization information from token field

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/loader/ManagerCacheClusterConfigLoader.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/loader/ManagerCacheClusterConfigLoader.java
@@ -47,6 +47,7 @@ public class ManagerCacheClusterConfigLoader implements CacheClusterConfigLoader
         for (CacheClusterObject obj : dataProxyCluster.getCacheClusterSet().getCacheClusters()) {
             CacheClusterConfig config = new CacheClusterConfig();
             config.setClusterName(obj.getName());
+            config.setToken(obj.getToken());
             config.getParams().putAll(obj.getParams());
             configList.add(config);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/pojo/CacheClusterConfig.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/pojo/CacheClusterConfig.java
@@ -27,6 +27,7 @@ import java.util.Map;
 public class CacheClusterConfig {
 
     private String clusterName;
+    private String token;
     private Map<String, String> params = new HashMap<>();
 
     /**
@@ -45,6 +46,24 @@ public class CacheClusterConfig {
      */
     public void setClusterName(String clusterName) {
         this.clusterName = clusterName;
+    }
+
+    /**
+     * get token
+     *
+     * @return the token
+     */
+    public String getToken() {
+        return token;
+    }
+
+    /**
+     * set token
+     *
+     * @param token the token to set
+     */
+    public void setToken(String token) {
+        this.token = token;
     }
 
     /**

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -119,6 +119,9 @@ public class PulsarHandler implements MessageQueueHandler {
         try {
             String serviceUrl = config.getParams().get(KEY_SERVICE_URL);
             String authentication = config.getParams().get(KEY_AUTHENTICATION);
+            if (StringUtils.isEmpty(authentication)) {
+                authentication = config.getToken();
+            }
             Context context = sinkContext.getProducerContext();
             ClientBuilder builder = PulsarClient.builder();
             if (StringUtils.isNotEmpty(authentication)) {


### PR DESCRIPTION

- Fixes #7815

Based on the change of the issue (#7810), when DataProxy initializes the Pulsar client, if the params parameter set in the cluster configuration CacheClusterConfig does not carry authentication information, the authorization information is obtained from the token field