### PR TITLE
[INLONG-8072][Manager] Fix NPE when taskName of streamSink is empty or null

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/SortClusterServiceImpl.java
@@ -184,6 +184,8 @@ public class SortClusterServiceImpl implements SortClusterService {
         // get all stream sinks
         Map<String, List<StreamSinkEntity>> task2AllStreams = sinkEntities.stream()
                 .filter(entity -> StringUtils.isNotBlank(entity.getInlongClusterName()))
+                .filter(entity -> StringUtils.isNotBlank(entity.getSortTaskName()))
+                .filter(entity -> StringUtils.isNotBlank(entity.getDataNodeName()))
                 .collect(Collectors.groupingBy(StreamSinkEntity::getSortTaskName));
 
         // get all data nodes and group by node name


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Fixes #8072

### Motivation

Fix NPE when taskName of streamSink is empty or null

### Modifications

Add filter to filter out streamsinks with blank task name and blank datanode name

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? no
