### PR TITLE
[INLONG-7858][Sort] Fix Oracle CDC fetch two different db name for the same table

### DIFF
--- a/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/utils/OracleConnectionUtils.java
+++ b/inlong-sort/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/utils/OracleConnectionUtils.java
@@ -99,7 +99,7 @@ public class OracleConnectionUtils {
                             String schemaName = rs.getString(1);
                             String tableName = rs.getString(2);
                             TableId tableId =
-                                    new TableId(jdbcConnection.database(), schemaName, tableName);
+                                    new TableId(jdbcConnection.database().toUpperCase(), schemaName, tableName);
                             tableIdSet.add(tableId);
                         }
                     });


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7858][Sort] Fix Oracle CDC fetch two different db name for the same table

- Fixes #7858 

### Motivation

If the database name configured for Oracle CDC in Flink SQL is lowercase, such as the following example (`'database-name' = 'xe'`), 

```sql
CREATE TABLE products (
     ID INT NOT NULL,
     NAME STRING,
     DESCRIPTION STRING,
     WEIGHT DECIMAL(10, 3),
     PRIMARY KEY(id) NOT ENFORCED
     ) WITH (
     'connector' = 'oracle-cdc',
     'hostname' = 'localhost',
     'port' = '1521',
     'username' = 'flinkuser',
     'password' = 'flinkpw',
     'database-name' = 'xe',
     'schema-name' = 'FLINKUSER',
     'table-name' = 'TEST_03');
```

the following problems will occur:
1. For the same table (`TEST_03`)，the snapshot phase  will use the lowercase database name  (`xe.FLINKUSER.TEST_03 `), and the incremental phase will use the uppercase database name (`XE.FLINKUSER.TEST_03 `).
2. For the same table (`TEST_03 `), after being captured in the snapshot phase, it will be captured again in the incremental phase because their database names are inconsistent.

<img width="1166" alt="image" src="https://user-images.githubusercontent.com/111486498/232319947-bb0b8ae5-be1d-452f-bed9-aa2ea2f140ca.png">


In `OracleConnectorConfig`, the database name in Flink SQL is converted to uppercase, but the database name used in the snapshot phase is directly taken from Flink SQL. Therefore, when constructing the `tableId`, the database name in Flink SQL also needs to be converted to uppercase.

<img width="1467" alt="企业微信截图_92720bc3-5148-463a-9b35-12c3c8f77570" src="https://user-images.githubusercontent.com/111486498/232319384-94ceef68-a5e6-4238-9506-30a7546184e2.png">

### Modifications

When constructing the `tableId`, the database name in Flink SQL needs to be converted to uppercase.

```java
            jdbcConnection.query(
                    queryTablesSql,
                    rs -> {
                        while (rs.next()) {
                            String schemaName = rs.getString(1);
                            String tableName = rs.getString(2);
                            TableId tableId =
                                    new TableId(jdbcConnection.database().toUpperCase(), schemaName, tableName);
                            tableIdSet.add(tableId);
                        }
                    });
```
