### PR TITLE
[INLONG-7828][Sort] Mysql CDC check the availability of binlog based on gitd firstly

### DIFF
--- a/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/context/StatefulTaskContext.java
+++ b/inlong-sort/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/task/context/StatefulTaskContext.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.cdc.mysql.debezium.task.context;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.mysql.GtidSet;
 import io.debezium.connector.mysql.MySqlChangeEventSourceMetricsFactory;
 import io.debezium.connector.mysql.MySqlConnection;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
@@ -191,6 +192,59 @@ public class StatefulTaskContext {
     }
 
     private boolean isBinlogAvailable(MySqlOffsetContext offset) {
+        String gtidSet = offset.gtidSet();
+        if (gtidSet != null) {
+            return checkGtidSet(offset);
+        }
+        return checkBinlogFilename(offset);
+    }
+
+    private boolean checkGtidSet(MySqlOffsetContext offset) {
+
+        String gtidStr = offset.gtidSet();
+
+        if (gtidStr.trim().isEmpty()) {
+            return true; // start at beginning ...
+        }
+
+        String availableGtidStr = connection.knownGtidSet();
+        if (availableGtidStr == null || availableGtidStr.trim().isEmpty()) {
+            // Last offsets had GTIDs but the server does not use them ...
+            LOG.warn(
+                    "Connector used GTIDs previously, but MySQL does not know of any GTIDs or they are not enabled");
+            return false;
+        }
+        // GTIDs are enabled
+        GtidSet gtidSet = new GtidSet(gtidStr);
+        // Get the GTID set that is available in the server ...
+        GtidSet availableGtidSet = new GtidSet(availableGtidStr);
+        if (gtidSet.isContainedWithin(availableGtidSet)) {
+            LOG.info(
+                    "MySQL current GTID set {} does contain the GTID set {} required by the connector.",
+                    availableGtidSet,
+                    gtidSet);
+            // The replication is concept of mysql master-slave replication protocol ...
+            final GtidSet gtidSetToReplicate =
+                    connection.subtractGtidSet(availableGtidSet, gtidSet);
+            final GtidSet purgedGtidSet = connection.purgedGtidSet();
+            LOG.info("Server has already purged {} GTIDs", purgedGtidSet);
+            final GtidSet nonPurgedGtidSetToReplicate =
+                    connection.subtractGtidSet(gtidSetToReplicate, purgedGtidSet);
+            LOG.info(
+                    "GTID set {} known by the server but not processed yet, for replication are available only GTID set {}",
+                    gtidSetToReplicate,
+                    nonPurgedGtidSetToReplicate);
+            if (!gtidSetToReplicate.equals(nonPurgedGtidSetToReplicate)) {
+                LOG.warn("Some of the GTIDs needed to replicate have been already purged");
+                return false;
+            }
+            return true;
+        }
+        LOG.info("Connector last known GTIDs are {}, but MySQL has {}", gtidSet, availableGtidSet);
+        return false;
+    }
+
+    private boolean checkBinlogFilename(MySqlOffsetContext offset) {
         String binlogFilename = offset.getSourceInfo().getString(BINLOG_FILENAME_OFFSET_KEY);
         if (binlogFilename == null) {
             return true; // start at current position


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7828][Sort] Mysql CDC check the availability of binlog based on gitd firstly

- Fixes #7828 

### Motivation

When connecting to the Mysql master, if the master-slave switch is executed, the binlog file of the master will change, and the task may fail to find the binlog file. 

```
Caused by: java.lang.IllegalStateException: The connector is trying to read binlog starting at Struct{version=1.5.4.Final,connector=mysql,name=mysql_binlog_source,ts_ms=1681704265482,db=,server_id=0,file=mysql-bin.000014,pos=315,row=0}, but this is no longer available on the server. Reconfigure the connector to use a snapshot when needed.
	at org.apache.inlong.sort.cdc.mysql.debezium.task.context.StatefulTaskContext.loadStartingOffsetState(StatefulTaskContext.java:187) ~[classes/:?]
	at org.apache.inlong.sort.cdc.mysql.debezium.task.context.StatefulTaskContext.configure(StatefulTaskContext.java:119) ~[classes/:?]
	at org.apache.inlong.sort.cdc.mysql.debezium.reader.BinlogSplitReader.submitSplit(BinlogSplitReader.java:90) ~[classes/:?]
	at org.apache.inlong.sort.cdc.mysql.debezium.reader.BinlogSplitReader.submitSplit(BinlogSplitReader.java:61) ~[classes/:?]
	at org.apache.inlong.sort.cdc.mysql.source.reader.MySqlSplitReader.checkSplitOrStartNext(MySqlSplitReader.java:165) ~[classes/:?]
	at org.apache.inlong.sort.cdc.mysql.source.reader.MySqlSplitReader.fetch(MySqlSplitReader.java:74) ~[classes/:?]
	at org.apache.flink.connector.base.source.reader.fetcher.FetchTask.run(FetchTask.java:56) ~[flink-connector-base-1.13.5.jar:1.13.5]
	at org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher.runOnce(SplitFetcher.java:140) ~[flink-connector-base-1.13.5.jar:1.13.5]
	... 6 more
```

Referring to this https://github.com/ververica/flink-cdc-connectors/pull/761, we need to first check binlog availability based on GTID, and then check binlog availability from binlog files.

### Modifications

Check the availability of binlog based on gitd firstly.

```java
    private boolean isBinlogAvailable(MySqlOffsetContext offset) {
        String gtidSet = offset.gtidSet();
        if (gtidSet != null) {
            return checkGtidSet(offset);
        }
        return checkBinlogFilename(offset);
    
```