### PR TITLE
[INLONG-8038][Sort] Optimize MySQL CDC chunk splitting

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -228,10 +228,7 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                                                 .map(MySqlSnapshotSplit::toSchemaLessSnapshotSplit)
                                                 .collect(Collectors.toList());
                                 synchronized (lock) {
-                                    int size = schemaLessSnapshotSplits.size();
-                                    // move the last snapshot split to the front of the remaining splits.
-                                    remainingSplits.add(0, schemaLessSnapshotSplits.get(size - 1));
-                                    remainingSplits.addAll(schemaLessSnapshotSplits.subList(0, size - 1));
+                                    addNewlyAddedSplits(schemaLessSnapshotSplits);
                                     remainingTables.remove(nextTable);
                                     addAlreadyProcessedTablesIfNotExists(nextTable);
                                     lock.notify();
@@ -398,6 +395,14 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
         if (executor != null) {
             executor.shutdown();
         }
+    }
+
+    private void addNewlyAddedSplits(List<MySqlSchemalessSnapshotSplit> schemaLessSnapshotSplits) {
+        int size = schemaLessSnapshotSplits.size();
+        // move the last snapshot split to the front of the remaining splits to prevent OOM
+        // caused by the excessive data of the last snapshot split.
+        remainingSplits.add(0, schemaLessSnapshotSplits.get(size - 1));
+        remainingSplits.addAll(schemaLessSnapshotSplits.subList(0, size - 1));
     }
 
     private void addAlreadyProcessedTablesIfNotExists(TableId tableId) {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/assigners/MySqlSnapshotSplitAssigner.java
@@ -228,7 +228,10 @@ public class MySqlSnapshotSplitAssigner implements MySqlSplitAssigner {
                                                 .map(MySqlSnapshotSplit::toSchemaLessSnapshotSplit)
                                                 .collect(Collectors.toList());
                                 synchronized (lock) {
-                                    remainingSplits.addAll(schemaLessSnapshotSplits);
+                                    int size = schemaLessSnapshotSplits.size();
+                                    // move the last snapshot split to the front of the remaining splits.
+                                    remainingSplits.add(0, schemaLessSnapshotSplits.get(size - 1));
+                                    remainingSplits.addAll(schemaLessSnapshotSplits.subList(0, size - 1));
                                     remainingTables.remove(nextTable);
                                     addAlreadyProcessedTablesIfNotExists(nextTable);
                                     lock.notify();


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8038][Sort] Optimize MySQL CDC chunk splitting logic

- Fixes #8038 

### Motivation

When the data volume grows rapidly and the snapshot phase takes a long time, the data volume of the last chunk may be very large, leading to OOM. Therefore, it is recommended to read the last chunk first to prevent OOM.
Because these splits are assigned to readers in order, we only need to adjust the order of splits by moving the last split to the front.

```java
  // assign splits in order 
  Optional<MySqlSplit> split = splitAssigner.getNext();
  if (split.isPresent()) {
      final MySqlSplit mySqlSplit = split.get();
      context.assignSplit(mySqlSplit, nextAwaiting);
      awaitingReader.remove();
      LOG.info("Assign split {} to subtask {}", mySqlSplit, nextAwaiting);
  } else {
      // there is no available splits by now, skip assigning
      wakeupBinlogReaderIfNeed();
      break;
  }
```
code link: https://github.com/apache/inlong/blob/370815119d7d8898bbf13febc5b70628893ef43f/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/enumerator/MySqlSourceEnumerator.java#LL200C1-L210C14


### Modifications

Move the last snapshot split to the front of the remaining splits.

```java
synchronized (lock) {
    remainingSplits.addAll(schemaLessSnapshotSplits);
    int size = schemaLessSnapshotSplits.size();
    // move the last snapshot split to the front of the remaining splits.
    remainingSplits.add(0, schemaLessSnapshotSplits.get(size - 1));
    remainingSplits.addAll(schemaLessSnapshotSplits.subList(0, size - 1));
    remainingTables.remove(nextTable);
    addAlreadyProcessedTablesIfNotExists(nextTable);
    lock.notify();
}
```