### PR TITLE
[INLONG-7850][Sort] Add support for extracting ddl statement and operation from origin data

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/AbstractDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/AbstractDynamicSchemaFormat.java
@@ -42,6 +42,8 @@ public abstract class AbstractDynamicSchemaFormat<T> {
 
     public static final Pattern PATTERN = Pattern.compile("\\$\\{\\s*([\\w.-]+)\\s*}", Pattern.CASE_INSENSITIVE);
 
+    public static final String OPERATION = "operation";
+
     /**
      * Extract values by key from the raw data
      *
@@ -124,6 +126,22 @@ public abstract class AbstractDynamicSchemaFormat<T> {
      * @return The flag of whether is ddl
      */
     public abstract boolean extractDDLFlag(T data);
+
+    /**
+     * Extract ddl statement
+     *
+     * @param data The raw data
+     * @return A ddl statement
+     */
+    public abstract String extractDDL(T data);
+
+    /**
+     * Extract operation
+     *
+     * @param data The raw data
+     * @return A operation replace a ddl
+     */
+    public abstract T extractOperation(T data);
 
     public RowType extractSchema(T data) {
         return extractSchema(data, extractPrimaryKeyNames(data));

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/CanalJsonDynamicSchemaFormat.java
@@ -42,6 +42,7 @@ public class CanalJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     private static final String OP_INSERT = "INSERT";
     private static final String OP_UPDATE = "UPDATE";
     private static final String OP_DELETE = "DELETE";
+    private static final String DDL = "sql";
 
     protected CanalJsonDynamicSchemaFormat(Map<String, String> props) {
         super(props);
@@ -101,6 +102,19 @@ public class CanalJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
     @Override
     public boolean extractDDLFlag(JsonNode data) {
         return data.has(DDL_FLAG) && data.get(DDL_FLAG).asBoolean(false);
+    }
+
+    @Override
+    public String extractDDL(JsonNode data) {
+        if (extractDDLFlag(data) && data.has(DDL)) {
+            return data.get(DDL).asText();
+        }
+        return null;
+    }
+
+    @Override
+    public JsonNode extractOperation(JsonNode data) {
+        return data.get(OPERATION);
     }
 
     @Override

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/format/DebeziumJsonDynamicSchemaFormat.java
@@ -44,7 +44,7 @@ import java.util.Map;
  */
 public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
 
-    private static final String DDL_FLAG = "ddl";
+    private static final String DDL = "ddl";
     private static final String SCHEMA = "schema";
     private static final String SQL_TYPE = "sqlType";
     private static final String AFTER = "after";
@@ -186,11 +186,29 @@ public class DebeziumJsonDynamicSchemaFormat extends JsonDynamicSchemaFormat {
 
     @Override
     public boolean extractDDLFlag(JsonNode data) {
+        String ddl = extractDDL(data);
+        return ddl != null && !ddl.trim().isEmpty();
+    }
+
+    @Override
+    public String extractDDL(JsonNode data) {
         JsonNode payload = data.get(PAYLOAD);
         if (payload == null) {
-            return data.has(DDL_FLAG) && data.get(DDL_FLAG).asBoolean(false);
+            if (data.has(DDL)) {
+                return data.get(DDL).asText();
+            }
+            return null;
         }
-        return extractDDLFlag(payload);
+        return extractDDL(payload);
+    }
+
+    @Override
+    public JsonNode extractOperation(JsonNode data) {
+        JsonNode payload = data.get(PAYLOAD);
+        if (payload == null) {
+            return data.get(OPERATION);
+        }
+        return extractOperation(payload);
     }
 
     public RowType extractSchemaFromExtractInfo(JsonNode data, List<String> pkNames) {


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title: [INLONG-7850][Sort] Add support for extracting ddl statement and operation from origin data

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7850

### Motivation

Add support for extracting ddl statement and operation from origin data

### Modifications

1. Defines the abstract method with extractDDL  and extractOperation in AbstractDynamicSchemaFormat
2. Implement the abstract method in CanalJsonDynamicSchemaFormat and DebeziumJsonDynamicSchemaFormat
