### PR TITLE
[INLONG-8084][DataProxy] Add abnormal event statistics in sink

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -76,16 +76,25 @@ public class CommonConfigHolder {
     public static final String KEY_ENABLE_WHITELIST = "proxy.enable.whitelist";
     public static final boolean VAL_DEF_ENABLE_WHITELIST = false;
     // whether enable file metric, optional field.
-    public static final String KEY_ENABLE_FILEMETRIC = "filemetric.enable";
+    public static final String KEY_ENABLE_FILEMETRIC = "file.metric.enable";
     public static final boolean VAL_DEF_ENABLE_FILEMETRIC = true;
     // file metric statistic interval (second)
-    public static final String KEY_FILEMETRIC_STAT_INTERVAL_SEC = "filemetric.statinvl.sec";
+    public static final String KEY_FILEMETRIC_STAT_INTERVAL_SEC = "file.metric.stat.interval.sec";
     public static final int VAL_DEF_FILEMETRIC_STAT_INVL_SEC = 60;
     public static final int VAL_MIN_FILEMETRIC_STAT_INVL_SEC = 0;
     // file metric max statistic key count
-    public static final String KEY_FILEMETRIC_MAXCACHE_CNT = "filemetric.maxcache.cnt";
+    public static final String KEY_FILEMETRIC_MAXCACHE_CNT = "file.metric.max.cache.cnt";
     public static final int VAL_DEF_FILEMETRIC_MAXCACHE_CNT = 1000000;
     public static final int VAL_MIN_FILEMETRIC_MAXCACHE_CNT = 0;
+    // source metric statistic name
+    public static final String KEY_FILEMETRIC_SOURCE_OUTPUT_NAME = "file.metric.source.output.name";
+    public static final String VAL_DEF_FILEMETRIC_SOURCE_OUTPUT_NAME = "Source";
+    // sink metric statistic name
+    public static final String KEY_FILEMETRIC_SINK_OUTPUT_NAME = "file.metric.sink.output.name";
+    public static final String VAL_DEF_FILEMETRIC_SINK_OUTPUT_NAME = "Sink";
+    // event metric statistic name
+    public static final String KEY_FILEMETRIC_EVENT_OUTPUT_NAME = "file.metric.event.output.name";
+    public static final String VAL_DEF_FILEMETRIC_EVENT_OUTPUT_NAME = "DataProxy_monitors";
     // Audit fields
     public static final String KEY_ENABLE_AUDIT = "audit.enable";
     public static final boolean VAL_DEF_ENABLE_AUDIT = true;
@@ -154,6 +163,9 @@ public class CommonConfigHolder {
     private boolean enableFileMetric = VAL_DEF_ENABLE_FILEMETRIC;
     private int fileMetricStatInvlSec = VAL_DEF_FILEMETRIC_STAT_INVL_SEC;
     private int fileMetricStatCacheCnt = VAL_DEF_FILEMETRIC_MAXCACHE_CNT;
+    private String fileMetricSourceOutName = VAL_DEF_FILEMETRIC_SOURCE_OUTPUT_NAME;
+    private String fileMetricSinkOutName = VAL_DEF_FILEMETRIC_SINK_OUTPUT_NAME;
+    private String fileMetricEventOutName = VAL_DEF_FILEMETRIC_EVENT_OUTPUT_NAME;
 
     /**
      * get instance for common.properties config manager
@@ -306,6 +318,18 @@ public class CommonConfigHolder {
         return msgCompressType;
     }
 
+    public String getFileMetricSourceOutName() {
+        return fileMetricSourceOutName;
+    }
+
+    public String getFileMetricSinkOutName() {
+        return fileMetricSinkOutName;
+    }
+
+    public String getFileMetricEventOutName() {
+        return fileMetricEventOutName;
+    }
+
     private void preReadFields() {
         String tmpValue;
         // read cluster tag
@@ -377,6 +401,21 @@ public class CommonConfigHolder {
             if (maxCacheCnt >= VAL_MIN_FILEMETRIC_STAT_INVL_SEC) {
                 this.fileMetricStatCacheCnt = maxCacheCnt;
             }
+        }
+        // read source file statistic output name
+        tmpValue = this.props.get(KEY_FILEMETRIC_SOURCE_OUTPUT_NAME);
+        if (StringUtils.isNotBlank(tmpValue)) {
+            this.fileMetricSourceOutName = tmpValue.trim();
+        }
+        // read sink file statistic output name
+        tmpValue = this.props.get(KEY_FILEMETRIC_SINK_OUTPUT_NAME);
+        if (StringUtils.isNotBlank(tmpValue)) {
+            this.fileMetricSinkOutName = tmpValue.trim();
+        }
+        // read event file statistic output name
+        tmpValue = this.props.get(KEY_FILEMETRIC_EVENT_OUTPUT_NAME);
+        if (StringUtils.isNotBlank(tmpValue)) {
+            this.fileMetricEventOutName = tmpValue.trim();
         }
         // read whether enable audit
         tmpValue = this.props.get(KEY_ENABLE_AUDIT);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -75,6 +75,17 @@ public class CommonConfigHolder {
     // whether enable whitelist, optional field.
     public static final String KEY_ENABLE_WHITELIST = "proxy.enable.whitelist";
     public static final boolean VAL_DEF_ENABLE_WHITELIST = false;
+    // whether enable file metric, optional field.
+    public static final String KEY_ENABLE_FILEMETRIC = "filemetric.enable";
+    public static final boolean VAL_DEF_ENABLE_FILEMETRIC = true;
+    // file metric statistic interval (second)
+    public static final String KEY_FILEMETRIC_STAT_INTERVAL_SEC = "filemetric.statinvl.sec";
+    public static final int VAL_DEF_FILEMETRIC_STAT_INVL_SEC = 60;
+    public static final int VAL_MIN_FILEMETRIC_STAT_INVL_SEC = 0;
+    // file metric max statistic key count
+    public static final String KEY_FILEMETRIC_MAXCACHE_CNT = "filemetric.maxcache.cnt";
+    public static final int VAL_DEF_FILEMETRIC_MAXCACHE_CNT = 1000000;
+    public static final int VAL_MIN_FILEMETRIC_MAXCACHE_CNT = 0;
     // Audit fields
     public static final String KEY_ENABLE_AUDIT = "audit.enable";
     public static final boolean VAL_DEF_ENABLE_AUDIT = true;
@@ -140,6 +151,9 @@ public class CommonConfigHolder {
     private String proxyNodeId = VAL_DEF_PROXY_NODE_ID;
     private String msgCompressType = VAL_DEF_MSG_COMPRESS_TYPE;
     private int prometheusHttpPort = VAL_DEF_PROMETHEUS_HTTP_PORT;
+    private boolean enableFileMetric = VAL_DEF_ENABLE_FILEMETRIC;
+    private int fileMetricStatInvlSec = VAL_DEF_FILEMETRIC_STAT_INVL_SEC;
+    private int fileMetricStatCacheCnt = VAL_DEF_FILEMETRIC_MAXCACHE_CNT;
 
     /**
      * get instance for common.properties config manager
@@ -230,6 +244,18 @@ public class CommonConfigHolder {
 
     public boolean isEnableAudit() {
         return enableAudit;
+    }
+
+    public boolean isEnableFileMetric() {
+        return enableFileMetric;
+    }
+
+    public int getFileMetricStatInvlSec() {
+        return fileMetricStatInvlSec;
+    }
+
+    public int getFileMetricStatCacheCnt() {
+        return fileMetricStatCacheCnt;
     }
 
     public HashSet<String> getAuditProxys() {
@@ -330,6 +356,27 @@ public class CommonConfigHolder {
         tmpValue = this.props.get(KEY_MANAGER_AUTH_SECRET_KEY);
         if (StringUtils.isNotBlank(tmpValue)) {
             this.managerAuthSecretKey = tmpValue.trim();
+        }
+        // read whether enable file metric
+        tmpValue = this.props.get(KEY_ENABLE_FILEMETRIC);
+        if (StringUtils.isNotEmpty(tmpValue)) {
+            this.enableFileMetric = "TRUE".equalsIgnoreCase(tmpValue.trim());
+        }
+        // read file metric statistic interval
+        tmpValue = this.props.get(KEY_FILEMETRIC_STAT_INTERVAL_SEC);
+        if (StringUtils.isNotEmpty(tmpValue)) {
+            int statInvl = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILEMETRIC_STAT_INVL_SEC);
+            if (statInvl >= VAL_MIN_FILEMETRIC_MAXCACHE_CNT) {
+                this.fileMetricStatInvlSec = statInvl;
+            }
+        }
+        // read file metric statistic max cache count
+        tmpValue = this.props.get(KEY_FILEMETRIC_MAXCACHE_CNT);
+        if (StringUtils.isNotEmpty(tmpValue)) {
+            int maxCacheCnt = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILEMETRIC_MAXCACHE_CNT);
+            if (maxCacheCnt >= VAL_MIN_FILEMETRIC_STAT_INVL_SEC) {
+                this.fileMetricStatCacheCnt = maxCacheCnt;
+            }
         }
         // read whether enable audit
         tmpValue = this.props.get(KEY_ENABLE_AUDIT);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -76,25 +76,25 @@ public class CommonConfigHolder {
     public static final String KEY_ENABLE_WHITELIST = "proxy.enable.whitelist";
     public static final boolean VAL_DEF_ENABLE_WHITELIST = false;
     // whether enable file metric, optional field.
-    public static final String KEY_ENABLE_FILEMETRIC = "file.metric.enable";
-    public static final boolean VAL_DEF_ENABLE_FILEMETRIC = true;
+    public static final String KEY_ENABLE_FILE_METRIC = "file.metric.enable";
+    public static final boolean VAL_DEF_ENABLE_FILE_METRIC = true;
     // file metric statistic interval (second)
-    public static final String KEY_FILEMETRIC_STAT_INTERVAL_SEC = "file.metric.stat.interval.sec";
-    public static final int VAL_DEF_FILEMETRIC_STAT_INVL_SEC = 60;
-    public static final int VAL_MIN_FILEMETRIC_STAT_INVL_SEC = 0;
+    public static final String KEY_FILE_METRIC_STAT_INTERVAL_SEC = "file.metric.stat.interval.sec";
+    public static final int VAL_DEF_FILE_METRIC_STAT_INVL_SEC = 60;
+    public static final int VAL_MIN_FILE_METRIC_STAT_INVL_SEC = 0;
     // file metric max statistic key count
-    public static final String KEY_FILEMETRIC_MAXCACHE_CNT = "file.metric.max.cache.cnt";
-    public static final int VAL_DEF_FILEMETRIC_MAXCACHE_CNT = 1000000;
-    public static final int VAL_MIN_FILEMETRIC_MAXCACHE_CNT = 0;
+    public static final String KEY_FILE_METRIC_MAX_CACHE_CNT = "file.metric.max.cache.cnt";
+    public static final int VAL_DEF_FILE_METRIC_MAX_CACHE_CNT = 1000000;
+    public static final int VAL_MIN_FILE_METRIC_MAX_CACHE_CNT = 0;
     // source metric statistic name
-    public static final String KEY_FILEMETRIC_SOURCE_OUTPUT_NAME = "file.metric.source.output.name";
-    public static final String VAL_DEF_FILEMETRIC_SOURCE_OUTPUT_NAME = "Source";
+    public static final String KEY_FILE_METRIC_SOURCE_OUTPUT_NAME = "file.metric.source.output.name";
+    public static final String VAL_DEF_FILE_METRIC_SOURCE_OUTPUT_NAME = "Source";
     // sink metric statistic name
-    public static final String KEY_FILEMETRIC_SINK_OUTPUT_NAME = "file.metric.sink.output.name";
-    public static final String VAL_DEF_FILEMETRIC_SINK_OUTPUT_NAME = "Sink";
+    public static final String KEY_FILE_METRIC_SINK_OUTPUT_NAME = "file.metric.sink.output.name";
+    public static final String VAL_DEF_FILE_METRIC_SINK_OUTPUT_NAME = "Sink";
     // event metric statistic name
-    public static final String KEY_FILEMETRIC_EVENT_OUTPUT_NAME = "file.metric.event.output.name";
-    public static final String VAL_DEF_FILEMETRIC_EVENT_OUTPUT_NAME = "DataProxy_monitors";
+    public static final String KEY_FILE_METRIC_EVENT_OUTPUT_NAME = "file.metric.event.output.name";
+    public static final String VAL_DEF_FILE_METRIC_EVENT_OUTPUT_NAME = "DataProxy_monitors";
     // Audit fields
     public static final String KEY_ENABLE_AUDIT = "audit.enable";
     public static final boolean VAL_DEF_ENABLE_AUDIT = true;
@@ -160,12 +160,12 @@ public class CommonConfigHolder {
     private String proxyNodeId = VAL_DEF_PROXY_NODE_ID;
     private String msgCompressType = VAL_DEF_MSG_COMPRESS_TYPE;
     private int prometheusHttpPort = VAL_DEF_PROMETHEUS_HTTP_PORT;
-    private boolean enableFileMetric = VAL_DEF_ENABLE_FILEMETRIC;
-    private int fileMetricStatInvlSec = VAL_DEF_FILEMETRIC_STAT_INVL_SEC;
-    private int fileMetricStatCacheCnt = VAL_DEF_FILEMETRIC_MAXCACHE_CNT;
-    private String fileMetricSourceOutName = VAL_DEF_FILEMETRIC_SOURCE_OUTPUT_NAME;
-    private String fileMetricSinkOutName = VAL_DEF_FILEMETRIC_SINK_OUTPUT_NAME;
-    private String fileMetricEventOutName = VAL_DEF_FILEMETRIC_EVENT_OUTPUT_NAME;
+    private boolean enableFileMetric = VAL_DEF_ENABLE_FILE_METRIC;
+    private int fileMetricStatInvlSec = VAL_DEF_FILE_METRIC_STAT_INVL_SEC;
+    private int fileMetricStatCacheCnt = VAL_DEF_FILE_METRIC_MAX_CACHE_CNT;
+    private String fileMetricSourceOutName = VAL_DEF_FILE_METRIC_SOURCE_OUTPUT_NAME;
+    private String fileMetricSinkOutName = VAL_DEF_FILE_METRIC_SINK_OUTPUT_NAME;
+    private String fileMetricEventOutName = VAL_DEF_FILE_METRIC_EVENT_OUTPUT_NAME;
 
     /**
      * get instance for common.properties config manager
@@ -382,38 +382,38 @@ public class CommonConfigHolder {
             this.managerAuthSecretKey = tmpValue.trim();
         }
         // read whether enable file metric
-        tmpValue = this.props.get(KEY_ENABLE_FILEMETRIC);
+        tmpValue = this.props.get(KEY_ENABLE_FILE_METRIC);
         if (StringUtils.isNotEmpty(tmpValue)) {
             this.enableFileMetric = "TRUE".equalsIgnoreCase(tmpValue.trim());
         }
         // read file metric statistic interval
-        tmpValue = this.props.get(KEY_FILEMETRIC_STAT_INTERVAL_SEC);
+        tmpValue = this.props.get(KEY_FILE_METRIC_STAT_INTERVAL_SEC);
         if (StringUtils.isNotEmpty(tmpValue)) {
-            int statInvl = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILEMETRIC_STAT_INVL_SEC);
-            if (statInvl >= VAL_MIN_FILEMETRIC_MAXCACHE_CNT) {
+            int statInvl = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILE_METRIC_STAT_INVL_SEC);
+            if (statInvl >= VAL_MIN_FILE_METRIC_MAX_CACHE_CNT) {
                 this.fileMetricStatInvlSec = statInvl;
             }
         }
         // read file metric statistic max cache count
-        tmpValue = this.props.get(KEY_FILEMETRIC_MAXCACHE_CNT);
+        tmpValue = this.props.get(KEY_FILE_METRIC_MAX_CACHE_CNT);
         if (StringUtils.isNotEmpty(tmpValue)) {
-            int maxCacheCnt = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILEMETRIC_MAXCACHE_CNT);
-            if (maxCacheCnt >= VAL_MIN_FILEMETRIC_STAT_INVL_SEC) {
+            int maxCacheCnt = NumberUtils.toInt(tmpValue.trim(), VAL_DEF_FILE_METRIC_MAX_CACHE_CNT);
+            if (maxCacheCnt >= VAL_MIN_FILE_METRIC_STAT_INVL_SEC) {
                 this.fileMetricStatCacheCnt = maxCacheCnt;
             }
         }
         // read source file statistic output name
-        tmpValue = this.props.get(KEY_FILEMETRIC_SOURCE_OUTPUT_NAME);
+        tmpValue = this.props.get(KEY_FILE_METRIC_SOURCE_OUTPUT_NAME);
         if (StringUtils.isNotBlank(tmpValue)) {
             this.fileMetricSourceOutName = tmpValue.trim();
         }
         // read sink file statistic output name
-        tmpValue = this.props.get(KEY_FILEMETRIC_SINK_OUTPUT_NAME);
+        tmpValue = this.props.get(KEY_FILE_METRIC_SINK_OUTPUT_NAME);
         if (StringUtils.isNotBlank(tmpValue)) {
             this.fileMetricSinkOutName = tmpValue.trim();
         }
         // read event file statistic output name
-        tmpValue = this.props.get(KEY_FILEMETRIC_EVENT_OUTPUT_NAME);
+        tmpValue = this.props.get(KEY_FILE_METRIC_EVENT_OUTPUT_NAME);
         if (StringUtils.isNotBlank(tmpValue)) {
             this.fileMetricEventOutName = tmpValue.trim();
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -23,17 +23,6 @@ public class StatConstants {
     public static final java.lang.String EVENT_SERVICE_UNREADY = "sink.unready";
     public static final java.lang.String EVENT_VISITIP_ILLEGAL = "links.illegal";
     public static final java.lang.String EVENT_NOTOPIC = "config.notopic";
-
-    public static final java.lang.String METASINK_SUCCESS = "metasink.success";
-    public static final java.lang.String METASINK_DROPPED = "metasink.dropped";
-    public static final java.lang.String METASINK_RETRY = "metasink.retry";
-    public static final java.lang.String METASINK_OTHEREXP = "metasink.otherexp";
-    public static final java.lang.String METASINK_NOTOPIC = "metasink.notopic";
-    public static final java.lang.String METASINK_NOSLAVE = "metasink.noslave";
-    public static final java.lang.String METASINK_MSG_NOTOPIC = "metasink.msgnotopic";
-    public static final java.lang.String METASINK_PROCESS_SPEED = "metasink.process.speed";
-    public static final java.lang.String EVENT_OTHEREXP = "socketmsg.otherexp";
-    public static final java.lang.String EVENT_INVALID = "socketmsg.invalid";
     // source
     public static final java.lang.String EVENT_LINKS_OVERMAX = "links.overmax";
     public static final java.lang.String EVENT_LINKS_IN = "links.linkin";
@@ -71,6 +60,22 @@ public class StatConstants {
     public static final java.lang.String EVENT_HTTP_BODYOVERMAXLEN = "httpmsg.bodyovermax";
     public static final java.lang.String EVENT_HTTP_POST_SUCCESS = "httpmsg.success";
     public static final java.lang.String EVENT_HTTP_POST_DROPPED = "httpmsg.dropped";
+
+    public static final java.lang.String EVENT_SINK_NOUID = "sink.nouid";
+    public static final java.lang.String EVENT_SINK_NOTOPIC = "sink.notopic";
+    public static final java.lang.String EVENT_SINK_NOPRODUCER = "sink.noproducer";
+    public static final java.lang.String EVENT_SINK_SENDEXCEPT = "sink.sendexcept";
+    public static final java.lang.String EVENT_SINK_FAILRETRY = "sink.retry";
+    public static final java.lang.String EVENT_SINK_FAILDROPPED = "sink.dropped";
+    public static final java.lang.String EVENT_SINK_SUCCESS = "sink.success";
+    public static final java.lang.String EVENT_SINK_RECEIVEEXCEPT = "sink.rcvexcept";
+
+    public static final java.lang.String METASINK_OTHEREXP = "metasink.otherexp";
+    public static final java.lang.String METASINK_NOSLAVE = "metasink.noslave";
+    public static final java.lang.String METASINK_MSG_NOTOPIC = "metasink.msgnotopic";
+    public static final java.lang.String METASINK_PROCESS_SPEED = "metasink.process.speed";
+    public static final java.lang.String EVENT_OTHEREXP = "socketmsg.otherexp";
+    public static final java.lang.String EVENT_INVALID = "socketmsg.invalid";
 
     public static final java.lang.String AGENT_MESSAGES_SENT_SUCCESS = "agent.messages.success";
     public static final java.lang.String AGENT_PACKAGES_SENT_SUCCESS = "agent.packages.success";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/SinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/SinkContext.java
@@ -25,6 +25,7 @@ import org.apache.inlong.common.monitor.MonitorIndex;
 import org.apache.inlong.common.monitor.MonitorIndexExt;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
+import org.apache.inlong.dataproxy.consts.AttrConstants;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItemSet;
 import org.apache.inlong.dataproxy.sink.mq.BatchPackProfile;
 import org.apache.inlong.dataproxy.sink.mq.MessageQueueHandler;
@@ -87,11 +88,12 @@ public class SinkContext {
     public void start() {
         // init monitor logic
         if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
-            this.monitorIndex = new MonitorIndex("Sink",
+            this.monitorIndex = new MonitorIndex(CommonConfigHolder.getInstance().getFileMetricSinkOutName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
             this.monitorIndexExt = new MonitorIndexExt(
-                    "DataProxy_monitors#" + this.getSinkName(),
+                    CommonConfigHolder.getInstance().getFileMetricEventOutName()
+                            + AttrConstants.SEP_HASHTAG + this.getSinkName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -25,6 +25,7 @@ import org.apache.flume.conf.Configurable;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.holder.CacheClusterConfigHolder;
 import org.apache.inlong.dataproxy.config.holder.IdTopicConfigHolder;
+import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
 import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
 import org.apache.inlong.dataproxy.sink.common.SinkContext;
@@ -271,9 +272,11 @@ public class MessageQueueZoneSinkContext extends SinkContext {
     public void processSendFail(BatchPackProfile currentRecord, String mqName, String topic, long sendTime) {
         if (currentRecord.isResend()) {
             dispatchQueue.offer(currentRecord);
+            fileMetricEventInc(StatConstants.EVENT_SINK_FAILRETRY);
             this.addSendResultMetric(currentRecord, mqName, topic, false, sendTime);
         } else {
             currentRecord.fail();
+            fileMetricEventInc(StatConstants.EVENT_SINK_FAILDROPPED);
         }
     }
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
@@ -33,6 +33,7 @@ import org.apache.inlong.common.monitor.MonitorIndexExt;
 import org.apache.inlong.dataproxy.admin.ProxyServiceMBean;
 import org.apache.inlong.dataproxy.channel.FailoverChannelProcessor;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
+import org.apache.inlong.dataproxy.consts.AttrConstants;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItemSet;
 import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
@@ -234,11 +235,12 @@ public abstract class BaseSource
         MetricRegister.register(metricItemSet);
         // init monitor logic
         if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
-            this.monitorIndex = new MonitorIndex("Source",
+            this.monitorIndex = new MonitorIndex(CommonConfigHolder.getInstance().getFileMetricSourceOutName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
             this.monitorIndexExt = new MonitorIndexExt(
-                    "DataProxy_monitors#" + this.getProtocolName(),
+                    CommonConfigHolder.getInstance().getFileMetricEventOutName()
+                            + AttrConstants.SEP_HASHTAG + this.getProtocolName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
@@ -109,13 +109,10 @@ public abstract class BaseSource
     // send buffer size
     protected int maxSendBufferSize;
     // file metric statistic
-    protected boolean fileMetricOn;
-    protected int monitorStatInvlSec;
-    protected int maxMonitorStatCnt;
     protected MonitorIndex monitorIndex = null;
+    private MonitorIndexExt monitorIndexExt = null;
     // metric set
     protected DataProxyMetricItemSet metricItemSet;
-    private MonitorIndexExt monitorIndexExt = null;
 
     public BaseSource() {
         super();
@@ -195,27 +192,12 @@ public abstract class BaseSource
                 SourceConstants.SRCCXT_MAX_READ_IDLE_TIME_MS + " must be in ["
                         + SourceConstants.VAL_MIN_READ_IDLE_TIME_MS + ", "
                         + SourceConstants.VAL_MAX_READ_IDLE_TIME_MS + "]");
-        // get file metric statistic
-        this.monitorStatInvlSec = ConfStringUtils.getIntValue(context,
-                SourceConstants.SRCCXT_STAT_INTERVAL_SEC, SourceConstants.VAL_DEF_STAT_INVL_SEC);
-        Preconditions.checkArgument((this.monitorStatInvlSec >= SourceConstants.VAL_MIN_STAT_INVL_SEC),
-                SourceConstants.SRCCXT_STAT_INTERVAL_SEC + " must be >= "
-                        + SourceConstants.VAL_MIN_STAT_INVL_SEC);
-        // get max monitor key count
-        this.maxMonitorStatCnt = ConfStringUtils.getIntValue(context,
-                SourceConstants.SRCCXT_MAX_MONITOR_STAT_CNT, SourceConstants.VAL_DEF_MON_STAT_CNT);
-        Preconditions.checkArgument(this.maxMonitorStatCnt >= SourceConstants.VAL_MIN_MON_STAT_CNT,
-                SourceConstants.SRCCXT_MAX_MONITOR_STAT_CNT + " must be >= "
-                        + SourceConstants.VAL_MIN_MON_STAT_CNT);
         // get max connect count
         this.maxConnections = ConfStringUtils.getIntValue(context,
                 SourceConstants.SRCCXT_MAX_CONNECTION_CNT, SourceConstants.VAL_DEF_MAX_CONNECTION_CNT);
         Preconditions.checkArgument(this.maxConnections >= SourceConstants.VAL_MIN_CONNECTION_CNT,
                 SourceConstants.SRCCXT_MAX_CONNECTION_CNT + " must be >= "
                         + SourceConstants.VAL_MIN_CONNECTION_CNT);
-        // get whether enable file metric
-        this.fileMetricOn = context.getBoolean(SourceConstants.SRCCXT_FILE_METRIC_ON,
-                SourceConstants.VAL_DEF_FILE_METRIC_ON);
         // get max receive buffer size
         this.maxRcvBufferSize = ConfStringUtils.getIntValue(context,
                 SourceConstants.SRCCXT_RECEIVE_BUFFER_SIZE, SourceConstants.VAL_DEF_RECEIVE_BUFFER_SIZE);
@@ -251,10 +233,14 @@ public abstract class BaseSource
                 CommonConfigHolder.getInstance().getClusterName(), getName(), String.valueOf(srcPort));
         MetricRegister.register(metricItemSet);
         // init monitor logic
-        if (fileMetricOn) {
-            this.monitorIndex = new MonitorIndex("Source", monitorStatInvlSec, maxMonitorStatCnt);
+        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+            this.monitorIndex = new MonitorIndex("Source",
+                    CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
+                    CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
             this.monitorIndexExt = new MonitorIndexExt(
-                    "DataProxy_monitors#" + this.getProtocolName(), monitorStatInvlSec, maxMonitorStatCnt);
+                    "DataProxy_monitors#" + this.getProtocolName(),
+                    CommonConfigHolder.getInstance().getFileMetricStatInvlSec(),
+                    CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
         }
         startSource();
         // register
@@ -285,7 +271,7 @@ public abstract class BaseSource
         // stop super class
         super.stop();
         // stop file statistic index
-        if (fileMetricOn) {
+        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
             if (monitorIndex != null) {
                 monitorIndex.shutDown();
             }
@@ -373,13 +359,13 @@ public abstract class BaseSource
     }
 
     public void fileMetricEventInc(String eventKey) {
-        if (fileMetricOn) {
+        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
             monitorIndexExt.incrementAndGet(eventKey);
         }
     }
 
     public void fileMetricRecordAdd(String key, int cnt, int packCnt, long packSize, int failCnt) {
-        if (fileMetricOn) {
+        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
             monitorIndex.addAndGet(key, cnt, packCnt, packSize, failCnt);
         }
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
@@ -62,17 +62,11 @@ public class SourceConstants {
     public static final int VAL_DEF_WORKER_THREADS = Runtime.getRuntime().availableProcessors();
     public static final int VAL_MIN_WORKER_THREADS = 1;
     public static final int VAL_MAX_WORKER_THREADS = Runtime.getRuntime().availableProcessors() * 2;
-    // file metric statistic interval(second)
-    public static final String SRCCXT_STAT_INTERVAL_SEC = "stat-interval-sec";
-    public static final int VAL_DEF_STAT_INVL_SEC = 60;
-    public static final int VAL_MIN_STAT_INVL_SEC = 0;
+
     // max file statistic key count
     public static final String SRCCXT_MAX_MONITOR_STAT_CNT = "max-monitor-cnt";
     public static final int VAL_DEF_MON_STAT_CNT = 1000000;
     public static final int VAL_MIN_MON_STAT_CNT = 0;
-    // max file statistic key count
-    public static final String SRCCXT_FILE_METRIC_ON = "file-metric-on";
-    public static final boolean VAL_DEF_FILE_METRIC_ON = true;
     // max connection count
     public static final String SRCCXT_MAX_CONNECTION_CNT = "connections";
     public static final int VAL_DEF_MAX_CONNECTION_CNT = 5000;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
@@ -62,11 +62,6 @@ public class SourceConstants {
     public static final int VAL_DEF_WORKER_THREADS = Runtime.getRuntime().availableProcessors();
     public static final int VAL_MIN_WORKER_THREADS = 1;
     public static final int VAL_MAX_WORKER_THREADS = Runtime.getRuntime().availableProcessors() * 2;
-
-    // max file statistic key count
-    public static final String SRCCXT_MAX_MONITOR_STAT_CNT = "max-monitor-cnt";
-    public static final int VAL_DEF_MON_STAT_CNT = 1000000;
-    public static final int VAL_MIN_MON_STAT_CNT = 0;
     // max connection count
     public static final String SRCCXT_MAX_CONNECTION_CNT = "connections";
     public static final int VAL_DEF_MAX_CONNECTION_CNT = 5000;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/httpMsg/InLongHttpMsgHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/httpMsg/InLongHttpMsgHandler.java
@@ -274,7 +274,8 @@ public class InLongHttpMsgHandler extends SimpleChannelInboundHandler<FullHttpRe
         // build metric data item
         dataTime = dataTime / 1000 / 60 / 10;
         dataTime = dataTime * 1000 * 60 * 10;
-        strBuff.append("http").append(AttrConstants.SEP_HASHTAG).append(topicName)
+        strBuff.append(source.getProtocolName())
+                .append(AttrConstants.SEP_HASHTAG).append(topicName)
                 .append(AttrConstants.SEP_HASHTAG).append(streamId)
                 .append(AttrConstants.SEP_HASHTAG).append(clientIp)
                 .append(AttrConstants.SEP_HASHTAG).append(NetworkUtils.getLocalIp())


### PR DESCRIPTION
- Fixes #8084 

1. Summarize the abnormal event statistics function parameters into the common.properties file for configuration;
2. Add abnormal event statistics on the sink side
3. Fix the bug that the proxy and the order-preserving type are not responsed when the message is discarded