### PR TITLE
[INLONG-7855][Sort] Fix Sort hang up reader in snapshot phase when reducing parallelism

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlBinlogSplitReadTask.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlBinlogSplitReadTask.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.cdc.mysql.debezium.task;
 
+import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.github.shyiko.mysql.binlog.BinaryLogClient.EventListener;
 import com.github.shyiko.mysql.binlog.event.Event;
 import io.debezium.DebeziumException;
 import io.debezium.connector.mysql.MySqlConnection;
@@ -28,6 +30,7 @@ import io.debezium.connector.mysql.MySqlTaskContext;
 import io.debezium.pipeline.ErrorHandler;
 import io.debezium.relational.TableId;
 import io.debezium.util.Clock;
+import java.util.List;
 import org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.EventDispatcherImpl;
 import org.apache.inlong.sort.cdc.mysql.debezium.dispatcher.SignalEventDispatcher;
 import org.apache.inlong.sort.cdc.mysql.debezium.reader.SnapshotSplitReader.SnapshotBinlogSplitChangeEventSourceContextImpl;
@@ -52,6 +55,7 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
     private final SignalEventDispatcher signalEventDispatcher;
     private final ErrorHandler errorHandler;
     private ChangeEventSourceContext context;
+    private final MySqlTaskContext taskContext;
 
     /**
      * Constructor of MySqlBinlogSplitReadTask.
@@ -80,6 +84,8 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
         this.eventDispatcher = dispatcher;
         this.offsetContext = offsetContext;
         this.errorHandler = errorHandler;
+        this.taskContext = taskContext;
+
         this.signalEventDispatcher =
                 new SignalEventDispatcher(
                         offsetContext.getPartition(), topic, eventDispatcher.getQueue());
@@ -88,6 +94,29 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
     @Override
     public void execute(ChangeEventSourceContext context) throws InterruptedException {
         this.context = context;
+
+        /**
+         * Clear reusedBinaryLogClient's eventListeners and lifecycleListeners of the last run to
+         * fix hung up of snapshot phase.
+         */
+        final BinaryLogClient client = taskContext.getBinaryLogClient();
+        final List<EventListener> eventListeners = client.getEventListeners();
+        final List<BinaryLogClient.LifecycleListener> lifecycleListeners =
+            client.getLifecycleListeners();
+
+        eventListeners.forEach(
+            listener -> {
+                if (eventListeners.indexOf(listener) != eventListeners.size() - 1) {
+                    client.unregisterEventListener(listener);
+                }
+            });
+        lifecycleListeners.forEach(
+            listener -> {
+                if (lifecycleListeners.indexOf(listener) != lifecycleListeners.size() - 1) {
+                    client.unregisterLifecycleListener(listener);
+                }
+            });
+
         super.execute(context);
     }
 

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlBinlogSplitReadTask.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/MySqlBinlogSplitReadTask.java
@@ -91,31 +91,31 @@ public class MySqlBinlogSplitReadTask extends MySqlStreamingChangeEventSource {
                         offsetContext.getPartition(), topic, eventDispatcher.getQueue());
     }
 
+    /**
+     * Clear reusedBinaryLogClient's eventListeners and lifecycleListeners of the last run to
+     * fix hung up of snapshot phase.
+     */
     @Override
     public void execute(ChangeEventSourceContext context) throws InterruptedException {
         this.context = context;
 
-        /**
-         * Clear reusedBinaryLogClient's eventListeners and lifecycleListeners of the last run to
-         * fix hung up of snapshot phase.
-         */
         final BinaryLogClient client = taskContext.getBinaryLogClient();
         final List<EventListener> eventListeners = client.getEventListeners();
         final List<BinaryLogClient.LifecycleListener> lifecycleListeners =
-            client.getLifecycleListeners();
+                client.getLifecycleListeners();
 
         eventListeners.forEach(
-            listener -> {
-                if (eventListeners.indexOf(listener) != eventListeners.size() - 1) {
-                    client.unregisterEventListener(listener);
-                }
-            });
+                listener -> {
+                    if (eventListeners.indexOf(listener) != eventListeners.size() - 1) {
+                        client.unregisterEventListener(listener);
+                    }
+                });
         lifecycleListeners.forEach(
-            listener -> {
-                if (lifecycleListeners.indexOf(listener) != lifecycleListeners.size() - 1) {
-                    client.unregisterLifecycleListener(listener);
-                }
-            });
+                listener -> {
+                    if (lifecycleListeners.indexOf(listener) != lifecycleListeners.size() - 1) {
+                        client.unregisterLifecycleListener(listener);
+                    }
+                });
 
         super.execute(context);
     }


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7855 

### Motivation

 Fix Sort hang up reader in snapshot phase when reducing parallelism

1、When a subtask receives two chunk splits to read;
2、The first chunk reads perfectly, and then it will start a BinlogClient to read the binlogs from lw to hw in chunk1. 
3、When the second chunk arrives the BinlogClient will be reused
4、So when reading chunk2 and start to read from lw to hw in chunk2, the binlog reader will be reused and the event listener in chunk1 will be reused also. So that the BINLOG_END event in chunk2 will never be received  

### Modifications

remove the eventListener in the formal chunk 

### Documentation

  - Does this pull request introduce a new feature? (no)