### PR TITLE
[INLONG-7993][Sort] Kafka connector should support group offset

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/enums/KafkaScanStartupMode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/enums/KafkaScanStartupMode.java
@@ -27,7 +27,8 @@ public enum KafkaScanStartupMode {
     EARLIEST_OFFSET("earliest-offset"),
     LATEST_OFFSET("latest-offset"),
     SPECIFIC_OFFSETS("specific-offsets"),
-    TIMESTAMP_MILLIS("timestamp");
+    TIMESTAMP_MILLIS("timestamp"),
+    GROUP_OFFSETS("group-offsets");
 
     KafkaScanStartupMode(String value) {
         this.value = value;

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -127,6 +127,9 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
             Preconditions.checkArgument(StringUtils.isNotBlank(scanTimestampMillis), "scanTimestampMillis is empty");
             this.scanTimestampMillis = scanTimestampMillis;
         }
+        if (KafkaScanStartupMode.GROUP_OFFSETS == kafkaScanStartupMode) {
+            Preconditions.checkArgument(StringUtils.isNotBlank(groupId), "group is empty when enable group offsets");
+        }
     }
 
     /**


### PR DESCRIPTION
- Fixes #7993 

### Motivation

- Fixes #7993 

### Modifications

add group offset in kafka connector 

### Verifying this change

when enable group offset, the startUpmode should be "group-offsets", and group id must be set 

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
