### PR TITLE
[INLONG-7862][Sort] MongoCDC supports disabling the Changelog Normalize operator

### DIFF
--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSource.java
@@ -81,6 +81,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
     private final String inlongAudit;
     private final String rowValidator;
     private final boolean sourceMultipleEnable;
+    private final boolean changelogNormalizeEnabled;
 
     // --------------------------------------------------------------------------------------------
     // Mutable attributes
@@ -113,7 +114,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
             String inlongMetric,
             String inlongAudit,
             String rowFilter,
-            Boolean sourceMultipleEnable) {
+            Boolean sourceMultipleEnable,
+            Boolean changelogNormalizeEnabled) {
         this.physicalSchema = physicalSchema;
         this.hosts = checkNotNull(hosts);
         this.username = username;
@@ -137,11 +139,12 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
         this.inlongAudit = inlongAudit;
         this.rowValidator = rowFilter;
         this.sourceMultipleEnable = sourceMultipleEnable;
+        this.changelogNormalizeEnabled = changelogNormalizeEnabled;
     }
 
     @Override
     public ChangelogMode getChangelogMode() {
-        if (this.sourceMultipleEnable) {
+        if (this.sourceMultipleEnable  || !changelogNormalizeEnabled) {
             return ChangelogMode.all();
         } else {
             return ChangelogMode.newBuilder()
@@ -286,7 +289,8 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                         inlongMetric,
                         inlongAudit,
                         rowValidator,
-                        sourceMultipleEnable);
+                        sourceMultipleEnable,
+                        changelogNormalizeEnabled);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSource.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSource.java
@@ -144,7 +144,7 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
 
     @Override
     public ChangelogMode getChangelogMode() {
-        if (this.sourceMultipleEnable  || !changelogNormalizeEnabled) {
+        if (this.sourceMultipleEnable || !changelogNormalizeEnabled) {
             return ChangelogMode.all();
         } else {
             return ChangelogMode.newBuilder()

--- a/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSourceFactory.java
+++ b/inlong-sort/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/table/MongoDBTableSourceFactory.java
@@ -73,6 +73,15 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                             + "\"+U\" represents UPDATE_AFTER.\n"
                             + "\"-D\" represents DELETE.");
 
+    public static final ConfigOption<Boolean> CHANGELOG_NORMALIZE_ENABLED =
+            ConfigOptions.key("changelog.normalize.enabled")
+                    .booleanType()
+                    .defaultValue(Boolean.TRUE)
+                    .withDescription("MongoDB's Change Stream lacks the -U message, "
+                            + "so it needs to be converted to Flink UPSERT changelog using "
+                            + "the Changelog Normalize operator. The default value is true. (For scenarios that do not "
+                            + "require the -U message, this operator can be disabled.) \n");
+
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
         final FactoryUtil.TableFactoryHelper helper =
@@ -121,6 +130,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         final String rowKindFiltered = config.get(ROW_KINDS_FILTERED).isEmpty()
                 ? ROW_KINDS_FILTERED.defaultValue()
                 : config.get(ROW_KINDS_FILTERED);
+        Boolean changelogNormalizeEnabled = config.get(CHANGELOG_NORMALIZE_ENABLED);
 
         return new MongoDBTableSource(
                 physicalSchema,
@@ -143,7 +153,8 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
                 inlongMetric,
                 inlongAudit,
                 rowKindFiltered,
-                sourceMultipleEnable);
+                sourceMultipleEnable,
+                changelogNormalizeEnabled);
     }
 
     private void checkPrimaryKey(UniqueConstraint pk, String message) {
@@ -186,6 +197,7 @@ public class MongoDBTableSourceFactory implements DynamicTableSourceFactory {
         options.add(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
         options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE_MB);
         options.add(CHUNK_META_GROUP_SIZE);
+        options.add(CHANGELOG_NORMALIZE_ENABLED);
         return options;
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7862][Sort] MongoCDC supports disabling the Changelog Normalize operator

- Fixes #7862 

### Motivation

MongoDB CDC is implemented based on MongoDB's official Change Streams. However, Change Streams lack pre-update messages (-U). In order to convert them to Flink's standard upsert changelog, Flink introduces the Change Normalize operator to transform them into standard changelog, as shown in the figure below:

<img width="656" alt="image" src="https://user-images.githubusercontent.com/111486498/232951072-b2637868-de27-46d5-8510-508375352d57.png">

However, Change Normalize will bring additional computational overhead. When the amount of data is particularly large, this operator will consume performance. Therefore, we may add a parameter to control whether to use the Change Normalize operator.

The impact of turning off the Change Normalize operator is as follows:

1. Advantages: Efficiency improvement for synchronizing large amounts of data
2. Disadvantages: It does not affect insert and update operations, but it will affect delete operations. When the downstream table is not based on _id as the primary key, the delete operation will be filtered and cannot be synchronized to the downstream.

### Modifications

Add a parameter to control whether to use the Change Normalize operator.

### Documentation

  - Does this pull request introduce a new feature? (yes )
  - If yes, how is the feature documented? (not applicable)
  - If a feature is not applicable for documentation, explain why?

I think this is a experimental feature, so there's no need to document it.
