### PR TITLE
[INLONG-8029][Sort] use fixed subscription name when start a pulsar reader

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/FlinkPulsarSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/FlinkPulsarSource.java
@@ -620,7 +620,8 @@ public class FlinkPulsarSource<T>
                 getRuntimeContext().getUserCodeClassLoader(),
                 streamingRuntime,
                 useMetrics,
-                excludeStartMessageIds);
+                excludeStartMessageIds,
+                getSubscriptionName());
 
         if (!running) {
             return;
@@ -642,7 +643,8 @@ public class FlinkPulsarSource<T>
             ClassLoader userCodeClassLoader,
             StreamingRuntimeContext streamingRuntime,
             boolean useMetrics,
-            Set<TopicRange> excludeStartMessageIds) throws Exception {
+            Set<TopicRange> excludeStartMessageIds,
+            String subscriptionName) throws Exception {
 
         // readerConf.putIfAbsent(PulsarOptions.SUBSCRIPTION_ROLE_OPTION_KEY, getSubscriptionName());
 
@@ -657,6 +659,7 @@ public class FlinkPulsarSource<T>
                 streamingRuntime,
                 clientConfigurationData,
                 readerConf,
+                subscriptionName,
                 pollTimeoutMs,
                 commitMaxRetries,
                 deserializer,

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/FlinkPulsarSourceWithoutAdmin.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/FlinkPulsarSourceWithoutAdmin.java
@@ -608,6 +608,7 @@ public class FlinkPulsarSourceWithoutAdmin<T>
                 streamingRuntime,
                 clientConfigurationData,
                 readerConf,
+                getSubscriptionName(),
                 pollTimeoutMs,
                 commitMaxRetries,
                 deserializer,

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/PulsarFetcher.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/PulsarFetcher.java
@@ -117,6 +117,8 @@ public class PulsarFetcher<T> {
 
     protected final Map<String, Object> readerConf;
 
+    protected final String subscriptionName;
+
     protected final PulsarDeserializationSchema<T> deserializer;
 
     protected final int pollTimeoutMs;
@@ -181,7 +183,8 @@ public class PulsarFetcher<T> {
             PulsarDeserializationSchema<T> deserializer,
             PulsarMetadataReader metadataReader,
             MetricGroup consumerMetricGroup,
-            boolean useMetrics) throws Exception {
+            boolean useMetrics,
+            String subscriptionName) throws Exception {
         this(
                 sourceContext,
                 seedTopicsWithInitialOffsets,
@@ -193,6 +196,7 @@ public class PulsarFetcher<T> {
                 runtimeContext,
                 clientConf,
                 readerConf,
+                subscriptionName,
                 pollTimeoutMs,
                 3, // commit retries before fail
                 deserializer,
@@ -212,6 +216,7 @@ public class PulsarFetcher<T> {
             StreamingRuntimeContext runtimeContext,
             ClientConfigurationData clientConf,
             Map<String, Object> readerConf,
+            String subscriptionName,
             int pollTimeoutMs,
             int commitMaxRetries,
             PulsarDeserializationSchema<T> deserializer,
@@ -221,6 +226,7 @@ public class PulsarFetcher<T> {
 
         this.sourceContext = sourceContext;
         this.watermarkOutput = new SourceContextWatermarkOutputAdapter<>(sourceContext);
+        this.subscriptionName = subscriptionName;
         this.watermarkOutputMultiplexer = new WatermarkOutputMultiplexer(watermarkOutput);
         this.useMetrics = useMetrics;
         this.consumerMetricGroup = checkNotNull(consumerMetricGroup);
@@ -525,7 +531,7 @@ public class PulsarFetcher<T> {
                 exceptionProxy,
                 failOnDataLoss,
                 useEarliestWhenDataLoss,
-                excludeStartMessageIds.contains(state.getTopicRange()));
+                excludeStartMessageIds.contains(state.getTopicRange()), subscriptionName);
     }
 
     /**

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/ReaderThread.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors-v1.13/pulsar/src/main/java/org/apache/inlong/sort/pulsar/internal/ReaderThread.java
@@ -63,6 +63,7 @@ public class ReaderThread<T> extends Thread {
     private boolean failOnDataLoss = true;
     private boolean useEarliestWhenDataLoss = false;
     private final PulsarCollector pulsarCollector;
+    private final String subscriptionName;
 
     protected volatile boolean running = true;
     protected volatile boolean closed = false;
@@ -78,7 +79,8 @@ public class ReaderThread<T> extends Thread {
             Map<String, Object> readerConf,
             PulsarDeserializationSchema<T> deserializer,
             int pollTimeoutMs,
-            ExceptionProxy exceptionProxy) {
+            ExceptionProxy exceptionProxy,
+            String subscriptionName) {
         this.owner = owner;
         this.state = state;
         this.clientConf = clientConf;
@@ -86,9 +88,9 @@ public class ReaderThread<T> extends Thread {
         this.deserializer = deserializer;
         this.pollTimeoutMs = pollTimeoutMs;
         this.exceptionProxy = exceptionProxy;
-
         this.topicRange = state.getTopicRange();
         this.startMessageId = state.getOffset();
+        this.subscriptionName = subscriptionName;
         this.pulsarCollector = new PulsarCollector();
     }
 
@@ -102,8 +104,10 @@ public class ReaderThread<T> extends Thread {
             ExceptionProxy exceptionProxy,
             boolean failOnDataLoss,
             boolean useEarliestWhenDataLoss,
-            boolean excludeMessageId) {
-        this(owner, state, clientConf, readerConf, deserializer, pollTimeoutMs, exceptionProxy);
+            boolean excludeMessageId,
+            String subscriptionName) {
+        this(owner, state, clientConf, readerConf, deserializer, pollTimeoutMs, exceptionProxy,
+                subscriptionName);
         this.failOnDataLoss = failOnDataLoss;
         this.useEarliestWhenDataLoss = useEarliestWhenDataLoss;
         this.excludeMessageId = excludeMessageId;
@@ -141,6 +145,7 @@ public class ReaderThread<T> extends Thread {
                 .newReader(deserializer.getSchema())
                 .topic(topicRange.getTopic())
                 .startMessageId(startMessageId)
+                .subscriptionName(subscriptionName)
                 .loadConf(readerConf);
         log.info("Create a reader at topic {} starting from message {} (inclusive) : config = {}",
                 topicRange, startMessageId, readerConf);


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8029 

### Motivation

Fixes #8029 

### Modifications

use fixed subscription name when starting a pulsar reader
see https://github.com/streamnative/pulsar-flink/blob/master/docs/README_CN.md

### Verifying this change
run pulsar migrate test 