### PR TITLE
[INLONG-7903][Sort] Kafka sink supports fixed partition strategy

### DIFF
--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -195,13 +195,16 @@ public final class Constants {
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "Pattern rules and partition maps");
+                            "Pattern rules and partition map string, " +
+                                    "eg: databasePattern1&tablePattern1:partition1,"
+                                    + "databasePattern2&tablePattern2:partition2,"
+                                    + "DEFAULT_PARTITION:partition3");
     public static final ConfigOption<Map<String, String>> DATASOURCE_PARTITION_MAP =
             ConfigOptions.key("datasource.partition.map")
                     .mapType()
                     .noDefaultValue()
                     .withDescription(
-                            "Datasource and partition maps");
+                            "Datasource and partition maps, eg: <datasource1,partition1>");
     public static final ConfigOption<String> SINK_MULTIPLE_DATABASE_PATTERN =
             ConfigOptions.key("sink.multiple.database-pattern")
                     .stringType()

--- a/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-connectors/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -20,6 +20,9 @@ package org.apache.inlong.sort.base;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
+
+import java.util.Map;
+
 import static org.apache.inlong.common.constant.Constants.METRICS_AUDIT_PROXY_HOSTS_KEY;
 
 /**
@@ -187,7 +190,18 @@ public final class Constants {
                     .noDefaultValue()
                     .withDescription(
                             "The format of multiple sink, it represents the real format of the raw binary data");
-
+    public static final ConfigOption<String> PATTERN_PARTITION_MAP =
+            ConfigOptions.key("pattern.partition.map")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Pattern rules and partition maps");
+    public static final ConfigOption<Map<String, String>> DATASOURCE_PARTITION_MAP =
+            ConfigOptions.key("datasource.partition.map")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Datasource and partition maps");
     public static final ConfigOption<String> SINK_MULTIPLE_DATABASE_PATTERN =
             ConfigOptions.key("sink.multiple.database-pattern")
                     .stringType()

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
@@ -58,7 +58,6 @@ public class InLongFixedPartitionPartitioner<T> extends FlinkKafkaPartitioner<T>
 
     private final int defaultPartitionId;
 
-
     public InLongFixedPartitionPartitioner(String patternPartitionMapConfig, String partitionPattern) {
         this.patternPartitionMap = configToMap(patternPartitionMapConfig);
         this.regexPatternMap = new HashMap<>();

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
@@ -32,6 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+/**
+ * Fixed partitions according to the given library name and table name rules.
+ * */
 public class InLongFixedPartitionPartitioner<T> extends FlinkKafkaPartitioner<T> {
 
     private static final Logger LOG = LoggerFactory.getLogger(InLongFixedPartitionPartitioner.class);
@@ -72,6 +75,10 @@ public class InLongFixedPartitionPartitioner<T> extends FlinkKafkaPartitioner<T>
         dynamicSchemaFormat = DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
     }
 
+    /***
+     * Partition mapping is performed according to the library name and table name rules,
+     * and no matching is written to the default partition.
+     * */
     @Override
     public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
         try {

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kafka.partitioner;
+
+import lombok.Setter;
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.inlong.sort.base.format.AbstractDynamicSchemaFormat;
+import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public class InLongFixedPartitionPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InLongFixedPartitionPartitioner.class);
+
+    private final Map<String, String> patternPartitionMap;
+    private final Map<String, Pattern> regexPatternMap;
+    private AbstractDynamicSchemaFormat dynamicSchemaFormat;
+
+    /**
+     * The format used to deserialization the raw data(bytes array)
+     */
+    @Setter
+    private String sinkMultipleFormat;
+
+    private final String DEFAULT_PARTITION = "DEFAULT_PARTITION";
+
+    private String databasePattern;
+    private String tablePattern;
+
+    private final static String DELIMITER1 = "&";
+    private final static String DELIMITER2 = "_";
+    private final static String DELIMITER3 = ":";
+    private final static String DELIMITER4 = ",";
+
+    private final int defaultPartitionId;
+
+
+    public InLongFixedPartitionPartitioner(String patternPartitionMapConfig, String partitionPattern) {
+        this.patternPartitionMap = configToMap(patternPartitionMapConfig);
+        this.regexPatternMap = new HashMap<>();
+        this.databasePattern = partitionPattern.split(DELIMITER2)[0];
+        this.tablePattern = partitionPattern.split(DELIMITER2)[1];
+        this.defaultPartitionId = Integer.parseInt(patternPartitionMap.getOrDefault(DEFAULT_PARTITION, "0"));
+    }
+
+    @Override
+    public void open(int parallelInstanceId, int parallelInstances) {
+        super.open(parallelInstanceId, parallelInstances);
+        dynamicSchemaFormat = DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
+    }
+
+    @Override
+    public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+        try {
+            for (Map.Entry<String, String> entry : patternPartitionMap.entrySet()) {
+                if (DEFAULT_PARTITION.equals(entry.getKey())) {
+                    continue;
+                }
+                String databaseName = dynamicSchemaFormat.parse(value, databasePattern);
+                String tableName = dynamicSchemaFormat.parse(value, tablePattern);
+                List<String> regexList = Arrays.asList(entry.getKey().split(DELIMITER1));
+                String databaseNameRegex = regexList.get(0);
+                String tableNameRegex = regexList.get(1);
+
+                if (match(databaseName, databaseNameRegex) && match(tableName, tableNameRegex)) {
+                    return Integer.parseInt(entry.getValue());
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Extract partition failed", e);
+        }
+        return defaultPartitionId;
+    }
+
+    private boolean match(String name, String nameRegex) {
+        if (nameRegex.equals("*")) {
+            return true;
+        }
+        return regexPatternMap.computeIfAbsent(nameRegex, regex -> Pattern.compile(regex))
+                .matcher(name)
+                .matches();
+    }
+
+    private Map<String, String> configToMap(String patternPartitionMapStr) {
+        if (patternPartitionMapStr == null) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> patternPartitionMap = new LinkedHashMap<>();
+        for (String entry : patternPartitionMapStr.split(DELIMITER4)) {
+            String pattern = entry.split(DELIMITER3)[0];
+            String partition = entry.split(DELIMITER3)[1];
+            patternPartitionMap.put(pattern, partition);
+        }
+        return patternPartitionMap;
+    }
+}

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitioner.java
@@ -41,6 +41,7 @@ public class InLongFixedPartitionPartitioner<T> extends FlinkKafkaPartitioner<T>
 
     private final Map<String, String> patternPartitionMap;
     private final Map<String, Pattern> regexPatternMap;
+    @Setter
     private AbstractDynamicSchemaFormat dynamicSchemaFormat;
 
     /**

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -56,17 +56,12 @@ import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink;
+import org.apache.inlong.sort.kafka.partitioner.InLongFixedPartitionPartitioner;
 import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
@@ -98,11 +93,8 @@ import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.get
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.validateTableSourceOptions;
 import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
 import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
-import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
-import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
-import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
-import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
-import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.base.Constants.*;
+import static org.apache.inlong.sort.base.Constants.DATASOURCE_PARTITION_MAP;
 import static org.apache.inlong.sort.kafka.table.KafkaOptions.KAFKA_IGNORE_ALL_CHANGELOG;
 
 /**
@@ -117,6 +109,8 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
     public static final String IDENTIFIER = "kafka-inlong";
 
     public static final String SINK_PARTITIONER_VALUE_RAW_HASH = "raw-hash";
+
+    public static final String SINK_PARTITIONER_VALUE_INLONG_FIXED_PARTITION = "inlong-fixed-partition";
 
     public static final ConfigOption<String> SINK_MULTIPLE_PARTITION_PATTERN =
             ConfigOptions.key("sink.multiple.partition-pattern")
@@ -241,9 +235,21 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
 
     private Optional<FlinkKafkaPartitioner<RowData>> getFlinkKafkaPartitioner(
             ReadableConfig tableOptions, ClassLoader classLoader) {
+        if (tableOptions.getOptional(SINK_PARTITIONER).isPresent() && SINK_PARTITIONER_VALUE_INLONG_FIXED_PARTITION
+                .equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
+            InLongFixedPartitionPartitioner<RowData> inLongFixedPartitionPartitioner =
+                    new InLongFixedPartitionPartitioner<>(tableOptions.getOptional(PATTERN_PARTITION_MAP)
+                                    .orElse(null),
+                            tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
+                                    .orElse(null));
+            inLongFixedPartitionPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT)
+                    .orElse(null));
+            return Optional.of(inLongFixedPartitionPartitioner);
+        }
         if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
                 && SINK_PARTITIONER_VALUE_RAW_HASH.equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
-            RawDataHashPartitioner<RowData> rawHashPartitioner = new RawDataHashPartitioner<>();
+            RawDataHashPartitioner<RowData> rawHashPartitioner = new RawDataHashPartitioner<>(tableOptions
+                    .getOptional(DATASOURCE_PARTITION_MAP).orElse(Collections.emptyMap()));
             rawHashPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT).orElse(null));
             rawHashPartitioner.setPartitionPattern(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
                     .orElse(null));

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -61,7 +61,14 @@ import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Pattern;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
@@ -239,7 +246,7 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
                 .equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
             InLongFixedPartitionPartitioner<RowData> inLongFixedPartitionPartitioner =
                     new InLongFixedPartitionPartitioner<>(tableOptions.getOptional(PATTERN_PARTITION_MAP)
-                                    .orElse(null),
+                            .orElse(null),
                             tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
                                     .orElse(null));
             inLongFixedPartitionPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT)

--- a/inlong-sort/sort-connectors/kafka/src/test/java/InLongFixedPartitionPartitionerTest.java
+++ b/inlong-sort/sort-connectors/kafka/src/test/java/InLongFixedPartitionPartitionerTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.apache.inlong.sort.kafka.partitioner.InLongFixedPartitionPartitioner;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * The unit tests for {@link InLongFixedPartitionPartitioner}.
+ */
+public class InLongFixedPartitionPartitionerTest {
+
+    @Test
+    public void testFixedPartitionPartitioner() {
+        String patternPartitionMapConfig = "database*&table*:1,DEFAULT_PARTITION:2";
+        String partitionPattern = "${database}_${table}";
+        InLongFixedPartitionPartitioner inLongFixedPartitionPartitioner =
+                new InLongFixedPartitionPartitioner(patternPartitionMapConfig, partitionPattern);
+        byte[] value = "{database:db1,table:tb1}".getBytes();
+        int partition = inLongFixedPartitionPartitioner.partition(null, null,
+                value, null, new int[]{0, 1, 2, 3});
+        Assert.assertEquals(2, partition);
+    }
+}

--- a/inlong-sort/sort-connectors/kafka/src/test/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitionerTest.java
+++ b/inlong-sort/sort-connectors/kafka/src/test/java/org/apache/inlong/sort/kafka/partitioner/InLongFixedPartitionPartitionerTest.java
@@ -14,23 +14,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package org.apache.inlong.sort.kafka.partitioner;/*
+                                                 * Licensed to the Apache Software Foundation (ASF) under one or more
+                                                 * contributor license agreements. See the NOTICE file distributed with
+                                                 * this work for additional information regarding copyright ownership.
+                                                 * The ASF licenses this file to You under the Apache License, Version 2.0
+                                                 * (the "License"); you may not use this file except in compliance with
+                                                 * the License. You may obtain a copy of the License at
+                                                 *
+                                                 * http://www.apache.org/licenses/LICENSE-2.0
+                                                 *
+                                                 * Unless required by applicable law or agreed to in writing, software
+                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                 * See the License for the specific language governing permissions and
+                                                 * limitations under the License.
+                                                 */
+
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.inlong.sort.base.format.AbstractDynamicSchemaFormat;
-import org.apache.inlong.sort.kafka.partitioner.InLongFixedPartitionPartitioner;
 import org.junit.Assert;
 import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
 /**
- * The unit tests for {@link InLongFixedPartitionPartitioner}.
+ * The unit tests for {@link
+ * org.apache.inlong.sort.kafka.partitioner.InLongFixedPartitionPartitioner}.
  */
 public class InLongFixedPartitionPartitionerTest {
+
     private String databasePattern = "${database}";
     private String tablePattern = "${table}";
     private AbstractDynamicSchemaFormat dynamicSchemaFormat = new TestDynamicSchemaFormat();
-    class TestDynamicSchemaFormat extends AbstractDynamicSchemaFormat{
+    class TestDynamicSchemaFormat extends AbstractDynamicSchemaFormat {
 
         @Override
         public String extract(Object data, String key) {
@@ -69,8 +88,10 @@ public class InLongFixedPartitionPartitionerTest {
 
         @Override
         public String parse(Object data, String pattern) throws IOException {
-            if(databasePattern.equals(pattern)) return "db1";
-            if(tablePattern.equals(pattern)) return "tb1";
+            if (databasePattern.equals(pattern))
+                return "db1";
+            if (tablePattern.equals(pattern))
+                return "tb1";
             return null;
         }
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes https://github.com/apache/inlong/issues/7903

### Motivation

Kafka sink supports fixed partition strategy.


### Modifications
1. Added InLongFixedPartitionPartitioner;
2. In RawDataHashPartitioner, it is supported to specify the partition strategy according to the data source;


### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
