### PR TITLE
[INLONG-7900][Sort] Support partition by primary key when upsert single table of Kafka

### DIFF
--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
@@ -37,6 +37,7 @@ import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.apache.inlong.sort.base.metric.sub.SinkTopicMetricData;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink.WritableMetadata;
+import org.apache.inlong.sort.kafka.partitioner.PrimaryKeyPartitioner;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -161,6 +162,10 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
             multipleSink = true;
             jsonDynamicSchemaFormat =
                     (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
+        }
+
+        if (partitioner instanceof PrimaryKeyPartitioner) {
+            ((PrimaryKeyPartitioner<?>) partitioner).setValueFieldGetters(valueFieldGetters);
         }
     }
 

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kafka.partitioner;
+
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The PrimaryKey Partitioner is used to extract primary key from single table messages:
+ *
+ * @param <T>
+ */
+public class PrimaryKeyPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RawDataHashPartitioner.class);
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public void open(int parallelInstanceId, int parallelInstances) {
+        super.open(parallelInstanceId, parallelInstances);
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+        Preconditions.checkArgument(
+                partitions != null && partitions.length > 0,
+                "Partitions of the target topic is empty.");
+        try {
+            return partitions[(key.hashCode() & Integer.MAX_VALUE) % partitions.length];
+        } catch (Exception e) {
+            LOG.warn("Extract partition failed", e);
+        }
+        // If kafka can't parse, then at least write everything to the first partition.
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof RawDataHashPartitioner;
+    }
+
+    @Override
+    public int hashCode() {
+        return RawDataHashPartitioner.class.hashCode();
+    }
+}

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
@@ -77,8 +77,10 @@ public class PrimaryKeyPartitioner<T> extends FlinkKafkaPartitioner<T> {
         this.partitionKey = partitionKey;
     }
 
-    // input: rowdata, a list of integer of corresponding position within schema, partitions
-    // output: partition number
+    /**
+     * input: rowdata,  partitions
+     * output: the hashed partition number
+     */
     private int getPartition(RowData data, int[] partitions) {
         List<Integer> pos = getFieldPos();
         // parse out the List<String> from partitionkey and then get list of positions in schema.
@@ -92,7 +94,9 @@ public class PrimaryKeyPartitioner<T> extends FlinkKafkaPartitioner<T> {
         return partitions[((int) ((hashCode & Integer.MAX_VALUE) % partitions.length))];
     }
 
-    // output: a list of integer of corresponding position within schema
+    /**
+     * output: integer list of partitionKeys' corresponding positions within schema
+     */
     private List<Integer> getFieldPos() {
         // the positions of the partition keys.
         List<Integer> positions = new ArrayList<>();

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/PrimaryKeyPartitioner.java
@@ -49,13 +49,13 @@ public class PrimaryKeyPartitioner<T> extends FlinkKafkaPartitioner<T> {
         Preconditions.checkArgument(
                 partitions != null && partitions.length > 0,
                 "Partitions of the target topic is empty.");
-        //single table currently support: avro/csv/json/canal
+        // single table currently support: avro/csv/json/canal
         try {
-            //used for avro/csv/json formats
+            // used for avro/csv/json formats
             if (key != null) {
                 return partitions[(Arrays.hashCode(key) & Integer.MAX_VALUE) % partitions.length];
             } else {
-                //used for canal-json formats, since single table does not support debezium-json for now.
+                // used for canal-json formats, since single table does not support debezium-json for now.
                 AbstractDynamicSchemaFormat dynamicSchemaFormat = DynamicSchemaFormatFactory.getFormat("canal-json");
                 List<String> values = dynamicSchemaFormat.extractPrimaryKeyValues(value);
                 if (values == null || values.isEmpty()) {

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -56,6 +56,7 @@ import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink;
+import org.apache.inlong.sort.kafka.partitioner.PrimaryKeyPartitioner;
 import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
 
 import javax.annotation.Nullable;
@@ -117,6 +118,7 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
     public static final String IDENTIFIER = "kafka-inlong";
 
     public static final String SINK_PARTITIONER_VALUE_RAW_HASH = "raw-hash";
+    public static final String SINK_PARTITIONER_VALUE_PRIMARY_KEY = "primaryKey";
 
     public static final ConfigOption<String> SINK_MULTIPLE_PARTITION_PATTERN =
             ConfigOptions.key("sink.multiple.partition-pattern")
@@ -248,6 +250,10 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
             rawHashPartitioner.setPartitionPattern(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
                     .orElse(null));
             return Optional.of(rawHashPartitioner);
+        } else if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
+                && SINK_PARTITIONER_VALUE_PRIMARY_KEY.equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
+            PrimaryKeyPartitioner<RowData> primaryKeyPartitioner = new PrimaryKeyPartitioner<>();
+            return Optional.of(primaryKeyPartitioner);
         }
         Optional<FlinkKafkaPartitioner<RowData>> partitioner = KafkaOptions
                 .getFlinkKafkaPartitioner(tableOptions, classLoader);

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/UpsertKafkaDynamicTableFactory.java
@@ -50,7 +50,6 @@ import org.apache.inlong.sort.base.dirty.sink.DirtySink;
 import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink;
 import org.apache.inlong.sort.kafka.partitioner.PrimaryKeyPartitioner;
-import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -297,7 +296,8 @@ public class UpsertKafkaDynamicTableFactory
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(tableOptions);
         final DirtySink<Object> dirtySink = DirtySinkFactoryUtils.createDirtySink(context, dirtyOptions);
         final boolean multipleSink = tableOptions.getOptional(SINK_MULTIPLE_FORMAT).isPresent();
-        final FlinkKafkaPartitioner<RowData> partitioner=getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null);
+        final FlinkKafkaPartitioner<RowData> partitioner =
+                getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null);
 
         // use {@link org.apache.kafka.clients.producer.internals.DefaultPartitioner}.
         // it will use hash partition if key is set else in round-robin behaviour.


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7900 

### Motivation
See issue.

### Modifications
Added PrimaryKeyPartitioner, and made modifications to support upsert-kafka


### Verifying this change
1. execute the sql in the issue again
2. create a kafka-mysql task to consume all the messages back to mysql

the mysql table fluctuated from 1000-2000 rows, and in the end it reduced to 0 rows, so I assume that the issue has been solved, since if it is still round robin, some update queries will be unordered, and it is unlikely that 3890 remaining records can be reduced to 0. The format used is json, for canal-json/avro/csv, I only tested that the primaryKey partitition is in effect and there are no errors. 

  
