### PR TITLE
[INLONG-7660][Sort] Support DDL model for MySQL connector when running in all migrate mode

### DIFF
--- a/inlong-common/pom.xml
+++ b/inlong-common/pom.xml
@@ -84,6 +84,10 @@
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.jsqlparser</groupId>
+            <artifactId>jsqlparser</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/Utils/ColumnUtils.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/Utils/ColumnUtils.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.Utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.sf.jsqlparser.statement.create.table.ColDataType;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column.ColumnBuilder;
+import org.apache.inlong.sort.protocol.ddl.expressions.Position;
+import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
+
+/**
+ * Utils for parse from statement in sqlParser to a column object.
+ */
+public class ColumnUtils {
+
+    public static final String DEFAULT = "default";
+    public static final String NULL = "null";
+    public static final String NOT = "not";
+    public static final String COMMENT = "comment";
+    public static final String AFTER = "after";
+
+    /**
+     * parse column definition to a Column object
+     * this method is used for alter operation where a first flag is passed
+     * to determine whether the column is in the first position of one table.
+     */
+    public static Column parseColumnWithPosition(boolean isFirst,
+            Map<String, Integer> sqlType,
+            ColumnDefinition columnDefinition) {
+
+        ColDataType colDataType = columnDefinition.getColDataType();
+
+        List<String> definitions = new ArrayList<>();
+        if (colDataType.getArgumentsStringList() != null) {
+            definitions.addAll(colDataType.getArgumentsStringList());
+        }
+
+        List<String> columnSpecs = columnDefinition.getColumnSpecs();
+
+        ColumnBuilder columnBuilder = Column.builder();
+        String columnName = reformatName(columnDefinition.getColumnName());
+        columnBuilder.name(columnName)
+                .definition(definitions).isNullable(parseNullable(columnSpecs))
+                .defaultValue(parseDefaultValue(columnSpecs))
+                .jdbcType(sqlType.get(columnName))
+                .comment(parseComment(columnSpecs));
+
+        if (isFirst) {
+            // the column is in the first position of one table
+            columnBuilder.position(new Position(PositionType.FIRST, null));
+        } else {
+            columnBuilder.position(parsePosition(columnSpecs));
+        }
+
+        return columnBuilder.build();
+    }
+
+    /**
+     * parse column definitions to Column list.
+     * this method is used for createTable operation.
+     * @param sqlType the sql type map
+     * @param columnDefinitions the column definition list
+     * @return the column list
+     */
+    public static List<Column> parseColumns(Map<String, Integer> sqlType,
+            List<ColumnDefinition> columnDefinitions) {
+        List<Column> columns = new ArrayList<>();
+        columnDefinitions.forEach(columnDefinition -> {
+            columns.add(parseColumnWithPosition(false, sqlType, columnDefinition));
+        });
+        return columns;
+    }
+
+    public static String parseDefaultValue(List<String> specs) {
+        return removeContinuousQuotes(parseAdjacentString(specs, DEFAULT, false));
+    }
+
+    public static boolean parseNullable(List<String> specs) {
+        return !parseAdjacentString(specs, NULL, true).equalsIgnoreCase(NOT);
+    }
+
+    public static String parseComment(List<String> specs) {
+        return removeContinuousQuotes(parseAdjacentString(specs, COMMENT, false));
+    }
+
+    public static Position parsePosition(List<String> specs) {
+        String afterColumn = reformatName(parseAdjacentString(specs, AFTER, false));
+        if (!afterColumn.isEmpty()) {
+            return new Position(PositionType.AFTER, afterColumn);
+        }
+        return null;
+    }
+
+    /**
+     * get the string before or after the specific string in a list
+     * @param stringList the string list
+     * @param specificString the specific string
+     * @param front is front of the specific string
+     * @return the string before or after the specific string
+     */
+    public static String parseAdjacentString(List<String> stringList,
+            String specificString, boolean front) {
+
+        if (stringList == null || stringList.isEmpty()) {
+            return "";
+        }
+
+        for (int i = 0; i < stringList.size(); i++) {
+            if (stringList.get(i).equalsIgnoreCase(specificString)) {
+                if (front && i > 0) {
+                    return stringList.get(i - 1);
+                } else if (i < stringList.size() - 1) {
+                    return stringList.get(i + 1);
+                }
+            }
+        }
+        return "";
+
+    }
+
+    /**
+     * remove the continuous char in the string from both sides.
+     * @param str the input string, target the char to be removed
+     * @return the string without continuous chars from both sides
+     */
+    public static String removeContinuousChar(String str, char target) {
+        if (str == null || str.length() < 2) {
+            return str;
+        }
+        int start = 0;
+        int end = str.length() - 1;
+        while (start <= end && str.charAt(start) == target) {
+            start++;
+        }
+        while (end >= start && str.charAt(end) == target) {
+            end--;
+        }
+        return str.substring(start, end + 1);
+    }
+
+    public static String removeContinuousQuotes(String str) {
+        return removeContinuousChar(str, '\'');
+    }
+
+    public static String reformatName(String str) {
+        return removeContinuousChar(str, '`');
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/AlterType.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/AlterType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.enums;
+
+/**
+ * Alter type for alter column operation
+ */
+public enum AlterType {
+
+    RENAME_COLUMN,
+    ADD_COLUMN,
+    DROP_COLUMN,
+    MODIFY_COLUMN,
+    CHANGE_COLUMN
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/IndexType.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/IndexType.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.enums;
+
+/**
+ * Index type for create table operation
+ * only support normal index and primary key
+ */
+public enum IndexType {
+
+    NORMAL_INDEX,
+    PRIMARY_KEY
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/OperationType.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/OperationType.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.enums;
+
+/**
+ * Operation type for ddl operation
+ */
+public enum OperationType {
+
+    CREATE,
+    ALTER,
+    DROP,
+    RENAME,
+    TRUNCATE,
+    INSERT,
+    UPDATE,
+    DELETE,
+    OTHER
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/PositionType.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/enums/PositionType.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.enums;
+
+/**
+ * Position type for add column operation
+ */
+public enum PositionType {
+
+    /**
+     * add column to first position of a table
+     */
+    FIRST,
+
+    /**
+     * add column after a certain column
+     */
+    AFTER
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/AlterColumn.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/AlterColumn.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.expressions;
+
+import lombok.Data;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.inlong.sort.protocol.ddl.enums.AlterType;
+
+/**
+ * Alter column expression.
+ */
+@JsonInclude(Include.NON_NULL)
+@Data
+public class AlterColumn {
+
+    @JsonProperty("alterType")
+    private AlterType alterType;
+
+    @JsonProperty("newColumn")
+    private Column newColumn;
+
+    @JsonProperty("oldColumn")
+    private Column oldColumn;
+
+    @JsonCreator
+    public AlterColumn(@JsonProperty("alterType") AlterType alterType,
+            @JsonProperty("newColumn") Column newColumn,
+            @JsonProperty("oldColumn") Column oldColumn) {
+        this.alterType = alterType;
+        this.newColumn = newColumn;
+        this.oldColumn = oldColumn;
+    }
+
+    public AlterColumn(@JsonProperty("alterType") AlterType alterType) {
+        this.alterType = alterType;
+    }
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Column.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Column.java
@@ -25,6 +25,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * Column represents a column in a table.
+ */
 @Data
 @Builder
 @JsonInclude(Include.NON_NULL)

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Column.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Column.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.expressions;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Data;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+
+@Data
+@Builder
+@JsonInclude(Include.NON_NULL)
+public class Column {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("definition")
+    private List<String> definition;
+    @JsonProperty("jdbcType")
+    private int jdbcType;
+    @JsonProperty("position")
+    private Position position;
+    @JsonProperty("isNullable")
+    private boolean isNullable;
+    @JsonProperty("defaultValue")
+    private String defaultValue;
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonCreator
+    public Column(@JsonProperty("name") String name, @JsonProperty("definition") List<String> definition,
+            @JsonProperty("jdbcType") int jdbcType, @JsonProperty("position") Position position,
+            @JsonProperty("isNullable") boolean isNullable, @JsonProperty("defaultValue") String defaultValue,
+            @JsonProperty("comment") String comment) {
+        this.name = name;
+        this.definition = definition;
+        this.jdbcType = jdbcType;
+        this.position = position;
+        this.defaultValue = defaultValue;
+        this.comment = comment;
+        this.isNullable = isNullable;
+    }
+
+    public Column(@JsonProperty("name") String name) {
+        this.name = name;
+    }
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Position.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Position.java
@@ -24,6 +24,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
 
+/**
+ * Position represents the position of a column in a table.
+ * It can be either before or after a specific column.
+ */
 @JsonInclude(Include.NON_NULL)
 @Data
 public class Position {

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Position.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/expressions/Position.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.expressions;
+
+import lombok.Data;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
+
+@JsonInclude(Include.NON_NULL)
+@Data
+public class Position {
+
+    @JsonProperty("positionType")
+    private PositionType positionType;
+
+    @JsonProperty("columnName")
+    private String columnName;
+
+    @JsonCreator
+    public Position(@JsonProperty("positionType") PositionType positionType,
+            @JsonProperty("columnName") String columnName) {
+        this.positionType = positionType;
+        this.columnName = columnName;
+    }
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/indexes/Index.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/indexes/Index.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.indexes;
+
+import java.util.List;
+import lombok.Data;
+import org.apache.inlong.sort.protocol.ddl.enums.IndexType;
+
+/**
+ * Index for create table operation
+ */
+@Data
+public class Index {
+
+    private IndexType indexType;
+
+    private String indexName;
+
+    private List<String> indexColumns;
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/AlterOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/AlterOperation.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
+
+/**
+ * Alter operation which contains alter columns.
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("alterOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class AlterOperation extends Operation {
+
+    @JsonProperty("alterColumns")
+    private List<AlterColumn> alterColumns;
+
+    @JsonCreator
+    public AlterOperation(@JsonProperty("alterColumns") List<AlterColumn> alterColumns) {
+        super(OperationType.ALTER);
+        this.alterColumns = alterColumns;
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/CreateTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/CreateTableOperation.java
@@ -29,6 +29,10 @@ import org.apache.inlong.sort.protocol.ddl.expressions.Column;
 import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
 import org.apache.inlong.sort.protocol.ddl.indexes.Index;
 
+/**
+ * CreateTableOperation represents a create table operation
+ * it can be "create table like" or "create table with columns and indexes"
+ */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("createTableOperation")
 @JsonInclude(Include.NON_NULL)

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/CreateTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/CreateTableOperation.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+import org.apache.inlong.sort.protocol.ddl.indexes.Index;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("createTableOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class CreateTableOperation extends Operation {
+
+    @JsonProperty("columns")
+    private List<Column> columns;
+
+    @JsonProperty("indexes")
+    private List<Index> indexes;
+
+    @JsonProperty("likeTable")
+    private String likeTable;
+
+    @JsonProperty("comment")
+    private String comment;
+
+    @JsonCreator
+    public CreateTableOperation(@JsonProperty("columns") List<Column> columns,
+            @JsonProperty("indexes") List<Index> indexes,
+            @JsonProperty("likeTable") String likeTable,
+            @JsonProperty("comment") String comment) {
+        super(OperationType.CREATE);
+        this.columns = columns;
+        this.indexes = indexes;
+        this.likeTable = likeTable;
+        this.comment = comment;
+    }
+
+    public CreateTableOperation() {
+        super(OperationType.CREATE);
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/DropTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/DropTableOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("dropTableOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class DropTableOperation extends Operation {
+
+    @JsonCreator
+    public DropTableOperation() {
+        super(OperationType.DROP);
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/DropTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/DropTableOperation.java
@@ -25,6 +25,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
 
+/**
+ * DropTableOperation represents a drop operation on table
+ */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("dropTableOperation")
 @JsonInclude(Include.NON_NULL)

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
@@ -24,6 +24,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSub
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
 
+/**
+ * Operation represents a ddl operation.
+ */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({
         @JsonSubTypes.Type(value = AlterOperation.class, name = "alterOperation"),

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonSubTypes;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AlterOperation.class, name = "alterOperation"),
+        @JsonSubTypes.Type(value = CreateTableOperation.class, name = "createTableOperation"),
+        @JsonSubTypes.Type(value = DropTableOperation.class, name = "dropTableOperation"),
+        @JsonSubTypes.Type(value = TruncateTableOperation.class, name = "truncateTableOperation"),
+        @JsonSubTypes.Type(value = RenameTableOperation.class, name = "renameTableOperation")
+})
+@Data
+@NoArgsConstructor
+public abstract class Operation {
+
+    @JsonProperty("operationType")
+    private OperationType operationType;
+
+    public Operation(@JsonProperty("operationType") OperationType type) {
+        this.operationType = type;
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/RenameTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/RenameTableOperation.java
@@ -25,6 +25,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
 
+/**
+ * RenameTableOperation represents a rename operation on table
+ */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("renameTableOperation")
 @JsonInclude(Include.NON_NULL)

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/RenameTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/RenameTableOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("renameTableOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class RenameTableOperation extends Operation {
+
+    @JsonCreator
+    public RenameTableOperation() {
+        super(OperationType.RENAME);
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/TruncateTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/TruncateTableOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("truncateTableOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class TruncateTableOperation extends Operation {
+
+    @JsonCreator
+    public TruncateTableOperation() {
+        super(OperationType.TRUNCATE);
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/TruncateTableOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/TruncateTableOperation.java
@@ -25,6 +25,9 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInc
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
 import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
 
+/**
+ * TruncateTableOperation represents a truncate operation on table
+ */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("truncateTableOperation")
 @JsonInclude(Include.NON_NULL)

--- a/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-connectors/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -746,6 +746,7 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
             emit(record, insert, tableSchema, out);
         } catch (Exception e) {
             LOG.error("Failed to extract DDL record {}", record, e);
+            throw new RuntimeException(e);
         }
 
     }

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
@@ -17,17 +17,16 @@
 
 package org.apache.inlong.sort.cdc.mysql.table;
 
-import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.isSnapshotRecord;
-
-import static org.apache.inlong.sort.base.Constants.DDL_FIELD_NAME;
+import static org.apache.inlong.sort.cdc.mysql.utils.MetaDataUtils.getCanalData;
+import static org.apache.inlong.sort.cdc.mysql.utils.MetaDataUtils.getDebeziumData;
+import static org.apache.inlong.sort.cdc.mysql.utils.MetaDataUtils.getMetaData;
+import static org.apache.inlong.sort.cdc.mysql.utils.MetaDataUtils.getOpType;
 
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
 import io.debezium.data.Envelope.FieldName;
 import io.debezium.relational.Table;
 import io.debezium.relational.history.TableChanges;
-import io.debezium.relational.history.TableChanges.TableChange;
-import java.util.LinkedHashMap;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericArrayData;
@@ -38,17 +37,11 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.inlong.sort.cdc.base.debezium.table.MetadataConverter;
-import org.apache.inlong.sort.cdc.base.util.RecordUtils;
-import org.apache.inlong.sort.formats.json.canal.CanalJson;
-import org.apache.inlong.sort.formats.json.debezium.DebeziumJson;
-import org.apache.inlong.sort.formats.json.debezium.DebeziumJson.Source;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -60,421 +53,360 @@ public enum MySqlReadableMetadata {
      * Name of the table that contain the row.
      */
     TABLE_NAME(
-            "table_name",
-            DataTypes.STRING().notNull(),
-            new MetadataConverter() {
+        "table_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
+            }
+        }),
 
     /**
      * Name of the database that contain the row.
      */
     DATABASE_NAME(
-            "database_name",
-            DataTypes.STRING().notNull(),
-            new MetadataConverter() {
+        "database_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
+            }
+        }),
 
     /**
      * It indicates the time that the change was made in the database. If the record is read from
      * snapshot of the table instead of the binlog, the value is always 0.
      */
     OP_TS(
-            "op_ts",
-            DataTypes.TIMESTAMP_LTZ(3).notNull(),
-            new MetadataConverter() {
+        "op_ts",
+        DataTypes.TIMESTAMP_LTZ(3).notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    Struct messageStruct = (Struct) record.value();
-                    Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-                    return TimestampData.fromEpochMillis(
-                            (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+                return TimestampData.fromEpochMillis(
+                    (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+            }
+        }),
 
     DATA_DEFAULT(
-            "meta.data",
-            DataTypes.STRING(),
-            new MetadataConverter() {
+        "meta.data",
+        DataTypes.STRING(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return null;
-                }
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
 
-                @Override
-                public Object read(SourceRecord record,
-                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                    // construct canal json
-                    return getCanalData(record, (GenericRowData) rowData, tableSchema);
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record,
+                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                // construct canal json
+                return getCanalData(record, (GenericRowData) rowData, tableSchema);
+            }
+        }),
 
     DATA(
-            "meta.data_canal",
-            DataTypes.STRING(),
-            new MetadataConverter() {
+        "meta.data_canal",
+        DataTypes.STRING(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return null;
-                }
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
 
-                @Override
-                public Object read(SourceRecord record,
-                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                    // construct canal json
-                    return getCanalData(record, (GenericRowData) rowData, tableSchema);
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record,
+                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                // construct canal json
+                return getCanalData(record, (GenericRowData) rowData, tableSchema);
+            }
+        }),
 
     DATA_DEBEZIUM(
-            "meta.data_debezium",
-            DataTypes.STRING(),
-            new MetadataConverter() {
+        "meta.data_debezium",
+        DataTypes.STRING(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return null;
-                }
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
 
-                @Override
-                public Object read(SourceRecord record,
-                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                    // construct debezium json
-                    Struct messageStruct = (Struct) record.value();
-                    Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-                    GenericRowData data = (GenericRowData) rowData;
-                    Map<String, Object> field = (Map<String, Object>) data.getField(0);
-
-                    Source source = Source.builder().db(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY))
-                            .table(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY))
-                            .name(sourceStruct.getString(AbstractSourceInfo.SERVER_NAME_KEY))
-                            .sqlType(getSqlType(tableSchema))
-                            .pkNames(getPkNames(tableSchema))
-                            .mysqlType(getMysqlType(tableSchema))
-                            .build();
-                    DebeziumJson debeziumJson = DebeziumJson.builder().after(field).source(source)
-                            .tsMs(sourceStruct.getInt64(AbstractSourceInfo.TIMESTAMP_KEY)).op(getDebeziumOpType(data))
-                            .tableChange(tableSchema).incremental(isSnapshotRecord(sourceStruct)).build();
-
-                    try {
-                        return StringData.fromString(OBJECT_MAPPER.writeValueAsString(debeziumJson));
-                    } catch (Exception e) {
-                        throw new IllegalStateException("exception occurs when get meta data", e);
-                    }
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record,
+                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                return getDebeziumData(record, tableSchema, (GenericRowData) rowData);
+            }
+        }),
 
     /**
      * Name of the table that contain the row. .
      */
     META_TABLE_NAME(
-            "meta.table_name",
-            DataTypes.STRING().notNull(),
-            new MetadataConverter() {
+        "meta.table_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
+            }
+        }),
 
     /**
      * Name of the database that contain the row.
      */
     META_DATABASE_NAME(
-            "meta.database_name",
-            DataTypes.STRING().notNull(),
-            new MetadataConverter() {
+        "meta.database_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
+            }
+        }),
 
     /**
      * It indicates the time that the change was made in the database. If the record is read from
      * snapshot of the table instead of the binlog, the value is always 0.
      */
     META_OP_TS(
-            "meta.op_ts",
-            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-            new MetadataConverter() {
+        "meta.op_ts",
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    Struct messageStruct = (Struct) record.value();
-                    Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-                    return TimestampData.fromEpochMillis(
-                            (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+                return TimestampData.fromEpochMillis(
+                    (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+            }
+        }),
 
     /**
      * Operation type, INSERT/UPDATE/DELETE.
      */
     OP_TYPE(
-            "meta.op_type",
-            DataTypes.STRING().notNull(),
-            new MetadataConverter() {
+        "meta.op_type",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString(getOpType(record));
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString(getOpType(record));
+            }
+        }),
 
     /**
      * Not important, a simple increment counter.
      */
     BATCH_ID(
-            "meta.batch_id",
-            DataTypes.BIGINT().nullable(),
-            new MetadataConverter() {
+        "meta.batch_id",
+        DataTypes.BIGINT().nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                private long id = 0;
+            private long id = 0;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return id++;
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return id++;
+            }
+        }),
 
     /**
      * Source does not emit ddl data.
      */
     IS_DDL(
-            "meta.is_ddl",
-            DataTypes.BOOLEAN().notNull(),
-            new MetadataConverter() {
+        "meta.is_ddl",
+        DataTypes.BOOLEAN().notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return false;
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return false;
+            }
+        }),
 
     /**
      * The update-before data for UPDATE record.
      */
     OLD(
-            "meta.update_before",
-            DataTypes.ARRAY(
-                    DataTypes.MAP(
-                            DataTypes.STRING().nullable(),
-                            DataTypes.STRING().nullable())
-                            .nullable())
-                    .nullable(),
-            new MetadataConverter() {
+        "meta.update_before",
+        DataTypes.ARRAY(
+                DataTypes.MAP(
+                        DataTypes.STRING().nullable(),
+                        DataTypes.STRING().nullable())
+                    .nullable())
+            .nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    final Envelope.Operation op = Envelope.operationFor(record);
-                    if (op != Envelope.Operation.UPDATE) {
-                        return null;
-                    }
-                    return record;
+            @Override
+            public Object read(SourceRecord record) {
+                final Envelope.Operation op = Envelope.operationFor(record);
+                if (op != Envelope.Operation.UPDATE) {
+                    return null;
                 }
-            }),
+                return record;
+            }
+        }),
 
     MYSQL_TYPE(
-            "meta.mysql_type",
-            DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
-            new MetadataConverter() {
+        "meta.mysql_type",
+        DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
+
+            @Override
+            public Object read(
+                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                if (tableSchema == null) {
                     return null;
                 }
+                Map<StringData, StringData> mysqlType = new HashMap<>();
+                final Table table = tableSchema.getTable();
+                table.columns()
+                    .forEach(
+                        column -> {
+                            mysqlType.put(
+                                StringData.fromString(column.name()),
+                                StringData.fromString(
+                                    String.format(
+                                        "%s(%d)",
+                                        column.typeName(),
+                                        column.length())));
+                        });
 
-                @Override
-                public Object read(
-                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                    if (tableSchema == null) {
-                        return null;
-                    }
-                    Map<StringData, StringData> mysqlType = new HashMap<>();
-                    final Table table = tableSchema.getTable();
-                    table.columns()
-                            .forEach(
-                                    column -> {
-                                        mysqlType.put(
-                                                StringData.fromString(column.name()),
-                                                StringData.fromString(
-                                                        String.format(
-                                                                "%s(%d)",
-                                                                column.typeName(),
-                                                                column.length())));
-                                    });
-
-                    return new GenericMapData(mysqlType);
-                }
-            }),
+                return new GenericMapData(mysqlType);
+            }
+        }),
 
     PK_NAMES(
-            "meta.pk_names",
-            DataTypes.ARRAY(DataTypes.STRING().nullable()).nullable(),
-            new MetadataConverter() {
+        "meta.pk_names",
+        DataTypes.ARRAY(DataTypes.STRING().nullable()).nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
+
+            @Override
+            public Object read(
+                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                if (tableSchema == null) {
                     return null;
                 }
-
-                @Override
-                public Object read(
-                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                    if (tableSchema == null) {
-                        return null;
-                    }
-                    return new GenericArrayData(
-                            tableSchema.getTable().primaryKeyColumnNames().stream()
-                                    .map(StringData::fromString)
-                                    .toArray());
-                }
-            }),
+                return new GenericArrayData(
+                    tableSchema.getTable().primaryKeyColumnNames().stream()
+                        .map(StringData::fromString)
+                        .toArray());
+            }
+        }),
 
     SQL(
-            "meta.sql",
-            DataTypes.STRING().nullable(),
-            new MetadataConverter() {
+        "meta.sql",
+        DataTypes.STRING().nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    return StringData.fromString("");
-                }
-            }),
+            @Override
+            public Object read(SourceRecord record) {
+                return StringData.fromString("");
+            }
+        }),
 
     SQL_TYPE(
-            "meta.sql_type",
-            DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.INT().nullable()).nullable(),
-            new MetadataConverter() {
+        "meta.sql_type",
+        DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.INT().nullable()).nullable(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
+            @Override
+            public Object read(SourceRecord record) {
+                return null;
+            }
+
+            @Override
+            public Object read(
+                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                if (tableSchema == null) {
                     return null;
                 }
+                Map<StringData, Integer> mysqlType = new HashMap<>();
+                final Table table = tableSchema.getTable();
+                table.columns()
+                    .forEach(
+                        column -> {
+                            mysqlType.put(
+                                StringData.fromString(column.name()),
+                                column.jdbcType());
+                        });
 
-                @Override
-                public Object read(
-                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                    if (tableSchema == null) {
-                        return null;
-                    }
-                    Map<StringData, Integer> mysqlType = new HashMap<>();
-                    final Table table = tableSchema.getTable();
-                    table.columns()
-                            .forEach(
-                                    column -> {
-                                        mysqlType.put(
-                                                StringData.fromString(column.name()),
-                                                column.jdbcType());
-                                    });
-
-                    return new GenericMapData(mysqlType);
-                }
-            }),
+                return new GenericMapData(mysqlType);
+            }
+        }),
 
     TS(
-            "meta.ts",
-            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-            new MetadataConverter() {
+        "meta.ts",
+        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+        new MetadataConverter() {
 
-                private static final long serialVersionUID = 1L;
+            private static final long serialVersionUID = 1L;
 
-                @Override
-                public Object read(SourceRecord record) {
-                    Struct messageStruct = (Struct) record.value();
-                    return TimestampData.fromEpochMillis(
-                            (Long) messageStruct.get(FieldName.TIMESTAMP));
-                }
-            });
-
-    private static StringData getCanalData(SourceRecord record, GenericRowData rowData,
-            TableChange tableSchema) {
-        Struct messageStruct = (Struct) record.value();
-        Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-        // tableName
-        String tableName = getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY);
-        // databaseName
-        String databaseName = getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY);
-        // opTs
-        long opTs = (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY);
-        // actual data
-        GenericRowData data = rowData;
-        Map<String, Object> field = (Map<String, Object>) data.getField(0);
-        List<Map<String, Object>> dataList = new ArrayList<>();
-
-        CanalJson canalJson = CanalJson.builder()
-                .database(databaseName)
-                .es(opTs).pkNames(getPkNames(tableSchema))
-                .mysqlType(getMysqlType(tableSchema)).table(tableName)
-                .type(getCanalOpType(rowData)).sqlType(getSqlType(tableSchema))
-                .incremental(isSnapshotRecord(sourceStruct)).build();
-
-        try {
-            if (RecordUtils.isDdlRecord(messageStruct)) {
-                canalJson.setSql((String) field.get(DDL_FIELD_NAME));
-                canalJson.setDdl(true);
-                canalJson.setData(dataList);
-            } else {
-                canalJson.setDdl(false);
-                canalJson.setTs((Long) messageStruct.get(FieldName.TIMESTAMP));
-                dataList.add(field);
-                canalJson.setData(dataList);
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                return TimestampData.fromEpochMillis(
+                    (Long) messageStruct.get(FieldName.TIMESTAMP));
             }
-            return StringData.fromString(OBJECT_MAPPER.writeValueAsString(canalJson));
-        } catch (Exception e) {
-            throw new IllegalStateException("exception occurs when get meta data", e);
-        }
-
-    }
+        });
 
     private final String key;
     private final DataType dataType;
@@ -485,103 +417,6 @@ public enum MySqlReadableMetadata {
         this.key = key;
         this.dataType = dataType;
         this.converter = converter;
-    }
-
-    private static String getOpType(SourceRecord record) {
-        String opType;
-        final Envelope.Operation op = Envelope.operationFor(record);
-        if (op == Envelope.Operation.CREATE || op == Envelope.Operation.READ) {
-            opType = "INSERT";
-        } else if (op == Envelope.Operation.DELETE) {
-            opType = "DELETE";
-        } else {
-            opType = "UPDATE";
-        }
-        return opType;
-    }
-
-    private static String getCanalOpType(GenericRowData record) {
-        String opType;
-        switch (record.getRowKind()) {
-            case DELETE:
-            case UPDATE_BEFORE:
-                opType = "DELETE";
-                break;
-            case INSERT:
-            case UPDATE_AFTER:
-                opType = "INSERT";
-                break;
-            default:
-                throw new IllegalStateException("the record only have states in DELETE, "
-                        + "UPDATE_BEFORE, INSERT and UPDATE_AFTER");
-        }
-        return opType;
-    }
-
-    private static String getDebeziumOpType(GenericRowData record) {
-        String opType;
-        switch (record.getRowKind()) {
-            case DELETE:
-            case UPDATE_BEFORE:
-                opType = "d";
-                break;
-            case INSERT:
-            case UPDATE_AFTER:
-                opType = "c";
-                break;
-            default:
-                throw new IllegalStateException("the record only have states in DELETE, "
-                        + "UPDATE_BEFORE, INSERT and UPDATE_AFTER");
-        }
-        return opType;
-    }
-
-    private static List<String> getPkNames(@Nullable TableChanges.TableChange tableSchema) {
-        if (tableSchema == null) {
-            return null;
-        }
-        return tableSchema.getTable().primaryKeyColumnNames();
-    }
-
-    public static Map<String, String> getMysqlType(@Nullable TableChanges.TableChange tableSchema) {
-        if (tableSchema == null) {
-            return null;
-        }
-        Map<String, String> mysqlType = new LinkedHashMap<>();
-        final Table table = tableSchema.getTable();
-        table.columns()
-                .forEach(
-                        column -> {
-                            mysqlType.put(
-                                    column.name(),
-                                    String.format(
-                                            "%s(%d)",
-                                            column.typeName(),
-                                            column.length()));
-                        });
-        return mysqlType;
-    }
-
-    /**
-     * get sql type from table schema, represents the jdbc data type
-     *
-     * @param tableSchema table schema
-     */
-    public static Map<String, Integer> getSqlType(@Nullable TableChanges.TableChange tableSchema) {
-        if (tableSchema == null) {
-            return null;
-        }
-        Map<String, Integer> sqlType = new LinkedHashMap<>();
-        final Table table = tableSchema.getTable();
-        table.columns().forEach(
-                column -> sqlType.put(column.name(), column.jdbcType()));
-        return sqlType;
-    }
-
-    public static String getMetaData(SourceRecord record, String tableNameKey) {
-        Struct messageStruct = (Struct) record.value();
-        Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-        return sourceStruct.getString(tableNameKey);
     }
 
     public String getKey() {

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlReadableMetadata.java
@@ -53,360 +53,360 @@ public enum MySqlReadableMetadata {
      * Name of the table that contain the row.
      */
     TABLE_NAME(
-        "table_name",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
+            "table_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
+                }
+            }),
 
     /**
      * Name of the database that contain the row.
      */
     DATABASE_NAME(
-        "database_name",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
+            "database_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
+                }
+            }),
 
     /**
      * It indicates the time that the change was made in the database. If the record is read from
      * snapshot of the table instead of the binlog, the value is always 0.
      */
     OP_TS(
-        "op_ts",
-        DataTypes.TIMESTAMP_LTZ(3).notNull(),
-        new MetadataConverter() {
+            "op_ts",
+            DataTypes.TIMESTAMP_LTZ(3).notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                Struct messageStruct = (Struct) record.value();
-                Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-                return TimestampData.fromEpochMillis(
-                    (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct messageStruct = (Struct) record.value();
+                    Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+                    return TimestampData.fromEpochMillis(
+                            (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+                }
+            }),
 
     DATA_DEFAULT(
-        "meta.data",
-        DataTypes.STRING(),
-        new MetadataConverter() {
+            "meta.data",
+            DataTypes.STRING(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
+                @Override
+                public Object read(SourceRecord record) {
+                    return null;
+                }
 
-            @Override
-            public Object read(SourceRecord record,
-                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                // construct canal json
-                return getCanalData(record, (GenericRowData) rowData, tableSchema);
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record,
+                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                    // construct canal json
+                    return getCanalData(record, (GenericRowData) rowData, tableSchema);
+                }
+            }),
 
     DATA(
-        "meta.data_canal",
-        DataTypes.STRING(),
-        new MetadataConverter() {
+            "meta.data_canal",
+            DataTypes.STRING(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
+                @Override
+                public Object read(SourceRecord record) {
+                    return null;
+                }
 
-            @Override
-            public Object read(SourceRecord record,
-                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                // construct canal json
-                return getCanalData(record, (GenericRowData) rowData, tableSchema);
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record,
+                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                    // construct canal json
+                    return getCanalData(record, (GenericRowData) rowData, tableSchema);
+                }
+            }),
 
     DATA_DEBEZIUM(
-        "meta.data_debezium",
-        DataTypes.STRING(),
-        new MetadataConverter() {
+            "meta.data_debezium",
+            DataTypes.STRING(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
+                @Override
+                public Object read(SourceRecord record) {
+                    return null;
+                }
 
-            @Override
-            public Object read(SourceRecord record,
-                @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
-                return getDebeziumData(record, tableSchema, (GenericRowData) rowData);
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record,
+                        @Nullable TableChanges.TableChange tableSchema, RowData rowData) {
+                    return getDebeziumData(record, tableSchema, (GenericRowData) rowData);
+                }
+            }),
 
     /**
      * Name of the table that contain the row. .
      */
     META_TABLE_NAME(
-        "meta.table_name",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
+            "meta.table_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY));
+                }
+            }),
 
     /**
      * Name of the database that contain the row.
      */
     META_DATABASE_NAME(
-        "meta.database_name",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
+            "meta.database_name",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY));
+                }
+            }),
 
     /**
      * It indicates the time that the change was made in the database. If the record is read from
      * snapshot of the table instead of the binlog, the value is always 0.
      */
     META_OP_TS(
-        "meta.op_ts",
-        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-        new MetadataConverter() {
+            "meta.op_ts",
+            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                Struct messageStruct = (Struct) record.value();
-                Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
-                return TimestampData.fromEpochMillis(
-                    (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct messageStruct = (Struct) record.value();
+                    Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+                    return TimestampData.fromEpochMillis(
+                            (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+                }
+            }),
 
     /**
      * Operation type, INSERT/UPDATE/DELETE.
      */
     OP_TYPE(
-        "meta.op_type",
-        DataTypes.STRING().notNull(),
-        new MetadataConverter() {
+            "meta.op_type",
+            DataTypes.STRING().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString(getOpType(record));
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString(getOpType(record));
+                }
+            }),
 
     /**
      * Not important, a simple increment counter.
      */
     BATCH_ID(
-        "meta.batch_id",
-        DataTypes.BIGINT().nullable(),
-        new MetadataConverter() {
+            "meta.batch_id",
+            DataTypes.BIGINT().nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            private long id = 0;
+                private long id = 0;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return id++;
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return id++;
+                }
+            }),
 
     /**
      * Source does not emit ddl data.
      */
     IS_DDL(
-        "meta.is_ddl",
-        DataTypes.BOOLEAN().notNull(),
-        new MetadataConverter() {
+            "meta.is_ddl",
+            DataTypes.BOOLEAN().notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return false;
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return false;
+                }
+            }),
 
     /**
      * The update-before data for UPDATE record.
      */
     OLD(
-        "meta.update_before",
-        DataTypes.ARRAY(
-                DataTypes.MAP(
-                        DataTypes.STRING().nullable(),
-                        DataTypes.STRING().nullable())
-                    .nullable())
-            .nullable(),
-        new MetadataConverter() {
+            "meta.update_before",
+            DataTypes.ARRAY(
+                    DataTypes.MAP(
+                            DataTypes.STRING().nullable(),
+                            DataTypes.STRING().nullable())
+                            .nullable())
+                    .nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                final Envelope.Operation op = Envelope.operationFor(record);
-                if (op != Envelope.Operation.UPDATE) {
-                    return null;
+                @Override
+                public Object read(SourceRecord record) {
+                    final Envelope.Operation op = Envelope.operationFor(record);
+                    if (op != Envelope.Operation.UPDATE) {
+                        return null;
+                    }
+                    return record;
                 }
-                return record;
-            }
-        }),
+            }),
 
     MYSQL_TYPE(
-        "meta.mysql_type",
-        DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
-        new MetadataConverter() {
+            "meta.mysql_type",
+            DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.STRING().nullable()).nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
-
-            @Override
-            public Object read(
-                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                if (tableSchema == null) {
+                @Override
+                public Object read(SourceRecord record) {
                     return null;
                 }
-                Map<StringData, StringData> mysqlType = new HashMap<>();
-                final Table table = tableSchema.getTable();
-                table.columns()
-                    .forEach(
-                        column -> {
-                            mysqlType.put(
-                                StringData.fromString(column.name()),
-                                StringData.fromString(
-                                    String.format(
-                                        "%s(%d)",
-                                        column.typeName(),
-                                        column.length())));
-                        });
 
-                return new GenericMapData(mysqlType);
-            }
-        }),
+                @Override
+                public Object read(
+                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                    if (tableSchema == null) {
+                        return null;
+                    }
+                    Map<StringData, StringData> mysqlType = new HashMap<>();
+                    final Table table = tableSchema.getTable();
+                    table.columns()
+                            .forEach(
+                                    column -> {
+                                        mysqlType.put(
+                                                StringData.fromString(column.name()),
+                                                StringData.fromString(
+                                                        String.format(
+                                                                "%s(%d)",
+                                                                column.typeName(),
+                                                                column.length())));
+                                    });
+
+                    return new GenericMapData(mysqlType);
+                }
+            }),
 
     PK_NAMES(
-        "meta.pk_names",
-        DataTypes.ARRAY(DataTypes.STRING().nullable()).nullable(),
-        new MetadataConverter() {
+            "meta.pk_names",
+            DataTypes.ARRAY(DataTypes.STRING().nullable()).nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
-
-            @Override
-            public Object read(
-                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                if (tableSchema == null) {
+                @Override
+                public Object read(SourceRecord record) {
                     return null;
                 }
-                return new GenericArrayData(
-                    tableSchema.getTable().primaryKeyColumnNames().stream()
-                        .map(StringData::fromString)
-                        .toArray());
-            }
-        }),
+
+                @Override
+                public Object read(
+                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                    if (tableSchema == null) {
+                        return null;
+                    }
+                    return new GenericArrayData(
+                            tableSchema.getTable().primaryKeyColumnNames().stream()
+                                    .map(StringData::fromString)
+                                    .toArray());
+                }
+            }),
 
     SQL(
-        "meta.sql",
-        DataTypes.STRING().nullable(),
-        new MetadataConverter() {
+            "meta.sql",
+            DataTypes.STRING().nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return StringData.fromString("");
-            }
-        }),
+                @Override
+                public Object read(SourceRecord record) {
+                    return StringData.fromString("");
+                }
+            }),
 
     SQL_TYPE(
-        "meta.sql_type",
-        DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.INT().nullable()).nullable(),
-        new MetadataConverter() {
+            "meta.sql_type",
+            DataTypes.MAP(DataTypes.STRING().nullable(), DataTypes.INT().nullable()).nullable(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                return null;
-            }
-
-            @Override
-            public Object read(
-                SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
-                if (tableSchema == null) {
+                @Override
+                public Object read(SourceRecord record) {
                     return null;
                 }
-                Map<StringData, Integer> mysqlType = new HashMap<>();
-                final Table table = tableSchema.getTable();
-                table.columns()
-                    .forEach(
-                        column -> {
-                            mysqlType.put(
-                                StringData.fromString(column.name()),
-                                column.jdbcType());
-                        });
 
-                return new GenericMapData(mysqlType);
-            }
-        }),
+                @Override
+                public Object read(
+                        SourceRecord record, @Nullable TableChanges.TableChange tableSchema) {
+                    if (tableSchema == null) {
+                        return null;
+                    }
+                    Map<StringData, Integer> mysqlType = new HashMap<>();
+                    final Table table = tableSchema.getTable();
+                    table.columns()
+                            .forEach(
+                                    column -> {
+                                        mysqlType.put(
+                                                StringData.fromString(column.name()),
+                                                column.jdbcType());
+                                    });
+
+                    return new GenericMapData(mysqlType);
+                }
+            }),
 
     TS(
-        "meta.ts",
-        DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
-        new MetadataConverter() {
+            "meta.ts",
+            DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(3).notNull(),
+            new MetadataConverter() {
 
-            private static final long serialVersionUID = 1L;
+                private static final long serialVersionUID = 1L;
 
-            @Override
-            public Object read(SourceRecord record) {
-                Struct messageStruct = (Struct) record.value();
-                return TimestampData.fromEpochMillis(
-                    (Long) messageStruct.get(FieldName.TIMESTAMP));
-            }
-        });
+                @Override
+                public Object read(SourceRecord record) {
+                    Struct messageStruct = (Struct) record.value();
+                    return TimestampData.fromEpochMillis(
+                            (Long) messageStruct.get(FieldName.TIMESTAMP));
+                }
+            });
 
     private final String key;
     private final DataType dataType;

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mysql.utils;
+
+import static org.apache.inlong.sort.base.Constants.DDL_FIELD_NAME;
+import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.isSnapshotRecord;
+import static org.apache.inlong.sort.cdc.mysql.utils.OperationUtils.generateOperation;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.FieldName;
+import io.debezium.relational.Table;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.relational.history.TableChanges.TableChange;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.inlong.sort.cdc.base.util.RecordUtils;
+import org.apache.inlong.sort.formats.json.canal.CanalJson;
+import org.apache.inlong.sort.formats.json.debezium.DebeziumJson;
+import org.apache.inlong.sort.formats.json.debezium.DebeziumJson.Source;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utils for generating metadata in mysql cdc.
+ */
+public class MetaDataUtils {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Logger LOG = LoggerFactory.getLogger(MetaDataUtils.class);
+
+    /**
+     * get sql type from table schema, represents the jdbc data type
+     *
+     * @param tableSchema table schema
+     */
+    public static Map<String, Integer> getSqlType(@Nullable TableChanges.TableChange tableSchema) {
+        if (tableSchema == null) {
+            return null;
+        }
+        Map<String, Integer> sqlType = new LinkedHashMap<>();
+        final Table table = tableSchema.getTable();
+        table.columns().forEach(
+                column -> sqlType.put(column.name(), column.jdbcType()));
+        return sqlType;
+    }
+
+    public static String getMetaData(SourceRecord record, String tableNameKey) {
+        Struct messageStruct = (Struct) record.value();
+        Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+        return sourceStruct.getString(tableNameKey);
+    }
+
+    public static String getOpType(SourceRecord record) {
+        String opType;
+        final Envelope.Operation op = Envelope.operationFor(record);
+        if (op == Envelope.Operation.CREATE || op == Envelope.Operation.READ) {
+            opType = "INSERT";
+        } else if (op == Envelope.Operation.DELETE) {
+            opType = "DELETE";
+        } else {
+            opType = "UPDATE";
+        }
+        return opType;
+    }
+
+    public static String getCanalOpType(GenericRowData record) {
+        String opType;
+        switch (record.getRowKind()) {
+            case DELETE:
+            case UPDATE_BEFORE:
+                opType = "DELETE";
+                break;
+            case INSERT:
+            case UPDATE_AFTER:
+                opType = "INSERT";
+                break;
+            default:
+                throw new IllegalStateException("the record only have states in DELETE, "
+                        + "UPDATE_BEFORE, INSERT and UPDATE_AFTER");
+        }
+        return opType;
+    }
+
+    public static String getDebeziumOpType(GenericRowData record) {
+        String opType;
+        switch (record.getRowKind()) {
+            case DELETE:
+            case UPDATE_BEFORE:
+                opType = "d";
+                break;
+            case INSERT:
+            case UPDATE_AFTER:
+                opType = "c";
+                break;
+            default:
+                throw new IllegalStateException("the record only have states in DELETE, "
+                        + "UPDATE_BEFORE, INSERT and UPDATE_AFTER");
+        }
+        return opType;
+    }
+
+    public static List<String> getPkNames(@Nullable TableChanges.TableChange tableSchema) {
+        if (tableSchema == null) {
+            return null;
+        }
+        return tableSchema.getTable().primaryKeyColumnNames();
+    }
+
+    public static Map<String, String> getMysqlType(@Nullable TableChanges.TableChange tableSchema) {
+        if (tableSchema == null) {
+            return null;
+        }
+        Map<String, String> mysqlType = new LinkedHashMap<>();
+        final Table table = tableSchema.getTable();
+        table.columns()
+                .forEach(
+                        column -> {
+                            mysqlType.put(
+                                    column.name(),
+                                    String.format(
+                                            "%s(%d)",
+                                            column.typeName(),
+                                            column.length()));
+                        });
+        return mysqlType;
+    }
+
+    public static StringData getCanalData(SourceRecord record, GenericRowData rowData,
+            TableChange tableSchema) {
+        Struct messageStruct = (Struct) record.value();
+        Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+        // tableName
+        String tableName = getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY);
+        // databaseName
+        String databaseName = getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY);
+        // opTs
+        long opTs = (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY);
+        // actual data
+        Map<String, Object> field = (Map<String, Object>) rowData.getField(0);
+        List<Map<String, Object>> dataList = new ArrayList<>();
+
+        CanalJson canalJson = CanalJson.builder()
+                .database(databaseName)
+                .es(opTs).pkNames(getPkNames(tableSchema))
+                .mysqlType(getMysqlType(tableSchema)).table(tableName)
+                .incremental(!isSnapshotRecord(sourceStruct))
+                .dataSourceName(sourceStruct.getString(AbstractSourceInfo.SERVER_NAME_KEY))
+                .type(getCanalOpType(rowData))
+                .sqlType(getSqlType(tableSchema))
+                .build();
+
+        try {
+            if (RecordUtils.isDdlRecord(messageStruct)) {
+                String sql = (String) field.get(DDL_FIELD_NAME);
+                canalJson.setSql(sql);
+                canalJson.setOperation(generateOperation(sql, tableSchema));
+                canalJson.setDdl(true);
+                canalJson.setData(dataList);
+            } else {
+                canalJson.setDdl(false);
+                canalJson.setTs((Long) messageStruct.get(FieldName.TIMESTAMP));
+                dataList.add(field);
+                canalJson.setData(dataList);
+            }
+            LOG.debug("canal json: {}", canalJson);
+            return StringData.fromString(OBJECT_MAPPER.writeValueAsString(canalJson));
+        } catch (Exception e) {
+            throw new IllegalStateException("exception occurs when get meta data", e);
+        }
+    }
+
+    public static StringData getDebeziumData(SourceRecord record, TableChange tableSchema,
+            GenericRowData rowData) {
+        // construct debezium json
+        Struct messageStruct = (Struct) record.value();
+        Struct sourceStruct = messageStruct.getStruct(FieldName.SOURCE);
+        GenericRowData data = rowData;
+        Map<String, Object> field = (Map<String, Object>) data.getField(0);
+
+        Source source = Source.builder().db(getMetaData(record, AbstractSourceInfo.DATABASE_NAME_KEY))
+                .table(getMetaData(record, AbstractSourceInfo.TABLE_NAME_KEY))
+                .name(sourceStruct.getString(AbstractSourceInfo.SERVER_NAME_KEY))
+                .sqlType(getSqlType(tableSchema))
+                .pkNames(getPkNames(tableSchema))
+                .mysqlType(getMysqlType(tableSchema))
+                .build();
+        DebeziumJson debeziumJson = DebeziumJson.builder().source(source)
+                .tsMs(sourceStruct.getInt64(AbstractSourceInfo.TIMESTAMP_KEY)).op(getDebeziumOpType(data))
+                .dataSourceName(sourceStruct.getString(AbstractSourceInfo.SERVER_NAME_KEY))
+                .tableChange(tableSchema).incremental(!isSnapshotRecord(sourceStruct)).build();
+
+        try {
+            if (RecordUtils.isDdlRecord(messageStruct)) {
+                String sql = (String) field.get(DDL_FIELD_NAME);
+                debeziumJson.setDdl(sql);
+                debeziumJson.setOperation(generateOperation(sql, tableSchema));
+                debeziumJson.setAfter(new HashMap<>());
+            } else {
+                debeziumJson.setAfter(field);
+            }
+            return StringData.fromString(OBJECT_MAPPER.writeValueAsString(debeziumJson));
+        } catch (Exception e) {
+            throw new IllegalStateException("exception occurs when get meta data {}", e);
+        }
+
+    }
+
+}

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
@@ -178,7 +178,7 @@ public class MetaDataUtils {
             if (RecordUtils.isDdlRecord(messageStruct)) {
                 String sql = (String) field.get(DDL_FIELD_NAME);
                 canalJson.setSql(sql);
-                canalJson.setOperation(generateOperation(sql, tableSchema));
+                canalJson.setOperation(generateOperation(sql, getSqlType(tableSchema)));
                 canalJson.setDdl(true);
                 canalJson.setData(dataList);
             } else {
@@ -218,7 +218,7 @@ public class MetaDataUtils {
             if (RecordUtils.isDdlRecord(messageStruct)) {
                 String sql = (String) field.get(DDL_FIELD_NAME);
                 debeziumJson.setDdl(sql);
-                debeziumJson.setOperation(generateOperation(sql, tableSchema));
+                debeziumJson.setOperation(generateOperation(sql, getSqlType(tableSchema)));
                 debeziumJson.setAfter(new HashMap<>());
             } else {
                 debeziumJson.setAfter(field);

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/OperationUtils.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/OperationUtils.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.mysql.utils;
+
+import static org.apache.inlong.sort.cdc.mysql.utils.MetaDataUtils.getSqlType;
+import static org.apache.inlong.sort.protocol.ddl.Utils.ColumnUtils.parseColumnWithPosition;
+import static org.apache.inlong.sort.protocol.ddl.Utils.ColumnUtils.parseColumns;
+import static org.apache.inlong.sort.protocol.ddl.Utils.ColumnUtils.parseComment;
+import static org.apache.inlong.sort.protocol.ddl.Utils.ColumnUtils.reformatName;
+
+import io.debezium.relational.history.TableChanges.TableChange;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.alter.Alter;
+import net.sf.jsqlparser.statement.alter.RenameTableStatement;
+import net.sf.jsqlparser.statement.create.table.ColumnDefinition;
+import net.sf.jsqlparser.statement.create.table.CreateTable;
+import net.sf.jsqlparser.statement.drop.Drop;
+import net.sf.jsqlparser.statement.truncate.Truncate;
+import org.apache.commons.lang.StringUtils;
+import org.apache.inlong.sort.cdc.base.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column;
+import org.apache.inlong.sort.protocol.ddl.enums.AlterType;
+import org.apache.inlong.sort.protocol.ddl.enums.IndexType;
+import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
+import org.apache.inlong.sort.protocol.ddl.indexes.Index;
+import org.apache.inlong.sort.protocol.ddl.operations.AlterOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.CreateTableOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.DropTableOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.Operation;
+import org.apache.inlong.sort.protocol.ddl.operations.RenameTableOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.TruncateTableOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utils for generate operation from statement from sqlParser.
+ */
+public class OperationUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RowDataDebeziumDeserializeSchema.class);
+    public static final String PRIMARY_KEY = "PRIMARY KEY";
+    public static final String NORMAL_INDEX = "NORMAL_INDEX";
+    public static final String FIRST = "FIRST";
+
+    /**
+     * generate operation from sql and table schema.
+     * @param sql sql from binlog
+     * @param tableSchema table schema
+     * @return Operation
+     */
+    public static Operation generateOperation(String sql, TableChange tableSchema) {
+        try {
+            // now sqlParser don't support first position
+            // remove it first and add it later
+            boolean endsWithFirst = StringUtils.endsWithIgnoreCase(sql, FIRST);
+            if (endsWithFirst) {
+                sql = removeFirstFlag(sql);
+            }
+            Statement statement = CCJSqlParserUtil.parse(sql);
+            if (statement instanceof Alter) {
+                return parseAlterOperation(
+                        (Alter) statement, tableSchema, endsWithFirst);
+            } else if (statement instanceof CreateTable) {
+                return parseCreateTableOperation(
+                        (CreateTable) statement, tableSchema);
+            } else if (statement instanceof Drop) {
+                return new DropTableOperation();
+            } else if (statement instanceof Truncate) {
+                return new TruncateTableOperation();
+            } else if (statement instanceof RenameTableStatement) {
+                return new RenameTableOperation();
+            } else {
+                LOG.warn("doesn't support sql {}, statement {}", sql, statement);
+            }
+        } catch (Exception e) {
+            LOG.error("parse ddl error: {}， set ddl to null", sql, e);
+        }
+        return null;
+    }
+
+    /**
+     * parse alter operation from Alter from sqlParser.
+     * @param statement alter statement
+     * @param tableSchema table schema
+     * @param isFirst whether the column is first
+     * @return AlterOperation
+     */
+    private static AlterOperation parseAlterOperation(Alter statement,
+            TableChange tableSchema, boolean isFirst) {
+
+        Map<String, Integer> sqlType = getSqlType(tableSchema);
+        List<AlterColumn> alterColumns = new ArrayList<>();
+        statement.getAlterExpressions().forEach(alterExpression -> {
+            switch (alterExpression.getOperation()) {
+                case DROP:
+                    alterColumns.add(new AlterColumn(AlterType.DROP_COLUMN,
+                            null,
+                            Column.builder().name(reformatName(alterExpression.getColumnName()))
+                                    .build()));
+                    break;
+                case ADD:
+                    alterColumns.add(new AlterColumn(AlterType.ADD_COLUMN,
+                            parseColumnWithPosition(isFirst, sqlType,
+                                    alterExpression.getColDataTypeList().get(0)),
+                            null));
+                    break;
+                case RENAME:
+                    alterColumns.add(new AlterColumn(AlterType.CHANGE_COLUMN,
+                            new Column(reformatName(alterExpression.getColumnName())),
+                            new Column(reformatName(alterExpression.getColumnOldName()))));
+                    break;
+                case MODIFY:
+                    // modify column use change column type
+                case CHANGE:
+                    alterColumns.add(new AlterColumn(AlterType.CHANGE_COLUMN,
+                            parseColumnWithPosition(isFirst, sqlType,
+                                    alterExpression.getColDataTypeList().get(0)),
+                            new Column(reformatName(alterExpression.getColumnOldName()))));
+                    break;
+                default:
+                    LOG.warn("doesn't support alter operation {}, statement {}",
+                            alterExpression.getOperation(), statement);
+            }
+
+        });
+
+        return new AlterOperation(alterColumns);
+    }
+
+    /**
+     * parse create table operation from CreateTable from sqlParser.
+     * @param statement create table statement
+     * @param tableSchema table schema
+     * @return CreateTableOperation
+     */
+    private static CreateTableOperation parseCreateTableOperation(
+            CreateTable statement, TableChange tableSchema) {
+
+        Map<String, Integer> sqlType = getSqlType(tableSchema);
+        CreateTableOperation createTableOperation = new CreateTableOperation();
+        List<ColumnDefinition> columnDefinitions = statement.getColumnDefinitions();
+
+        if (statement.getLikeTable() != null) {
+            createTableOperation.setLikeTable(parseLikeTable(statement));
+            return createTableOperation;
+        }
+
+        createTableOperation.setColumns(parseColumns(sqlType, columnDefinitions));
+        createTableOperation.setIndexes(parseIndexes(statement));
+        createTableOperation.setComment(parseComment(statement.getTableOptionsStrings()));
+
+        return createTableOperation;
+    }
+
+    /**
+     * parse indexes from statement
+     * only support primary key and normal index.
+     * @param statement create table statement
+     * @return list of indexes
+     */
+    private static List<Index> parseIndexes(CreateTable statement) {
+
+        if (statement.getIndexes() == null) {
+            return new ArrayList<>();
+        }
+        List<Index> indexList = new ArrayList<>();
+
+        for (net.sf.jsqlparser.statement.create.table.Index perIndex : statement.getIndexes()) {
+            Index index = new Index();
+            switch (perIndex.getType()) {
+                case PRIMARY_KEY:
+                    index.setIndexType(IndexType.PRIMARY_KEY);
+                    break;
+                case NORMAL_INDEX:
+                    index.setIndexType(IndexType.NORMAL_INDEX);
+                    break;
+                default:
+                    LOG.error("unsupported index type {}", perIndex.getType());
+                    break;
+            }
+            List<String> columns = new ArrayList<>();
+            perIndex.getColumnsNames().forEach(columnName -> columns.add(reformatName(columnName)));
+            index.setIndexName(reformatName(perIndex.getName()));
+            index.setIndexColumns(columns);
+            indexList.add(index);
+        }
+
+        return indexList;
+
+    }
+
+    /**
+     * remove the first flag from sql.
+     * @param sql sql from binlog
+     * @return sql without first flag
+     */
+    private static String removeFirstFlag(String sql) {
+        return sql.substring(0, StringUtils.lastIndexOfIgnoreCase(sql, FIRST));
+    }
+
+    /**
+     * get like table from statement.
+     * @param statement create table statement
+     * @return like table name
+     */
+    private static String parseLikeTable(CreateTable statement) {
+        if (statement.getLikeTable() != null) {
+            return statement.getLikeTable().getName();
+        }
+        return "";
+    }
+
+}

--- a/inlong-sort/sort-connectors/mysql-cdc/src/test/java/org/apache/inlong/sort/cdc/TestOperation.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/test/java/org/apache/inlong/sort/cdc/TestOperation.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc;
+
+import java.util.HashMap;
+import org.apache.inlong.sort.cdc.mysql.utils.OperationUtils;
+import org.apache.inlong.sort.protocol.ddl.enums.AlterType;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
+import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
+import org.apache.inlong.sort.protocol.ddl.operations.AlterOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.Operation;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test for table operations
+ */
+public class TestOperation {
+
+    @Test
+    public void testRenameTableOperation() {
+        String sql = "rename table `tv3` to `tv4`";
+        HashMap<String, Integer> sqlType = new HashMap<>();
+        sqlType.put("tv3", 1);
+        Operation operation = OperationUtils.generateOperation(sql, sqlType);
+        assert operation != null;
+        Assert.assertEquals(operation.getOperationType(), OperationType.RENAME);
+    }
+
+    @Test
+    public void testDropTableOperation() {
+        String sql = "drop table `tv3`";
+        HashMap<String, Integer> sqlType = new HashMap<>();
+        sqlType.put("tv3", 1);
+        Operation operation = OperationUtils.generateOperation(sql, sqlType);
+        assert operation != null;
+        Assert.assertEquals(operation.getOperationType(), OperationType.DROP);
+    }
+
+    @Test
+    public void testAddColumnOperation() {
+        String sql = "alter table a add column b int comment \"test\" first";
+        HashMap<String, Integer> sqlType = new HashMap<>();
+        sqlType.put("b", 1);
+        Operation operation = OperationUtils.generateOperation(sql, sqlType);
+        assert operation != null;
+        Assert.assertEquals(operation.getOperationType(), OperationType.ALTER);
+        AlterColumn alterColumn = ((AlterOperation) operation).getAlterColumns().get(0);
+        Assert.assertEquals(alterColumn.getAlterType(), AlterType.ADD_COLUMN);
+        Assert.assertEquals(alterColumn.getNewColumn().getName(), "b");
+        Assert.assertEquals(alterColumn.getNewColumn().getPosition().getPositionType(), PositionType.FIRST);
+        Assert.assertNull(alterColumn.getNewColumn().getPosition().getColumnName());
+    }
+
+    @Test
+    public void testRenameColumnOperation() {
+        String sql = "alter table a CHANGE b c int";
+        HashMap<String, Integer> sqlType = new HashMap<>();
+        sqlType.put("c", 1);
+        Operation operation = OperationUtils.generateOperation(sql, sqlType);
+        assert operation != null;
+        Assert.assertEquals(operation.getOperationType(), OperationType.ALTER);
+        AlterColumn alterColumn = ((AlterOperation) operation).getAlterColumns().get(0);
+        Assert.assertEquals(alterColumn.getAlterType(), AlterType.CHANGE_COLUMN);
+        Assert.assertEquals(alterColumn.getNewColumn().getName(), "c");
+        Assert.assertEquals(alterColumn.getOldColumn().getName(), "b");
+    }
+
+}

--- a/inlong-sort/sort-formats/format-json/pom.xml
+++ b/inlong-sort/sort-formats/format-json/pom.xml
@@ -78,7 +78,11 @@
             <artifactId>debezium-core</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
@@ -70,21 +70,21 @@ public class CanalJson {
 
     @JsonCreator
     public CanalJson(@Nullable @JsonProperty("data") List<Map<String, Object>> data,
-        @JsonProperty("es") long es,
-        @JsonProperty("table") String table,
-        @JsonProperty("type") String type,
-        @JsonProperty("database") String database,
-        @JsonProperty("ts") long ts,
-        @JsonProperty("sql") String sql,
-        @Nullable @JsonProperty("mysqlType") Map<String, String> mysqlType,
-        @Nullable @JsonProperty("sqlType") Map<String, Integer> sqlType,
-        @JsonProperty("isDdl") boolean isDdl,
-        @Nullable @JsonProperty("pkNames") List<String> pkNames,
-        @JsonProperty("schema") String schema,
-        @Nullable @JsonProperty("oracleType") Map<String, String> oracleType,
-        @JsonProperty("operation") Operation operation,
-        @JsonProperty("incremental") Boolean incremental,
-        @JsonProperty("dataSourceName") String dataSourceName) {
+            @JsonProperty("es") long es,
+            @JsonProperty("table") String table,
+            @JsonProperty("type") String type,
+            @JsonProperty("database") String database,
+            @JsonProperty("ts") long ts,
+            @JsonProperty("sql") String sql,
+            @Nullable @JsonProperty("mysqlType") Map<String, String> mysqlType,
+            @Nullable @JsonProperty("sqlType") Map<String, Integer> sqlType,
+            @JsonProperty("isDdl") boolean isDdl,
+            @Nullable @JsonProperty("pkNames") List<String> pkNames,
+            @JsonProperty("schema") String schema,
+            @Nullable @JsonProperty("oracleType") Map<String, String> oracleType,
+            @JsonProperty("operation") Operation operation,
+            @JsonProperty("incremental") Boolean incremental,
+            @JsonProperty("dataSourceName") String dataSourceName) {
         this.data = data;
         this.es = es;
         this.table = table;

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/canal/CanalJson.java
@@ -19,13 +19,18 @@ package org.apache.inlong.sort.formats.json.canal;
 
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Data;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.operations.Operation;
 
 @Builder
+@JsonTypeName("canalJson")
 @JsonInclude(Include.NON_NULL)
 @Data
 public class CanalJson {
@@ -56,7 +61,46 @@ public class CanalJson {
     private String schema;
     @JsonProperty("oracleType")
     private Map<String, String> oracleType;
+    @JsonProperty("operation")
+    private Operation operation;
     @JsonProperty("incremental")
     private Boolean incremental;
+    @JsonProperty("dataSourceName")
+    private String dataSourceName;
+
+    @JsonCreator
+    public CanalJson(@Nullable @JsonProperty("data") List<Map<String, Object>> data,
+        @JsonProperty("es") long es,
+        @JsonProperty("table") String table,
+        @JsonProperty("type") String type,
+        @JsonProperty("database") String database,
+        @JsonProperty("ts") long ts,
+        @JsonProperty("sql") String sql,
+        @Nullable @JsonProperty("mysqlType") Map<String, String> mysqlType,
+        @Nullable @JsonProperty("sqlType") Map<String, Integer> sqlType,
+        @JsonProperty("isDdl") boolean isDdl,
+        @Nullable @JsonProperty("pkNames") List<String> pkNames,
+        @JsonProperty("schema") String schema,
+        @Nullable @JsonProperty("oracleType") Map<String, String> oracleType,
+        @JsonProperty("operation") Operation operation,
+        @JsonProperty("incremental") Boolean incremental,
+        @JsonProperty("dataSourceName") String dataSourceName) {
+        this.data = data;
+        this.es = es;
+        this.table = table;
+        this.type = type;
+        this.database = database;
+        this.ts = ts;
+        this.sql = sql;
+        this.mysqlType = mysqlType;
+        this.sqlType = sqlType;
+        this.isDdl = isDdl;
+        this.pkNames = pkNames;
+        this.schema = schema;
+        this.oracleType = oracleType;
+        this.operation = operation;
+        this.incremental = incremental;
+        this.dataSourceName = dataSourceName;
+    }
 
 }

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJson.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJson.java
@@ -57,14 +57,14 @@ public class DebeziumJson {
     private String dataSourceName;
 
     public DebeziumJson(@JsonProperty("before") Map<String, String> before,
-        @JsonProperty("after") Map<String, Object> after,
-        @JsonProperty("source") Source source,
-        @JsonProperty("tableChange") TableChange tableChange,
-        @JsonProperty("tsMs") long tsMs, @JsonProperty("op") String op,
-        @JsonProperty("incremental") boolean incremental,
-        @JsonProperty("ddl") String ddl,
-        @JsonProperty("operation") Operation operation,
-        @JsonProperty("dataSourceName") String dataSourceName) {
+            @JsonProperty("after") Map<String, Object> after,
+            @JsonProperty("source") Source source,
+            @JsonProperty("tableChange") TableChange tableChange,
+            @JsonProperty("tsMs") long tsMs, @JsonProperty("op") String op,
+            @JsonProperty("incremental") boolean incremental,
+            @JsonProperty("ddl") String ddl,
+            @JsonProperty("operation") Operation operation,
+            @JsonProperty("dataSourceName") String dataSourceName) {
         this.before = before;
         this.after = after;
         this.source = source;

--- a/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJson.java
+++ b/inlong-sort/sort-formats/format-json/src/main/java/org/apache/inlong/sort/formats/json/debezium/DebeziumJson.java
@@ -18,22 +18,64 @@
 package org.apache.inlong.sort.formats.json.debezium;
 
 import io.debezium.relational.history.TableChanges;
+import io.debezium.relational.history.TableChanges.TableChange;
 import java.util.List;
 import java.util.Map;
 import lombok.Builder;
 import lombok.Data;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.ddl.operations.Operation;
 
-@Data
 @Builder
+@JsonTypeName("canalJson")
+@JsonInclude(Include.NON_NULL)
+@Data
 public class DebeziumJson {
 
+    @JsonProperty("before")
     private Map<String, String> before;
+    @JsonProperty("after")
     private Map<String, Object> after;
+    @JsonProperty("source")
     private Source source;
+    @JsonProperty("tableChange")
     private TableChanges.TableChange tableChange;
+    @JsonProperty("tsMs")
     private long tsMs;
+    @JsonProperty("op")
     private String op;
-    private Boolean incremental;
+    @JsonProperty("incremental")
+    private boolean incremental;
+    @JsonProperty("ddl")
+    private String ddl;
+    @JsonProperty("operation")
+    private Operation operation;
+    @JsonProperty("dataSourceName")
+    private String dataSourceName;
+
+    public DebeziumJson(@JsonProperty("before") Map<String, String> before,
+        @JsonProperty("after") Map<String, Object> after,
+        @JsonProperty("source") Source source,
+        @JsonProperty("tableChange") TableChange tableChange,
+        @JsonProperty("tsMs") long tsMs, @JsonProperty("op") String op,
+        @JsonProperty("incremental") boolean incremental,
+        @JsonProperty("ddl") String ddl,
+        @JsonProperty("operation") Operation operation,
+        @JsonProperty("dataSourceName") String dataSourceName) {
+        this.before = before;
+        this.after = after;
+        this.source = source;
+        this.tableChange = tableChange;
+        this.tsMs = tsMs;
+        this.op = op;
+        this.incremental = incremental;
+        this.ddl = ddl;
+        this.operation = operation;
+        this.dataSourceName = dataSourceName;
+    }
 
     @Builder
     @Data

--- a/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/CanalJsonSerializationTest.java
+++ b/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/CanalJsonSerializationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.formats.json.canal;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column;
+import org.apache.inlong.sort.protocol.ddl.expressions.Position;
+import org.apache.inlong.sort.protocol.ddl.enums.AlterType;
+import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
+import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
+import org.apache.inlong.sort.protocol.ddl.operations.AlterOperation;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CanalJsonSerializationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CanalJsonSerializationTest.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testCanalJsonSerialization() {
+
+        List<AlterColumn> alterColumns = new ArrayList<>();
+
+        Column column = new Column("columnDataType.getColumnName()", new ArrayList<>(),
+                1,
+                new Position(PositionType.FIRST, null), true, "23",
+                "23");
+
+        alterColumns.add(new AlterColumn(AlterType.ADD_COLUMN, column, null));
+
+        AlterOperation alterOperation = new AlterOperation(alterColumns);
+
+        CanalJson canalJson = CanalJson.builder()
+                .data(null)
+                .es(0)
+                .table("table")
+                .type("type")
+                .database("database")
+                .ts(0)
+                .sql("sql")
+                .mysqlType(null)
+                .sqlType(null)
+                .pkNames(null)
+                .schema("schema")
+                .oracleType(null)
+                .operation(alterOperation)
+                .incremental(false)
+                .build();
+
+        ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+        try {
+            String writeValueAsString = OBJECT_MAPPER.writeValueAsString(canalJson);
+            LOG.info(writeValueAsString);
+            objectMapper.readValue(writeValueAsString, CanalJson.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/CanalJsonSerializationTest.java
+++ b/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/CanalJsonSerializationTest.java
@@ -31,6 +31,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test for {@link CanalJson}.
+ */
 public class CanalJsonSerializationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CanalJsonSerializationTest.class);

--- a/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
+++ b/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class DebeziumJsonSerializationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CanalJsonSerializationTest.class);

--- a/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
+++ b/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
@@ -33,6 +33,9 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Test for {@link DebeziumJson}.
+ */
 public class DebeziumJsonSerializationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(CanalJsonSerializationTest.class);

--- a/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
+++ b/inlong-sort/sort-formats/format-json/src/test/java/org/apache/inlong/sort/formats/json/canal/DebeziumJsonSerializationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.formats.json.canal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.inlong.sort.formats.json.debezium.DebeziumJson;
+import org.apache.inlong.sort.protocol.ddl.expressions.Column;
+import org.apache.inlong.sort.protocol.ddl.expressions.Position;
+import org.apache.inlong.sort.protocol.ddl.enums.AlterType;
+import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
+import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
+import org.apache.inlong.sort.protocol.ddl.operations.AlterOperation;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class DebeziumJsonSerializationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CanalJsonSerializationTest.class);
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void testDebeziumJsonSerialization() {
+
+        List<AlterColumn> alterColumns = new ArrayList<>();
+
+        Column column = new Column("columnDataType.getColumnName()", new ArrayList<>(),
+                1,
+                new Position(PositionType.FIRST, null), true, "23",
+                "23");
+
+        alterColumns.add(new AlterColumn(AlterType.ADD_COLUMN, column, null));
+
+        AlterOperation alterOperation = new AlterOperation(alterColumns);
+
+        DebeziumJson debeziumJson = DebeziumJson.builder().source(null)
+                .dataSourceName("dataSourceName")
+                .tableChange(null).incremental(false).build();
+
+        debeziumJson.setDdl("");
+        debeziumJson.setOperation(alterOperation);
+        debeziumJson.setAfter(new HashMap<>());
+
+        ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+        try {
+            String writeValueAsString = OBJECT_MAPPER.writeValueAsString(debeziumJson);
+            LOG.info(writeValueAsString);
+            objectMapper.readValue(writeValueAsString, DebeziumJson.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -873,7 +873,6 @@ The text of each license is the standard Apache 2.0 license.
   net.sf.jpam:jpam:1.1 - JPam (http://jpam.sourceforge.net/), (The Apache Software License, Version 2.0)
   com.cedarsoftware:json-io:2.5.1 - Java JSON serialization (https://github.com/jdereg/json-io), (Apache License, Version 2.0)
   net.minidev:json-smart:2.3 - JSON Small and Fast Parser (https://github.com/netplex/json-smart-v2/tree/v2.3), (The Apache Software License, Version 2.0)
-  com.github.jsqlparser:jsqlparser:2.1 - JSQLParser library (https://github.com/JSQLParser/JSqlParser), (The Apache Software License, Version 2.0;  GNU Library or Lesser General Public License (LGPL) V2.1)
   com.github.jsqlparser:jsqlparser:4.2 - JSQLParser library (https://github.com/JSQLParser/JSqlParser), (The Apache Software License, Version 2.0;  GNU Library or Lesser General Public License (LGPL) V2.1)
   org.apache.kerby:kerb-admin:1.0.1 - Kerby-kerb Admin (http://directory.apache.org/kerby/kerby-kerb/kerb-admin), (Apache License, Version 2.0)
   org.apache.kerby:kerb-client:1.0.1 - Kerby-kerb Client (http://directory.apache.org/kerby/kerby-kerb/kerb-client), (Apache License, Version 2.0)

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -874,6 +874,7 @@ The text of each license is the standard Apache 2.0 license.
   com.cedarsoftware:json-io:2.5.1 - Java JSON serialization (https://github.com/jdereg/json-io), (Apache License, Version 2.0)
   net.minidev:json-smart:2.3 - JSON Small and Fast Parser (https://github.com/netplex/json-smart-v2/tree/v2.3), (The Apache Software License, Version 2.0)
   com.github.jsqlparser:jsqlparser:2.1 - JSQLParser library (https://github.com/JSQLParser/JSqlParser), (The Apache Software License, Version 2.0;  GNU Library or Lesser General Public License (LGPL) V2.1)
+  com.github.jsqlparser:jsqlparser:4.2 - JSQLParser library (https://github.com/JSQLParser/JSqlParser), (The Apache Software License, Version 2.0;  GNU Library or Lesser General Public License (LGPL) V2.1)
   org.apache.kerby:kerb-admin:1.0.1 - Kerby-kerb Admin (http://directory.apache.org/kerby/kerby-kerb/kerb-admin), (Apache License, Version 2.0)
   org.apache.kerby:kerb-client:1.0.1 - Kerby-kerb Client (http://directory.apache.org/kerby/kerby-kerb/kerb-client), (Apache License, Version 2.0)
   org.apache.kerby:kerb-common:1.0.1 - Kerby-kerb Common (http://directory.apache.org/kerby/kerby-kerb/kerb-common), (Apache License, Version 2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
         <tomcat.version>8.5.53</tomcat.version>
         <jedis.version>2.9.0</jedis.version>
         <poi.version>5.2.3</poi.version>
+        <jsqlparser.version>4.2</jsqlparser.version>
     </properties>
 
     <dependencyManagement>
@@ -232,6 +233,11 @@
                 <groupId>org.apache.flume</groupId>
                 <artifactId>flume-ng-configuration</artifactId>
                 <version>${flume.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jsqlparser</groupId>
+                <artifactId>jsqlparser</artifactId>
+                <version>${jsqlparser.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7660 

### Motivation

With the in-depth use of community users, it is found that for some CDC data source synchronization scenarios, when DDL occurs in upstream data sources, the following pain points often exist:

1 The DDL change of the upstream data source causes task errors and the data cannot be correctly synchronized to the downstream.

2 To synchronize the DDL changes of the upstream data source to the downstream, it is necessary to manually process the DDL change process: task suspension -> downstream processing DDL changes -> task restart, which cost a lot of time 

3 it is often necessary to manually convert the upstream DDL to the DDL supported by the downstream, which requires the person who operates the DDL change to be familiar with both upstream and downstream data sources.

Aiming at these pain points, InLong Sort designed a DDL change solution to support DDL changes during data synchronization and ensure data consistency during DDL changes as much as possible.

### Modifications

![image](https://user-images.githubusercontent.com/26538404/231754315-a17c32cb-4393-47ac-a5e1-e823f74a576f.png)


1. Enable ddl awareness on the debezium side
2. Use sql parser to parse to the corresponding DDL model
3 Add a Operation in canal Json and debezium json for the downstream to do ddl operation 

### Verifying this change

Run CanalJsonSerializationTest 

### Documentation

  - Does this pull request introduce a new feature? (yes)