### PR TITLE
[INLONG-8024][Manager] Add extended properties when getting the status of the sort task info

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/SortStatusInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/SortStatusInfo.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.pojo.sort;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -41,4 +42,6 @@ public class SortStatusInfo {
     @ApiModelProperty(value = "Sort status info")
     private SortStatus sortStatus;
 
+    @ApiModelProperty("Extended properties of sort")
+    private Map<String, Object> properties;
 }


### PR DESCRIPTION

- Fixes #8024

### Motivation

 Add extended properties when getting the status of the sort task info

### Modifications

When calling the Inlong-Sort-API  /sort/listStatus ，add other extended parameters when getting the status of the sort task. 
