### PR TITLE
[INLONG-8068][Manager] Support repeatable read for http request

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/InlongShiroImpl.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/InlongShiroImpl.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.web.auth.openapi.OpenAPIAuthenticatingRealm;
 import org.apache.inlong.manager.web.auth.openapi.OpenAPIFilter;
 import org.apache.inlong.manager.web.auth.web.AuthenticationFilter;
 import org.apache.inlong.manager.web.auth.web.WebAuthorizingRealm;
+import org.apache.inlong.manager.web.filter.HttpServletRequestFilter;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.authc.credential.HashedCredentialsMatcher;
 import org.apache.shiro.mgt.SecurityManager;
@@ -55,6 +56,7 @@ public class InlongShiroImpl implements InlongShiro {
 
     private static final String FILTER_NAME_WEB = "authWeb";
     private static final String FILTER_NAME_API = "authAPI";
+    private static final String FILTER_NAME_REQUEST = "request";
 
     @Autowired
     private UserService userService;
@@ -94,9 +96,13 @@ public class InlongShiroImpl implements InlongShiro {
         shiroFilterFactoryBean.setSecurityManager(securityManager);
         // anon: can be accessed by anyone, authc: only authentication is successful can be accessed
         Map<String, Filter> filters = new LinkedHashMap<>();
+
+        //request filter
         filters.put(FILTER_NAME_WEB, new AuthenticationFilter());
+
         shiroFilterFactoryBean.setFilters(filters);
         Map<String, String> pathDefinitions = new LinkedHashMap<>();
+
         // login, register request
         pathDefinitions.put("/api/anno/**/*", "anon");
 
@@ -117,6 +123,10 @@ public class InlongShiroImpl implements InlongShiro {
 
         // other web
         pathDefinitions.put("/**", FILTER_NAME_WEB);
+
+        // request filter
+        //filters.put(FILTER_NAME_REQUEST, new HttpServletRequestFilter());
+        //pathDefinitions.put("/**", FILTER_NAME_REQUEST);
 
         shiroFilterFactoryBean.setFilterChainDefinitionMap(pathDefinitions);
         return shiroFilterFactoryBean;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/web/AuthenticationFilter.java
@@ -59,7 +59,6 @@ public class AuthenticationFilter implements Filter {
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-
         Subject subject = SecurityUtils.getSubject();
         if (subject.isAuthenticated()) {
             UserInfo loginUserInfo = (UserInfo) subject.getPrincipal();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/HttpServletRequestFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/HttpServletRequestFilter.java
@@ -1,0 +1,35 @@
+package org.apache.inlong.manager.web.filter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.manager.web.utils.InlongRequestWrapper;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * HttpServletRequestFilter
+ * Make All
+ */
+@Slf4j
+@Component
+@WebFilter
+@Order(0)
+public class HttpServletRequestFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        ServletRequest requestWrapper = null;
+        if (servletRequest instanceof HttpServletRequest) {
+            requestWrapper = new InlongRequestWrapper((HttpServletRequest) servletRequest);
+        }
+        if (null == requestWrapper) {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } else {
+            filterChain.doFilter(requestWrapper, servletResponse);
+        }
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/HttpContextUtils.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/HttpContextUtils.java
@@ -1,0 +1,106 @@
+package org.apache.inlong.manager.web.utils;
+
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletRequest;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * HttpContextUtils
+ */
+public class HttpContextUtils {
+
+    /**
+     * Get request params
+     * @param request
+     * @return
+     */
+    public static Map<String, String> getParameterMapAll(HttpServletRequest request) {
+        Enumeration<String> parameters = request.getParameterNames();
+
+        Map<String, String> params = new HashMap<>();
+        while (parameters.hasMoreElements()) {
+            String parameter = parameters.nextElement();
+            String value = request.getParameter(parameter);
+            params.put(parameter, value);
+        }
+        return params;
+    }
+
+    public static Map<String, String[]> getParameterMap(HttpServletRequest request) {
+        Map<String, String[]> paramMap = new HashMap<>();
+        String queryString = request.getQueryString();
+        if (queryString != null && queryString.trim().length() > 0) {
+            String[] params = queryString.split("&");
+            for (int i = 0; i < params.length; i++) {
+                int splitIndex = params[i].indexOf("=");
+                if (splitIndex == -1) {
+                    continue;
+                }
+                String key = params[i].substring(0, splitIndex);
+                if (!paramMap.containsKey(key)) {
+                    if (splitIndex < params[i].length()) {
+                        String value = params[i].substring(splitIndex + 1);
+                        paramMap.put(key, new String[]{value});
+                    }
+                }
+            }
+        }
+        return paramMap;
+    }
+
+    public static Map<String, String> getHeaderMapAll(HttpServletRequest request) {
+        Enumeration<String> headerNames = request.getHeaderNames();
+        Map<String, String> headers = new HashMap<>();
+        while (headerNames.hasMoreElements()) {
+            String parameter = headerNames.nextElement();
+            String value = request.getHeader(parameter);
+            headers.put(parameter, value);
+        }
+        return headers;
+    }
+
+    /**
+     * Get request body
+     * @param request
+     * @return
+     */
+    public static String getBodyString(ServletRequest request) {
+        StringBuilder sb = new StringBuilder();
+        InputStream inputStream = null;
+        BufferedReader reader = null;
+        try {
+            inputStream = request.getInputStream();
+            reader = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            String line = "";
+            while ((line = reader.readLine()) != null) {
+                sb.append(line);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            if (inputStream != null) {
+                try {
+                    inputStream.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (reader != null) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
@@ -1,0 +1,127 @@
+package org.apache.inlong.manager.web.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * Inlong http request wrapper
+ */
+@Slf4j
+public class InlongRequestWrapper extends HttpServletRequestWrapper {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private String bodyParams;
+
+    private Map<String, String[]> params;
+
+    private Map<String, String> headers;
+
+    public InlongRequestWrapper(HttpServletRequest request) {
+        super(request);
+        this.bodyParams = HttpContextUtils.getBodyString(request);
+        this.params = HttpContextUtils.getParameterMap(request);
+        this.headers = HttpContextUtils.getHeaderMapAll(request);
+        log.info("body={}, params={}, headers={}", bodyParams, params, headers);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String result;
+        Object v = params.get(name);
+        if (v == null) {
+            result = null;
+        } else if (v instanceof String[]) {
+            String[] strArr = (String[]) v;
+            if (strArr.length > 0) {
+                result = strArr[0];
+            } else {
+                result = null;
+            }
+        } else if (v instanceof String) {
+            result = (String) v;
+        } else {
+            result = v.toString();
+        }
+        return result;
+    }
+
+    @Override
+    public Map<String, String[]> getParameterMap() {
+        return params;
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        String[] result;
+        Object v = params.get(name);
+        if (v == null) {
+            result = null;
+        } else if (v instanceof String[]) {
+            result = (String[]) v;
+        } else if (v instanceof String) {
+            result = new String[]{(String) v};
+        } else {
+            result = new String[]{v.toString()};
+        }
+        return result;
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        final ByteArrayInputStream inputStream = new ByteArrayInputStream(bodyParams.getBytes(StandardCharsets.UTF_8));
+        return new ServletInputStream() {
+            @Override
+            public boolean isFinished() {
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return false;
+            }
+
+            @Override
+            public void setReadListener(ReadListener readListener) {
+                // no op
+            }
+
+            @Override
+            public int read() {
+                return inputStream.read();
+            }
+        };
+    }
+
+    @Override
+    public BufferedReader getReader() {
+        return new BufferedReader(new InputStreamReader(this.getInputStream()));
+    }
+
+    public void addHeader(String name, String value) {
+        headers.put(name, value);
+    }
+
+    public void addBodyParam(String key, String value) throws JsonProcessingException {
+        ObjectNode objectNode = (ObjectNode) mapper.readTree(bodyParams);
+        objectNode.put(key, value);
+        bodyParams = objectNode.toString();
+    }
+
+    public void addParameter(String name, String value) {
+        params.put(name, new String[]{value});
+    }
+
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8068
- Parent #7914 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

For multi-tenancy, inlong must modify the http request body and params.
The NPE will be thrown when spring handler the request, because the namespace filter has read the request body.
So, it's necessary to add a request filter to support repeatable read for request body

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
