### PR TITLE
[INLONG-8005][Sort] Fix duplicate split request when add new table in mysql connector

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
@@ -173,8 +173,8 @@ public class MySqlSourceReader<T>
             MySqlSplit mySqlSplit = mySqlSplitState.toMySqlSplit();
             if (mySqlSplit.isBinlogSplit()) {
                 LOG.info(
-                    "binlog split reader suspended due to newly added table, offset {}",
-                    mySqlSplitState.asBinlogSplitState().getStartingOffset());
+                        "binlog split reader suspended due to newly added table, offset {}",
+                        mySqlSplitState.asBinlogSplitState().getStartingOffset());
                 mySqlSourceReaderContext.resetStopBinlogSplitReader();
                 suspendedBinlogSplit = toSuspendedBinlogSplit(mySqlSplit.asBinlogSplit());
                 context.sendSourceEventToCoordinator(new SuspendBinlogReaderAckEvent());

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlSourceReader.java
@@ -168,22 +168,28 @@ public class MySqlSourceReader<T>
 
     @Override
     protected void onSplitFinished(Map<String, MySqlSplitState> finishedSplitIds) {
+        boolean requestNextSplit = true;
         for (MySqlSplitState mySqlSplitState : finishedSplitIds.values()) {
             MySqlSplit mySqlSplit = mySqlSplitState.toMySqlSplit();
             if (mySqlSplit.isBinlogSplit()) {
                 LOG.info(
-                        "binlog split reader suspended due to newly added table, offset {}",
-                        mySqlSplitState.asBinlogSplitState().getStartingOffset());
-
+                    "binlog split reader suspended due to newly added table, offset {}",
+                    mySqlSplitState.asBinlogSplitState().getStartingOffset());
                 mySqlSourceReaderContext.resetStopBinlogSplitReader();
                 suspendedBinlogSplit = toSuspendedBinlogSplit(mySqlSplit.asBinlogSplit());
                 context.sendSourceEventToCoordinator(new SuspendBinlogReaderAckEvent());
+                // do not request next split when the reader is suspended, the suspended reader will
+                // automatically request the next split after it has been wakeup
+                requestNextSplit = false;
             } else {
                 finishedUnackedSplits.put(mySqlSplit.splitId(), mySqlSplit.asSnapshotSplit());
             }
         }
         reportFinishedSnapshotSplitsIfNeed();
-        context.sendSplitRequest();
+        LOG.info("request for new split finished unacked splits:{}", finishedUnackedSplits);
+        if (requestNextSplit) {
+            context.sendSplitRequest();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8005 

### Motivation
- Fixes #8005 

### Modifications
see also in https://github.com/ververica/flink-cdc-connectors/issues/1149

remove the duplicate split request when binlog reader hangs up 

### Documentation

  - Does this pull request introduce a new feature? (no)
