### PR TITLE
[INLONG-7952][Sort] Mask sensitive message of Flink SQL in the logs

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/util/MaskDataUtils.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/MaskDataUtils.java
@@ -119,7 +119,7 @@ public class MaskDataUtils {
             for (String separator : SEPARATORS) {
                 idxSeparator = StringUtils.indexOf(builder, separator, keywordStart + keywordLength);
                 int delimiterPos = keywordStart + keywordLength;
-                while (isDelimiter(builder.charAt(delimiterPos))) {
+                while (delimiterPos < buffLength && isDelimiter(builder.charAt(delimiterPos))) {
                     delimiterPos++;
                 }
                 if (delimiterPos == idxSeparator) {
@@ -271,7 +271,7 @@ public class MaskDataUtils {
      */
     private static int maskStartPosition(int idxSeparator, String separator, StringBuilder builder) {
         int charPos = idxSeparator + separator.length();
-        while (isDelimiter(builder.charAt(charPos))) {
+        while (charPos < builder.length() && isDelimiter(builder.charAt(charPos))) {
             charPos++;
         }
         return charPos;

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/MaskDataUtils.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/MaskDataUtils.java
@@ -32,7 +32,8 @@ public class MaskDataUtils {
             "token", "secret_token", "secretToken",
             "secret_id", "secretId",
             "secret_key", "secretKey",
-            "public_key", "publicKey");
+            "public_key", "publicKey",
+            "gateway.url");
     private static final List<String> SEPARATORS = Arrays.asList(":", "=", "\": \"", "\":\"");
     private static final List<Character> STOP_CHARACTERS = Arrays.asList('\'', '"');
     private static final List<Character> KNOWN_DELIMITERS =
@@ -117,8 +118,12 @@ public class MaskDataUtils {
             int idxSeparator;
             for (String separator : SEPARATORS) {
                 idxSeparator = StringUtils.indexOf(builder, separator, keywordStart + keywordLength);
-                if (idxSeparator == keywordStart + keywordLength) {
-                    charPos = maskStartPosition(keywordStart, keywordLength, separator, builder);
+                int delimiterPos = keywordStart + keywordLength;
+                while (isDelimiter(builder.charAt(delimiterPos))) {
+                    delimiterPos++;
+                }
+                if (delimiterPos == idxSeparator) {
+                    charPos = maskStartPosition(idxSeparator, separator, builder);
 
                     int endPos = detectEnd(builder, buffLength, charPos, keywordUsed, keywordLength, separator);
 
@@ -259,19 +264,28 @@ public class MaskDataUtils {
     /**
      * the start position of sensitive data
      *
-     * @param keywordStart the start position of keyword
-     * @param keywordLength the length of keyword
+     * @param idxSeparator the start position of separator character
      * @param separator the separator character of keyword and sensitive data
      * @param builder raw data
      * @return the start position of sensitive data
      */
-    private static int maskStartPosition(int keywordStart, int keywordLength, String separator,
-            StringBuilder builder) {
-        int charPos = keywordStart + keywordLength + separator.length();
-        if (Character.isWhitespace(builder.charAt(charPos))) {
+    private static int maskStartPosition(int idxSeparator, String separator, StringBuilder builder) {
+        int charPos = idxSeparator + separator.length();
+        while (isDelimiter(builder.charAt(charPos))) {
             charPos++;
         }
         return charPos;
+    }
+
+    /**
+     * mask sensitive message
+     * @param message raw message
+     * @return non-sensitive message
+     */
+    public static String maskSensitiveMessage(String message) {
+        StringBuilder buffer = new StringBuilder(message);
+        mask(buffer);
+        return buffer.toString();
     }
 
 }

--- a/inlong-common/src/test/java/org/apache/inlong/common/util/MaskDataUtilsTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/util/MaskDataUtilsTest.java
@@ -61,4 +61,49 @@ public class MaskDataUtilsTest {
         assertEquals(masked, buffer.toString());
     }
 
+    /**
+     * Remove sensitive message in flink sql
+     */
+    @Test
+    public void testMaskFlinkSql() {
+        String unmasked = "CREATE TABLE `table_1`(\n"
+                + "    PRIMARY KEY (`id`) NOT ENFORCED,\n"
+                + "    `id` INT,\n"
+                + "    `name` STRING,\n"
+                + "    `age` INT)\n"
+                + "    WITH (\n"
+                + "    'inlong.metric.labels' = 'groupId=1&streamId=1&nodeId=1',\n"
+                + "    'connector' = 'mysql-cdc-inlong',\n"
+                + "    'hostname' = 'localhost',\n"
+                + "    'database-name' = 'test',\n"
+                + "    'port' = '3306',\n"
+                + "    'server-id' = '10011',\n"
+                + "    'scan.incremental.snapshot.enabled' = 'true',\n"
+                + "    'username' = 'root',\n"
+                + "    'password' = 'inlong',\n"
+                + "    'table-name' = 'user'\n"
+                + ")";
+
+        String masked = "CREATE TABLE `table_1`(\n"
+                + "    PRIMARY KEY (`id`) NOT ENFORCED,\n"
+                + "    `id` INT,\n"
+                + "    `name` STRING,\n"
+                + "    `age` INT)\n"
+                + "    WITH (\n"
+                + "    'inlong.metric.labels' = 'groupId=1&streamId=1&nodeId=1',\n"
+                + "    'connector' = 'mysql-cdc-inlong',\n"
+                + "    'hostname' = 'localhost',\n"
+                + "    'database-name' = 'test',\n"
+                + "    'port' = '3306',\n"
+                + "    'server-id' = '10011',\n"
+                + "    'scan.incremental.snapshot.enabled' = 'true',\n"
+                + "    'username' = 'root',\n"
+                + "    'password' = '******',\n"
+                + "    'table-name' = 'user'\n"
+                + ")";
+        StringBuilder buffer = new StringBuilder(unmasked);
+        MaskDataUtils.mask(buffer);
+        assertEquals(masked, buffer.toString());
+    }
+
 }

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/impl/FlinkSqlParser.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.parser.impl;
 
+import static org.apache.inlong.common.util.MaskDataUtils.maskSensitiveMessage;
+
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.table.api.TableEnvironment;
@@ -283,14 +285,14 @@ public class FlinkSqlParser implements Parser {
         if (node instanceof ExtractNode) {
             log.info("start parse node, node id:{}", node.getId());
             String sql = genCreateSql(node);
-            log.info("node id:{}, create table sql:\n{}", node.getId(), sql);
+            log.info("node id:{}, create table sql:\n{}", node.getId(), maskSensitiveMessage(sql));
             registerTableSql(node, sql);
             hasParsedSet.add(node.getId());
         } else {
             Preconditions.checkNotNull(relation, "relation is null");
             if (node instanceof LoadNode) {
                 String createSql = genCreateSql(node);
-                log.info("node id:{}, create table sql:\n{}", node.getId(), createSql);
+                log.info("node id:{}, create table sql:\n{}", node.getId(), maskSensitiveMessage(createSql));
                 registerTableSql(node, createSql);
                 hasParsedSet.add(node.getId());
             } else if (node instanceof TransformNode) {
@@ -300,9 +302,9 @@ public class FlinkSqlParser implements Parser {
                 Preconditions.checkState(!transformNode.getFieldRelations().isEmpty(),
                         "field relations is empty");
                 String createSql = genCreateSql(node);
-                log.info("node id:{}, create table sql:\n{}", node.getId(), createSql);
+                log.info("node id:{}, create table sql:\n{}", node.getId(), maskSensitiveMessage(createSql));
                 String selectSql = genTransformSelectSql(transformNode, relation, nodeMap);
-                log.info("node id:{}, tansform sql:\n{}", node.getId(), selectSql);
+                log.info("node id:{}, transform sql:\n{}", node.getId(), maskSensitiveMessage(selectSql));
                 registerTableSql(node, createSql + " AS\n" + selectSql);
                 hasParsedSet.add(node.getId());
             }

--- a/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/result/FlinkSqlParseResult.java
+++ b/inlong-sort/sort-core/src/main/java/org/apache/inlong/sort/parser/result/FlinkSqlParseResult.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.parser.result;
 
+import static org.apache.inlong.common.util.MaskDataUtils.maskSensitiveMessage;
+
 import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -84,7 +86,7 @@ public class FlinkSqlParseResult implements ParseResult, Serializable {
 
     private void executeCreateTableSqls(List<String> sqls) {
         for (String sql : sqls) {
-            log.info("execute createSql:\n{}", sql);
+            log.info("execute createSql:\n{}", maskSensitiveMessage(sql));
             tableEnv.executeSql(sql);
         }
     }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-7952][Sort] Mask sensitive message of Flink SQL in the logs

- Fixes #7952 

### Motivation

The logs printed in **Inlong** contain password message in Flink SQL, and we hope to replace the password or other sensitive message with * for display.

```sql
4123 [main] INFO  org.apache.inlong.sort.parser.impl.FlinkSqlParser [] - start parse node, node id:1
4131 [main] INFO  org.apache.inlong.sort.parser.impl.FlinkSqlParser [] - node id:1, create table sql:
CREATE TABLE `table_1`(
    PRIMARY KEY (`id`) NOT ENFORCED,
    `id` INT,
    `name` STRING,
    `age` INT)
    WITH (
    'inlong.metric.labels' = 'groupId=1&streamId=1&nodeId=1',
    'connector' = 'mysql-cdc-inlong',
    'hostname' = 'localhost',
    'database-name' = 'test',
    'port' = '3306',
    'server-id' = '10011',
    'scan.incremental.snapshot.enabled' = 'true',
    'username' = 'root',
    'password' = '******',
    'table-name' = 'user'
)
```


### Modifications

Mask sensitive message at the location where Flink SQL is printed.

### Verifying this change

Run `MaskDataUtilsTest.java`
