### PR TITLE
[INLONG-7888][Manager] Fix the empty fields in lightweight task

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
@@ -54,6 +54,7 @@ import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.MetaFieldInfo;
 
 import lombok.extern.slf4j.Slf4j;
+
 import java.math.BigDecimal;
 import java.util.List;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/TransformNodeUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/TransformNodeUtils.java
@@ -110,7 +110,7 @@ public class TransformNodeUtils {
         transformNode.setName(transformResponse.getTransformName());
         // Filter constant fields
         List<FieldInfo> fieldInfos = transformResponse.getFieldList().stream()
-                .filter(s -> s.getFieldValue() == null)
+                .filter(s -> s.getFieldValue() != null)
                 .map(FieldInfoUtils::parseStreamField).collect(Collectors.toList());
         transformNode.setFields(fieldInfos);
         transformNode.setFieldRelations(FieldRelationUtils.createFieldRelations(transformResponse, constantFieldMap));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -130,6 +130,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                 auditIds.add(auditService.getAuditId(sink.getSinkType(), false));
             }
             for (StreamSource source : sources) {
+                source.setFieldList(inlongStream.getFieldList());
                 Map<String, Object> properties = source.getProperties();
                 properties.putIfAbsent("metrics.audit.key", String.join("&", auditIds));
             }
@@ -148,7 +149,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                     relations = NodeRelationUtils.createNodeRelations(sources, sinks);
                 }
             } else {
-                relations = NodeRelationUtils.createNodeRelations(inlongStream);
+                relations = NodeRelationUtils.createNodeRelations(sources, sinks);
             }
 
             // create extract-transform-load nodes


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #7888 

### Motivation

`fields`  is empty in `StreamSource`.

### Modifications

1. Set `StreamSource.fieldList` from `InlongStream.fieldList`.(If the dashboard supports creating fields directly in the source, it can be ignored)
2. In lightweight mode, `NodeRelation` should get the node name from `source` and `sink`, not `InlongStreamInfo.extParams`.

### Verifying this change

Creating lightweight tasks also requires dashboard support, it can only be created by modifying the parameters of DB now.
