### PR TITLE
[INLONG-7934][Manager] Optimize the serializationType to support debezium json

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mongodb/MongoDBSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mongodb/MongoDBSourceRequest.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.enums.DataFormat;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.source.SourceRequest;
 
@@ -56,6 +57,7 @@ public class MongoDBSourceRequest extends SourceRequest {
 
     public MongoDBSourceRequest() {
         this.setSourceType(SourceType.MONGODB);
+        this.setSerializationType(DataFormat.DEBEZIUM_JSON.getName());
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oracle/OracleSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oracle/OracleSourceRequest.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.enums.DataFormat;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.source.SourceRequest;
 
@@ -68,6 +69,7 @@ public class OracleSourceRequest extends SourceRequest {
 
     public OracleSourceRequest() {
         this.setSourceType(SourceType.ORACLE);
+        this.setSerializationType(DataFormat.DEBEZIUM_JSON.getName());
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/postgresql/PostgreSQLSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/postgresql/PostgreSQLSourceRequest.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.enums.DataFormat;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.source.SourceRequest;
 
@@ -73,6 +74,7 @@ public class PostgreSQLSourceRequest extends SourceRequest {
 
     public PostgreSQLSourceRequest() {
         this.setSourceType(SourceType.POSTGRESQL);
+        this.setSerializationType(DataFormat.DEBEZIUM_JSON.getName());
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/sqlserver/SQLServerSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/sqlserver/SQLServerSourceRequest.java
@@ -23,6 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.enums.DataFormat;
 import org.apache.inlong.manager.common.util.JsonTypeDefine;
 import org.apache.inlong.manager.pojo.source.SourceRequest;
 
@@ -68,6 +69,7 @@ public class SQLServerSourceRequest extends SourceRequest {
 
     public SQLServerSourceRequest() {
         this.setSourceType(SourceType.SQLSERVER);
+        this.setSerializationType(DataFormat.DEBEZIUM_JSON.getName());
     }
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
@@ -316,7 +316,7 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
      * @return serialization type
      */
     protected String getSerializationType(StreamSource streamSource, String streamDataType) {
-        if(StringUtils.isNotBlank(streamSource.getSerializationType())) {
+        if (StringUtils.isNotBlank(streamSource.getSerializationType())) {
             return streamSource.getSerializationType();
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/AbstractSourceOperator.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.service.source;
 import com.github.pagehelper.Page;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.common.enums.DataTypeEnum;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -305,5 +306,20 @@ public abstract class AbstractSourceOperator implements StreamSourceOperator {
 
         sourceFieldMapper.insertAll(entityList);
         LOGGER.debug("success to save source fields");
+    }
+
+    /**
+     * If the stream source can only use one data type, return the data type that has been set.
+     *
+     * @param streamSource stream source
+     * @param streamDataType stream data type
+     * @return serialization type
+     */
+    protected String getSerializationType(StreamSource streamSource, String streamDataType) {
+        if(StringUtils.isNotBlank(streamSource.getSerializationType())) {
+            return streamSource.getSerializationType();
+        }
+
+        return DataTypeEnum.forType(streamDataType).getType();
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -128,15 +128,7 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
-                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
-                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                        kafkaSource.setSerializationType(serializationType);
-                    }
-                } else {
-                    kafkaSource.setSerializationType(sourceInfo.getSerializationType());
-                }
+                kafkaSource.setSerializationType(getSerializationType(sourceInfo, streamInfo.getDataType()));
             }
 
             // if the SerializationType is still null, set it to the CSV

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -113,10 +113,6 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
             kafkaSource.setSourceName(streamId);
             kafkaSource.setBootstrapServers(bootstrapServers);
             kafkaSource.setTopic(streamInfo.getMqResource());
-            if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                kafkaSource.setSerializationType(serializationType);
-            }
             String topicName = streamInfo.getMqResource();
             if (StringUtils.isBlank(topicName) || topicName.equals(streamId)) {
                 // the default mq resource (stream id) is not sufficient to discriminate different kafka topics
@@ -131,8 +127,13 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {
                     continue;
                 }
-                if (StringUtils.isEmpty(kafkaSource.getSerializationType()) && StringUtils.isNotEmpty(
-                        sourceInfo.getSerializationType())) {
+
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
+                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+                        kafkaSource.setSerializationType(serializationType);
+                    }
+                } else {
                     kafkaSource.setSerializationType(sourceInfo.getSerializationType());
                 }
             }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/kafka/KafkaSourceOperator.java
@@ -128,7 +128,8 @@ public class KafkaSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
+                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
                     if (StringUtils.isNotBlank(streamInfo.getDataType())) {
                         String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
                         kafkaSource.setSerializationType(serializationType);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -131,10 +131,6 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
             pulsarSource.setAdminUrl(adminUrl);
             pulsarSource.setServiceUrl(serviceUrl);
             pulsarSource.setInlongComponent(true);
-            if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                pulsarSource.setSerializationType(serializationType);
-            }
             pulsarSource.setWrapWithInlongMsg(streamInfo.getWrapWithInlongMsg());
             pulsarSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
@@ -149,10 +145,16 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
                 if (!Objects.equal(streamId, sourceInfo.getInlongStreamId())) {
                     continue;
                 }
-                if (StringUtils.isEmpty(pulsarSource.getSerializationType())
-                        && StringUtils.isNotEmpty(sourceInfo.getSerializationType())) {
+
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
+                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+                        pulsarSource.setSerializationType(serializationType);
+                    }
+                } else {
                     pulsarSource.setSerializationType(sourceInfo.getSerializationType());
                 }
+
                 // currently, only reuse the primary key from Kafka source
                 if (SourceType.KAFKA.equals(sourceInfo.getSourceType())) {
                     pulsarSource.setPrimaryKey(((KafkaSource) sourceInfo).getPrimaryKey());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -146,15 +146,7 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
-                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
-                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                        pulsarSource.setSerializationType(serializationType);
-                    }
-                } else {
-                    pulsarSource.setSerializationType(sourceInfo.getSerializationType());
-                }
+                pulsarSource.setSerializationType(getSerializationType(sourceInfo, streamInfo.getDataType()));
 
                 // currently, only reuse the primary key from Kafka source
                 if (SourceType.KAFKA.equals(sourceInfo.getSourceType())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/pulsar/PulsarSourceOperator.java
@@ -146,7 +146,8 @@ public class PulsarSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
+                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
                     if (StringUtils.isNotBlank(streamInfo.getDataType())) {
                         String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
                         pulsarSource.setSerializationType(serializationType);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -20,8 +20,6 @@ package org.apache.inlong.manager.service.source.tubemq;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.inlong.common.enums.DataTypeEnum;
 import org.apache.inlong.manager.common.consts.SourceType;
 import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
@@ -117,15 +115,7 @@ public class TubeMQSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
-                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
-                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                        tubeMQSource.setSerializationType(serializationType);
-                    }
-                } else {
-                    tubeMQSource.setSerializationType(sourceInfo.getSerializationType());
-                }
+                tubeMQSource.setSerializationType(getSerializationType(sourceInfo, streamInfo.getDataType()));
             }
             tubeMQSource.setFieldList(streamInfo.getFieldList());
             sourceMap.computeIfAbsent(streamId, key -> Lists.newArrayList()).add(tubeMQSource);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -110,17 +110,21 @@ public class TubeMQSourceOperator extends AbstractSourceOperator {
             tubeMQSource.setTopic(streamInfo.getMqResource());
             tubeMQSource.setGroupId(streamId);
             tubeMQSource.setMasterRpc(masterRpc);
-            if (StringUtils.isNotBlank(streamInfo.getDataType())) {
-                String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
-                tubeMQSource.setSerializationType(serializationType);
-            }
             tubeMQSource.setIgnoreParseError(streamInfo.getIgnoreParseError());
 
             for (StreamSource sourceInfo : streamSources) {
                 if (!Objects.equals(streamId, sourceInfo.getInlongStreamId())) {
                     continue;
                 }
-                tubeMQSource.setSerializationType(sourceInfo.getSerializationType());
+
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                    if (StringUtils.isNotBlank(streamInfo.getDataType())) {
+                        String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
+                        tubeMQSource.setSerializationType(serializationType);
+                    }
+                } else {
+                    tubeMQSource.setSerializationType(sourceInfo.getSerializationType());
+                }
             }
             tubeMQSource.setFieldList(streamInfo.getFieldList());
             sourceMap.computeIfAbsent(streamId, key -> Lists.newArrayList()).add(tubeMQSource);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/tubemq/TubeMQSourceOperator.java
@@ -117,7 +117,8 @@ public class TubeMQSourceOperator extends AbstractSourceOperator {
                     continue;
                 }
 
-                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE)) {
+                if (sourceInfo.getSourceType().equalsIgnoreCase(SourceType.FILE) ||
+                        sourceInfo.getSourceType().equalsIgnoreCase(SourceType.AUTO_PUSH)) {
                     if (StringUtils.isNotBlank(streamInfo.getDataType())) {
                         String serializationType = DataTypeEnum.forType(streamInfo.getDataType()).getType();
                         tubeMQSource.setSerializationType(serializationType);


### PR DESCRIPTION
- Fixes #7934 

### Motivation

1. We need to use different data serialization types based on different data sources. For files, various formats such as CSV and JSON can be used, but for MySQL, PostgreSQL, etc., only debezium Json can be used, so it is placed in the `serializationType` of the stream source as a fixed value.

### Modifications

1. If the source does not set the serialization type, it is considered that it can use multiple data types.
2. Set fixed value for source using debezium.

### Verifying this change

![image](https://user-images.githubusercontent.com/58519431/234782385-f898af81-ac47-4945-a828-4ac8729d6c75.png)

![image](https://user-images.githubusercontent.com/58519431/234782458-3293b75e-c6f2-41b8-8a0f-9f650cab21a0.png)
