### PR TITLE
[INLONG-8042][CI] Update the CI workflow to avoid the network being unreachable

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000
         env:
           CI: false
 

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -76,7 +76,7 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Build with Maven
-        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+        run: mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000
         env:
           CI: false
 

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build with Maven
         run: |
-          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          mvn --batch-mode --update-snapshots -e -V clean install -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Daether.connector.http.reuseConnections=false -Daether.connector.requestTimeout=60000
         env:
           CI: false
 

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -24,11 +24,11 @@
       <list>
         <IssueNavigationLink>
           <option name="issueRegexp" value="INLONG\-(\d+)" />
-          <option name="linkRegexp" value="https://github.com/apache/incubator-inlong/issues/$1" />
+          <option name="linkRegexp" value="https://github.com/apache/inlong/issues/$1" />
         </IssueNavigationLink>
         <IssueNavigationLink>
           <option name="issueRegexp" value="#(\d+)" />
-          <option name="linkRegexp" value="https://github.com/apache/incubator-inlong/pull/$1" />
+          <option name="linkRegexp" value="https://github.com/apache/inlong/pull/$1" />
         </IssueNavigationLink>
       </list>
     </option>


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8042 

### Motivation

- Maven http connection reset on GitHub Actions VMs.
- Maven is switching to "Maven Resolver" ("aether") in newer versions instead of using Wagon.

### Modifications

- Disable Maven http connection pooling also for aether
- Set request timeout to 60000ms also for aether

Also, I changed the link to the inlong project in idea/vcs.xml
