### PR TITLE
[INLONG-7386][Sort] Postgres connector supports parallel read

### DIFF
--- a/inlong-sort/sort-connectors/postgres-cdc/pom.xml
+++ b/inlong-sort/sort-connectors/postgres-cdc/pom.xml
@@ -29,10 +29,20 @@
     <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-postgres-cdc</name>
 
+    <properties>
+        <postgress.debezium.version>1.6.4.Final</postgress.debezium.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.ververica</groupId>
-            <artifactId>flink-connector-postgres-cdc</artifactId>
+            <artifactId>flink-connector-debezium</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-cdc-base</artifactId>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -54,30 +64,51 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-connector-postgres</artifactId>
-            <version>${debezium.version}</version>
+            <version>${postgress.debezium.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>42.4.1</version>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-api</artifactId>
-            <version>${debezium.version}</version>
+            <version>${postgress.debezium.version}</version>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-embedded</artifactId>
-            <version>${debezium.version}</version>
+            <version>${postgress.debezium.version}</version>
         </dependency>
         <dependency>
             <groupId>io.debezium</groupId>
             <artifactId>debezium-core</artifactId>
-            <version>${debezium.version}</version>
+            <version>${postgress.debezium.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-format-json</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-guava</artifactId>
+            <version>30.1.1-jre-16.0</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>4.0.3</version>
         </dependency>
     </dependencies>
 
@@ -103,11 +134,15 @@
                                     <include>io.debezium:debezium-connector-postgres</include>
                                     <include>com.ververica:flink-connector-debezium</include>
                                     <include>com.ververica:flink-connector-postgres-cdc</include>
+                                    <include>com.ververica:flink-cdc-base</include>
                                     <include>com.google.protobuf:protobuf-java</include>
                                     <include>com.google.guava:*</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>org.postgresql:postgresql</include>
                                     <include>com.fasterxml.*:*</include>
+                                    <include>com.zaxxer:HikariCP</include>
+                                    <include>com.google.code.gson:*</include>
+                                    <include>org.apache.flink:flink-shaded-guava</include>
                                     <!--  Include fixed version 18.0-13.0 of flink shaded guava  -->
                                     <include>org.apache.flink:flink-shaded-guava</include>
                                     <include>com.google.protobuf:*</include>
@@ -118,6 +153,7 @@
                                     <artifact>org.apache.inlong:sort-connector-*</artifact>
                                     <includes>
                                         <include>org/apache/inlong/**</include>
+                                        <include>io/debezium/connector/postgresql/**</include>
                                         <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
                                     </includes>
                                 </filter>

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/PostgresObjectFactory.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/PostgresObjectFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.relational.TableId;
+import io.debezium.schema.TopicSelector;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.ZoneOffset;
+
+/**
+ * A factory for creating various Debezium objects
+ *
+ * <p>It is a hack to access package-private constructor in debezium.
+ */
+public class PostgresObjectFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresObjectFactory.class);
+
+    /** Create a new PostgresSchema and initialize the content of the schema. */
+    public static PostgresSchema newSchema(
+            PostgresConnection connection,
+            PostgresConnectorConfig config,
+            TypeRegistry typeRegistry,
+            TopicSelector<TableId> topicSelector,
+            PostgresValueConverter valueConverter)
+            throws SQLException {
+        PostgresSchema schema =
+                new PostgresSchema(config, typeRegistry, topicSelector, valueConverter);
+        schema.refresh(connection, false);
+        return schema;
+    }
+
+    public static PostgresTaskContext newTaskContext(
+            PostgresConnectorConfig connectorConfig,
+            PostgresSchema schema,
+            TopicSelector<TableId> topicSelector) {
+        return new PostgresTaskContext(connectorConfig, schema, topicSelector);
+    }
+
+    public static PostgresEventMetadataProvider newEventMetadataProvider() {
+        return new PostgresEventMetadataProvider();
+    }
+
+    /**
+     * Create a new PostgresVauleConverterBuilder instance and offer type registry for JDBC
+     * connection.
+     *
+     * <p>It is created in this package because some methods (e.g., includeUnknownDatatypes) of
+     * PostgresConnectorConfig is protected.
+     */
+    public static PostgresConnection.PostgresValueConverterBuilder newPostgresValueConverterBuilder(
+            PostgresConnectorConfig config) {
+        return typeRegistry -> new PostgresValueConverter(
+                StandardCharsets.UTF_8,
+                config.getDecimalMode(),
+                config.getTemporalPrecisionMode(),
+                ZoneOffset.UTC,
+                null,
+                config.includeUnknownDatatypes(),
+                typeRegistry,
+                config.hStoreHandlingMode(),
+                config.binaryHandlingMode(),
+                config.intervalHandlingMode(),
+                config.toastedValuePlaceholder());
+    }
+
+    // modified from
+    // io.debezium.connector.postgresql.PostgresConnectorTask.createReplicationConnection
+    public static ReplicationConnection createReplicationConnection(
+            PostgresTaskContext taskContext,
+            boolean doSnapshot,
+            PostgresConnectorConfig connectorConfig) {
+        int maxRetries = connectorConfig.maxRetries();
+        Duration retryDelay = connectorConfig.retryDelay();
+
+        final Metronome metronome = Metronome.parker(retryDelay, Clock.SYSTEM);
+        short retryCount = 0;
+        while (retryCount <= maxRetries) {
+            try {
+                LOGGER.info("Creating a new replication connection for {}", taskContext);
+                return taskContext.createReplicationConnection(doSnapshot);
+            } catch (SQLException ex) {
+                retryCount++;
+                if (retryCount > maxRetries) {
+                    LOGGER.error(
+                            "Too many errors connecting to server. All {} retries failed.",
+                            maxRetries);
+                    throw new FlinkRuntimeException(ex);
+                }
+
+                LOGGER.warn(
+                        "Error connecting to server; will attempt retry {} of {} after {} "
+                                + "seconds. Exception message: {}",
+                        retryCount,
+                        maxRetries,
+                        retryDelay.getSeconds(),
+                        ex.getMessage());
+                try {
+                    metronome.pause();
+                } catch (InterruptedException e) {
+                    LOGGER.warn("Connection retry sleep interrupted by exception: " + e);
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+        LOGGER.error("Failed to create replication connection after {} retries", maxRetries);
+        throw new FlinkRuntimeException(
+                "Failed to create replication connection for " + taskContext);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/Utils.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/Utils.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql;
+
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.Instant;
+
+/** A utility class for accessing various Debezium package-private methods. */
+public final class Utils {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
+
+    public static Lsn lastKnownLsn(PostgresOffsetContext ctx) {
+        return ctx.lsn();
+    }
+
+    public static PostgresOffset currentOffset(PostgresConnection jdbcConnection) {
+        Long lsn;
+        long txId;
+        try {
+            lsn = jdbcConnection.currentXLogLocation();
+            txId = jdbcConnection.currentTransactionId();
+            LOGGER.trace("Read xlogStart at '{}' from transaction '{}'", Lsn.valueOf(lsn), txId);
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException("Error getting current Lsn/txId " + e.getMessage(), e);
+        }
+
+        try {
+            jdbcConnection.commit();
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(e);
+        }
+
+        return new PostgresOffset(lsn, txId, Instant.MIN);
+    }
+
+    public static PostgresSchema refreshSchema(
+            PostgresSchema schema,
+            PostgresConnection pgConnection,
+            boolean printReplicaIdentityInfo)
+            throws SQLException {
+        return schema.refresh(pgConnection, printReplicaIdentityInfo);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/io/debezium/connector/postgresql/connection/PostgresConnection.java
@@ -1,0 +1,812 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.debezium.connector.postgresql.connection;
+
+import com.zaxxer.hikari.pool.HikariProxyConnection;
+import io.debezium.DebeziumException;
+import io.debezium.annotation.VisibleForTesting;
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PgOid;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresType;
+import io.debezium.connector.postgresql.PostgresValueConverter;
+import io.debezium.connector.postgresql.TypeRegistry;
+import io.debezium.connector.postgresql.spi.SlotState;
+import io.debezium.data.SpecialValueDecimal;
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.ColumnEditor;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.schema.DatabaseSchema;
+import io.debezium.util.Clock;
+import io.debezium.util.Metronome;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.postgresql.core.BaseConnection;
+import org.postgresql.jdbc.PgConnection;
+import org.postgresql.jdbc.TimestampUtils;
+import org.postgresql.replication.LogSequenceNumber;
+import org.postgresql.util.PGmoney;
+import org.postgresql.util.PSQLState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.Charset;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * {@link JdbcConnection} connection extension used for connecting to Postgres instances.
+ *
+ * @author Horia Chiorean
+ *     <p>Copied from Debezium 1.6.4-Final with two additional methods:
+ *     <ul>
+ *       <li>Constructor PostgresConnection( Configuration config, PostgresValueConverterBuilder
+ *           valueConverterBuilder, ConnectionFactory factory) to allow passing a custom
+ *           ConnectionFactory
+ *       <li>override connection() to return a unwrapped PgConnection (otherwise, it will complain
+ *           about HikariProxyConnection cannot be cast to class org.postgresql.core.BaseConnection)
+ *     </ul>
+ */
+public class PostgresConnection extends JdbcConnection {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(PostgresConnection.class);
+
+    private static final String URL_PATTERN =
+            "jdbc:postgresql://${"
+                    + JdbcConfiguration.HOSTNAME
+                    + "}:${"
+                    + JdbcConfiguration.PORT
+                    + "}/${"
+                    + JdbcConfiguration.DATABASE
+                    + "}";
+    protected static final ConnectionFactory FACTORY =
+            JdbcConnection.patternBasedFactory(
+                    URL_PATTERN,
+                    org.postgresql.Driver.class.getName(),
+                    PostgresConnection.class.getClassLoader(),
+                    JdbcConfiguration.PORT.withDefault(
+                            PostgresConnectorConfig.PORT.defaultValueAsString()));
+
+    /**
+     * Obtaining a replication slot may fail if there's a pending transaction. We're retrying to get
+     * a slot for 30 min.
+     */
+    private static final int MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT = 900;
+
+    private static final Duration PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS =
+            Duration.ofSeconds(2);
+
+    private final TypeRegistry typeRegistry;
+    private final PostgresDefaultValueConverter defaultValueConverter;
+
+    /**
+     * Creates a Postgres connection using the supplied configuration. If necessary this connection
+     * is able to resolve data type mappings. Such a connection requires a {@link
+     * PostgresValueConverter}, and will provide its own {@link TypeRegistry}. Usually only one such
+     * connection per connector is needed.
+     *
+     * @param config {@link Configuration} instance, may not be null.
+     * @param valueConverterBuilder supplies a configured {@link PostgresValueConverter} for a given
+     *     {@link TypeRegistry}
+     */
+    public PostgresConnection(
+            Configuration config, PostgresValueConverterBuilder valueConverterBuilder) {
+        super(
+                config,
+                FACTORY,
+                PostgresConnection::validateServerVersion,
+                PostgresConnection::defaultSettings);
+        if (Objects.isNull(valueConverterBuilder)) {
+            this.typeRegistry = null;
+            this.defaultValueConverter = null;
+        } else {
+            this.typeRegistry = new TypeRegistry(this);
+
+            final PostgresValueConverter valueConverter =
+                    valueConverterBuilder.build(this.typeRegistry);
+            this.defaultValueConverter =
+                    new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils());
+        }
+    }
+
+    /** Creates a Postgres connection using the supplied configuration with customized factory */
+    public PostgresConnection(
+            Configuration config,
+            PostgresValueConverterBuilder valueConverterBuilder,
+            ConnectionFactory factory) {
+        super(
+                config,
+                factory,
+                PostgresConnection::validateServerVersion,
+                PostgresConnection::defaultSettings);
+        LOGGER.info("PostgresConnection get config:{}", config);
+        if (Objects.isNull(valueConverterBuilder)) {
+            this.typeRegistry = null;
+            this.defaultValueConverter = null;
+        } else {
+            this.typeRegistry = new TypeRegistry(this);
+
+            final PostgresValueConverter valueConverter =
+                    valueConverterBuilder.build(this.typeRegistry);
+            this.defaultValueConverter =
+                    new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils());
+        }
+    }
+
+    /** Return an unwrapped PgConnection instead of HikariProxyConnection */
+    @Override
+    public synchronized Connection connection() throws SQLException {
+        Connection conn = connection(true);
+        if (conn instanceof HikariProxyConnection) {
+            // assuming HikariCP use org.postgresql.jdbc.PgConnection
+            return conn.unwrap(PgConnection.class);
+        }
+        return conn;
+    }
+
+    /**
+     * Create a Postgres connection using the supplied configuration and {@link TypeRegistry}
+     *
+     * @param config {@link Configuration} instance, may not be null.
+     * @param typeRegistry an existing/already-primed {@link TypeRegistry} instance
+     */
+    public PostgresConnection(Configuration config, TypeRegistry typeRegistry) {
+        super(
+                config,
+                FACTORY,
+                PostgresConnection::validateServerVersion,
+                PostgresConnection::defaultSettings);
+        if (Objects.isNull(typeRegistry)) {
+            this.typeRegistry = null;
+            this.defaultValueConverter = null;
+        } else {
+            this.typeRegistry = typeRegistry;
+            final PostgresValueConverter valueConverter =
+                    PostgresValueConverter.of(
+                            new PostgresConnectorConfig(config),
+                            this.getDatabaseCharset(),
+                            typeRegistry);
+            this.defaultValueConverter =
+                    new PostgresDefaultValueConverter(valueConverter, this.getTimestampUtils());
+        }
+    }
+
+    /**
+     * Creates a Postgres connection using the supplied configuration. The connector is the regular
+     * one without datatype resolution capabilities.
+     *
+     * @param config {@link Configuration} instance, may not be null.
+     */
+    public PostgresConnection(Configuration config) {
+        this(config, (TypeRegistry) null);
+    }
+
+    /**
+     * Returns a JDBC connection string for the current configuration.
+     *
+     * @return a {@code String} where the variables in {@code urlPattern} are replaced with values
+     *     from the configuration
+     */
+    public String connectionString() {
+        return connectionString(URL_PATTERN);
+    }
+
+    /**
+     * Prints out information about the REPLICA IDENTITY status of a table. This in turn determines
+     * how much information is available for UPDATE and DELETE operations for logical replication.
+     *
+     * @param tableId the identifier of the table
+     * @return the replica identity information; never null
+     * @throws SQLException if there is a problem obtaining the replica identity information for the
+     *     given table
+     */
+    public ServerInfo.ReplicaIdentity readReplicaIdentityInfo(TableId tableId) throws SQLException {
+        String statement =
+                "SELECT relreplident FROM pg_catalog.pg_class c "
+                        + "LEFT JOIN pg_catalog.pg_namespace n ON c.relnamespace=n.oid "
+                        + "WHERE n.nspname=? and c.relname=?";
+        String schema =
+                tableId.schema() != null && tableId.schema().length() > 0
+                        ? tableId.schema()
+                        : "public";
+        StringBuilder replIdentity = new StringBuilder();
+        prepareQuery(
+                statement,
+                stmt -> {
+                    stmt.setString(1, schema);
+                    stmt.setString(2, tableId.table());
+                },
+                rs -> {
+                    if (rs.next()) {
+                        replIdentity.append(rs.getString(1));
+                    } else {
+                        LOGGER.warn(
+                                "Cannot determine REPLICA IDENTITY information for table '{}'",
+                                tableId);
+                    }
+                });
+        return ServerInfo.ReplicaIdentity.parseFromDB(replIdentity.toString());
+    }
+
+    /**
+     * Returns the current state of the replication slot
+     *
+     * @param slotName the name of the slot
+     * @param pluginName the name of the plugin used for the desired slot
+     * @return the {@link SlotState} or null, if no slot state is found
+     * @throws SQLException
+     */
+    public SlotState getReplicationSlotState(String slotName, String pluginName)
+            throws SQLException {
+        ServerInfo.ReplicationSlot slot;
+        try {
+            slot = readReplicationSlotInfo(slotName, pluginName);
+            if (slot.equals(ServerInfo.ReplicationSlot.INVALID)) {
+                return null;
+            } else {
+                return slot.asSlotState();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConnectException(
+                    "Interrupted while waiting for valid replication slot info", e);
+        }
+    }
+
+    /**
+     * Fetches the state of a replication stage given a slot name and plugin name
+     *
+     * @param slotName the name of the slot
+     * @param pluginName the name of the plugin used for the desired slot
+     * @return the {@link ServerInfo.ReplicationSlot} object or a {@link
+     *     ServerInfo.ReplicationSlot#INVALID} if the slot is not valid
+     * @throws SQLException is thrown by the underlying JDBC
+     */
+    private ServerInfo.ReplicationSlot fetchReplicationSlotInfo(String slotName, String pluginName)
+            throws SQLException {
+        final String database = database();
+        final ServerInfo.ReplicationSlot slot =
+                queryForSlot(
+                        slotName,
+                        database,
+                        pluginName,
+                        rs -> {
+                            if (rs.next()) {
+                                boolean active = rs.getBoolean("active");
+                                final Lsn confirmedFlushedLsn =
+                                        parseConfirmedFlushLsn(slotName, pluginName, database, rs);
+                                if (confirmedFlushedLsn == null) {
+                                    return null;
+                                }
+                                Lsn restartLsn =
+                                        parseRestartLsn(slotName, pluginName, database, rs);
+                                if (restartLsn == null) {
+                                    return null;
+                                }
+                                final Long xmin = rs.getLong("catalog_xmin");
+                                return new ServerInfo.ReplicationSlot(
+                                        active, confirmedFlushedLsn, restartLsn, xmin);
+                            } else {
+                                LOGGER.debug(
+                                        "No replication slot '{}' is present for plugin '{}' and database '{}'",
+                                        slotName,
+                                        pluginName,
+                                        database);
+                                return ServerInfo.ReplicationSlot.INVALID;
+                            }
+                        });
+        return slot;
+    }
+
+    /**
+     * Fetches a replication slot, repeating the query until either the slot is created or until the
+     * max number of attempts has been reached
+     *
+     * <p>To fetch the slot without the retries, use the {@link
+     * PostgresConnection#fetchReplicationSlotInfo} call
+     *
+     * @param slotName the slot name
+     * @param pluginName the name of the plugin
+     * @return the {@link ServerInfo.ReplicationSlot} object or a {@link
+     *     ServerInfo.ReplicationSlot#INVALID} if the slot is not valid
+     * @throws SQLException is thrown by the underyling jdbc driver
+     * @throws InterruptedException is thrown if we don't return an answer within the set number of
+     *     retries
+     */
+    @VisibleForTesting
+    ServerInfo.ReplicationSlot readReplicationSlotInfo(String slotName, String pluginName)
+            throws SQLException, InterruptedException {
+        final String database = database();
+        final Metronome metronome =
+                Metronome.parker(PAUSE_BETWEEN_REPLICATION_SLOT_RETRIEVAL_ATTEMPTS, Clock.SYSTEM);
+
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT; attempt++) {
+            final ServerInfo.ReplicationSlot slot = fetchReplicationSlotInfo(slotName, pluginName);
+            if (slot != null) {
+                LOGGER.info("Obtained valid replication slot {}", slot);
+                return slot;
+            }
+            LOGGER.warn(
+                    "Cannot obtain valid replication slot '{}' for plugin '{}' and database '{}' [during attempt {} out of {}, concurrent tx probably blocks taking snapshot.",
+                    slotName,
+                    pluginName,
+                    database,
+                    attempt,
+                    MAX_ATTEMPTS_FOR_OBTAINING_REPLICATION_SLOT);
+            metronome.pause();
+        }
+
+        throw new ConnectException(
+                "Unable to obtain valid replication slot. "
+                        + "Make sure there are no long-running transactions running in parallel as they may hinder the allocation of the replication slot when starting this connector");
+    }
+
+    protected ServerInfo.ReplicationSlot queryForSlot(
+            String slotName,
+            String database,
+            String pluginName,
+            ResultSetMapper<ServerInfo.ReplicationSlot> map)
+            throws SQLException {
+        return prepareQueryAndMap(
+                "select * from pg_replication_slots where slot_name = ? and database = ? and plugin = ?",
+                statement -> {
+                    statement.setString(1, slotName);
+                    statement.setString(2, database);
+                    statement.setString(3, pluginName);
+                },
+                map);
+    }
+
+    /**
+     * Obtains the LSN to resume streaming from. On PG 9.5 there is no confirmed_flushed_lsn yet, so
+     * restart_lsn will be read instead. This may result in more records to be re-read after a
+     * restart.
+     */
+    private Lsn parseConfirmedFlushLsn(
+            String slotName, String pluginName, String database, ResultSet rs) {
+        Lsn confirmedFlushedLsn = null;
+
+        try {
+            confirmedFlushedLsn =
+                    tryParseLsn(slotName, pluginName, database, rs, "confirmed_flush_lsn");
+        } catch (SQLException e) {
+            LOGGER.info("unable to find confirmed_flushed_lsn, falling back to restart_lsn");
+            try {
+                confirmedFlushedLsn =
+                        tryParseLsn(slotName, pluginName, database, rs, "restart_lsn");
+            } catch (SQLException e2) {
+                throw new ConnectException(
+                        "Neither confirmed_flush_lsn nor restart_lsn could be found");
+            }
+        }
+
+        return confirmedFlushedLsn;
+    }
+
+    private Lsn parseRestartLsn(String slotName, String pluginName, String database, ResultSet rs) {
+        Lsn restartLsn = null;
+        try {
+            restartLsn = tryParseLsn(slotName, pluginName, database, rs, "restart_lsn");
+        } catch (SQLException e) {
+            throw new ConnectException("restart_lsn could be found");
+        }
+
+        return restartLsn;
+    }
+
+    private Lsn tryParseLsn(
+            String slotName, String pluginName, String database, ResultSet rs, String column)
+            throws ConnectException, SQLException {
+        Lsn lsn = null;
+
+        String lsnStr = rs.getString(column);
+        if (lsnStr == null) {
+            return null;
+        }
+        try {
+            lsn = Lsn.valueOf(lsnStr);
+        } catch (Exception e) {
+            throw new ConnectException(
+                    "Value "
+                            + column
+                            + " in the pg_replication_slots table for slot = '"
+                            + slotName
+                            + "', plugin = '"
+                            + pluginName
+                            + "', database = '"
+                            + database
+                            + "' is not valid. This is an abnormal situation and the database status should be checked.");
+        }
+        if (!lsn.isValid()) {
+            throw new ConnectException("Invalid LSN returned from database");
+        }
+        return lsn;
+    }
+
+    /**
+     * Drops a replication slot that was created on the DB
+     *
+     * @param slotName the name of the replication slot, may not be null
+     * @return {@code true} if the slot was dropped, {@code false} otherwise
+     */
+    public boolean dropReplicationSlot(String slotName) {
+        final int ATTEMPTS = 3;
+        for (int i = 0; i < ATTEMPTS; i++) {
+            try {
+                execute("select pg_drop_replication_slot('" + slotName + "')");
+                return true;
+            } catch (SQLException e) {
+                // slot is active
+                if (PSQLState.OBJECT_IN_USE.getState().equals(e.getSQLState())) {
+                    if (i < ATTEMPTS - 1) {
+                        LOGGER.debug(
+                                "Cannot drop replication slot '{}' because it's still in use",
+                                slotName);
+                    } else {
+                        LOGGER.warn(
+                                "Cannot drop replication slot '{}' because it's still in use",
+                                slotName);
+                        return false;
+                    }
+                } else if (PSQLState.UNDEFINED_OBJECT.getState().equals(e.getSQLState())) {
+                    LOGGER.debug("Replication slot {} has already been dropped", slotName);
+                    return false;
+                } else {
+                    LOGGER.error("Unexpected error while attempting to drop replication slot", e);
+                    return false;
+                }
+            }
+            try {
+                Metronome.parker(Duration.ofSeconds(1), Clock.system()).pause();
+            } catch (InterruptedException e) {
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Drops the debezium publication that was created.
+     *
+     * @param publicationName the publication name, may not be null
+     * @return {@code true} if the publication was dropped, {@code false} otherwise
+     */
+    public boolean dropPublication(String publicationName) {
+        try {
+            LOGGER.debug("Dropping publication '{}'", publicationName);
+            execute("DROP PUBLICATION " + publicationName);
+            return true;
+        } catch (SQLException e) {
+            if (PSQLState.UNDEFINED_OBJECT.getState().equals(e.getSQLState())) {
+                LOGGER.debug("Publication {} has already been dropped", publicationName);
+            } else {
+                LOGGER.error("Unexpected error while attempting to drop publication", e);
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        try {
+            super.close();
+        } catch (SQLException e) {
+            LOGGER.error("Unexpected error while closing Postgres connection", e);
+        }
+    }
+
+    /**
+     * Returns the PG id of the current active transaction
+     *
+     * @return a PG transaction identifier, or null if no tx is active
+     * @throws SQLException if anything fails.
+     */
+    public Long currentTransactionId() throws SQLException {
+        AtomicLong txId = new AtomicLong(0);
+        query(
+                "select * from txid_current()",
+                rs -> {
+                    if (rs.next()) {
+                        txId.compareAndSet(0, rs.getLong(1));
+                    }
+                });
+        long value = txId.get();
+        return value > 0 ? value : null;
+    }
+
+    /**
+     * Returns the current position in the server tx log.
+     *
+     * @return a long value, never negative
+     * @throws SQLException if anything unexpected fails.
+     */
+    public long currentXLogLocation() throws SQLException {
+        AtomicLong result = new AtomicLong(0);
+        int majorVersion = connection().getMetaData().getDatabaseMajorVersion();
+        query(
+                majorVersion >= 10
+                        ? "select * from pg_current_wal_lsn()"
+                        : "select * from pg_current_xlog_location()",
+                rs -> {
+                    if (!rs.next()) {
+                        throw new IllegalStateException(
+                                "there should always be a valid xlog position");
+                    }
+                    result.compareAndSet(0, LogSequenceNumber.valueOf(rs.getString(1)).asLong());
+                });
+        return result.get();
+    }
+
+    /**
+     * Returns information about the PG server to which this instance is connected.
+     *
+     * @return a {@link ServerInfo} instance, never {@code null}
+     * @throws SQLException if anything fails
+     */
+    public ServerInfo serverInfo() throws SQLException {
+        ServerInfo serverInfo = new ServerInfo();
+        query(
+                "SELECT version(), current_user, current_database()",
+                rs -> {
+                    if (rs.next()) {
+                        serverInfo
+                                .withServer(rs.getString(1))
+                                .withUsername(rs.getString(2))
+                                .withDatabase(rs.getString(3));
+                    }
+                });
+        String username = serverInfo.username();
+        if (username != null) {
+            query(
+                    "SELECT oid, rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication FROM pg_roles "
+                            + "WHERE pg_has_role('"
+                            + username
+                            + "', oid, 'member')",
+                    rs -> {
+                        while (rs.next()) {
+                            String roleInfo =
+                                    "superuser: "
+                                            + rs.getBoolean(3)
+                                            + ", replication: "
+                                            + rs.getBoolean(8)
+                                            + ", inherit: "
+                                            + rs.getBoolean(4)
+                                            + ", create role: "
+                                            + rs.getBoolean(5)
+                                            + ", create db: "
+                                            + rs.getBoolean(6)
+                                            + ", can log in: "
+                                            + rs.getBoolean(7);
+                            String roleName = rs.getString(2);
+                            serverInfo.addRole(roleName, roleInfo);
+                        }
+                    });
+        }
+        return serverInfo;
+    }
+
+    public Charset getDatabaseCharset() {
+        try {
+            return Charset.forName(((BaseConnection) connection()).getEncoding().name());
+        } catch (SQLException e) {
+            throw new DebeziumException("Couldn't obtain encoding for database " + database(), e);
+        }
+    }
+
+    public TimestampUtils getTimestampUtils() {
+        try {
+            return ((PgConnection) this.connection()).getTimestampUtils();
+        } catch (SQLException e) {
+            throw new DebeziumException(
+                    "Couldn't get timestamp utils from underlying connection", e);
+        }
+    }
+
+    protected static void defaultSettings(Configuration.Builder builder) {
+        // we require Postgres 9.4 as the minimum server version since that's where logical
+        // replication was first introduced
+        builder.with("assumeMinServerVersion", "9.4");
+    }
+
+    private static void validateServerVersion(Statement statement) throws SQLException {
+        DatabaseMetaData metaData = statement.getConnection().getMetaData();
+        int majorVersion = metaData.getDatabaseMajorVersion();
+        int minorVersion = metaData.getDatabaseMinorVersion();
+        if (majorVersion < 9 || (majorVersion == 9 && minorVersion < 4)) {
+            throw new SQLException("Cannot connect to a version of Postgres lower than 9.4");
+        }
+    }
+
+    @Override
+    protected int resolveNativeType(String typeName) {
+        return getTypeRegistry().get(typeName).getRootType().getOid();
+    }
+
+    @Override
+    protected int resolveJdbcType(int metadataJdbcType, int nativeType) {
+        // Special care needs to be taken for columns that use user-defined domain type data types
+        // where resolution of the column's JDBC type needs to be that of the root type instead of
+        // the actual column to properly influence schema building and value conversion.
+        return getTypeRegistry().get(nativeType).getRootType().getJdbcId();
+    }
+
+    @Override
+    protected Optional<ColumnEditor> readTableColumn(
+            ResultSet columnMetadata, TableId tableId, Tables.ColumnNameFilter columnFilter)
+            throws SQLException {
+        return doReadTableColumn(columnMetadata, tableId, columnFilter);
+    }
+
+    public Optional<Column> readColumnForDecoder(
+            ResultSet columnMetadata, TableId tableId, Tables.ColumnNameFilter columnNameFilter)
+            throws SQLException {
+        return doReadTableColumn(columnMetadata, tableId, columnNameFilter)
+                .map(ColumnEditor::create);
+    }
+
+    private Optional<ColumnEditor> doReadTableColumn(
+            ResultSet columnMetadata, TableId tableId, Tables.ColumnNameFilter columnFilter)
+            throws SQLException {
+        final String columnName = columnMetadata.getString(4);
+        if (columnFilter == null
+                || columnFilter.matches(
+                        tableId.catalog(), tableId.schema(), tableId.table(), columnName)) {
+            final ColumnEditor column = Column.editor().name(columnName);
+            column.type(columnMetadata.getString(6));
+
+            // first source the length/scale from the column metadata provided by the driver
+            // this may be overridden below if the column type is a user-defined domain type
+            column.length(columnMetadata.getInt(7));
+            if (columnMetadata.getObject(9) != null) {
+                column.scale(columnMetadata.getInt(9));
+            }
+
+            column.optional(isNullable(columnMetadata.getInt(11)));
+            column.position(columnMetadata.getInt(17));
+            column.autoIncremented("YES".equalsIgnoreCase(columnMetadata.getString(23)));
+
+            String autogenerated = null;
+            try {
+                autogenerated = columnMetadata.getString(24);
+            } catch (SQLException e) {
+                // ignore, some drivers don't have this index - e.g. Postgres
+            }
+            column.generated("YES".equalsIgnoreCase(autogenerated));
+
+            // Lookup the column type from the TypeRegistry
+            // For all types, we need to set the Native and Jdbc types by using the root-type
+            final PostgresType nativeType = getTypeRegistry().get(column.typeName());
+            column.nativeType(nativeType.getRootType().getOid());
+            column.jdbcType(nativeType.getRootType().getJdbcId());
+
+            // For domain types, the postgres driver is unable to traverse a nested unbounded
+            // hierarchy of types and report the right length/scale of a given type. We use
+            // the TypeRegistry to accomplish this since it is capable of traversing the type
+            // hierarchy upward to resolve length/scale regardless of hierarchy depth.
+            if (TypeRegistry.DOMAIN_TYPE == nativeType.getJdbcId()) {
+                column.length(nativeType.getDefaultLength());
+                column.scale(nativeType.getDefaultScale());
+            }
+
+            final String defaultValue = columnMetadata.getString(13);
+            if (defaultValue != null) {
+                getDefaultValue(column.create(), defaultValue).ifPresent(column::defaultValue);
+            }
+
+            return Optional.of(column);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    protected Optional<Object> getDefaultValue(Column column, String defaultValue) {
+        return defaultValueConverter.parseDefaultValue(column, defaultValue);
+    }
+
+    public TypeRegistry getTypeRegistry() {
+        Objects.requireNonNull(typeRegistry, "Connection does not provide type registry");
+        return typeRegistry;
+    }
+
+    @Override
+    public <T extends DatabaseSchema<TableId>> Object getColumnValue(
+            ResultSet rs, int columnIndex, Column column, Table table, T schema)
+            throws SQLException {
+        try {
+            final ResultSetMetaData metaData = rs.getMetaData();
+            final String columnTypeName = metaData.getColumnTypeName(columnIndex);
+            final PostgresType type =
+                    ((PostgresSchema) schema).getTypeRegistry().get(columnTypeName);
+
+            LOGGER.trace("Type of incoming data is: {}", type.getOid());
+            LOGGER.trace("ColumnTypeName is: {}", columnTypeName);
+            LOGGER.trace("Type is: {}", type);
+
+            if (type.isArrayType()) {
+                return rs.getArray(columnIndex);
+            }
+
+            switch (type.getOid()) {
+                case PgOid.MONEY:
+                    // TODO author=Horia Chiorean date=14/11/2016 description=workaround for
+                    // https://github.com/pgjdbc/pgjdbc/issues/100
+                    final String sMoney = rs.getString(columnIndex);
+                    if (sMoney == null) {
+                        return sMoney;
+                    }
+                    if (sMoney.startsWith("-")) {
+                        // PGmoney expects negative values to be provided in the format of
+                        // "($XXXXX.YY)"
+                        final String negativeMoney = "(" + sMoney.substring(1) + ")";
+                        return new PGmoney(negativeMoney).val;
+                    }
+                    return new PGmoney(sMoney).val;
+                case PgOid.BIT:
+                    return rs.getString(columnIndex);
+                case PgOid.NUMERIC:
+                    final String s = rs.getString(columnIndex);
+                    if (s == null) {
+                        return s;
+                    }
+
+                    Optional<SpecialValueDecimal> value = PostgresValueConverter.toSpecialValue(s);
+                    return value.isPresent()
+                            ? value.get()
+                            : new SpecialValueDecimal(rs.getBigDecimal(columnIndex));
+                case PgOid.TIME:
+                    // To handle time 24:00:00 supported by TIME columns, read the column as a
+                    // string.
+                case PgOid.TIMETZ:
+                    // In order to guarantee that we resolve TIMETZ columns with proper microsecond
+                    // precision,
+                    // read the column as a string instead and then re-parse inside the converter.
+                    return rs.getString(columnIndex);
+                default:
+                    Object x = rs.getObject(columnIndex);
+                    if (x != null) {
+                        LOGGER.trace(
+                                "rs getobject returns class: {}; rs getObject value is: {}",
+                                x.getClass(),
+                                x);
+                    }
+                    return x;
+            }
+        } catch (SQLException e) {
+            // not a known type
+            return super.getColumnValue(rs, columnIndex, column, table, schema);
+        }
+    }
+
+    @FunctionalInterface
+    public interface PostgresValueConverterBuilder {
+
+        PostgresValueConverter build(TypeRegistry registry);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/DebeziumSourceFunction.java
@@ -21,6 +21,7 @@ import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.ververica.cdc.debezium.Validator;
 import com.ververica.cdc.debezium.internal.DebeziumChangeConsumer;
 import com.ververica.cdc.debezium.internal.DebeziumOffset;
@@ -71,7 +72,6 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.shaded.guava18.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
 import org.apache.flink.util.Collector;

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresChunkSplitter.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresChunkSplitter.java
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source;
+
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfig;
+import org.apache.inlong.sort.cdc.base.source.assigner.splitter.ChunkRange;
+import org.apache.inlong.sort.cdc.base.source.assigner.splitter.JdbcSourceChunkSplitter;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SnapshotSplit;
+import org.apache.inlong.sort.cdc.base.util.ObjectUtils;
+import org.apache.inlong.sort.cdc.postgres.source.utils.PgQueryUtils;
+import org.apache.inlong.sort.cdc.postgres.source.utils.PgTypeUtils;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges.TableChange;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.math.BigDecimal;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.inlong.sort.cdc.base.util.ObjectUtils.doubleCompare;
+import static java.math.BigDecimal.ROUND_CEILING;
+
+/**
+ * The splitter to split the table into chunks using primary-key (by default) or a given split key.
+ */
+public class PostgresChunkSplitter implements JdbcSourceChunkSplitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresChunkSplitter.class);
+
+    private final JdbcSourceConfig sourceConfig;
+    private final PostgresDialect dialect;
+
+    public PostgresChunkSplitter(JdbcSourceConfig sourceConfig, PostgresDialect postgresDialect) {
+        this.sourceConfig = sourceConfig;
+        this.dialect = postgresDialect;
+    }
+
+    private static String splitId(TableId tableId, int chunkId) {
+        return tableId.toString() + ":" + chunkId;
+    }
+
+    private static void maySleep(int count, TableId tableId) {
+        // every 10 queries to sleep 100ms
+        if (count % 10 == 0) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // nothing to do
+            }
+            LOG.info("JdbcSourceChunkSplitter has split {} chunks for table {}", count, tableId);
+        }
+    }
+
+    public static Column getSplitColumn(Table table, @Nullable String chunkKeyColumn) {
+        List<Column> primaryKeys = table.primaryKeyColumns();
+        if (primaryKeys.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "Incremental snapshot for tables requires primary key,"
+                                    + " but table %s doesn't have primary key.",
+                            table.id()));
+        }
+
+        if (chunkKeyColumn != null) {
+            Optional<Column> targetPkColumn =
+                    primaryKeys.stream()
+                            .filter(col -> chunkKeyColumn.equals(col.name()))
+                            .findFirst();
+            if (targetPkColumn.isPresent()) {
+                return targetPkColumn.get();
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Chunk key column '%s' doesn't exist in the primary key [%s] of the table %s.",
+                            chunkKeyColumn,
+                            primaryKeys.stream().map(Column::name).collect(Collectors.joining(",")),
+                            table.id()));
+        }
+
+        // use first field in primary key as the split key
+        return primaryKeys.get(0);
+    }
+
+    @Override
+    public Collection<SnapshotSplit> generateSplits(TableId tableId) {
+        try (JdbcConnection jdbc = dialect.openJdbcConnection(sourceConfig)) {
+
+            LOG.info("Start splitting table {} into chunks...", tableId);
+            long start = System.currentTimeMillis();
+
+            Table table =
+                    Objects.requireNonNull(dialect.queryTableSchema(jdbc, tableId)).getTable();
+            Column splitColumn = getSplitColumn(table, sourceConfig.getChunkKeyColumn());
+            final List<ChunkRange> chunks;
+            try {
+                chunks = splitTableIntoChunks(jdbc, tableId, splitColumn);
+            } catch (SQLException e) {
+                throw new FlinkRuntimeException("Failed to split chunks for table " + tableId, e);
+            }
+
+            // convert chunks into splits
+            List<SnapshotSplit> splits = new ArrayList<>();
+            RowType splitType = getSplitType(splitColumn);
+            for (int i = 0; i < chunks.size(); i++) {
+                ChunkRange chunk = chunks.get(i);
+                SnapshotSplit split =
+                        createSnapshotSplit(
+                                jdbc,
+                                tableId,
+                                i,
+                                splitType,
+                                chunk.getChunkStart(),
+                                chunk.getChunkEnd());
+                splits.add(split);
+            }
+
+            long end = System.currentTimeMillis();
+            LOG.info(
+                    "Split table {} into {} chunks, time cost: {}ms.",
+                    tableId,
+                    splits.size(),
+                    end - start);
+            return splits;
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(
+                    String.format("Generate Splits for table %s error", tableId), e);
+        }
+    }
+
+    @Override
+    public Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+            throws SQLException {
+        return PgQueryUtils.queryMinMax(jdbc, tableId, columnName);
+    }
+
+    @Override
+    public Object queryMin(
+            JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+            throws SQLException {
+        return PgQueryUtils.queryMin(jdbc, tableId, columnName, excludedLowerBound);
+    }
+
+    @Override
+    public Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String columnName,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        return PgQueryUtils.queryNextChunkMax(
+                jdbc, tableId, columnName, chunkSize, includedLowerBound);
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Utilities
+    // --------------------------------------------------------------------------------------------
+
+    @Override
+    public Long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId) throws SQLException {
+        return PgQueryUtils.queryApproximateRowCnt(jdbc, tableId);
+    }
+
+    @Override
+    public String buildSplitScanQuery(
+            TableId tableId, RowType splitKeyType, boolean isFirstSplit, boolean isLastSplit) {
+        return PgQueryUtils.buildSplitScanQuery(tableId, splitKeyType, isFirstSplit, isLastSplit);
+    }
+
+    @Override
+    public DataType fromDbzColumn(Column splitColumn) {
+        return PgTypeUtils.fromDbzColumn(splitColumn);
+    }
+
+    /**
+     * We can use evenly-sized chunks or unevenly-sized chunks when split table into chunks, using
+     * evenly-sized chunks which is much efficient, using unevenly-sized chunks which will request
+     * many queries and is not efficient.
+     */
+    private List<ChunkRange> splitTableIntoChunks(
+            JdbcConnection jdbc, TableId tableId, Column splitColumn) throws SQLException {
+        final String splitColumnName = splitColumn.name();
+        final Object[] minMax = queryMinMax(jdbc, tableId, splitColumnName);
+        final Object min = minMax[0];
+        final Object max = minMax[1];
+        if (min == null || max == null || min.equals(max)) {
+            // empty table, or only one row, return full table scan as a chunk
+            return Collections.singletonList(ChunkRange.all());
+        }
+
+        final int chunkSize = sourceConfig.getSplitSize();
+        final double distributionFactorUpper = sourceConfig.getDistributionFactorUpper();
+        final double distributionFactorLower = sourceConfig.getDistributionFactorLower();
+
+        if (isEvenlySplitColumn(splitColumn)) {
+            long approximateRowCnt = queryApproximateRowCnt(jdbc, tableId);
+            double distributionFactor =
+                    calculateDistributionFactor(tableId, min, max, approximateRowCnt);
+
+            boolean dataIsEvenlyDistributed =
+                    doubleCompare(distributionFactor, distributionFactorLower) >= 0
+                            && doubleCompare(distributionFactor, distributionFactorUpper) <= 0;
+
+            if (dataIsEvenlyDistributed) {
+                // the minimum dynamic chunk size is at least 1
+                final int dynamicChunkSize = Math.max((int) (distributionFactor * chunkSize), 1);
+                return splitEvenlySizedChunks(
+                        tableId, min, max, approximateRowCnt, chunkSize, dynamicChunkSize);
+            } else {
+                return splitUnevenlySizedChunks(
+                        jdbc, tableId, splitColumnName, min, max, chunkSize);
+            }
+        } else {
+            return splitUnevenlySizedChunks(jdbc, tableId, splitColumnName, min, max, chunkSize);
+        }
+    }
+
+    /**
+     * Split table into evenly sized chunks based on the numeric min and max value of split column,
+     * and tumble chunks in step size.
+     */
+    private List<ChunkRange> splitEvenlySizedChunks(
+            TableId tableId,
+            Object min,
+            Object max,
+            long approximateRowCnt,
+            int chunkSize,
+            int dynamicChunkSize) {
+        LOG.info(
+                "Use evenly-sized chunk optimization for table {}, the approximate row count is {}, the chunk size is {}, the dynamic chunk size is {}",
+                tableId,
+                approximateRowCnt,
+                chunkSize,
+                dynamicChunkSize);
+        if (approximateRowCnt <= chunkSize) {
+            // there is no more than one chunk, return full table as a chunk
+            return Collections.singletonList(ChunkRange.all());
+        }
+
+        final List<ChunkRange> splits = new ArrayList<>();
+        Object chunkStart = null;
+        Object chunkEnd = ObjectUtils.plus(min, dynamicChunkSize);
+        while (ObjectUtils.compare(chunkEnd, max) <= 0) {
+            splits.add(ChunkRange.of(chunkStart, chunkEnd));
+            chunkStart = chunkEnd;
+            try {
+                chunkEnd = ObjectUtils.plus(chunkEnd, dynamicChunkSize);
+            } catch (ArithmeticException e) {
+                // Stop chunk split to avoid dead loop when number overflows.
+                break;
+            }
+        }
+        // add the ending split
+        splits.add(ChunkRange.of(chunkStart, null));
+        return splits;
+    }
+
+    // ------------------------------------------------------------------------------------------
+
+    /** Split table into unevenly sized chunks by continuously calculating next chunk max value. */
+    private List<ChunkRange> splitUnevenlySizedChunks(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String splitColumnName,
+            Object min,
+            Object max,
+            int chunkSize)
+            throws SQLException {
+        LOG.info(
+                "Use unevenly-sized chunks for table {}, the chunk size is {}", tableId, chunkSize);
+        final List<ChunkRange> splits = new ArrayList<>();
+        Object chunkStart = null;
+        Object chunkEnd = nextChunkEnd(jdbc, min, tableId, splitColumnName, max, chunkSize);
+        int count = 0;
+        while (chunkEnd != null && ObjectUtils.compare(chunkEnd, max) <= 0) {
+            // we start from [null, min + chunk_size) and avoid [null, min)
+            splits.add(ChunkRange.of(chunkStart, chunkEnd));
+            // may sleep a while to avoid DDOS on PostgreSQL server
+            maySleep(count++, tableId);
+            chunkStart = chunkEnd;
+            chunkEnd = nextChunkEnd(jdbc, chunkEnd, tableId, splitColumnName, max, chunkSize);
+        }
+        // add the ending split
+        splits.add(ChunkRange.of(chunkStart, null));
+        return splits;
+    }
+
+    private Object nextChunkEnd(
+            JdbcConnection jdbc,
+            Object previousChunkEnd,
+            TableId tableId,
+            String splitColumnName,
+            Object max,
+            int chunkSize)
+            throws SQLException {
+        // chunk end might be null when max values are removed
+        Object chunkEnd =
+                queryNextChunkMax(jdbc, tableId, splitColumnName, chunkSize, previousChunkEnd);
+        if (Objects.equals(previousChunkEnd, chunkEnd)) {
+            // we don't allow equal chunk start and end,
+            // should query the next one larger than chunkEnd
+            chunkEnd = queryMin(jdbc, tableId, splitColumnName, chunkEnd);
+        }
+        if (ObjectUtils.compare(chunkEnd, max) >= 0) {
+            return null;
+        } else {
+            return chunkEnd;
+        }
+    }
+
+    private SnapshotSplit createSnapshotSplit(
+            JdbcConnection jdbc,
+            TableId tableId,
+            int chunkId,
+            RowType splitKeyType,
+            Object chunkStart,
+            Object chunkEnd) {
+        // currently, we only support single split column
+        Object[] splitStart = chunkStart == null ? null : new Object[]{chunkStart};
+        Object[] splitEnd = chunkEnd == null ? null : new Object[]{chunkEnd};
+        Map<TableId, TableChange> schema = new HashMap<>();
+        schema.put(tableId, dialect.queryTableSchema(jdbc, tableId));
+        return new SnapshotSplit(
+                tableId,
+                splitId(tableId, chunkId),
+                splitKeyType,
+                splitStart,
+                splitEnd,
+                null,
+                schema);
+    }
+
+    /** Returns the distribution factor of the given table. */
+    private double calculateDistributionFactor(
+            TableId tableId, Object min, Object max, long approximateRowCnt) {
+
+        if (!min.getClass().equals(max.getClass())) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Unsupported operation type, the MIN value type %s is different with MAX value type %s.",
+                            min.getClass().getSimpleName(), max.getClass().getSimpleName()));
+        }
+        if (approximateRowCnt == 0) {
+            return Double.MAX_VALUE;
+        }
+        BigDecimal difference = ObjectUtils.minus(max, min);
+        // factor = (max - min + 1) / rowCount
+        final BigDecimal subRowCnt = difference.add(BigDecimal.valueOf(1));
+        double distributionFactor =
+                subRowCnt.divide(new BigDecimal(approximateRowCnt), 4, ROUND_CEILING).doubleValue();
+        LOG.info(
+                "The distribution factor of table {} is {} according to the min split key {}, max split key {} and approximate row count {}",
+                tableId,
+                distributionFactor,
+                min,
+                max,
+                approximateRowCnt);
+        return distributionFactor;
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresConnectionPoolFactory.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresConnectionPoolFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source;
+
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfig;
+import org.apache.inlong.sort.cdc.base.relational.connection.JdbcConnectionPoolFactory;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** A connection pool factory to create pooled Postgres {@link HikariDataSource}. */
+public class PostgresConnectionPoolFactory extends JdbcConnectionPoolFactory {
+
+    public static final String JDBC_URL_PATTERN = "jdbc:postgresql://%s:%s/%s";
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresConnectionPoolFactory.class);
+
+    @Override
+    public String getJdbcUrl(JdbcSourceConfig sourceConfig) {
+
+        String hostName = sourceConfig.getHostname();
+        int port = sourceConfig.getPort();
+        String database = sourceConfig.getDatabaseList().get(0);
+        return String.format(JDBC_URL_PATTERN, hostName, port, database);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresDialect.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresDialect.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source;
+
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfig;
+import org.apache.inlong.sort.cdc.base.dialect.JdbcDataSourceDialect;
+import org.apache.inlong.sort.cdc.base.relational.connection.JdbcConnectionFactory;
+import org.apache.inlong.sort.cdc.base.relational.connection.JdbcConnectionPoolFactory;
+import org.apache.inlong.sort.cdc.base.source.assigner.splitter.ChunkSplitter;
+import org.apache.inlong.sort.cdc.base.source.meta.offset.Offset;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitBase;
+import org.apache.inlong.sort.cdc.base.source.reader.external.FetchTask;
+import org.apache.inlong.sort.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.inlong.sort.cdc.postgres.source.config.PostgresSourceConfig;
+import org.apache.inlong.sort.cdc.postgres.source.config.PostgresSourceConfigFactory;
+import org.apache.inlong.sort.cdc.postgres.source.fetch.PostgresScanFetchTask;
+import org.apache.inlong.sort.cdc.postgres.source.fetch.PostgresSourceFetchTaskContext;
+import org.apache.inlong.sort.cdc.postgres.source.fetch.PostgresStreamFetchTask;
+import org.apache.inlong.sort.cdc.postgres.source.utils.PgSchema;
+import org.apache.inlong.sort.cdc.postgres.source.utils.TableDiscoveryUtils;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.TableChanges.TableChange;
+
+import javax.annotation.Nullable;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.debezium.connector.postgresql.PostgresObjectFactory.newPostgresValueConverterBuilder;
+import static io.debezium.connector.postgresql.Utils.currentOffset;
+
+/** The dialect for Postgres. */
+public class PostgresDialect implements JdbcDataSourceDialect {
+
+    private static final long serialVersionUID = 1L;
+    private final PostgresSourceConfig sourceConfig;
+
+    private transient PgSchema schema;
+
+    @Nullable
+    private PostgresStreamFetchTask streamFetchTask;
+
+    public PostgresDialect(PostgresSourceConfigFactory configFactory) {
+        this.sourceConfig = configFactory.create(0);
+    }
+
+    @Override
+    public JdbcConnection openJdbcConnection(JdbcSourceConfig sourceConfig) {
+        PostgresSourceConfig postgresSourceConfig = (PostgresSourceConfig) sourceConfig;
+        PostgresConnectorConfig dbzConfig = postgresSourceConfig.getDbzConnectorConfig();
+
+        PostgresConnection.PostgresValueConverterBuilder valueConverterBuilder =
+                newPostgresValueConverterBuilder(dbzConfig);
+        PostgresConnection jdbc =
+                new PostgresConnection(
+                        dbzConfig.getJdbcConfig(),
+                        valueConverterBuilder,
+                        new JdbcConnectionFactory(sourceConfig, getPooledDataSourceFactory()));
+
+        try {
+            jdbc.connect();
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(e);
+        }
+        return jdbc;
+    }
+
+    @Override
+    public String getName() {
+        return "PostgreSQL";
+    }
+
+    @Override
+    public Offset displayCurrentOffset(JdbcSourceConfig sourceConfig) {
+
+        try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
+            return currentOffset((PostgresConnection) jdbc);
+
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isDataCollectionIdCaseSensitive(JdbcSourceConfig sourceConfig) {
+        // from Postgres docs:
+        //
+        // SQL is case insensitive about key words and identifiers,
+        // except when identifiers are double-quoted to preserve the case
+        return true;
+    }
+
+    @Override
+    public ChunkSplitter createChunkSplitter(JdbcSourceConfig sourceConfig) {
+        return new PostgresChunkSplitter(sourceConfig, this);
+    }
+
+    @Override
+    public List<TableId> discoverDataCollections(JdbcSourceConfig sourceConfig) {
+        try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
+            return TableDiscoveryUtils.listTables(
+                    // there is always a single database provided
+                    sourceConfig.getDatabaseList().get(0),
+                    jdbc,
+                    ((PostgresSourceConfig) sourceConfig).getTableFilters());
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException("Error to discover tables: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Map<TableId, TableChange> discoverDataCollectionSchemas(JdbcSourceConfig sourceConfig) {
+        final List<TableId> capturedTableIds = discoverDataCollections(sourceConfig);
+
+        try (JdbcConnection jdbc = openJdbcConnection(sourceConfig)) {
+            // fetch table schemas
+            Map<TableId, TableChange> tableSchemas = new HashMap<>();
+            for (TableId tableId : capturedTableIds) {
+                TableChange tableSchema = queryTableSchema(jdbc, tableId);
+                tableSchemas.put(tableId, tableSchema);
+            }
+            return tableSchemas;
+        } catch (Exception e) {
+            throw new FlinkRuntimeException(
+                    "Error to discover table schemas: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public JdbcConnectionPoolFactory getPooledDataSourceFactory() {
+        return new PostgresConnectionPoolFactory();
+    }
+
+    @Override
+    public TableChange queryTableSchema(JdbcConnection jdbc, TableId tableId) {
+        if (schema == null) {
+            schema = new PgSchema((PostgresConnection) jdbc, sourceConfig);
+        }
+        return schema.getTableSchema(tableId);
+    }
+
+    @Override
+    public FetchTask<SourceSplitBase> createFetchTask(SourceSplitBase sourceSplitBase) {
+        if (sourceSplitBase.isSnapshotSplit()) {
+            return new PostgresScanFetchTask(sourceSplitBase.asSnapshotSplit());
+        } else {
+            this.streamFetchTask = new PostgresStreamFetchTask(sourceSplitBase.asStreamSplit());
+            return this.streamFetchTask;
+        }
+    }
+
+    @Override
+    public JdbcSourceFetchTaskContext createFetchTaskContext(
+            SourceSplitBase sourceSplitBase, JdbcSourceConfig taskSourceConfig) {
+        return new PostgresSourceFetchTaskContext(taskSourceConfig, this);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (streamFetchTask != null) {
+            streamFetchTask.commitCurrentOffset();
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresSourceBuilder.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/PostgresSourceBuilder.java
@@ -1,0 +1,268 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source;
+
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.inlong.sort.cdc.base.config.SourceConfig;
+import org.apache.inlong.sort.cdc.base.source.jdbc.JdbcIncrementalSource;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceRecords;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitState;
+import org.apache.inlong.sort.cdc.base.source.metrics.SourceReaderMetrics;
+import org.apache.inlong.sort.cdc.postgres.source.config.PostgresSourceConfigFactory;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffsetFactory;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.postgres.source.reader.PostgresSourceRecordEmitter;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The source builder for PostgresIncrementalSource. */
+@Experimental
+public class PostgresSourceBuilder<T> {
+
+    private final PostgresSourceConfigFactory configFactory = new PostgresSourceConfigFactory();
+    private DebeziumDeserializationSchema<T> deserializer;
+
+    /**
+     * The name of the Postgres logical decoding plug-in installed on the server. Supported values
+     * are decoderbufs, wal2json, wal2json_rds, wal2json_streaming, wal2json_rds_streaming and
+     * pgoutput.
+     */
+    public PostgresSourceBuilder<T> decodingPluginName(String name) {
+        this.configFactory.decodingPluginName(name);
+        return this;
+    }
+
+    /** The hostname of the database to monitor for changes. */
+    public PostgresSourceBuilder<T> hostname(String hostname) {
+        this.configFactory.hostname(hostname);
+        return this;
+    }
+
+    public PostgresSourceBuilder<T> inlongMetric(String inlongMetric) {
+        this.configFactory.inlongMetric(inlongMetric);
+        return this;
+    }
+
+    public PostgresSourceBuilder<T> inlongAudit(String inlongAudit) {
+        this.configFactory.inlongAudit(inlongAudit);
+        return this;
+    }
+
+    /** Integer port number of the Postgres database server. */
+    public PostgresSourceBuilder<T> port(int port) {
+        this.configFactory.port(port);
+        return this;
+    }
+
+    /** The name of the PostgreSQL database from which to stream the changes. */
+    public PostgresSourceBuilder<T> database(String database) {
+        this.configFactory.database(database);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match database names to be monitored; any
+     * database name not included in the whitelist will be excluded from monitoring.
+     */
+    public PostgresSourceBuilder<T> schemaList(String... schemaList) {
+        this.configFactory.schemaList(schemaList);
+        return this;
+    }
+
+    /**
+     * An required list of regular expressions that match fully-qualified table identifiers for
+     * tables to be monitored; any table not included in the list will be excluded from monitoring.
+     * Each identifier is of the form {@code <schemaName>.<tableName>}.
+     */
+    public PostgresSourceBuilder<T> tableList(String... tableList) {
+        this.configFactory.tableList(tableList);
+        return this;
+    }
+
+    /** Name of the Postgres database to use when connecting to the Postgres database server. */
+    public PostgresSourceBuilder<T> username(String username) {
+        this.configFactory.username(username);
+        return this;
+    }
+
+    /** Password to use when connecting to the Postgres database server. */
+    public PostgresSourceBuilder<T> password(String password) {
+        this.configFactory.password(password);
+        return this;
+    }
+
+    /**
+     * The name of the PostgreSQL logical decoding slot that was created for streaming changes from
+     * a particular plug-in for a particular database/schema. The server uses this slot to stream
+     * events to the connector that you are configuring. Default is "flink".
+     *
+     * <p>Slot names must conform to <a
+     * href="https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION">PostgreSQL
+     * replication slot naming rules</a>, which state: "Each replication slot has a name, which can
+     * contain lower-case letters, numbers, and the underscore character."
+     */
+    public PostgresSourceBuilder<T> slotName(String slotName) {
+        this.configFactory.slotName(slotName);
+        return this;
+    }
+
+    /**
+     * The split size (number of rows) of table snapshot, captured tables are split into multiple
+     * splits when read the snapshot of table.
+     */
+    public PostgresSourceBuilder<T> splitSize(int splitSize) {
+        this.configFactory.splitSize(splitSize);
+        return this;
+    }
+
+    /**
+     * The group size of split meta, if the meta size exceeds the group size, the meta will be
+     * divided into multiple groups.
+     */
+    public PostgresSourceBuilder<T> splitMetaGroupSize(int splitMetaGroupSize) {
+        this.configFactory.splitMetaGroupSize(splitMetaGroupSize);
+        return this;
+    }
+
+    /**
+     * The upper bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public PostgresSourceBuilder<T> distributionFactorUpper(double distributionFactorUpper) {
+        this.configFactory.distributionFactorUpper(distributionFactorUpper);
+        return this;
+    }
+
+    /**
+     * The lower bound of split key evenly distribution factor, the factor is used to determine
+     * whether the table is evenly distribution or not.
+     */
+    public PostgresSourceBuilder<T> distributionFactorLower(double distributionFactorLower) {
+        this.configFactory.distributionFactorLower(distributionFactorLower);
+        return this;
+    }
+
+    /** The maximum fetch size for per poll when read table snapshot. */
+    public PostgresSourceBuilder<T> fetchSize(int fetchSize) {
+        this.configFactory.fetchSize(fetchSize);
+        return this;
+    }
+
+    /**
+     * The maximum time that the connector should wait after trying to connect to the Postgres
+     * database server before timing out.
+     */
+    public PostgresSourceBuilder<T> connectTimeout(Duration connectTimeout) {
+        this.configFactory.connectTimeout(connectTimeout);
+        return this;
+    }
+
+    /** The max retry times to get connection. */
+    public PostgresSourceBuilder<T> connectMaxRetries(int connectMaxRetries) {
+        this.configFactory.connectMaxRetries(connectMaxRetries);
+        return this;
+    }
+
+    /** The connection pool size. */
+    public PostgresSourceBuilder<T> connectionPoolSize(int connectionPoolSize) {
+        this.configFactory.connectionPoolSize(connectionPoolSize);
+        return this;
+    }
+
+    /** Whether the {@link PostgresIncrementalSource} should output the schema changes or not. */
+    public PostgresSourceBuilder<T> includeSchemaChanges(boolean includeSchemaChanges) {
+        this.configFactory.includeSchemaChanges(includeSchemaChanges);
+        return this;
+    }
+
+    /** Specifies the startup options. */
+    public PostgresSourceBuilder<T> startupOptions(StartupOptions startupOptions) {
+        this.configFactory.startupOptions(startupOptions);
+        return this;
+    }
+
+    /**
+     * The chunk key of table snapshot, captured tables are split into multiple chunks by the chunk
+     * key column when read the snapshot of table.
+     */
+    public PostgresSourceBuilder<T> chunkKeyColumn(String chunkKeyColumn) {
+        this.configFactory.chunkKeyColumn(chunkKeyColumn);
+        return this;
+    }
+
+    /** The Debezium Postgres connector properties. For example, "snapshot.mode". */
+    public PostgresSourceBuilder<T> debeziumProperties(Properties properties) {
+        this.configFactory.debeziumProperties(properties);
+        return this;
+    }
+
+    /**
+     * The deserializer used to convert from consumed {@link
+     * org.apache.kafka.connect.source.SourceRecord}.
+     */
+    public PostgresSourceBuilder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
+        this.deserializer = deserializer;
+        return this;
+    }
+
+    /** The heartbeat interval for the Postgres server. */
+    public PostgresSourceBuilder<T> heartbeatInterval(Duration heartbeatInterval) {
+        this.configFactory.heartbeatInterval(heartbeatInterval);
+        return this;
+    }
+
+    /**
+     * Build the {@link PostgresIncrementalSource}.
+     *
+     * @return a PostgresParallelSource with the settings made for this builder.
+     */
+    public PostgresIncrementalSource<T> build() {
+        PostgresOffsetFactory offsetFactory = new PostgresOffsetFactory();
+        PostgresDialect dialect = new PostgresDialect(configFactory);
+        return new PostgresIncrementalSource<>(
+                configFactory, checkNotNull(deserializer), offsetFactory, dialect);
+    }
+
+    /** The Postgres source based on the incremental snapshot framework. */
+    @Experimental
+    public static class PostgresIncrementalSource<T> extends JdbcIncrementalSource<T> {
+
+        public PostgresIncrementalSource(
+                PostgresSourceConfigFactory configFactory,
+                DebeziumDeserializationSchema<T> deserializationSchema,
+                PostgresOffsetFactory offsetFactory,
+                PostgresDialect dataSourceDialect) {
+            super(configFactory, deserializationSchema, offsetFactory, dataSourceDialect);
+        }
+
+        @Override
+        protected RecordEmitter<SourceRecords, T, SourceSplitState> createRecordEmitter(SourceConfig sourceConfig,
+                SourceReaderMetrics sourceReaderMetrics) {
+            return new PostgresSourceRecordEmitter<>(
+                    deserializationSchema,
+                    sourceReaderMetrics,
+                    sourceConfig.isIncludeSchemaChanges(),
+                    offsetFactory);
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/config/PostgresSourceConfig.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/config/PostgresSourceConfig.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.config;
+
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import io.debezium.connector.AbstractSourceInfo;
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfig;
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.relational.RelationalTableFilters;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+/** The configuration for Postgres CDC source. */
+public class PostgresSourceConfig extends JdbcSourceConfig {
+
+    private static final long serialVersionUID = 1L;
+
+    public PostgresSourceConfig(
+            StartupOptions startupOptions,
+            List<String> databaseList,
+            List<String> schemaList,
+            List<String> tableList,
+            int splitSize,
+            int splitMetaGroupSize,
+            double distributionFactorUpper,
+            double distributionFactorLower,
+            boolean includeSchemaChanges,
+            Properties dbzProperties,
+            Configuration dbzConfiguration,
+            String driverClassName,
+            String hostname,
+            int port,
+            String username,
+            String password,
+            int fetchSize,
+            String serverTimeZone,
+            Duration connectTimeout,
+            int connectMaxRetries,
+            int connectionPoolSize,
+            @Nullable String chunkKeyColumn,
+            String inlongMetric,
+            String inlongAudit) {
+        super(
+                startupOptions,
+                databaseList,
+                schemaList,
+                tableList,
+                splitSize,
+                splitMetaGroupSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                includeSchemaChanges,
+                dbzProperties,
+                dbzConfiguration,
+                driverClassName,
+                hostname,
+                port,
+                username,
+                password,
+                fetchSize,
+                serverTimeZone,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                chunkKeyColumn,
+                inlongMetric,
+                inlongAudit);
+    }
+
+    @Override
+    public PostgresConnectorConfig getDbzConnectorConfig() {
+        return new PostgresConnectorConfig(getDbzConfiguration());
+    }
+
+    public RelationalTableFilters getTableFilters() {
+        return getDbzConnectorConfig().getTableFilters();
+    }
+
+    @Override
+    public List<String> getMetricLabelList() {
+        return Arrays.asList(AbstractSourceInfo.DATABASE_NAME_KEY,
+                AbstractSourceInfo.SCHEMA_NAME_KEY, AbstractSourceInfo.TABLE_NAME_KEY);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/config/PostgresSourceConfigFactory.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/config/PostgresSourceConfigFactory.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.config;
+
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfigFactory;
+import org.apache.inlong.sort.cdc.base.source.EmbeddedFlinkDatabaseHistory;
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnector;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.HEARTBEAT_INTERVAL;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Factory to create Configuration for Postgres source. */
+public class PostgresSourceConfigFactory extends JdbcSourceConfigFactory {
+
+    private Duration heartbeatInterval = HEARTBEAT_INTERVAL.defaultValue();
+
+    private static final String JDBC_DRIVER = "org.postgresql.Driver";
+
+    private String pluginName = "decoderbufs";
+
+    private String slotName = "flink";
+
+    private String database;
+
+    private List<String> schemaList;
+
+    private String inlongMetric;
+    private String inlongAudit;
+
+    public JdbcSourceConfigFactory inlongMetric(String inlongMetric) {
+        this.inlongMetric = inlongMetric;
+        return this;
+    }
+
+    public JdbcSourceConfigFactory inlongAudit(String inlongAudit) {
+        this.inlongAudit = inlongAudit;
+        return this;
+    }
+
+    /** Creates a new {@link PostgresSourceConfig} for the given subtask {@code subtaskId}. */
+    @Override
+    public PostgresSourceConfig create(int subtaskId) {
+        Properties props = new Properties();
+        props.setProperty("connector.class", PostgresConnector.class.getCanonicalName());
+        props.setProperty("plugin.name", pluginName);
+        // hard code server name, because we don't need to distinguish it, docs:
+        // Logical name that identifies and provides a namespace for the particular PostgreSQL
+        // database server/cluster being monitored. The logical name should be unique across
+        // all other connectors, since it is used as a prefix for all Kafka topic names coming
+        // from this connector. Only alphanumeric characters and underscores should be used.
+        props.setProperty("database.server.name", "postgres_cdc_source");
+        props.setProperty("database.hostname", checkNotNull(hostname));
+        props.setProperty("database.dbname", checkNotNull(database));
+        props.setProperty("database.user", checkNotNull(username));
+        props.setProperty("database.password", checkNotNull(password));
+        props.setProperty("database.port", String.valueOf(port));
+        props.setProperty("slot.name", checkNotNull(slotName));
+        // database history
+        props.setProperty(
+                "database.history", EmbeddedFlinkDatabaseHistory.class.getCanonicalName());
+        props.setProperty("database.history.instance.name", UUID.randomUUID() + "_" + subtaskId);
+        props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
+        props.setProperty("database.history.refer.ddl", String.valueOf(true));
+        // we have to enable heartbeat for PG to make sure DebeziumChangeConsumer#handleBatch
+        // is invoked after job restart
+        props.setProperty("heartbeat.interval.ms", String.valueOf(heartbeatInterval.toMillis()));
+        props.setProperty("include.schema.changes", String.valueOf(includeSchemaChanges));
+
+        if (schemaList != null) {
+            props.setProperty("schema.include.list", String.join(",", schemaList));
+        }
+
+        if (tableList != null) {
+            props.setProperty("table.include.list", String.join(",", tableList));
+        }
+
+        // override the user-defined debezium properties
+        if (dbzProperties != null) {
+            props.putAll(dbzProperties);
+        }
+
+        Configuration dbzConfiguration = Configuration.from(props);
+        return new PostgresSourceConfig(
+                startupOptions,
+                Collections.singletonList(database),
+                schemaList,
+                tableList,
+                splitSize,
+                splitMetaGroupSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                includeSchemaChanges,
+                props,
+                dbzConfiguration,
+                JDBC_DRIVER,
+                hostname,
+                port,
+                username,
+                password,
+                fetchSize,
+                serverTimeZone,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                chunkKeyColumn,
+                inlongMetric,
+                inlongAudit);
+    }
+
+    /**
+     * An optional list of regular expressions that match schema names to be monitored; any schema
+     * name not included in the whitelist will be excluded from monitoring. By default all
+     * non-system schemas will be monitored.
+     */
+    public void schemaList(String[] schemaList) {
+        this.schemaList = Arrays.asList(schemaList);
+    }
+
+    /**
+     * The name of the Postgres logical decoding plug-in installed on the server. Supported values
+     * are decoderbufs, wal2json, wal2json_rds, wal2json_streaming, wal2json_rds_streaming and
+     * pgoutput.
+     */
+    public void decodingPluginName(String name) {
+        this.pluginName = name;
+    }
+
+    /** The name of the PostgreSQL database from which to stream the changes. */
+    public void database(String database) {
+        this.database = database;
+    }
+
+    /**
+     * The name of the PostgreSQL logical decoding slot that was created for streaming changes from
+     * a particular plug-in for a particular database/schema. The server uses this slot to stream
+     * events to the connector that you are configuring. Default is "flink".
+     *
+     * <p>Slot names must conform to <a
+     * href="https://www.postgresql.org/docs/current/static/warm-standby.html#STREAMING-REPLICATION-SLOTS-MANIPULATION">PostgreSQL
+     * replication slot naming rules</a>, which state: "Each replication slot has a name, which can
+     * contain lower-case letters, numbers, and the underscore character."
+     */
+    public void slotName(String slotName) {
+        this.slotName = slotName;
+    }
+
+    /** The interval of heartbeat events. */
+    public void heartbeatInterval(Duration heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresScanFetchTask.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.fetch;
+
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SnapshotSplit;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitBase;
+import org.apache.inlong.sort.cdc.base.source.meta.split.StreamSplit;
+import org.apache.inlong.sort.cdc.base.source.meta.wartermark.WatermarkKind;
+import org.apache.inlong.sort.cdc.base.source.reader.external.FetchTask;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffset;
+import org.apache.inlong.sort.cdc.postgres.source.utils.PgQueryUtils;
+import io.debezium.config.Configuration;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.heartbeat.Heartbeat;
+import io.debezium.pipeline.EventDispatcher;
+import io.debezium.pipeline.source.AbstractSnapshotChangeEventSource;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.pipeline.source.spi.SnapshotProgressListener;
+import io.debezium.pipeline.spi.OffsetContext;
+import io.debezium.pipeline.spi.SnapshotResult;
+import io.debezium.relational.RelationalSnapshotChangeEventSource;
+import io.debezium.relational.SnapshotChangeRecordEmitter;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.util.Clock;
+import io.debezium.util.ColumnUtils;
+import io.debezium.util.Strings;
+import io.debezium.util.Threads;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Objects;
+
+import static io.debezium.connector.postgresql.Utils.currentOffset;
+import static io.debezium.connector.postgresql.Utils.refreshSchema;
+import static io.debezium.relational.RelationalSnapshotChangeEventSource.LOG_INTERVAL;
+
+/** A {@link FetchTask} implementation for Postgres to read snapshot split. */
+public class PostgresScanFetchTask implements FetchTask<SourceSplitBase> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresScanFetchTask.class);
+
+    private final SnapshotSplit split;
+    private volatile boolean taskRunning = false;
+
+    public PostgresScanFetchTask(SnapshotSplit split) {
+        this.split = split;
+    }
+
+    @Override
+    public SourceSplitBase getSplit() {
+        return split;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskRunning;
+    }
+
+    @Override
+    public void execute(Context context) throws Exception {
+        LOG.info("Execute ScanFetchTask for split: {}", split);
+        PostgresSourceFetchTaskContext ctx = (PostgresSourceFetchTaskContext) context;
+        LOG.info("lk_test Execute ScanFetchTask ctx.getOffsetContext: {}", ctx.getOffsetContext());
+
+        taskRunning = true;
+
+        SnapshotSplitReadTask snapshotSplitReadTask =
+                new SnapshotSplitReadTask(
+                        ctx.getConnection(),
+                        ctx.getDbzConnectorConfig(),
+                        ctx.getDatabaseSchema(),
+                        ctx.getOffsetContext(),
+                        ctx.getDispatcher(),
+                        ctx.getSnapshotChangeEventSourceMetrics(),
+                        split);
+
+        SnapshotSplitChangeEventSourceContext changeEventSourceContext =
+                new SnapshotSplitChangeEventSourceContext();
+        SnapshotResult<PostgresOffsetContext> snapshotResult =
+                snapshotSplitReadTask.execute(changeEventSourceContext, ctx.getOffsetContext());
+
+        if (!snapshotResult.isCompletedOrSkipped()) {
+            LOG.error("snapshotResult.isCompletedOrSkipped throw.");
+            taskRunning = false;
+            throw new IllegalStateException(
+                    String.format("Read snapshot for postgres split %s fail", split));
+        }
+
+        executeBackfillTask(ctx, changeEventSourceContext);
+    }
+
+    private void executeBackfillTask(
+            PostgresSourceFetchTaskContext ctx,
+            SnapshotSplitChangeEventSourceContext changeEventSourceContext)
+            throws InterruptedException {
+        final StreamSplit backfillSplit =
+                new StreamSplit(
+                        split.splitId(),
+                        changeEventSourceContext.getLowWatermark(),
+                        changeEventSourceContext.getHighWatermark(),
+                        new ArrayList<>(),
+                        split.getTableSchemas(),
+                        0);
+
+        // optimization that skip the WAL read when the low watermark >= high watermark
+        final boolean backfillRequired =
+                backfillSplit.getEndingOffset().isAtOrAfter(backfillSplit.getStartingOffset());
+        // lk_test TODO maybe has bug
+        LOG.info("in executeBackfillTask get getEndingOffset:{}, getStartingOffset:{}, backfillRequired:{}",
+                backfillSplit.getEndingOffset(), backfillSplit.getStartingOffset(), backfillRequired);
+        if (backfillRequired) {
+            LOG.info(
+                    "Skip the backfill {} for split {}: low watermark >= high watermark",
+                    backfillSplit,
+                    split);
+            ctx.getDispatcher()
+                    .dispatchWatermarkEvent(
+                            ctx.getOffsetContext().getPartition(),
+                            backfillSplit,
+                            backfillSplit.getEndingOffset(),
+                            WatermarkKind.END);
+
+            taskRunning = false;
+            return;
+        }
+
+        final PostgresOffsetContext.Loader loader =
+                new PostgresOffsetContext.Loader(ctx.getDbzConnectorConfig());
+        final PostgresOffsetContext postgresOffsetContext =
+                loader.load(backfillSplit.getStartingOffset().getOffset());
+
+        // we should only capture events for the current table,
+        // otherwise, we may not find corresponding schema
+        Configuration dbzConf =
+                ctx.getDbzConnectorConfig()
+                        .getConfig()
+                        .edit()
+                        .with("table.include.list", split.getTableId().toString())
+                        // Disable heartbeat event in snapshot split fetcher
+                        .with(Heartbeat.HEARTBEAT_INTERVAL, 0)
+                        .build();
+
+        final PostgresStreamFetchTask.StreamSplitReadTask backfillReadTask =
+                new PostgresStreamFetchTask.StreamSplitReadTask(
+                        new PostgresConnectorConfig(dbzConf),
+                        ctx.getSnapShotter(),
+                        ctx.getConnection(),
+                        ctx.getDispatcher(),
+                        ctx.getErrorHandler(),
+                        ctx.getTaskContext().getClock(),
+                        ctx.getDatabaseSchema(),
+                        ctx.getTaskContext(),
+                        ctx.getReplicationConnection(),
+                        backfillSplit);
+        LOG.info("Execute backfillReadTask for split {}", split);
+        backfillReadTask.execute(new PostgresChangeEventSourceContext(), postgresOffsetContext);
+    }
+
+    static class SnapshotSplitChangeEventSourceContext
+            implements
+                ChangeEventSource.ChangeEventSourceContext {
+
+        private PostgresOffset lowWatermark;
+        private PostgresOffset highWatermark;
+
+        public PostgresOffset getLowWatermark() {
+            return lowWatermark;
+        }
+
+        public void setLowWatermark(PostgresOffset lowWatermark) {
+            this.lowWatermark = lowWatermark;
+        }
+
+        public PostgresOffset getHighWatermark() {
+            return highWatermark;
+        }
+
+        public void setHighWatermark(PostgresOffset highWatermark) {
+            this.highWatermark = highWatermark;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return lowWatermark != null && highWatermark != null;
+        }
+    }
+
+    class PostgresChangeEventSourceContext implements ChangeEventSource.ChangeEventSourceContext {
+
+        public void finished() {
+            taskRunning = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return taskRunning;
+        }
+    }
+
+    /** A SnapshotChangeEventSource implementation for Postgres to read snapshot split. */
+    public static class SnapshotSplitReadTask extends AbstractSnapshotChangeEventSource {
+
+        private static final Logger LOG = LoggerFactory.getLogger(SnapshotSplitReadTask.class);
+
+        private final PostgresConnection jdbcConnection;
+        private final PostgresConnectorConfig connectorConfig;
+        private final JdbcSourceEventDispatcher dispatcher;
+        private final SnapshotSplit snapshotSplit;
+        private final PostgresOffsetContext offsetContext;
+        private final PostgresSchema databaseSchema;
+        private final SnapshotProgressListener snapshotProgressListener;
+        private final Clock clock;
+
+        public SnapshotSplitReadTask(
+                PostgresConnection jdbcConnection,
+                PostgresConnectorConfig connectorConfig,
+                PostgresSchema databaseSchema,
+                PostgresOffsetContext previousOffset,
+                JdbcSourceEventDispatcher dispatcher,
+                SnapshotProgressListener snapshotProgressListener,
+                SnapshotSplit snapshotSplit) {
+            super(connectorConfig, snapshotProgressListener);
+            this.jdbcConnection = jdbcConnection;
+            this.connectorConfig = connectorConfig;
+            this.snapshotProgressListener = snapshotProgressListener;
+            this.databaseSchema = databaseSchema;
+            this.dispatcher = dispatcher;
+            this.snapshotSplit = snapshotSplit;
+            this.offsetContext = previousOffset;
+            this.clock = Clock.SYSTEM;
+        }
+
+        @Override
+        protected SnapshotResult doExecute(
+                ChangeEventSourceContext context,
+                OffsetContext previousOffset,
+                SnapshotContext snapshotContext,
+                SnapshottingTask snapshottingTask)
+                throws Exception {
+            final RelationalSnapshotChangeEventSource.RelationalSnapshotContext ctx =
+                    (RelationalSnapshotChangeEventSource.RelationalSnapshotContext) snapshotContext;
+            ctx.offset = offsetContext;
+            refreshSchema(databaseSchema, jdbcConnection, false);
+
+            final PostgresOffset lowWatermark = currentOffset(jdbcConnection);
+            LOG.info(
+                    "Snapshot step 1 - Determining low watermark {} for split {}",
+                    lowWatermark,
+                    snapshotSplit);
+            ((SnapshotSplitChangeEventSourceContext) (context)).setLowWatermark(lowWatermark);
+            dispatcher.dispatchWatermarkEvent(
+                    offsetContext.getPartition(), snapshotSplit, lowWatermark, WatermarkKind.LOW);
+
+            LOG.info("Snapshot step 2 - Snapshotting data");
+            createDataEvents(ctx, snapshotSplit.getTableId());
+
+            final PostgresOffset highWatermark = currentOffset(jdbcConnection);
+            LOG.info(
+                    "Snapshot step 3 - Determining high watermark {} for split {}",
+                    highWatermark,
+                    snapshotSplit);
+            ((SnapshotSplitChangeEventSourceContext) (context)).setHighWatermark(highWatermark);
+            dispatcher.dispatchWatermarkEvent(
+                    offsetContext.getPartition(), snapshotSplit, highWatermark, WatermarkKind.HIGH);
+            return SnapshotResult.completed(ctx.offset);
+        }
+
+        private void createDataEvents(
+                RelationalSnapshotChangeEventSource.RelationalSnapshotContext snapshotContext,
+                TableId tableId)
+                throws InterruptedException {
+            EventDispatcher.SnapshotReceiver snapshotReceiver =
+                    dispatcher.getSnapshotChangeEventReceiver();
+            LOG.info("Snapshotting table {}", tableId);
+            createDataEventsForTable(
+                    snapshotContext,
+                    snapshotReceiver,
+                    Objects.requireNonNull(databaseSchema.tableFor(tableId)));
+            snapshotReceiver.completeSnapshot();
+        }
+
+        /** Dispatches the data change events for the records of a single table. */
+        private void createDataEventsForTable(
+                RelationalSnapshotChangeEventSource.RelationalSnapshotContext snapshotContext,
+                EventDispatcher.SnapshotReceiver snapshotReceiver,
+                Table table)
+                throws InterruptedException {
+
+            long exportStart = clock.currentTimeInMillis();
+            LOG.info(
+                    "Exporting data from split '{}' of table {}",
+                    snapshotSplit.splitId(),
+                    table.id());
+
+            final String selectSql =
+                    PgQueryUtils.buildSplitScanQuery(
+                            snapshotSplit.getTableId(),
+                            snapshotSplit.getSplitKeyType(),
+                            snapshotSplit.getSplitStart() == null,
+                            snapshotSplit.getSplitEnd() == null);
+            LOG.debug(
+                    "For split '{}' of table {} using select statement: '{}'",
+                    snapshotSplit.splitId(),
+                    table.id(),
+                    selectSql);
+
+            try (PreparedStatement selectStatement =
+                    PgQueryUtils.readTableSplitDataStatement(
+                            jdbcConnection,
+                            selectSql,
+                            snapshotSplit.getSplitStart() == null,
+                            snapshotSplit.getSplitEnd() == null,
+                            snapshotSplit.getSplitStart(),
+                            snapshotSplit.getSplitEnd(),
+                            snapshotSplit.getSplitKeyType().getFieldCount(),
+                            connectorConfig.getQueryFetchSize());
+                    ResultSet rs = selectStatement.executeQuery()) {
+
+                ColumnUtils.ColumnArray columnArray = ColumnUtils.toArray(rs, table);
+                long rows = 0;
+                Threads.Timer logTimer = getTableScanLogTimer();
+
+                while (rs.next()) {
+                    rows++;
+                    final Object[] row = new Object[columnArray.getGreatestColumnPosition()];
+                    for (int i = 0; i < columnArray.getColumns().length; i++) {
+                        row[columnArray.getColumns()[i].position() - 1] = rs.getObject(i + 1);
+                    }
+                    if (logTimer.expired()) {
+                        long stop = clock.currentTimeInMillis();
+                        LOG.info(
+                                "Exported {} records for split '{}' after {}",
+                                rows,
+                                snapshotSplit.splitId(),
+                                Strings.duration(stop - exportStart));
+                        snapshotProgressListener.rowsScanned(table.id(), rows);
+                        logTimer = getTableScanLogTimer();
+                    }
+                    snapshotContext.offset.event(table.id(), clock.currentTime());
+                    SnapshotChangeRecordEmitter emitter =
+                            new SnapshotChangeRecordEmitter(snapshotContext.offset, row, clock);
+                    dispatcher.dispatchSnapshotEvent(table.id(), emitter, snapshotReceiver);
+                }
+                LOG.info(
+                        "Finished exporting {} records for split '{}', total duration '{}'",
+                        rows,
+                        snapshotSplit.splitId(),
+                        Strings.duration(clock.currentTimeInMillis() - exportStart));
+            } catch (SQLException e) {
+                throw new FlinkRuntimeException(
+                        "Snapshotting of table " + table.id() + " failed", e);
+            }
+        }
+
+        private Threads.Timer getTableScanLogTimer() {
+            return Threads.timer(clock, LOG_INTERVAL);
+        }
+
+        @Override
+        protected SnapshottingTask getSnapshottingTask(OffsetContext previousOffset) {
+            return new SnapshottingTask(false, true);
+        }
+
+        @Override
+        protected SnapshotContext prepare(ChangeEventSourceContext changeEventSourceContext)
+                throws Exception {
+            return new PostgresSnapshotContext();
+        }
+
+        private static class PostgresSnapshotContext
+                extends
+                    RelationalSnapshotChangeEventSource.RelationalSnapshotContext {
+
+            public PostgresSnapshotContext() throws SQLException {
+                super("");
+            }
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresScanFetchTask.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresScanFetchTask.java
@@ -86,8 +86,6 @@ public class PostgresScanFetchTask implements FetchTask<SourceSplitBase> {
     public void execute(Context context) throws Exception {
         LOG.info("Execute ScanFetchTask for split: {}", split);
         PostgresSourceFetchTaskContext ctx = (PostgresSourceFetchTaskContext) context;
-        LOG.info("lk_test Execute ScanFetchTask ctx.getOffsetContext: {}", ctx.getOffsetContext());
-
         taskRunning = true;
 
         SnapshotSplitReadTask snapshotSplitReadTask =
@@ -131,7 +129,7 @@ public class PostgresScanFetchTask implements FetchTask<SourceSplitBase> {
         // optimization that skip the WAL read when the low watermark >= high watermark
         final boolean backfillRequired =
                 backfillSplit.getEndingOffset().isAtOrAfter(backfillSplit.getStartingOffset());
-        // lk_test TODO maybe has bug
+        //TODO maybe has bug
         LOG.info("in executeBackfillTask get getEndingOffset:{}, getStartingOffset:{}, backfillRequired:{}",
                 backfillSplit.getEndingOffset(), backfillSplit.getStartingOffset(), backfillRequired);
         if (backfillRequired) {

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresSourceFetchTaskContext.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresSourceFetchTaskContext.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.fetch;
+
+import io.debezium.connector.postgresql.PostgresObjectFactory;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.apache.inlong.sort.cdc.base.config.JdbcSourceConfig;
+import org.apache.inlong.sort.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.inlong.sort.cdc.base.source.EmbeddedFlinkDatabaseHistory;
+import org.apache.inlong.sort.cdc.base.source.meta.offset.Offset;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitBase;
+import org.apache.inlong.sort.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
+import org.apache.inlong.sort.cdc.postgres.source.PostgresDialect;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffset;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffsetFactory;
+import org.apache.inlong.sort.cdc.postgres.source.utils.PgTypeUtils;
+import io.debezium.connector.base.ChangeEventQueue;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresErrorHandler;
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresTaskContext;
+import io.debezium.connector.postgresql.PostgresTopicSelector;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.data.Envelope;
+import io.debezium.pipeline.DataChangeEvent;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.metrics.DefaultChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.metrics.SnapshotChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.StreamingChangeEventSourceMetrics;
+import io.debezium.pipeline.metrics.spi.ChangeEventSourceMetricsFactory;
+import io.debezium.pipeline.source.spi.EventMetadataProvider;
+import io.debezium.relational.Column;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.schema.TopicSelector;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.debezium.connector.AbstractSourceInfo.SCHEMA_NAME_KEY;
+import static io.debezium.connector.AbstractSourceInfo.TABLE_NAME_KEY;
+import static io.debezium.connector.postgresql.PostgresConnectorConfig.SNAPSHOT_MODE;
+import static io.debezium.connector.postgresql.PostgresObjectFactory.createReplicationConnection;
+import static io.debezium.connector.postgresql.PostgresObjectFactory.newPostgresValueConverterBuilder;
+
+/** The context of {@link PostgresScanFetchTask} and {@link PostgresStreamFetchTask}. */
+public class PostgresSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresSourceFetchTaskContext.class);
+
+    private PostgresTaskContext taskContext;
+    private ChangeEventQueue<DataChangeEvent> queue;
+    private PostgresConnection jdbcConnection;
+    private final AtomicReference<ReplicationConnection> replicationConnection =
+            new AtomicReference<>();
+    private PostgresOffsetContext offsetContext;
+    private PostgresSchema schema;
+    private ErrorHandler errorHandler;
+    private JdbcSourceEventDispatcher dispatcher;
+    private EventMetadataProvider metadataProvider;
+    private SnapshotChangeEventSourceMetrics snapshotChangeEventSourceMetrics;
+    private StreamingChangeEventSourceMetrics streamingChangeEventSourceMetrics;
+    private Snapshotter snapShotter;
+
+    public PostgresSourceFetchTaskContext(
+            JdbcSourceConfig sourceConfig, PostgresDialect dataSourceDialect) {
+        super(sourceConfig, dataSourceDialect);
+    }
+
+    @Override
+    public PostgresConnectorConfig getDbzConnectorConfig() {
+        return (PostgresConnectorConfig) super.getDbzConnectorConfig();
+    }
+
+    private PostgresOffsetContext loadStartingOffsetState(
+            PostgresOffsetContext.Loader loader, SourceSplitBase sourceSplitBase) {
+        Offset offset =
+                sourceSplitBase.isSnapshotSplit()
+                        ? new PostgresOffsetFactory()
+                                .createInitialOffset() // get an offset for starting snapshot
+                        : sourceSplitBase.asStreamSplit().getStartingOffset();
+
+        PostgresOffsetContext offsetContext =
+                loader.load(
+                        Objects.requireNonNull(offset, "offset is null for the sourceSplitBase")
+                                .getOffset());
+        return offsetContext;
+    }
+
+    @Override
+    public void configure(SourceSplitBase sourceSplitBase) {
+        LOG.info("Configuring PostgresSourceFetchTaskContext for split: {}", sourceSplitBase);
+        PostgresConnectorConfig dbzConfig = getDbzConnectorConfig();
+
+        PostgresConnectorConfig.SnapshotMode snapshotMode =
+                PostgresConnectorConfig.SnapshotMode.parse(
+                        dbzConfig.getConfig().getString(SNAPSHOT_MODE));
+        this.snapShotter = snapshotMode.getSnapshotter(dbzConfig.getConfig());
+
+        PostgresConnection.PostgresValueConverterBuilder valueConverterBuilder =
+                newPostgresValueConverterBuilder(dbzConfig);
+        this.jdbcConnection =
+                new PostgresConnection(dbzConfig.getJdbcConfig(), valueConverterBuilder);
+
+        TopicSelector<TableId> topicSelector = PostgresTopicSelector.create(dbzConfig);
+        EmbeddedFlinkDatabaseHistory.registerHistory(
+                sourceConfig
+                        .getDbzConfiguration()
+                        .getString(EmbeddedFlinkDatabaseHistory.DATABASE_HISTORY_INSTANCE_NAME),
+                sourceSplitBase.getTableSchemas().values());
+
+        try {
+            this.schema =
+                    PostgresObjectFactory.newSchema(
+                            jdbcConnection,
+                            dbzConfig,
+                            jdbcConnection.getTypeRegistry(),
+                            topicSelector,
+                            valueConverterBuilder.build(jdbcConnection.getTypeRegistry()));
+        } catch (SQLException e) {
+            throw new RuntimeException("Failed to initialize PostgresSchema", e);
+        }
+
+        this.offsetContext =
+                loadStartingOffsetState(
+                        new PostgresOffsetContext.Loader(dbzConfig), sourceSplitBase);
+        this.taskContext = PostgresObjectFactory.newTaskContext(dbzConfig, schema, topicSelector);
+
+        this.replicationConnection.compareAndSet(
+                null,
+                createReplicationConnection(
+                        this.taskContext, this.snapShotter.shouldSnapshot(), dbzConfig));
+
+        final int queueSize =
+                sourceSplitBase.isSnapshotSplit() ? Integer.MAX_VALUE : dbzConfig.getMaxQueueSize();
+        this.queue =
+                new ChangeEventQueue.Builder<DataChangeEvent>()
+                        .pollInterval(dbzConfig.getPollInterval())
+                        .maxBatchSize(dbzConfig.getMaxBatchSize())
+                        .maxQueueSize(queueSize)
+                        .maxQueueSizeInBytes(dbzConfig.getMaxQueueSizeInBytes())
+                        .loggingContextSupplier(
+                                () -> taskContext.configureLoggingContext(
+                                        "postgres-cdc-connector-task"))
+                        // do not buffer any element, we use signal event
+                        // .buffering()
+                        .build();
+
+        this.errorHandler = new PostgresErrorHandler(dbzConnectorConfig.getLogicalName(), queue);
+        this.metadataProvider = PostgresObjectFactory.newEventMetadataProvider();
+        this.dispatcher =
+                new JdbcSourceEventDispatcher(
+                        dbzConfig,
+                        topicSelector,
+                        schema,
+                        queue,
+                        dbzConfig.getTableFilters().dataCollectionFilter(),
+                        DataChangeEvent::new,
+                        metadataProvider,
+                        schemaNameAdjuster);
+
+        ChangeEventSourceMetricsFactory metricsFactory =
+                new DefaultChangeEventSourceMetricsFactory();
+        this.snapshotChangeEventSourceMetrics =
+                metricsFactory.getSnapshotMetrics(taskContext, queue, metadataProvider);
+        this.streamingChangeEventSourceMetrics =
+                metricsFactory.getStreamingMetrics(taskContext, queue, metadataProvider);
+    }
+
+    @Override
+    public PostgresSchema getDatabaseSchema() {
+        return schema;
+    }
+
+    @Override
+    public RowType getSplitType(Table table) {
+        List<Column> primaryKeys = table.primaryKeyColumns();
+        if (primaryKeys.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "Incremental snapshot for tables requires primary key,"
+                                    + " but table %s doesn't have primary key.",
+                            table.id()));
+        }
+
+        // use first field in primary key as the split key
+        return PgTypeUtils.getSplitType(primaryKeys.get(0));
+    }
+
+    @Override
+    public ErrorHandler getErrorHandler() {
+        return errorHandler;
+    }
+
+    @Override
+    public JdbcSourceEventDispatcher getDispatcher() {
+        return dispatcher;
+    }
+
+    @Override
+    public PostgresOffsetContext getOffsetContext() {
+        return offsetContext;
+    }
+
+    @Override
+    public ChangeEventQueue<DataChangeEvent> getQueue() {
+        return queue;
+    }
+
+    @Override
+    public Tables.TableFilter getTableFilter() {
+        return getDbzConnectorConfig().getTableFilters().dataCollectionFilter();
+    }
+
+    @Override
+    public TableId getTableId(SourceRecord record) {
+        Struct value = (Struct) record.value();
+        Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+        String schemaName = source.getString(SCHEMA_NAME_KEY);
+        String tableName = source.getString(TABLE_NAME_KEY);
+        return new TableId(null, schemaName, tableName);
+    }
+
+    public Offset getStreamOffset(SourceRecord sourceRecord) {
+        return PostgresOffset.of(sourceRecord);
+    }
+
+    public PostgresConnection getConnection() {
+        return jdbcConnection;
+    }
+
+    public PostgresTaskContext getTaskContext() {
+        return taskContext;
+    }
+
+    public ReplicationConnection getReplicationConnection() {
+        return replicationConnection.get();
+    }
+
+    public SnapshotChangeEventSourceMetrics getSnapshotChangeEventSourceMetrics() {
+        return snapshotChangeEventSourceMetrics;
+    }
+
+    public StreamingChangeEventSourceMetrics getStreamingChangeEventSourceMetrics() {
+        return streamingChangeEventSourceMetrics;
+    }
+
+    public Snapshotter getSnapShotter() {
+        return snapShotter;
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresStreamFetchTask.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/fetch/PostgresStreamFetchTask.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.fetch;
+
+import io.debezium.connector.postgresql.PostgresStreamingChangeEventSource;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitBase;
+import org.apache.inlong.sort.cdc.base.source.meta.split.StreamSplit;
+import org.apache.inlong.sort.cdc.base.source.meta.wartermark.WatermarkKind;
+import org.apache.inlong.sort.cdc.base.source.reader.external.FetchTask;
+import org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffset;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.PostgresSchema;
+import io.debezium.connector.postgresql.PostgresTaskContext;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.connector.postgresql.connection.ReplicationConnection;
+import io.debezium.connector.postgresql.spi.Snapshotter;
+import io.debezium.pipeline.ErrorHandler;
+import io.debezium.pipeline.source.spi.ChangeEventSource;
+import io.debezium.util.Clock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.inlong.sort.cdc.postgres.source.offset.PostgresOffset.NO_STOPPING_OFFSET;
+
+/** A {@link FetchTask} implementation for Postgres to read streaming changes. */
+public class PostgresStreamFetchTask implements FetchTask<SourceSplitBase> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresStreamFetchTask.class);
+
+    private final StreamSplit split;
+    private volatile boolean taskRunning = false;
+    private volatile boolean stopped = false;
+
+    private StreamSplitReadTask streamSplitReadTask;
+
+    private Long lastCommitLsn;
+
+    public PostgresStreamFetchTask(StreamSplit streamSplit) {
+        this.split = streamSplit;
+    }
+
+    @Override
+    public void execute(Context context) throws Exception {
+        if (stopped) {
+            LOG.debug(
+                    "StreamFetchTask for split: {} is already stopped and can not be executed",
+                    split);
+            return;
+        } else {
+            LOG.debug("execute StreamFetchTask for split: {}", split);
+        }
+
+        PostgresSourceFetchTaskContext sourceFetchContext =
+                (PostgresSourceFetchTaskContext) context;
+        taskRunning = true;
+        streamSplitReadTask =
+                new StreamSplitReadTask(
+                        sourceFetchContext.getDbzConnectorConfig(),
+                        sourceFetchContext.getSnapShotter(),
+                        sourceFetchContext.getConnection(),
+                        sourceFetchContext.getDispatcher(),
+                        sourceFetchContext.getErrorHandler(),
+                        sourceFetchContext.getTaskContext().getClock(),
+                        sourceFetchContext.getDatabaseSchema(),
+                        sourceFetchContext.getTaskContext(),
+                        sourceFetchContext.getReplicationConnection(),
+                        split);
+        StreamSplitChangeEventSourceContext changeEventSourceContext =
+                new StreamSplitChangeEventSourceContext();
+        streamSplitReadTask.execute(
+                changeEventSourceContext, sourceFetchContext.getOffsetContext());
+    }
+
+    @Override
+    public void stop() {
+        LOG.debug("stopping StreamFetchTask for split: {}", split);
+        if (streamSplitReadTask != null) {
+            ((StreamSplitChangeEventSourceContext) streamSplitReadTask.context).finished();
+        }
+        stopped = true;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return taskRunning;
+    }
+
+    @Override
+    public SourceSplitBase getSplit() {
+        return split;
+    }
+
+    public void commitCurrentOffset() {
+        if (streamSplitReadTask != null && streamSplitReadTask.offsetContext != null) {
+            PostgresOffsetContext postgresOffsetContext = streamSplitReadTask.offsetContext;
+
+            // only extracting and storing the lsn of the last commit
+            Long commitLsn =
+                    (Long) postgresOffsetContext
+                            .getOffset()
+                            .get(PostgresOffsetContext.LAST_COMMIT_LSN_KEY);
+            if (commitLsn != null
+                    && (lastCommitLsn == null
+                            || Lsn.valueOf(commitLsn).compareTo(Lsn.valueOf(lastCommitLsn)) > 0)) {
+                lastCommitLsn = commitLsn;
+
+                Map<String, Object> offsets = new HashMap<>();
+                offsets.put(PostgresOffsetContext.LAST_COMMIT_LSN_KEY, lastCommitLsn);
+                LOG.debug(
+                        "Committing offset {} for {}",
+                        Lsn.valueOf(lastCommitLsn),
+                        streamSplitReadTask.streamSplit);
+                streamSplitReadTask.commitOffset(offsets);
+            }
+        }
+    }
+
+    private class StreamSplitChangeEventSourceContext
+            implements
+                ChangeEventSource.ChangeEventSourceContext {
+
+        public void finished() {
+            taskRunning = false;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return taskRunning;
+        }
+    }
+
+    /** A {@link ChangeEventSource} implementation for Postgres to read streaming changes. */
+    public static class StreamSplitReadTask extends PostgresStreamingChangeEventSource {
+
+        private static final Logger LOG = LoggerFactory.getLogger(StreamSplitReadTask.class);
+        private final StreamSplit streamSplit;
+        private final JdbcSourceEventDispatcher dispatcher;
+        private final ErrorHandler errorHandler;
+
+        public ChangeEventSourceContext context;
+        public PostgresOffsetContext offsetContext;
+
+        public StreamSplitReadTask(
+                PostgresConnectorConfig connectorConfig,
+                Snapshotter snapshotter,
+                PostgresConnection connection,
+                JdbcSourceEventDispatcher dispatcher,
+                ErrorHandler errorHandler,
+                Clock clock,
+                PostgresSchema schema,
+                PostgresTaskContext taskContext,
+                ReplicationConnection replicationConnection,
+                StreamSplit streamSplit) {
+
+            super(
+                    connectorConfig,
+                    snapshotter,
+                    connection,
+                    dispatcher,
+                    errorHandler,
+                    clock,
+                    schema,
+                    taskContext,
+                    replicationConnection);
+            this.streamSplit = streamSplit;
+            this.dispatcher = dispatcher;
+            this.errorHandler = errorHandler;
+        }
+
+        @Override
+        public void execute(ChangeEventSourceContext context, PostgresOffsetContext offsetContext)
+                throws InterruptedException {
+            this.context = context;
+            this.offsetContext = offsetContext;
+
+            LOG.info("Execute StreamSplitReadTask for split: {}", streamSplit);
+
+            offsetContext.setStreamingStoppingLsn(
+                    ((PostgresOffset) streamSplit.getEndingOffset()).getLsn());
+            super.execute(context, offsetContext);
+            if (isBoundedRead()) {
+
+                LOG.info("StreamSplit is bounded read: {}", streamSplit);
+                final PostgresOffset currentOffset = PostgresOffset.of(offsetContext.getOffset());
+
+                if (currentOffset.isAtOrAfter(streamSplit.getEndingOffset())) {
+                    LOG.info("StreamSplitReadTask finished for {}", streamSplit);
+
+                    try {
+                        dispatcher.dispatchWatermarkEvent(
+                                offsetContext.getPartition(),
+                                streamSplit,
+                                currentOffset,
+                                WatermarkKind.END);
+                    } catch (InterruptedException e) {
+                        LOG.error("Send signal event error.", e);
+                        errorHandler.setProducerThrowable(
+                                new FlinkRuntimeException("Error processing WAL signal event", e));
+                    }
+
+                    ((PostgresScanFetchTask.PostgresChangeEventSourceContext) context).finished();
+                }
+            }
+        }
+
+        private boolean isBoundedRead() {
+            return !NO_STOPPING_OFFSET
+                    .getLsn()
+                    .equals(((PostgresOffset) streamSplit.getEndingOffset()).getLsn());
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/offset/PostgresOffset.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/offset/PostgresOffset.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.offset;
+
+import org.apache.inlong.sort.cdc.base.source.meta.offset.Offset;
+import io.debezium.connector.postgresql.SourceInfo;
+import io.debezium.connector.postgresql.connection.Lsn;
+import io.debezium.time.Conversions;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+/** The offset for Postgres. */
+public class PostgresOffset extends Offset {
+
+    private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(PostgresOffset.class);
+
+    // ref: io.debezium.connector.postgresql.spi.OffsetState (which is not serializable)
+
+    // workaround to make LSN serializable
+    private final Long lsn;
+    private final Long txid;
+    private final Instant lastCommitTs;
+
+    public static final PostgresOffset INITIAL_OFFSET =
+            new PostgresOffset(Lsn.INVALID_LSN.asLong(), null, Instant.MIN);
+    public static final PostgresOffset NO_STOPPING_OFFSET =
+            new PostgresOffset(Lsn.valueOf("FFFFFFFF/FFFFFFFF").asLong(), null, Instant.MAX);
+
+    // the offset abstract class has a protected field Map<String, String> offset
+    // - postgres requires non-string type in
+    // io.debezium.connector.postgresql.PostgresOffsetContext.Loader.load
+    // - this feels confusing and error prone (better to refactor cdc-base?)
+    private final Map<String, ?> offset;
+
+    // used by PostgresOffsetFactory
+    PostgresOffset(Map<String, String> offsetMap) {
+
+        String lastCommitTsStr = String.valueOf(offsetMap.get(SourceInfo.TIMESTAMP_USEC_KEY));
+
+        this.lsn = Long.valueOf(String.valueOf(offsetMap.get(SourceInfo.LSN_KEY)));
+        this.txid = this.longOffsetValue(offsetMap, SourceInfo.TXID_KEY);
+        this.lastCommitTs =
+                Conversions.toInstantFromMicros(
+                        Long.valueOf(
+                                String.valueOf(
+                                        offsetMap.getOrDefault(
+                                                SourceInfo.TIMESTAMP_USEC_KEY, "0"))));
+        this.offset = getOffsetMap(lsn, txid, lastCommitTs);
+    }
+
+    public PostgresOffset(Long lsn, Long txId, Instant lastCommitTs) {
+        this.lsn = lsn;
+        this.txid = txId;
+        this.lastCommitTs = lastCommitTs;
+        this.offset = getOffsetMap(lsn, txId, lastCommitTs);
+    }
+
+    private Map<String, ?> getOffsetMap(Long lsn, Long txId, Instant lastCommitTs) {
+        // keys are from io.debezium.connector.postgresql.PostgresOffsetContext.Loader.load
+        Map<String, Object> offsetMap = new HashMap<>();
+        offsetMap.put(SourceInfo.LSN_KEY, lsn);
+        if (txId != null) {
+            offsetMap.put(SourceInfo.TXID_KEY, txId);
+        }
+        if (lastCommitTs != null) {
+            offsetMap.put(SourceInfo.TIMESTAMP_USEC_KEY, Conversions.toEpochMicros(lastCommitTs));
+        }
+        return offsetMap;
+    }
+
+    public static PostgresOffset of(SourceRecord dataRecord) {
+        return of(dataRecord.sourceOffset());
+    }
+
+    public static PostgresOffset of(Map<String, ?> offsetMap) {
+        Map<String, String> offsetStrMap = new HashMap<>();
+        for (Map.Entry<String, ?> entry : offsetMap.entrySet()) {
+            offsetStrMap.put(
+                    entry.getKey(), entry.getValue() == null ? null : entry.getValue().toString());
+        }
+
+        return new PostgresOffset(offsetStrMap);
+    }
+
+    public Lsn getLsn() {
+        return Lsn.valueOf(lsn);
+    }
+
+    @Override
+    public int compareTo(Offset o) {
+        PostgresOffset rhs = (PostgresOffset) o;
+        LOG.debug("comparing {} and {}", this, rhs);
+        return Lsn.valueOf(this.lsn).compareTo(Lsn.valueOf(rhs.lsn));
+    }
+
+    @Override
+    public String toString() {
+        return "Offset{lsn="
+                + Lsn.valueOf(lsn)
+                + ", txId="
+                + txid
+                + ", lastCommitTs="
+                + lastCommitTs
+                + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PostgresOffset)) {
+            return false;
+        }
+        PostgresOffset that = (PostgresOffset) o;
+        return offset.equals(that.offset);
+    }
+
+    @Override
+    public Map<String, ?> getOffset() {
+
+        return offset;
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/offset/PostgresOffsetFactory.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/offset/PostgresOffsetFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.offset;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.base.source.meta.offset.Offset;
+import org.apache.inlong.sort.cdc.base.source.meta.offset.OffsetFactory;
+
+import java.util.Map;
+
+/** The factory to create {@link PostgresOffset}. */
+public class PostgresOffsetFactory extends OffsetFactory {
+
+    @Override
+    public Offset newOffset(Map<String, String> offset) {
+        return new PostgresOffset(offset);
+    }
+
+    @Override
+    public Offset newOffset(String filename, Long position) {
+        throw new FlinkRuntimeException(
+                "not supported create new Offset by Filename and Long position.");
+    }
+
+    @Override
+    public Offset newOffset(Long position) {
+        throw new FlinkRuntimeException("not supported create new Offset by Long position.");
+    }
+
+    @Override
+    public Offset createInitialOffset() {
+        return PostgresOffset.INITIAL_OFFSET;
+    }
+
+    @Override
+    public Offset createNoStoppingOffset() {
+        return PostgresOffset.NO_STOPPING_OFFSET;
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/options/PostgresSourceOptions.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/options/PostgresSourceOptions.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.options;
+
+import com.ververica.cdc.connectors.base.options.JdbcSourceOptions;
+import com.ververica.cdc.debezium.table.DebeziumChangelogMode;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.inlong.sort.cdc.postgres.source.PostgresSourceBuilder;
+
+import java.time.Duration;
+
+/** Configurations for {@link PostgresSourceBuilder.PostgresIncrementalSource}. */
+public class PostgresSourceOptions extends JdbcSourceOptions {
+
+    public static final ConfigOption<Integer> PORT =
+            ConfigOptions.key("port")
+                    .intType()
+                    .defaultValue(5432)
+                    .withDescription("Integer port number of the PostgreSQL database server.");
+
+    public static final ConfigOption<String> DECODING_PLUGIN_NAME =
+            ConfigOptions.key("decoding.plugin.name")
+                    .stringType()
+                    .defaultValue("decoderbufs")
+                    .withDescription(
+                            "The name of the Postgres logical decoding plug-in installed on the server.\n"
+                                    + "Supported values are decoderbufs, wal2json, wal2json_rds, wal2json_streaming,\n"
+                                    + "wal2json_rds_streaming and pgoutput.");
+
+    public static final ConfigOption<String> SLOT_NAME =
+            ConfigOptions.key("slot.name")
+                    .stringType()
+                    .defaultValue("flink")
+                    .withDescription(
+                            "The name of the PostgreSQL logical decoding slot that was created for streaming changes "
+                                    + "from a particular plug-in for a particular database/schema. The server uses this slot "
+                                    + "to stream events to the connector that you are configuring. Default is \"flink\".");
+
+    public static final ConfigOption<DebeziumChangelogMode> CHANGELOG_MODE =
+            ConfigOptions.key("changelog-mode")
+                    .enumType(DebeziumChangelogMode.class)
+                    .defaultValue(DebeziumChangelogMode.ALL)
+                    .withDescription(
+                            "The changelog mode used for encoding streaming changes.\n"
+                                    + "\"all\": Encodes changes as retract stream using all RowKinds. This is the default mode.\n"
+                                    + "\"upsert\": Encodes changes as upsert stream that describes idempotent updates on a key. It can be used for tables with primary keys when replica identity FULL is not an option.");
+
+    public static final ConfigOption<Duration> HEARTBEAT_INTERVAL =
+            ConfigOptions.key("heartbeat.interval.ms")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "Optional interval of sending heartbeat event for tracing the latest available replication slot offsets");
+
+    public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_ENABLED =
+            ConfigOptions.key("scan.incremental.snapshot.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Incremental snapshot is a new mechanism to read snapshot of a table. "
+                                    + "Compared to the old snapshot mechanism, the incremental snapshot has many advantages, including:\n"
+                                    + "(1) source can be parallel during snapshot reading, \n"
+                                    + "(2) source can perform checkpoints in the chunk granularity during snapshot reading, \n"
+                                    + "(3) source doesn't need to acquire global read lock before snapshot reading.");
+
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/options/SourceOptions.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/options/SourceOptions.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.options;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.inlong.sort.cdc.base.source.IncrementalSource;
+
+/** Configurations for {@link IncrementalSource}. */
+public class SourceOptions {
+
+    public static final ConfigOption<Boolean> SCAN_INCREMENTAL_SNAPSHOT_ENABLED =
+            ConfigOptions.key("scan.incremental.snapshot.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Incremental snapshot is a new mechanism to read snapshot of a table. "
+                                    + "Compared to the old snapshot mechanism, the incremental snapshot has many advantages, including:\n"
+                                    + "(1) source can be parallel during snapshot reading, \n"
+                                    + "(2) source can perform checkpoints in the chunk granularity during snapshot reading, \n"
+                                    + "(3) source doesn't need to acquire global read lock (FLUSH TABLES WITH READ LOCK) before snapshot reading.\n"
+                                    + "If you would like the source run in parallel, each parallel reader should have an unique server id, "
+                                    + "so the 'server-id' must be a range like '5400-6400', and the range must be larger than the parallelism.");
+
+    public static final ConfigOption<Integer> SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE =
+            ConfigOptions.key("scan.incremental.snapshot.chunk.size")
+                    .intType()
+                    .defaultValue(8096)
+                    .withDescription(
+                            "The chunk size (number of rows) of table snapshot, captured tables are split into multiple chunks when read the snapshot of table.");
+
+    public static final ConfigOption<Integer> SCAN_SNAPSHOT_FETCH_SIZE =
+            ConfigOptions.key("scan.snapshot.fetch.size")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription(
+                            "The maximum fetch size for per poll when read table snapshot.");
+
+    public static final ConfigOption<String> SCAN_STARTUP_MODE =
+            ConfigOptions.key("scan.startup.mode")
+                    .stringType()
+                    .defaultValue("initial")
+                    .withDescription(
+                            "Optional startup mode for CDC consumer, valid enumerations are "
+                                    + "\"initial\", \"earliest-offset\", \"latest-offset\", \"timestamp\"\n"
+                                    + "or \"specific-offset\"");
+
+    public static final ConfigOption<String> SCAN_STARTUP_SPECIFIC_OFFSET_FILE =
+            ConfigOptions.key("scan.startup.specific-offset.file")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional offsets used in case of \"specific-offset\" startup mode");
+
+    public static final ConfigOption<Integer> SCAN_STARTUP_SPECIFIC_OFFSET_POS =
+            ConfigOptions.key("scan.startup.specific-offset.pos")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional offsets used in case of \"specific-offset\" startup mode");
+
+    public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP_MILLIS =
+            ConfigOptions.key("scan.startup.timestamp-millis")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional timestamp used in case of \"timestamp\" startup mode");
+
+    public static final ConfigOption<Integer> CHUNK_META_GROUP_SIZE =
+            ConfigOptions.key("chunk-meta.group.size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "The group size of chunk meta, if the meta size exceeds the group size, the meta will be divided into multiple groups.");
+
+    public static final ConfigOption<Double> SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND =
+            ConfigOptions.key("chunk-key.even-distribution.factor.upper-bound")
+                    .doubleType()
+                    .defaultValue(1000.0d)
+                    .withFallbackKeys("split-key.even-distribution.factor.upper-bound")
+                    .withDescription(
+                            "The upper bound of chunk key distribution factor. The distribution factor is used to determine whether the"
+                                    + " table is evenly distribution or not."
+                                    + " The table chunks would use evenly calculation optimization when the data distribution is even,"
+                                    + " and the query for splitting would happen when it is uneven."
+                                    + " The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.");
+
+    public static final ConfigOption<Double> SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND =
+            ConfigOptions.key("chunk-key.even-distribution.factor.lower-bound")
+                    .doubleType()
+                    .defaultValue(0.05d)
+                    .withFallbackKeys("split-key.even-distribution.factor.lower-bound")
+                    .withDescription(
+                            "The lower bound of chunk key distribution factor. The distribution factor is used to determine whether the"
+                                    + " table is evenly distribution or not."
+                                    + " The table chunks would use evenly calculation optimization when the data distribution is even,"
+                                    + " and the query for splitting would happen when it is uneven."
+                                    + " The distribution factor could be calculated by (MAX(id) - MIN(id) + 1) / rowCount.");
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/reader/PostgresSourceRecordEmitter.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/reader/PostgresSourceRecordEmitter.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.reader;
+
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.document.Array;
+import io.debezium.relational.TableId;
+import io.debezium.relational.history.HistoryRecord;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.relational.history.TableChanges.TableChange;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.debezium.history.FlinkJsonTableChangeSerializer;
+import org.apache.inlong.sort.cdc.base.source.meta.offset.Offset;
+import org.apache.inlong.sort.cdc.base.source.meta.offset.OffsetFactory;
+import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitState;
+import org.apache.inlong.sort.cdc.base.source.metrics.SourceReaderMetrics;
+import org.apache.inlong.sort.cdc.base.source.reader.IncrementalSourceReader;
+import org.apache.inlong.sort.cdc.base.source.reader.IncrementalSourceRecordEmitter;
+import org.apache.inlong.sort.cdc.base.util.RecordUtils;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isHighWatermarkEvent;
+import static com.ververica.cdc.connectors.base.source.meta.wartermark.WatermarkEvent.isWatermarkEvent;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.getHistoryRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isDataChangeRecord;
+import static com.ververica.cdc.connectors.base.utils.SourceRecordUtils.isSchemaChangeEvent;
+import static org.apache.inlong.sort.cdc.base.util.SourceRecordUtils.isHeartbeatEvent;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link IncrementalSourceReader}.
+ *
+ * <p>The {@link RecordEmitter} buffers the snapshot records of split and call the stream reader to
+ * emit records rather than emit the records directly.
+ * Copy from com.ververica:flink-cdc-base:2.3.0.
+ */
+public class PostgresSourceRecordEmitter<T>
+        extends
+            IncrementalSourceRecordEmitter<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PostgresSourceRecordEmitter.class);
+    private static final FlinkJsonTableChangeSerializer TABLE_CHANGE_SERIALIZER =
+            new FlinkJsonTableChangeSerializer();
+
+    public PostgresSourceRecordEmitter(
+            DebeziumDeserializationSchema<T> debeziumDeserializationSchema,
+            SourceReaderMetrics sourceReaderMetrics,
+            boolean includeSchemaChanges,
+            OffsetFactory offsetFactory) {
+        super(debeziumDeserializationSchema, sourceReaderMetrics, includeSchemaChanges, offsetFactory);
+    }
+
+    @Override
+    protected void processElement(
+            SourceRecord element, SourceOutput<T> output, SourceSplitState splitState)
+            throws Exception {
+        if (isWatermarkEvent(element)) {
+            LOG.debug("PostgresSourceRecordEmitter Process WatermarkEvent: {}; splitState = {}", element, splitState);
+            Offset watermark = super.getOffsetPosition(element);
+            if (isHighWatermarkEvent(element) && splitState.isSnapshotSplitState()) {
+                LOG.info("PostgresSourceRecordEmitter Set HighWatermark {} for {}", watermark, splitState);
+                splitState.asSnapshotSplitState().setHighWatermark(watermark);
+            }
+        } else if (isSchemaChangeEvent(element) && splitState.isStreamSplitState()) {
+            LOG.debug("PostgresSourceRecordEmitter Process SchemaChangeEvent: {}; splitState = {}", element,
+                    splitState);
+            HistoryRecord historyRecord = getHistoryRecord(element);
+            Array tableChanges =
+                    historyRecord.document().getArray(HistoryRecord.Fields.TABLE_CHANGES);
+            TableChanges changes = TABLE_CHANGE_SERIALIZER.deserialize(tableChanges, true);
+            for (TableChanges.TableChange tableChange : changes) {
+                splitState.asStreamSplitState().recordSchema(tableChange.getId(), tableChange);
+            }
+            if (includeSchemaChanges) {
+                emitElement(element, output);
+            }
+        } else if (isDataChangeRecord(element)) {
+            LOG.debug("PostgresSourceRecordEmitter Process DataChangeRecord: {}; splitState = {}", element, splitState);
+            updateStartingOffsetForSplit(splitState, element);
+            reportMetrics(element);
+            final Map<TableId, TableChange> tableSchemas =
+                    splitState.getSourceSplitBase().getTableSchemas();
+            final TableChange tableSchema =
+                    tableSchemas.getOrDefault(RecordUtils.getTableId(element), null);
+            debeziumDeserializationSchema.deserialize(element, new Collector<T>() {
+
+                @Override
+                public void collect(T record) {
+                    Struct value = (Struct) element.value();
+                    Struct source = value.getStruct(Envelope.FieldName.SOURCE);
+                    String dbName = source.getString(AbstractSourceInfo.DATABASE_NAME_KEY);
+                    String schemaName = source.getString(AbstractSourceInfo.SCHEMA_NAME_KEY);
+                    String tableName = source.getString(AbstractSourceInfo.TABLE_NAME_KEY);
+                    sourceReaderMetrics
+                            .outputMetrics(dbName, schemaName, tableName, splitState.isSnapshotSplitState(), value);
+                    output.collect(record);
+                }
+
+                @Override
+                public void close() {
+
+                }
+            }, tableSchema);
+        } else if (isHeartbeatEvent(element)) {
+            LOG.debug("PostgresSourceRecordEmitterProcess Heartbeat: {}; splitState = {}", element, splitState);
+            updateStartingOffsetForSplit(splitState, element);
+        } else {
+            // unknown element
+            LOG.info(
+                    "Meet unknown element {} for splitState = {}, just skip.", element, splitState);
+        }
+    }
+
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgQueryUtils.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgQueryUtils.java
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.utils;
+
+import org.apache.flink.table.types.logical.RowType;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.apache.inlong.sort.cdc.base.util.SourceRecordUtils.rowToArray;
+
+/** Query-related Utilities for Postgres CDC source. */
+public class PgQueryUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PgQueryUtils.class);
+
+    private PgQueryUtils() {
+    }
+
+    public static Object[] queryMinMax(JdbcConnection jdbc, TableId tableId, String columnName)
+            throws SQLException {
+        final String minMaxQuery =
+                String.format(
+                        "SELECT MIN(%s), MAX(%s) FROM %s",
+                        quote(columnName), quote(columnName), quote(tableId));
+        return jdbc.queryAndMap(
+                minMaxQuery,
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]",
+                                        minMaxQuery));
+                    }
+                    return rowToArray(rs, 2);
+                });
+    }
+
+    public static long queryApproximateRowCnt(JdbcConnection jdbc, TableId tableId)
+            throws SQLException {
+        // The statement used to get approximate row count which is less
+        // accurate than COUNT(*), but is more efficient for large table.
+        // https://stackoverflow.com/questions/7943233/fast-way-to-discover-the-row-count-of-a-table-in-postgresql
+        // NOTE: it requires ANALYZE or VACUUM to be run first in PostgreSQL.
+        final String query =
+                String.format(
+                        "SELECT reltuples::bigint FROM pg_class WHERE oid = to_regclass('%s')",
+                        tableId.toString());
+
+        return jdbc.queryAndMap(
+                query,
+                rs -> {
+                    if (!rs.next()) {
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", query));
+                    }
+                    LOG.info("queryApproximateRowCnt: {} => {}", query, rs.getLong(1));
+                    return rs.getLong(1);
+                });
+    }
+
+    public static Object queryMin(
+            JdbcConnection jdbc, TableId tableId, String columnName, Object excludedLowerBound)
+            throws SQLException {
+        final String query =
+                String.format(
+                        "SELECT MIN(%s) FROM %s WHERE %s > ?",
+                        quote(columnName), quote(tableId), quote(columnName));
+        return jdbc.prepareQueryAndMap(
+                query,
+                ps -> ps.setObject(1, excludedLowerBound),
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", query));
+                    }
+                    LOG.info("{} => {}", query, rs.getObject(1));
+                    return rs.getObject(1);
+                });
+    }
+
+    public static Object queryNextChunkMax(
+            JdbcConnection jdbc,
+            TableId tableId,
+            String splitColumnName,
+            int chunkSize,
+            Object includedLowerBound)
+            throws SQLException {
+        String quotedColumn = quote(splitColumnName);
+        String query =
+                String.format(
+                        "SELECT MAX(%s) FROM ("
+                                + "SELECT %s FROM %s WHERE %s >= ? ORDER BY %s ASC LIMIT %s"
+                                + ") AS T",
+                        quotedColumn,
+                        quotedColumn,
+                        quote(tableId),
+                        quotedColumn,
+                        quotedColumn,
+                        chunkSize);
+        return jdbc.prepareQueryAndMap(
+                query,
+                ps -> ps.setObject(1, includedLowerBound),
+                rs -> {
+                    if (!rs.next()) {
+                        // this should never happen
+                        throw new SQLException(
+                                String.format(
+                                        "No result returned after running query [%s]", query));
+                    }
+                    return rs.getObject(1);
+                });
+    }
+
+    public static String buildSplitScanQuery(
+            TableId tableId, RowType pkRowType, boolean isFirstSplit, boolean isLastSplit) {
+        return buildSplitQuery(tableId, pkRowType, isFirstSplit, isLastSplit, -1, true);
+    }
+
+    private static String buildSplitQuery(
+            TableId tableId,
+            RowType pkRowType,
+            boolean isFirstSplit,
+            boolean isLastSplit,
+            int limitSize,
+            boolean isScanningData) {
+        final String condition;
+
+        if (isFirstSplit && isLastSplit) {
+            condition = null;
+        } else if (isFirstSplit) {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(pkRowType, sql, " <= ?");
+            if (isScanningData) {
+                sql.append(" AND NOT (");
+                addPrimaryKeyColumnsToCondition(pkRowType, sql, " = ?");
+                sql.append(")");
+            }
+            condition = sql.toString();
+        } else if (isLastSplit) {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(pkRowType, sql, " >= ?");
+            condition = sql.toString();
+        } else {
+            final StringBuilder sql = new StringBuilder();
+            addPrimaryKeyColumnsToCondition(pkRowType, sql, " >= ?");
+            if (isScanningData) {
+                sql.append(" AND NOT (");
+                addPrimaryKeyColumnsToCondition(pkRowType, sql, " = ?");
+                sql.append(")");
+            }
+            sql.append(" AND ");
+            addPrimaryKeyColumnsToCondition(pkRowType, sql, " <= ?");
+            condition = sql.toString();
+        }
+
+        if (isScanningData) {
+            return buildSelectWithRowLimits(
+                    tableId, limitSize, "*", Optional.ofNullable(condition), Optional.empty());
+        } else {
+            final String orderBy =
+                    pkRowType.getFieldNames().stream().collect(Collectors.joining(", "));
+            return buildSelectWithBoundaryRowLimits(
+                    tableId,
+                    limitSize,
+                    getPrimaryKeyColumnsProjection(pkRowType),
+                    getMaxPrimaryKeyColumnsProjection(pkRowType),
+                    Optional.ofNullable(condition),
+                    orderBy);
+        }
+    }
+
+    public static PreparedStatement readTableSplitDataStatement(
+            JdbcConnection jdbc,
+            String sql,
+            boolean isFirstSplit,
+            boolean isLastSplit,
+            Object[] splitStart,
+            Object[] splitEnd,
+            int primaryKeyNum,
+            int fetchSize) {
+        try {
+            final PreparedStatement statement = initStatement(jdbc, sql, fetchSize);
+            if (isFirstSplit && isLastSplit) {
+                return statement;
+            }
+            if (isFirstSplit) {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitEnd[i]);
+                    statement.setObject(i + 1 + primaryKeyNum, splitEnd[i]);
+                }
+            } else if (isLastSplit) {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitStart[i]);
+                }
+            } else {
+                for (int i = 0; i < primaryKeyNum; i++) {
+                    statement.setObject(i + 1, splitStart[i]);
+                    statement.setObject(i + 1 + primaryKeyNum, splitEnd[i]);
+                    statement.setObject(i + 1 + 2 * primaryKeyNum, splitEnd[i]);
+                }
+            }
+            return statement;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to build the split data read statement.", e);
+        }
+    }
+
+    public static String quote(String dbOrTableName) {
+        return "\"" + dbOrTableName + "\"";
+    }
+
+    public static String quote(TableId tableId) {
+        return tableId.toQuotedString('"');
+    }
+
+    private static PreparedStatement initStatement(JdbcConnection jdbc, String sql, int fetchSize)
+            throws SQLException {
+        final Connection connection = jdbc.connection();
+        connection.setAutoCommit(false);
+        final PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
+    }
+
+    private static void addPrimaryKeyColumnsToCondition(
+            RowType pkRowType, StringBuilder sql, String predicate) {
+        for (Iterator<String> fieldNamesIt = pkRowType.getFieldNames().iterator(); fieldNamesIt.hasNext();) {
+            sql.append(fieldNamesIt.next()).append(predicate);
+            if (fieldNamesIt.hasNext()) {
+                sql.append(" AND ");
+            }
+        }
+    }
+
+    private static String getPrimaryKeyColumnsProjection(RowType pkRowType) {
+        StringBuilder sql = new StringBuilder();
+        for (Iterator<String> fieldNamesIt = pkRowType.getFieldNames().iterator(); fieldNamesIt.hasNext();) {
+            sql.append(fieldNamesIt.next());
+            if (fieldNamesIt.hasNext()) {
+                sql.append(" , ");
+            }
+        }
+        return sql.toString();
+    }
+
+    private static String getMaxPrimaryKeyColumnsProjection(RowType pkRowType) {
+        StringBuilder sql = new StringBuilder();
+        for (Iterator<String> fieldNamesIt = pkRowType.getFieldNames().iterator(); fieldNamesIt.hasNext();) {
+            sql.append("MAX(" + fieldNamesIt.next() + ")");
+            if (fieldNamesIt.hasNext()) {
+                sql.append(" , ");
+            }
+        }
+        return sql.toString();
+    }
+
+    private static String buildSelectWithRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            Optional<String> condition,
+            Optional<String> orderBy) {
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(projection).append(" FROM ");
+        sql.append(quote(tableId));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        if (orderBy.isPresent()) {
+            sql.append(" ORDER BY ").append(orderBy.get());
+        }
+        if (limit > 0) {
+            sql.append(" LIMIT ").append(limit);
+        }
+        return sql.toString();
+    }
+
+    private static String buildSelectWithBoundaryRowLimits(
+            TableId tableId,
+            int limit,
+            String projection,
+            String maxColumnProjection,
+            Optional<String> condition,
+            String orderBy) {
+        final StringBuilder sql = new StringBuilder("SELECT ");
+        sql.append(maxColumnProjection);
+        sql.append(" FROM (");
+        sql.append("SELECT ");
+        sql.append(projection);
+        sql.append(" FROM ");
+        sql.append(quote(tableId));
+        if (condition.isPresent()) {
+            sql.append(" WHERE ").append(condition.get());
+        }
+        sql.append(" ORDER BY ").append(orderBy).append(" LIMIT ").append(limit);
+        sql.append(") T");
+        return sql.toString();
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgSchema.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgSchema.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.utils;
+
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.inlong.sort.cdc.postgres.source.config.PostgresSourceConfig;
+import io.debezium.connector.postgresql.PostgresConnectorConfig;
+import io.debezium.connector.postgresql.PostgresOffsetContext;
+import io.debezium.connector.postgresql.connection.PostgresConnection;
+import io.debezium.relational.Table;
+import io.debezium.relational.TableId;
+import io.debezium.relational.Tables;
+import io.debezium.relational.history.TableChanges;
+import io.debezium.relational.history.TableChanges.TableChange;
+import io.debezium.schema.SchemaChangeEvent;
+import io.debezium.util.Clock;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** A PgSchema similar to PostgresSchema with customization. */
+public class PgSchema {
+
+    // cache the schema for each table
+    private final Map<TableId, TableChange> schemasByTableId = new HashMap<>();
+    private final PostgresConnection jdbcConnection;
+    private final PostgresConnectorConfig dbzConfig;
+
+    public PgSchema(PostgresConnection jdbcConnection, PostgresSourceConfig sourceConfig) {
+        this.jdbcConnection = jdbcConnection;
+        this.dbzConfig = sourceConfig.getDbzConnectorConfig();
+    }
+
+    public TableChange getTableSchema(TableId tableId) {
+        // read schema from cache first
+        if (!schemasByTableId.containsKey(tableId)) {
+            try {
+                schemasByTableId.put(tableId, Objects.requireNonNull(readTableSchema(tableId)));
+            } catch (SQLException e) {
+                throw new FlinkRuntimeException("Failed to read table schema", e);
+            }
+        }
+        return schemasByTableId.get(tableId);
+    }
+
+    private TableChange readTableSchema(TableId tableId) throws SQLException {
+
+        final PostgresOffsetContext offsetContext =
+                PostgresOffsetContext.initialContext(dbzConfig, jdbcConnection, Clock.SYSTEM);
+
+        // set the events to populate proper sourceInfo into offsetContext
+        offsetContext.event(tableId, Instant.now());
+
+        Tables tables = new Tables();
+        try {
+            jdbcConnection.readSchema(
+                    tables,
+                    dbzConfig.databaseName(),
+                    tableId.schema(),
+                    dbzConfig.getTableFilters().dataCollectionFilter(),
+                    null,
+                    false);
+        } catch (SQLException e) {
+            throw new FlinkRuntimeException("Failed to read schema", e);
+        }
+
+        Table table = Objects.requireNonNull(tables.forTable(tableId));
+
+        // TODO: check whether we always set isFromSnapshot = true
+        SchemaChangeEvent schemaChangeEvent =
+                new SchemaChangeEvent(
+                        offsetContext.getPartition(),
+                        offsetContext.getOffset(),
+                        offsetContext.getSourceInfo(),
+                        dbzConfig.databaseName(),
+                        tableId.schema(),
+                        null,
+                        table,
+                        SchemaChangeEvent.SchemaChangeEventType.CREATE,
+                        true);
+
+        for (TableChanges.TableChange tableChange : schemaChangeEvent.getTableChanges()) {
+            this.schemasByTableId.put(tableId, tableChange);
+        }
+        return this.schemasByTableId.get(tableId);
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgTypeUtils.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/PgTypeUtils.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.utils;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import io.debezium.relational.Column;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.ROW;
+
+/** A utility class for converting Postgres types to Flink types. */
+public class PgTypeUtils {
+
+    private static final String PG_SMALLSERIAL = "smallserial";
+    private static final String PG_SERIAL = "serial";
+    private static final String PG_BIGSERIAL = "bigserial";
+    private static final String PG_BYTEA = "bytea";
+    private static final String PG_BYTEA_ARRAY = "_bytea";
+    private static final String PG_SMALLINT = "int2";
+    private static final String PG_SMALLINT_ARRAY = "_int2";
+    private static final String PG_INTEGER = "int4";
+    private static final String PG_INTEGER_ARRAY = "_int4";
+    private static final String PG_BIGINT = "int8";
+    private static final String PG_BIGINT_ARRAY = "_int8";
+    private static final String PG_REAL = "float4";
+    private static final String PG_REAL_ARRAY = "_float4";
+    private static final String PG_DOUBLE_PRECISION = "float8";
+    private static final String PG_DOUBLE_PRECISION_ARRAY = "_float8";
+    private static final String PG_NUMERIC = "numeric";
+    private static final String PG_NUMERIC_ARRAY = "_numeric";
+    private static final String PG_BOOLEAN = "bool";
+    private static final String PG_BOOLEAN_ARRAY = "_bool";
+    private static final String PG_TIMESTAMP = "timestamp";
+    private static final String PG_TIMESTAMP_ARRAY = "_timestamp";
+    private static final String PG_TIMESTAMPTZ = "timestamptz";
+    private static final String PG_TIMESTAMPTZ_ARRAY = "_timestamptz";
+    private static final String PG_DATE = "date";
+    private static final String PG_DATE_ARRAY = "_date";
+    private static final String PG_TIME = "time";
+    private static final String PG_TIME_ARRAY = "_time";
+    private static final String PG_TEXT = "text";
+    private static final String PG_TEXT_ARRAY = "_text";
+    private static final String PG_CHAR = "bpchar";
+    private static final String PG_CHAR_ARRAY = "_bpchar";
+    private static final String PG_CHARACTER = "character";
+    private static final String PG_CHARACTER_ARRAY = "_character";
+    private static final String PG_CHARACTER_VARYING = "varchar";
+    private static final String PG_CHARACTER_VARYING_ARRAY = "_varchar";
+
+    /** Returns a corresponding Flink data type from a debezium {@link Column}. */
+    public static DataType fromDbzColumn(Column column) {
+        DataType dataType = convertFromColumn(column);
+        if (column.isOptional()) {
+            return dataType;
+        } else {
+            return dataType.notNull();
+        }
+    }
+
+    public static RowType getSplitType(Column splitColumn) {
+        return (RowType) ROW(FIELD(splitColumn.name(), fromDbzColumn(splitColumn))).getLogicalType();
+    }
+
+    /**
+     * Returns a corresponding Flink data type from a debezium {@link Column} with nullable always
+     * be true.
+     */
+    private static DataType convertFromColumn(Column column) {
+        String typeName = column.typeName();
+
+        int precision = column.length();
+        int scale = column.scale().orElse(0);
+
+        switch (typeName) {
+            case PG_BOOLEAN:
+                return DataTypes.BOOLEAN();
+            case PG_BOOLEAN_ARRAY:
+                return DataTypes.ARRAY(DataTypes.BOOLEAN());
+            case PG_BYTEA:
+                return DataTypes.BYTES();
+            case PG_BYTEA_ARRAY:
+                return DataTypes.ARRAY(DataTypes.BYTES());
+            case PG_SMALLINT:
+            case PG_SMALLSERIAL:
+                return DataTypes.SMALLINT();
+            case PG_SMALLINT_ARRAY:
+                return DataTypes.ARRAY(DataTypes.SMALLINT());
+            case PG_INTEGER:
+            case PG_SERIAL:
+                return DataTypes.INT();
+            case PG_INTEGER_ARRAY:
+                return DataTypes.ARRAY(DataTypes.INT());
+            case PG_BIGINT:
+            case PG_BIGSERIAL:
+                return DataTypes.BIGINT();
+            case PG_BIGINT_ARRAY:
+                return DataTypes.ARRAY(DataTypes.BIGINT());
+            case PG_REAL:
+                return DataTypes.FLOAT();
+            case PG_REAL_ARRAY:
+                return DataTypes.ARRAY(DataTypes.FLOAT());
+            case PG_DOUBLE_PRECISION:
+                return DataTypes.DOUBLE();
+            case PG_DOUBLE_PRECISION_ARRAY:
+                return DataTypes.ARRAY(DataTypes.DOUBLE());
+            case PG_NUMERIC:
+                // see SPARK-26538: handle numeric without explicit precision and scale.
+                if (precision > 0) {
+                    return DataTypes.DECIMAL(precision, scale);
+                }
+                return DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18);
+            case PG_NUMERIC_ARRAY:
+                // see SPARK-26538: handle numeric without explicit precision and scale.
+                if (precision > 0) {
+                    return DataTypes.ARRAY(DataTypes.DECIMAL(precision, scale));
+                }
+                return DataTypes.ARRAY(DataTypes.DECIMAL(DecimalType.MAX_PRECISION, 18));
+            case PG_CHAR:
+            case PG_CHARACTER:
+                return DataTypes.CHAR(precision);
+            case PG_CHAR_ARRAY:
+            case PG_CHARACTER_ARRAY:
+                return DataTypes.ARRAY(DataTypes.CHAR(precision));
+            case PG_CHARACTER_VARYING:
+                return DataTypes.VARCHAR(precision);
+            case PG_CHARACTER_VARYING_ARRAY:
+                return DataTypes.ARRAY(DataTypes.VARCHAR(precision));
+            case PG_TEXT:
+                return DataTypes.STRING();
+            case PG_TEXT_ARRAY:
+                return DataTypes.ARRAY(DataTypes.STRING());
+            case PG_TIMESTAMP:
+                return DataTypes.TIMESTAMP(scale);
+            case PG_TIMESTAMP_ARRAY:
+                return DataTypes.ARRAY(DataTypes.TIMESTAMP(scale));
+            case PG_TIMESTAMPTZ:
+                return DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(scale);
+            case PG_TIMESTAMPTZ_ARRAY:
+                return DataTypes.ARRAY(DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE(scale));
+            case PG_TIME:
+                return DataTypes.TIME(scale);
+            case PG_TIME_ARRAY:
+                return DataTypes.ARRAY(DataTypes.TIME(scale));
+            case PG_DATE:
+                return DataTypes.DATE();
+            case PG_DATE_ARRAY:
+                return DataTypes.ARRAY(DataTypes.DATE());
+            default:
+                throw new UnsupportedOperationException(
+                        String.format("Doesn't support Postgres type '%s' yet", typeName));
+        }
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/TableDiscoveryUtils.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/source/utils/TableDiscoveryUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.postgres.source.utils;
+
+import io.debezium.jdbc.JdbcConnection;
+import io.debezium.relational.RelationalTableFilters;
+import io.debezium.relational.TableId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** A utility class for table discovery. */
+public class TableDiscoveryUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TableDiscoveryUtils.class);
+
+    public static List<TableId> listTables(
+            String database, JdbcConnection jdbc, RelationalTableFilters tableFilters)
+            throws SQLException {
+
+        Set<TableId> allTableIds =
+                jdbc.readTableNames(database, null, null, new String[]{"TABLE"});
+
+        Set<TableId> capturedTables = new HashSet<>();
+
+        for (TableId tableId : allTableIds) {
+            if (tableFilters.dataCollectionFilter().isIncluded(tableId)) {
+                LOG.debug("Adding table {} to the list of captured tables", tableId);
+                capturedTables.add(tableId);
+            } else {
+                LOG.debug(
+                        "Ignoring table {} as it's not included in the filter configuration",
+                        tableId);
+            }
+        }
+
+        return capturedTables.stream().sorted().collect(Collectors.toCollection(ArrayList::new));
+    }
+}

--- a/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLTableFactory.java
+++ b/inlong-sort/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/table/PostgreSQLTableFactory.java
@@ -17,27 +17,48 @@
 
 package org.apache.inlong.sort.cdc.postgres.table;
 
+import com.ververica.cdc.connectors.base.options.StartupOptions;
+import com.ververica.cdc.debezium.table.DebeziumChangelogMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
 import static com.ververica.cdc.debezium.table.DebeziumOptions.DEBEZIUM_OPTIONS_PREFIX;
 import static com.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
-import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
+import static com.ververica.cdc.debezium.utils.ResolvedSchemaUtils.getPhysicalSchema;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SOURCE_MULTIPLE_ENABLE;
 
+import static org.apache.inlong.sort.cdc.base.util.ObjectUtils.doubleCompare;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.CHANGELOG_MODE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.CHUNK_META_GROUP_SIZE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.CONNECTION_POOL_SIZE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.CONNECT_MAX_RETRIES;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.CONNECT_TIMEOUT;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.HEARTBEAT_INTERVAL;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SCAN_INCREMENTAL_SNAPSHOT_ENABLED;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SCAN_SNAPSHOT_FETCH_SIZE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SCAN_STARTUP_MODE;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND;
+import static org.apache.inlong.sort.cdc.postgres.source.options.PostgresSourceOptions.SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND;
+
 /**
  * Factory for creating configured instance of
- * {@link com.ververica.cdc.connectors.postgres.table.PostgreSQLTableSource}.
+ * {@link org.apache.inlong.sort.cdc.postgres.table.PostgreSQLTableSource}.
  */
 public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
 
@@ -158,13 +179,45 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         String pluginName = config.get(DECODING_PLUGIN_NAME);
         String slotName = config.get(SLOT_NAME);
         String serverTimeZone = config.get(SERVER_TIME_ZONE);
-        ResolvedSchema physicalSchema = context.getCatalogTable().getResolvedSchema();
+        // ResolvedSchema physicalSchema = context.getCatalogTable().getResolvedSchema();
         final boolean sourceMultipleEnable = config.get(SOURCE_MULTIPLE_ENABLE);
         String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
         String inlongAudit = config.get(INLONG_AUDIT);
         final boolean appendSource = config.get(APPEND_MODE);
         final String rowKindFiltered = config.get(ROW_KINDS_FILTERED).isEmpty() ? ROW_KINDS_FILTERED.defaultValue()
                 : config.get(ROW_KINDS_FILTERED);
+
+        DebeziumChangelogMode changelogMode = config.get(CHANGELOG_MODE);
+        ResolvedSchema physicalSchema =
+                getPhysicalSchema(context.getCatalogTable().getResolvedSchema());
+        if (changelogMode == DebeziumChangelogMode.UPSERT) {
+            checkArgument(
+                    physicalSchema.getPrimaryKey().isPresent(),
+                    "Primary key must be present when upsert mode is selected.");
+        }
+        boolean enableParallelRead = config.get(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
+        StartupOptions startupOptions = getStartupOptions(config);
+        int splitSize = config.get(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE);
+        int splitMetaGroupSize = config.get(CHUNK_META_GROUP_SIZE);
+        int fetchSize = config.get(SCAN_SNAPSHOT_FETCH_SIZE);
+        Duration connectTimeout = config.get(CONNECT_TIMEOUT);
+        int connectMaxRetries = config.get(CONNECT_MAX_RETRIES);
+        int connectionPoolSize = config.get(CONNECTION_POOL_SIZE);
+        double distributionFactorUpper = config.get(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND);
+        double distributionFactorLower = config.get(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
+        Duration heartbeatInterval = config.get(HEARTBEAT_INTERVAL);
+        String chunkKeyColumn =
+                config.getOptional(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN).orElse(null);
+
+        if (enableParallelRead) {
+            validateIntegerOption(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE, splitSize, 1);
+            validateIntegerOption(SCAN_SNAPSHOT_FETCH_SIZE, fetchSize, 1);
+            validateIntegerOption(CHUNK_META_GROUP_SIZE, splitMetaGroupSize, 1);
+            validateIntegerOption(CONNECTION_POOL_SIZE, connectionPoolSize, 1);
+            validateIntegerOption(CONNECT_MAX_RETRIES, connectMaxRetries, 0);
+            validateDistributionFactorUpper(distributionFactorUpper);
+            validateDistributionFactorLower(distributionFactorLower);
+        }
 
         return new PostgreSQLTableSource(
                 physicalSchema,
@@ -183,7 +236,19 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
                 rowKindFiltered,
                 sourceMultipleEnable,
                 inlongMetric,
-                inlongAudit);
+                inlongAudit,
+                enableParallelRead,
+                splitSize,
+                splitMetaGroupSize,
+                fetchSize,
+                connectTimeout,
+                connectMaxRetries,
+                connectionPoolSize,
+                distributionFactorUpper,
+                distributionFactorLower,
+                heartbeatInterval,
+                startupOptions,
+                chunkKeyColumn);
     }
 
     @Override
@@ -213,9 +278,78 @@ public class PostgreSQLTableFactory implements DynamicTableSourceFactory {
         options.add(SOURCE_MULTIPLE_ENABLE);
         options.add(INLONG_METRIC);
         options.add(INLONG_AUDIT);
-        options.add(AUDIT_KEYS);
         options.add(APPEND_MODE);
         options.add(ROW_KINDS_FILTERED);
+        options.add(CHANGELOG_MODE);
+        options.add(SCAN_STARTUP_MODE);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_ENABLED);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_SIZE);
+        options.add(SCAN_INCREMENTAL_SNAPSHOT_CHUNK_KEY_COLUMN);
+        options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND);
+        options.add(SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND);
+        options.add(CHUNK_META_GROUP_SIZE);
+        options.add(SCAN_SNAPSHOT_FETCH_SIZE);
+        options.add(CONNECT_TIMEOUT);
+        options.add(CONNECT_MAX_RETRIES);
+        options.add(CONNECTION_POOL_SIZE);
+        options.add(HEARTBEAT_INTERVAL);
         return options;
+    }
+
+    private static final String SCAN_STARTUP_MODE_VALUE_INITIAL = "initial";
+    private static final String SCAN_STARTUP_MODE_VALUE_LATEST = "latest-offset";
+    private static StartupOptions getStartupOptions(ReadableConfig config) {
+        String modeString = config.get(SCAN_STARTUP_MODE);
+
+        switch (modeString.toLowerCase()) {
+            case SCAN_STARTUP_MODE_VALUE_INITIAL:
+                return StartupOptions.initial();
+
+            case SCAN_STARTUP_MODE_VALUE_LATEST:
+                return StartupOptions.latest();
+
+            default:
+                throw new ValidationException(
+                        String.format(
+                                "Invalid value for option '%s'. Supported values are [%s, %s], but was: %s",
+                                SCAN_STARTUP_MODE.key(),
+                                SCAN_STARTUP_MODE_VALUE_INITIAL,
+                                SCAN_STARTUP_MODE_VALUE_LATEST,
+                                modeString));
+        }
+    }
+
+    /** Checks the value of given integer option is valid. */
+    private void validateIntegerOption(
+            ConfigOption<Integer> option, int optionValue, int exclusiveMin) {
+        checkState(
+                optionValue > exclusiveMin,
+                String.format(
+                        "The value of option '%s' must larger than %d, but is %d",
+                        option.key(), exclusiveMin, optionValue));
+    }
+
+    /** Checks the value of given evenly distribution factor upper bound is valid. */
+    private void validateDistributionFactorUpper(double distributionFactorUpper) {
+        checkState(
+                doubleCompare(distributionFactorUpper, 1.0d) >= 0,
+                String.format(
+                        "The value of option '%s' must larger than or equals %s, but is %s",
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_UPPER_BOUND.key(),
+                        1.0d,
+                        distributionFactorUpper));
+    }
+
+    /** Checks the value of given evenly distribution factor lower bound is valid. */
+    private void validateDistributionFactorLower(double distributionFactorLower) {
+        checkState(
+                doubleCompare(distributionFactorLower, 0.0d) >= 0
+                        && doubleCompare(distributionFactorLower, 1.0d) <= 0,
+                String.format(
+                        "The value of option '%s' must between %s and %s inclusively, but is %s",
+                        SPLIT_KEY_EVEN_DISTRIBUTION_FACTOR_LOWER_BOUND.key(),
+                        0.0d,
+                        1.0d,
+                        distributionFactorLower));
     }
 }


### PR DESCRIPTION
### [INLONG-7386][Sort] Postgres connector supports parallel read

- [INLONG-7386][Sort] Postgres connector supports parallel read

- Fixes #7386 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
