### PR TITLE
[INLONG-7959][Sort] Dynamic schema evolution support delete and update columns when sink to Iceberg

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
@@ -177,11 +177,83 @@ public interface TableChange {
 
     final class DeleteColumn implements ColumnChange {
 
+        private final String[] fieldsNames;
+
+        public DeleteColumn(String[] fieldsNames) {
+            Preconditions.checkArgument(fieldsNames.length > 0, "Invalid filed name: at least one is required");
+            this.fieldsNames = fieldsNames;
+        }
+
         @Override
         public String[] fieldNames() {
-            return new String[0];
+            return fieldsNames;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DeleteColumn)) {
+                return false;
+            }
+            DeleteColumn that = (DeleteColumn) o;
+            return Arrays.equals(fieldsNames, that.fieldsNames);
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(fieldsNames);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("DELETE COLUMNS `%s`", fieldsNames[fieldsNames.length - 1]);
         }
     }
+
+    final class UpdateColumn implements ColumnChange {
+
+        private final String[] fieldsNames;
+        private final LogicalType dataType;
+        private final boolean isNullable;
+        private final String comment;
+
+        public UpdateColumn(String[] fieldsNames, LogicalType dataType, boolean isNullable, String comment) {
+            Preconditions.checkArgument(fieldsNames.length > 0, "Invalid filed name: at least one is required");
+            this.fieldsNames = fieldsNames;
+            this.dataType = dataType;
+            this.isNullable = isNullable;
+            this.comment = comment;
+        }
+
+        @Override
+        public String[] fieldNames() {
+            return fieldsNames;
+        }
+
+        public LogicalType dataType() {
+            return dataType;
+        }
+
+        public boolean isNullable() {
+            return isNullable;
+        }
+
+        public String comment() {
+            return comment;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("UPDATE COLUMNS `%s` %s %s %s ",
+                    fieldsNames[fieldsNames.length - 1],
+                    dataType,
+                    isNullable ? "" : "NOT NULL",
+                    comment);
+        }
+    }
+
 
     /**
      * Represents a column change that is not recognized by the connector.

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
@@ -254,7 +254,6 @@ public interface TableChange {
         }
     }
 
-
     /**
      * Represents a column change that is not recognized by the connector.
      */

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/sink/TableChange.java
@@ -177,16 +177,16 @@ public interface TableChange {
 
     final class DeleteColumn implements ColumnChange {
 
-        private final String[] fieldsNames;
+        private final String[] fieldNames;
 
         public DeleteColumn(String[] fieldsNames) {
             Preconditions.checkArgument(fieldsNames.length > 0, "Invalid filed name: at least one is required");
-            this.fieldsNames = fieldsNames;
+            this.fieldNames = fieldsNames;
         }
 
         @Override
         public String[] fieldNames() {
-            return fieldsNames;
+            return fieldNames;
         }
 
         @Override
@@ -198,30 +198,30 @@ public interface TableChange {
                 return false;
             }
             DeleteColumn that = (DeleteColumn) o;
-            return Arrays.equals(fieldsNames, that.fieldsNames);
+            return Arrays.equals(fieldNames, that.fieldNames);
         }
 
         @Override
         public int hashCode() {
-            return Arrays.hashCode(fieldsNames);
+            return Arrays.hashCode(fieldNames);
         }
 
         @Override
         public String toString() {
-            return String.format("DELETE COLUMNS `%s`", fieldsNames[fieldsNames.length - 1]);
+            return String.format("DELETE COLUMNS `%s`", fieldNames[fieldNames.length - 1]);
         }
     }
 
     final class UpdateColumn implements ColumnChange {
 
-        private final String[] fieldsNames;
+        private final String[] fieldNames;
         private final LogicalType dataType;
         private final boolean isNullable;
         private final String comment;
 
-        public UpdateColumn(String[] fieldsNames, LogicalType dataType, boolean isNullable, String comment) {
-            Preconditions.checkArgument(fieldsNames.length > 0, "Invalid filed name: at least one is required");
-            this.fieldsNames = fieldsNames;
+        public UpdateColumn(String[] fieldNames, LogicalType dataType, boolean isNullable, String comment) {
+            Preconditions.checkArgument(fieldNames.length > 0, "Invalid filed name: at least one is required");
+            this.fieldNames = fieldNames;
             this.dataType = dataType;
             this.isNullable = isNullable;
             this.comment = comment;
@@ -229,7 +229,7 @@ public interface TableChange {
 
         @Override
         public String[] fieldNames() {
-            return fieldsNames;
+            return fieldNames;
         }
 
         public LogicalType dataType() {
@@ -247,7 +247,7 @@ public interface TableChange {
         @Override
         public String toString() {
             return String.format("UPDATE COLUMNS `%s` %s %s %s ",
-                    fieldsNames[fieldsNames.length - 1],
+                    fieldNames[fieldNames.length - 1],
                     dataType,
                     isNullable ? "" : "NOT NULL",
                     comment);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -57,7 +57,6 @@ import org.apache.inlong.sort.base.metric.sub.SinkTableMetricData;
 import org.apache.inlong.sort.base.sink.MultipleSinkOption;
 import org.apache.inlong.sort.base.sink.SchemaUpdateExceptionPolicy;
 import org.apache.inlong.sort.base.sink.TableChange;
-import org.apache.inlong.sort.base.sink.TableChange.AddColumn;
 import org.apache.inlong.sort.base.util.MetricStateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -471,7 +471,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         if (table.schema().sameSchema(oldSchema)) {
             List<TableChange> tableChanges = SchemaChangeUtils.diffSchema(oldSchema, newSchema);
             for (TableChange tableChange : tableChanges) {
-                if (!(tableChange instanceof TableChange.UnknownColumnChange) ) {
+                if (tableChange instanceof TableChange.UnknownColumnChange) {
                     throw new UnsupportedOperationException(
                             String.format("Unsupported table %s schema change: %s.", tableId.toString(), tableChange));
                 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -471,8 +471,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         if (table.schema().sameSchema(oldSchema)) {
             List<TableChange> tableChanges = SchemaChangeUtils.diffSchema(oldSchema, newSchema);
             for (TableChange tableChange : tableChanges) {
-                if (!(tableChange instanceof AddColumn)) {
-                    // todo:currently iceberg can only handle addColumn, so always return false
+                if (!(tableChange instanceof TableChange.UnknownColumnChange) ) {
                     throw new UnsupportedOperationException(
                             String.format("Unsupported table %s schema change: %s.", tableId.toString(), tableChange));
                 }
@@ -487,8 +486,12 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
     // =============================== Utils method =================================================================
     // The way to judge compatibility is whether all the field names in the old schema exist in the new schema
     private boolean isCompatible(Schema newSchema, Schema oldSchema) {
-        for (NestedField field : oldSchema.columns()) {
-            if (newSchema.findField(field.name()) == null) {
+        if (newSchema.columns().size() != oldSchema.columns().size()) {
+            return false;
+        }
+        for (NestedField oldField : oldSchema.columns()) {
+            NestedField newField = newSchema.findField(oldField.name());
+            if (newField == null || !oldField.type().equals(newField.type())) {
                 return false;
             }
         }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/SchemaChangeUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/SchemaChangeUtils.java
@@ -31,7 +31,11 @@ import org.apache.inlong.sort.iceberg.FlinkTypeToType;
 import org.apache.inlong.sort.base.sink.TableChange.ColumnPosition;
 import org.apache.inlong.sort.base.sink.TableChange.UnknownColumnChange;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 public class SchemaChangeUtils {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/SchemaChangeUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/SchemaChangeUtils.java
@@ -58,15 +58,15 @@ public class SchemaChangeUtils {
 
         List<TableChange> tableChanges = new ArrayList<>();
 
-        //step0: Unknown change
+        // step0: Unknown change
         if (!colsToDelete.isEmpty() && !colsToAdd.isEmpty()) {
             tableChanges.add(new UnknownColumnChange(
-                    String.format(" old schema: [%s] and new schema: [%s], it is unknown column change", oldSchema.toString(), newSchema.toString())
-            ));
+                    String.format(" old schema: [%s] and new schema: [%s], it is unknown column change",
+                            oldSchema.toString(), newSchema.toString())));
             return tableChanges;
         }
 
-        //step1: judge whether update column(only column type change and doc change)
+        // step1: judge whether update column(only column type change and doc change)
         for (String colName : intersectColSet) {
             NestedField oldField = oldSchema.findField(colName);
             NestedField newField = newSchema.findField(colName);
@@ -80,17 +80,16 @@ public class SchemaChangeUtils {
             }
         }
 
-        //step2: judge whether delete column
+        // step2: judge whether delete column
         for (String colName : oldFields) {
             if (colsToDelete.contains(colName)) {
                 tableChanges.add(
                         new TableChange.DeleteColumn(
-                                new String[]{colName}
-                        ));
+                                new String[]{colName}));
             }
         }
 
-        //step3: judge whether add column
+        // step3: judge whether add column
         if (!colsToAdd.isEmpty()) {
             for (int i = 0; i < newFields.size(); i++) {
                 String colName = newFields.get(i);
@@ -98,11 +97,11 @@ public class SchemaChangeUtils {
                     NestedField addField = newSchema.findField(colName);
                     tableChanges.add(
                             new TableChange.AddColumn(
-                                 new String[]{addField.name()},
-                                 FlinkSchemaUtil.convert(addField.type()),
-                                 !addField.isRequired(),
-                                 addField.doc(),
-                                i == 0 ? ColumnPosition.first() : ColumnPosition.after(newFields.get(i - 1))));
+                                    new String[]{addField.name()},
+                                    FlinkSchemaUtil.convert(addField.type()),
+                                    !addField.isRequired(),
+                                    addField.doc(),
+                                    i == 0 ? ColumnPosition.first() : ColumnPosition.after(newFields.get(i - 1))));
                 }
             }
         }
@@ -150,7 +149,7 @@ public class SchemaChangeUtils {
 
     public static void applyUpdateColumn(UpdateSchema pendingUpdate, TableChange.UpdateColumn update) {
         Type type = update.dataType().accept(new FlinkTypeToType(RowType.of(update.dataType())));
-        pendingUpdate.updateColumn(DOT.join(update.fieldNames()), type.asPrimitiveType(),  update.comment());
+        pendingUpdate.updateColumn(DOT.join(update.fieldNames()), type.asPrimitiveType(), update.comment());
     }
 
     public static String leafName(String[] fieldNames) {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/test/java/org/apache/inlong/sort/iceberg/sink/multiple/TestSchemaChangeUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/test/java/org/apache/inlong/sort/iceberg/sink/multiple/TestSchemaChangeUtils.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sort.iceberg.sink.multiple;
 
 import org.apache.iceberg.Schema;
@@ -46,10 +63,10 @@ public class TestSchemaChangeUtils {
         List<TableChange> tableChanges = deleteColumn();
         Assert.assertEquals("Table changes size must be 1 when del 1 column", 1, tableChanges.size());
         for (TableChange tableChange : tableChanges) {
-            Assert.assertTrue("The table change must be DeleteColumn ", tableChange instanceof TableChange.DeleteColumn);
+            Assert.assertTrue("The table change must be DeleteColumn ",
+                    tableChange instanceof TableChange.DeleteColumn);
         }
     }
-
 
     public List<TableChange> deleteColumn() {
         Schema delColSchema = new Schema(
@@ -64,23 +81,25 @@ public class TestSchemaChangeUtils {
         List<TableChange> updateTypeTableChanges = testUpdateTypeColumn();
         Assert.assertEquals("update 2 col, id: int -> double; age: int -> long", 2, updateTypeTableChanges.size());
         for (TableChange tableChange : updateTypeTableChanges) {
-            Assert.assertTrue("The table changes must be UpdateColumn ", tableChange instanceof TableChange.UpdateColumn);
+            Assert.assertTrue("The table changes must be UpdateColumn ",
+                    tableChange instanceof TableChange.UpdateColumn);
         }
 
         List<TableChange> updateCommentTableChanges = testCommentTypeColumn();
-        Assert.assertEquals("update 1 col comment, name comment: name -> family name:", 1, updateCommentTableChanges.size());
+        Assert.assertEquals("update 1 col comment, name comment: name -> family name:", 1,
+                updateCommentTableChanges.size());
         for (TableChange tableChange : updateCommentTableChanges) {
-            Assert.assertTrue("The table changes must be UpdateColumn ", tableChange instanceof TableChange.UpdateColumn);
+            Assert.assertTrue("The table changes must be UpdateColumn ",
+                    tableChange instanceof TableChange.UpdateColumn);
         }
     }
-
 
     public List<TableChange> testUpdateTypeColumn() {
         Schema updateTypeColSchema = new Schema(
                 Types.NestedField.required(1, "id", Types.DoubleType.get(), "primary key"),
                 Types.NestedField.optional(2, "name", Types.StringType.get(), "name"),
                 Types.NestedField.optional(3, "age", Types.LongType.get(), "age"));
-        return  SchemaChangeUtils.diffSchema(baseSchema, updateTypeColSchema);
+        return SchemaChangeUtils.diffSchema(baseSchema, updateTypeColSchema);
     }
 
     public List<TableChange> testCommentTypeColumn() {
@@ -100,7 +119,8 @@ public class TestSchemaChangeUtils {
         List<TableChange> tableChanges = SchemaChangeUtils.diffSchema(baseSchema, unknownColSchema);
         Assert.assertEquals("rename column is not supported.", 1, tableChanges.size());
         for (TableChange tableChange : tableChanges) {
-            Assert.assertTrue("The table changes must be UnknownColumnChange ", tableChange instanceof TableChange.UnknownColumnChange);
+            Assert.assertTrue("The table changes must be UnknownColumnChange ",
+                    tableChange instanceof TableChange.UnknownColumnChange);
         }
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes [#7959](https://github.com/apache/inlong/issues/7959)

### Motivation

*support delete,update column when multiple sink to iceberg table*

### Modifications

At present, when multiple table sink to iceberg, Dynamic schema evolution only support add column. Delete, reorder, type update,rename needs to be supported, so I plan to support these operation.The first step is delete column.
