### PR TITLE
[INLONG-7825][Sort] Fix cannot output ddl statement of captured tables

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -136,8 +136,6 @@ public final class Constants {
 
     public static final String DDL_FIELD_NAME = "ddl";
 
-    public static final String DDL_OP_DROP = "DROP";
-
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
                     .stringType()

--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -25,7 +25,6 @@ import io.debezium.relational.ColumnFilterMode;
 import io.debezium.relational.TableId;
 import io.debezium.relational.Tables;
 import io.debezium.relational.history.HistoryRecord;
-import io.debezium.relational.history.HistoryRecord.Fields;
 import io.debezium.relational.history.TableChanges;
 import io.debezium.relational.history.TableChanges.TableChange;
 import org.apache.flink.api.connector.source.SourceOutput;
@@ -47,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-import static org.apache.inlong.sort.base.Constants.DDL_OP_DROP;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getBinlogPosition;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getFetchTimestamp;
 import static org.apache.inlong.sort.cdc.mysql.source.utils.RecordUtils.getHistoryRecord;
@@ -126,15 +124,11 @@ public final class MySqlRecordEmitter<T>
                 }
             }
 
-            // for drop table ddl, there's no table change events
             if (tableChanges.isEmpty()) {
-                String ddl = historyRecord.document().getString(Fields.DDL_STATEMENTS);
-                if (ddl.toUpperCase().startsWith(DDL_OP_DROP)) {
-                    TableId tableId = RecordUtils.getTableId(element);
-                    // if this table is one of the captured tables, output the ddl element
-                    if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
-                        outputDdlElement(element, output, splitState, null);
-                    }
+                TableId tableId = RecordUtils.getTableId(element);
+                // if this table is one of the captured tables, output the ddl element
+                if (splitState.getMySQLSplit().getTableSchemas().containsKey(tableId)) {
+                    outputDdlElement(element, output, splitState, null);
                 }
             }
 


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7825][Sort] Fix cannot output ddl statement of captured tables


*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #7825 

### Motivation

Some captured table's DDL statements do not have tablechange, but they still need to be ouput downstream.

### Modifications

Remove the restriction of drop and send all DDL statements generated by captured tables downstream.