### PR TITLE
[INLONG-8101][Sort] Support multi-version packaging of sort-connectors

### DIFF
--- a/inlong-sort/sort-flink/pom.xml
+++ b/inlong-sort/sort-flink/pom.xml
@@ -30,19 +30,21 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Flink</name>
 
-    <modules>
-        <module>cdc-base</module>
-        <module>base</module>
-        <module>sort-flink-v1.13</module>
-        <module>sort-flink-v1.15</module>
-    </modules>
-
     <profiles>
         <profile>
-            <id>v1.13</id>
+            <id>flink-all-version</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+            <modules>
+                <module>cdc-base</module>
+                <module>base</module>
+                <module>sort-flink-v1.13</module>
+                <module>sort-flink-v1.15</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>v1.13</id>
             <modules>
                 <module>cdc-base</module>
                 <module>base</module>

--- a/inlong-sort/sort-flink/pom.xml
+++ b/inlong-sort/sort-flink/pom.xml
@@ -30,6 +30,13 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Flink</name>
 
+    <modules>
+        <module>cdc-base</module>
+        <module>base</module>
+        <module>sort-flink-v1.13</module>
+        <module>sort-flink-v1.15</module>
+    </modules>
+
     <profiles>
         <profile>
             <id>v1.13</id>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>sort-connector-doris</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
@@ -23,7 +23,7 @@
 
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
@@ -27,7 +27,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>sort-connectors</artifactId>
+    <artifactId>sort-connectors-v1.13</artifactId>
 
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Connectors v1.13</name>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
@@ -20,7 +20,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
     <artifactId>sort-connector-starrocks</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.inlong</groupId>
-        <artifactId>sort-connectors</artifactId>
+        <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
@@ -26,7 +26,8 @@
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>sort-connectors</artifactId>
+    <artifactId>sort-connectors-v1.15</artifactId>
+    <packaging>pom</packaging>
     <name>Apache InLong - Sort Connectors v1.15</name>
 
 </project>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
@@ -39,22 +39,32 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-streaming-scala_${flink.scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8101 

### Motivation

Now the packaging phase of sort connectors only support flink 1.13

If we need the package for flink 1.15 we should change the pom flink version to flink 1.15 which is time consuming.

### Modifications

change the pom. 
![image](https://github.com/apache/inlong/assets/26538404/83a4704d-56ef-47f6-b5ce-2a4693bbf7ce)

to package module flink1.13 and flink1.15 the same time and change the aritifact id to distinguish the two flink versions

### Verifying this change
![image](https://github.com/apache/inlong/assets/26538404/a14fcc79-5b08-4ec2-b83f-5c2d52ea150f)



### Documentation

  - Does this pull request introduce a new feature? (yes / no)