### PR TITLE
[INLONG-7833][Dashboard] Process optimization for creating source and sink

### DIFF
--- a/inlong-dashboard/src/plugins/sinks/common/SinkDefaultInfo.ts
+++ b/inlong-dashboard/src/plugins/sinks/common/SinkDefaultInfo.ts
@@ -21,6 +21,7 @@ import { DataWithBackend } from '@/plugins/DataWithBackend';
 import { RenderRow } from '@/plugins/RenderRow';
 import { RenderList } from '@/plugins/RenderList';
 import i18n from '@/i18n';
+import CheckCard from '@/ui/components/CheckCard';
 import { statusList, genStatusTag } from './status';
 import { sinks, defaultValue } from '..';
 
@@ -51,29 +52,12 @@ export class SinkDefaultInfo implements DataWithBackend, RenderRow, RenderList {
   readonly inlongStreamId: string;
 
   @FieldDecorator({
-    type: 'input',
-    rules: [
-      { required: true },
-      {
-        pattern: /^[a-zA-Z][a-zA-Z0-9_-]*$/,
-        message: i18n.t('meta.Sinks.SinkNameRule'),
-      },
-    ],
-    props: values => ({
-      disabled: !!values.id,
-      maxLength: 128,
-    }),
-  })
-  @ColumnDecorator()
-  @I18n('meta.Sinks.SinkName')
-  sinkName: string;
-
-  @FieldDecorator({
-    type: sinks.length > 3 ? 'select' : 'radio',
+    type: CheckCard,
     label: i18n.t('meta.Sinks.SinkType'),
     rules: [{ required: true }],
     initialValue: defaultValue,
     props: values => ({
+      span: 4,
       dropdownMatchSelectWidth: false,
       disabled: !!values.id,
       options: sinks
@@ -91,11 +75,31 @@ export class SinkDefaultInfo implements DataWithBackend, RenderRow, RenderList {
   sinkType: string;
 
   @FieldDecorator({
+    type: 'input',
+    rules: [
+      { required: true },
+      {
+        pattern: /^[a-zA-Z][a-zA-Z0-9_-]*$/,
+        message: i18n.t('meta.Sinks.SinkNameRule'),
+      },
+    ],
+    props: values => ({
+      disabled: !!values.id,
+      maxLength: 128,
+    }),
+    visible: values => Boolean(values.sinkType),
+  })
+  @ColumnDecorator()
+  @I18n('meta.Sinks.SinkName')
+  sinkName: string;
+
+  @FieldDecorator({
     type: 'textarea',
     props: {
       showCount: true,
       maxLength: 300,
     },
+    visible: values => Boolean(values.sinkType),
   })
   @I18n('meta.Sinks.Description')
   description: string;

--- a/inlong-dashboard/src/plugins/sources/common/SourceDefaultInfo.ts
+++ b/inlong-dashboard/src/plugins/sources/common/SourceDefaultInfo.ts
@@ -20,6 +20,7 @@
 import { DataWithBackend } from '@/plugins/DataWithBackend';
 import { RenderRow } from '@/plugins/RenderRow';
 import { RenderList } from '@/plugins/RenderList';
+import CheckCard from '@/ui/components/CheckCard';
 import { statusList, genStatusTag } from './status';
 import { sources, defaultValue } from '..';
 
@@ -50,19 +51,7 @@ export class SourceDefaultInfo implements DataWithBackend, RenderRow, RenderList
   readonly inlongStreamId: string;
 
   @FieldDecorator({
-    type: 'input',
-    rules: [{ required: true }],
-    props: values => ({
-      disabled: Boolean(values.id),
-      maxLength: 128,
-    }),
-  })
-  @ColumnDecorator()
-  @I18n('meta.Sources.Name')
-  sourceName: string;
-
-  @FieldDecorator({
-    type: sources.length > 3 ? 'select' : 'radio',
+    type: CheckCard,
     rules: [{ required: true }],
     initialValue: defaultValue,
     props: values => ({
@@ -81,6 +70,19 @@ export class SourceDefaultInfo implements DataWithBackend, RenderRow, RenderList
   })
   @I18n('meta.Sources.Type')
   sourceType: string;
+
+  @FieldDecorator({
+    type: 'input',
+    rules: [{ required: true }],
+    props: values => ({
+      disabled: Boolean(values.id),
+      maxLength: 128,
+    }),
+    visible: values => Boolean(values.sourceType),
+  })
+  @ColumnDecorator()
+  @I18n('meta.Sources.Name')
+  sourceName: string;
 
   @FieldDecorator({
     type: 'select',

--- a/inlong-dashboard/src/ui/components/CheckCard/index.module.less
+++ b/inlong-dashboard/src/ui/components/CheckCard/index.module.less
@@ -1,0 +1,45 @@
+
+/*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+.cardRow {
+  margin-top: -5px;
+  margin-bottom: -5px;
+}
+
+.cardCol {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.cardDisabled {
+  color: rgba(0, 0, 0, 0.25);
+  background-color: rgba(0, 0, 0, 0.04);
+  border-color: #d9d9d9;
+  cursor: not-allowed;
+}
+
+.editIcon {
+  &:hover {
+    transition: transform .3s;
+    transform: translateX(5px);
+  }
+}

--- a/inlong-dashboard/src/ui/components/CheckCard/index.tsx
+++ b/inlong-dashboard/src/ui/components/CheckCard/index.tsx
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { Card, Col, Row, theme } from 'antd';
+import { DoubleRightOutlined, DatabaseOutlined } from '@ant-design/icons';
+import styles from './index.module.less';
+
+export interface CheckCardOption {
+  label: string;
+  value: string | number;
+}
+
+export interface CheckCardProps {
+  value?: string | number;
+  onChange?: (value: boolean) => void;
+  options?: CheckCardOption[];
+  disabled: boolean;
+  span?: number;
+}
+
+const { useToken } = theme;
+
+const CheckCard: React.FC<CheckCardProps> = ({ options, value, onChange, disabled, span = 6 }) => {
+  const [currentValue, setCurrentValue] = useState(value);
+
+  const [isExpand, setExpandStatus] = useState(!Boolean(currentValue));
+
+  const { token } = useToken();
+
+  useEffect(() => {
+    if (value !== currentValue) {
+      setCurrentValue(value);
+      setExpandStatus(false);
+    }
+    // eslint-disable-next-line
+  }, [value]);
+
+  const handleCardClick = newValue => {
+    setExpandStatus(false);
+    if (newValue !== currentValue) {
+      setCurrentValue(newValue);
+      if (onChange) {
+        onChange(newValue);
+      }
+    }
+  };
+
+  return (
+    <Row gutter={10} className={styles.cardRow}>
+      {!isExpand ? (
+        <>
+          <Col span={span} className={styles.cardCol}>
+            <Card
+              size="small"
+              bodyStyle={{ textAlign: 'center' }}
+              className={disabled ? styles.cardDisabled : ''}
+            >
+              <DatabaseOutlined style={{ fontSize: 20 }} />
+              <div>{options.find(item => item.value === currentValue)?.label}</div>
+            </Card>
+          </Col>
+          {!disabled && (
+            <Col style={{ display: 'flex', alignItems: 'center' }}>
+              <DoubleRightOutlined
+                className={styles.editIcon}
+                onClick={() => setExpandStatus(true)}
+              />
+            </Col>
+          )}
+        </>
+      ) : (
+        options.map(item => (
+          <Col span={span} key={item.value} className={styles.cardCol} title={item.label}>
+            <Card
+              hoverable
+              size="small"
+              onClick={() => handleCardClick(item.value)}
+              style={item.value === currentValue ? { borderColor: token.colorPrimary } : {}}
+            >
+              {item.label}
+            </Card>
+          </Col>
+        ))
+      )}
+    </Row>
+  );
+};
+
+export default CheckCard;

--- a/inlong-dashboard/src/ui/components/FormGenerator/FormGenerator.tsx
+++ b/inlong-dashboard/src/ui/components/FormGenerator/FormGenerator.tsx
@@ -143,10 +143,20 @@ const FormGenerator: React.FC<FormGeneratorProps> = props => {
     [realTimeValues, form, viewOnly],
   );
 
+  useEffect(() => {
+    const reset = form?.resetFields;
+    if (reset) {
+      form.resetFields = (...args) => {
+        reset(...args);
+        setRealTimeValues(props.initialValues || {});
+      };
+    }
+  }, [form]);
+
   // A real-time value is generated when it is first mounted, because the initialValue may be defined on the FormItem
   useEffect(() => {
     if (props.initialValues) {
-      setRealTimeValues(props.initialValues);
+      setRealTimeValues(prev => ({ ...prev, ...props.initialValues }));
     } else if (form) {
       const timmer = setTimeout(() => {
         const { getFieldsValue } = form;

--- a/inlong-dashboard/src/ui/pages/GroupDetail/DataSources/DetailModal.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/DataSources/DetailModal.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useMemo, useState } from 'react';
-import { Modal, message } from 'antd';
+import { Modal, Spin, message } from 'antd';
 import { ModalProps } from 'antd/es/modal';
 import FormGenerator, { useForm } from '@/ui/components/FormGenerator';
 import { useRequest, useUpdateEffect } from '@/ui/hooks';
@@ -48,7 +48,7 @@ const Comp: React.FC<Props> = ({
 
   const [type, setType] = useState(defaultValue);
 
-  const { Entity } = useLoadMeta<SourceMetaType>('source', type);
+  const { loading, Entity } = useLoadMeta<SourceMetaType>('source', type);
 
   const { data, run: getData } = useRequest(
     id => ({
@@ -111,13 +111,15 @@ const Comp: React.FC<Props> = ({
         width={666}
         onOk={onOk}
       >
-        <FormGenerator
-          content={formContent}
-          onValuesChange={(c, values) => setType(values.sourceType)}
-          initialValues={id ? data : { inlongGroupId }}
-          form={form}
-          useMaxWidth
-        />
+        <Spin spinning={loading}>
+          <FormGenerator
+            content={formContent}
+            onValuesChange={(c, values) => setType(values.sourceType)}
+            initialValues={id ? data : { inlongGroupId }}
+            form={form}
+            useMaxWidth
+          />
+        </Spin>
       </Modal>
     </>
   );

--- a/inlong-dashboard/src/ui/pages/GroupDetail/DataSources/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/DataSources/index.tsx
@@ -192,6 +192,7 @@ const Comp = ({ inlongGroupId, inlongStreamId, readonly }: Props, ref) => {
       ].concat(
         pickObjectArray(['sourceType', 'status'], entityFields).map(item => ({
           ...item,
+          type: 'select',
           visible: true,
           initialValue: defaultValues[item.name],
         })),

--- a/inlong-dashboard/src/ui/pages/GroupDetail/DataStorage/DetailModal.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/DataStorage/DetailModal.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Button, Skeleton, Modal, message } from 'antd';
+import { Button, Spin, Modal, message } from 'antd';
 import { ModalProps } from 'antd/es/modal';
 import { useRequest, useUpdateEffect } from '@/ui/hooks';
 import { useTranslation } from 'react-i18next';
@@ -52,7 +52,7 @@ const Comp: React.FC<DetailModalProps> = ({
   // A: Avoid the table of the fields triggering the monitoring of the column change.
   const [sinkType, setSinkType] = useState('');
 
-  const { Entity } = useLoadMeta<SinkMetaType>('sink', sinkType);
+  const { loading: pluginLoading, Entity } = useLoadMeta<SinkMetaType>('sink', sinkType);
 
   const { data: groupData, run: getGroupData } = useRequest(`/group/get/${inlongGroupId}`, {
     manual: true,
@@ -137,7 +137,7 @@ const Comp: React.FC<DetailModalProps> = ({
       const row = new Entity().renderRow();
       return row.map(item => ({
         ...item,
-        col: item.type === EditableTable ? 24 : 12,
+        col: item.name === 'sinkType' || item.type === EditableTable ? 24 : 12,
       }));
     }
 
@@ -187,12 +187,10 @@ const Comp: React.FC<DetailModalProps> = ({
         ),
       ]}
     >
-      {loading ? (
-        <Skeleton active />
-      ) : (
+      <Spin spinning={loading || pluginLoading}>
         <FormGenerator
           labelCol={{ flex: '0 0 200px' }}
-          wrapperCol={{ flex: 1 }}
+          wrapperCol={{ flex: '1' }}
           col={12}
           content={formContent}
           form={form}
@@ -201,7 +199,7 @@ const Comp: React.FC<DetailModalProps> = ({
             setSinkType(values.sinkType);
           }}
         />
-      )}
+      </Spin>
     </Modal>
   );
 };


### PR DESCRIPTION
- Fixes #7833

In the existing process, we fill in the name first, and then select the type. But in fact, users should first pay attention to the type, which is more in line with usage habits.

As shown, in the new flow, the user first selects the type:

![image](https://user-images.githubusercontent.com/13777294/231386275-89152c5d-90a5-4b94-a904-bd5664e20be0.png)


After selecting the type, the configuration parameters of the corresponding type will appear:

![image](https://user-images.githubusercontent.com/13777294/231385442-0b13105a-0f30-4789-b236-4b4dc9498c19.png)
