### PR TITLE
[INLONG-8110][Sort] Only whole database migration need table level metric

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -17,9 +17,6 @@
 
 package org.apache.inlong.sort.base.metric.sub;
 
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.flink.metrics.MetricGroup;
 import org.apache.inlong.sort.base.Constants;
 import org.apache.inlong.sort.base.enums.ReadPhase;
 import org.apache.inlong.sort.base.metric.MetricOption;
@@ -27,6 +24,10 @@ import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
+
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.metrics.MetricGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.sort.base.metric.sub;
 
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.inlong.sort.base.Constants;
 import org.apache.inlong.sort.base.enums.ReadPhase;
 import org.apache.inlong.sort.base.metric.MetricOption;
@@ -24,10 +27,6 @@ import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
-
-import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.flink.metrics.MetricGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,6 +152,8 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
     public void outputMetricsWithEstimate(String database, String table, boolean isSnapshotRecord, Object data) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
             outputMetricsWithEstimate(data);
+            // output read phase metric
+            outputReadPhaseMetrics((isSnapshotRecord) ? ReadPhase.SNAPSHOT_PHASE : ReadPhase.INCREASE_PHASE);
             return;
         }
         // output sub source metric

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
@@ -17,10 +17,11 @@
 
 package org.apache.inlong.sort.cdc.mysql.source;
 
-import org.apache.flink.annotation.PublicEvolving;
 import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
 import org.apache.inlong.sort.cdc.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
+
+import org.apache.flink.annotation.PublicEvolving;
 
 import java.time.Duration;
 import java.util.Properties;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
@@ -17,11 +17,10 @@
 
 package org.apache.inlong.sort.cdc.mysql.source;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
 import org.apache.inlong.sort.cdc.mysql.source.config.MySqlSourceConfigFactory;
 import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
-
-import org.apache.flink.annotation.PublicEvolving;
 
 import java.time.Duration;
 import java.util.Properties;
@@ -260,6 +259,11 @@ public class MySqlSourceBuilder<T> {
 
     public MySqlSourceBuilder<T> inlongAudit(String inlongAudit) {
         this.configFactory.inlongAudit(inlongAudit);
+        return this;
+    }
+
+    public MySqlSourceBuilder<T> migrateAll(boolean migrateAll) {
+        this.configFactory.migrateAll(migrateAll);
         return this;
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
@@ -17,13 +17,15 @@
 
 package org.apache.inlong.sort.cdc.mysql.source.config;
 
-import io.debezium.config.Configuration;
-import io.debezium.connector.mysql.MySqlConnectorConfig;
-import io.debezium.relational.RelationalTableFilters;
 import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
 import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
 
+import io.debezium.config.Configuration;
+import io.debezium.connector.mysql.MySqlConnectorConfig;
+import io.debezium.relational.RelationalTableFilters;
+
 import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
@@ -17,15 +17,13 @@
 
 package org.apache.inlong.sort.cdc.mysql.source.config;
 
-import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
-import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
-
 import io.debezium.config.Configuration;
 import io.debezium.connector.mysql.MySqlConnectorConfig;
 import io.debezium.relational.RelationalTableFilters;
+import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
+import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
 
 import javax.annotation.Nullable;
-
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.List;
@@ -74,6 +72,7 @@ public class MySqlSourceConfig implements Serializable {
     private final boolean includeIncremental;
     private final boolean ghostDdlChange;
     private final String ghostTableRegex;
+    private final boolean migrateAll;
 
     MySqlSourceConfig(
             String hostname,
@@ -101,7 +100,8 @@ public class MySqlSourceConfig implements Serializable {
             String inlongAudit,
             boolean includeIncremental,
             boolean ghostDdlChange,
-            String ghostTableRegex) {
+            String ghostTableRegex,
+            boolean migrateAll) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -130,6 +130,7 @@ public class MySqlSourceConfig implements Serializable {
         this.includeIncremental = includeIncremental;
         this.ghostDdlChange = ghostDdlChange;
         this.ghostTableRegex = ghostTableRegex;
+        this.migrateAll = migrateAll;
     }
 
     public String getHostname() {
@@ -247,5 +248,9 @@ public class MySqlSourceConfig implements Serializable {
 
     public String getGhostTableRegex() {
         return ghostTableRegex;
+    }
+
+    public boolean isMigrateAll() {
+        return migrateAll;
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
@@ -17,9 +17,10 @@
 
 package org.apache.inlong.sort.cdc.mysql.source.config;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.inlong.sort.cdc.mysql.debezium.EmbeddedFlinkDatabaseHistory;
 import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
+
+import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
 import java.time.Duration;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
@@ -17,10 +17,9 @@
 
 package org.apache.inlong.sort.cdc.mysql.source.config;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.inlong.sort.cdc.mysql.debezium.EmbeddedFlinkDatabaseHistory;
 import org.apache.inlong.sort.cdc.mysql.table.StartupOptions;
-
-import org.apache.flink.annotation.Internal;
 
 import java.io.Serializable;
 import java.time.Duration;
@@ -79,6 +78,7 @@ public class MySqlSourceConfigFactory implements Serializable {
     private boolean includeIncremental;
     private boolean ghostDdlChange;
     private String ghostTableRegex;
+    private boolean migrateAll;
 
     public MySqlSourceConfigFactory inlongMetric(String inlongMetric) {
         this.inlongMetric = inlongMetric;
@@ -102,6 +102,11 @@ public class MySqlSourceConfigFactory implements Serializable {
 
     public MySqlSourceConfigFactory ghostTableRegex(String ghostTableRegex) {
         this.ghostTableRegex = ghostTableRegex;
+        return this;
+    }
+
+    public MySqlSourceConfigFactory migrateAll(boolean migrateAll) {
+        this.migrateAll = migrateAll;
         return this;
     }
 
@@ -391,6 +396,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 inlongAudit,
                 includeIncremental,
                 ghostDdlChange,
-                ghostTableRegex);
+                ghostTableRegex,
+                migrateAll);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/reader/MySqlRecordEmitter.java
@@ -17,6 +17,15 @@
 
 package org.apache.inlong.sort.cdc.mysql.source.reader;
 
+import org.apache.inlong.sort.base.enums.ReadPhase;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.debezium.history.FlinkJsonTableChangeSerializer;
+import org.apache.inlong.sort.cdc.base.util.ColumnFilterUtil;
+import org.apache.inlong.sort.cdc.mysql.source.config.MySqlSourceConfig;
+import org.apache.inlong.sort.cdc.mysql.source.metrics.MySqlSourceReaderMetrics;
+import org.apache.inlong.sort.cdc.mysql.source.offset.BinlogOffset;
+import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplitState;
+
 import com.ververica.cdc.connectors.mysql.source.utils.RecordUtils;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.data.Envelope;
@@ -36,14 +45,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
 import org.apache.flink.util.Collector;
-import org.apache.inlong.sort.base.enums.ReadPhase;
-import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
-import org.apache.inlong.sort.cdc.base.debezium.history.FlinkJsonTableChangeSerializer;
-import org.apache.inlong.sort.cdc.base.util.ColumnFilterUtil;
-import org.apache.inlong.sort.cdc.mysql.source.config.MySqlSourceConfig;
-import org.apache.inlong.sort.cdc.mysql.source.metrics.MySqlSourceReaderMetrics;
-import org.apache.inlong.sort.cdc.mysql.source.offset.BinlogOffset;
-import org.apache.inlong.sort.cdc.mysql.source.split.MySqlSplitState;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.source.SourceRecord;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
@@ -17,6 +17,13 @@
 
 package org.apache.inlong.sort.cdc.mysql.table;
 
+import org.apache.inlong.sort.base.filter.RowKindValidator;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.debezium.table.MetadataConverter;
+import org.apache.inlong.sort.cdc.base.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.inlong.sort.cdc.debezium.DebeziumSourceFunction;
+import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
+
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -29,14 +36,9 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
-import org.apache.inlong.sort.base.filter.RowKindValidator;
-import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
-import org.apache.inlong.sort.cdc.base.debezium.table.MetadataConverter;
-import org.apache.inlong.sort.cdc.base.debezium.table.RowDataDebeziumDeserializeSchema;
-import org.apache.inlong.sort.cdc.debezium.DebeziumSourceFunction;
-import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
 
 import javax.annotation.Nullable;
+
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Collections;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
@@ -17,13 +17,6 @@
 
 package org.apache.inlong.sort.cdc.mysql.table;
 
-import org.apache.inlong.sort.base.filter.RowKindValidator;
-import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
-import org.apache.inlong.sort.cdc.base.debezium.table.MetadataConverter;
-import org.apache.inlong.sort.cdc.base.debezium.table.RowDataDebeziumDeserializeSchema;
-import org.apache.inlong.sort.cdc.debezium.DebeziumSourceFunction;
-import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
-
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
@@ -36,9 +29,14 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
+import org.apache.inlong.sort.base.filter.RowKindValidator;
+import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
+import org.apache.inlong.sort.cdc.base.debezium.table.MetadataConverter;
+import org.apache.inlong.sort.cdc.base.debezium.table.RowDataDebeziumDeserializeSchema;
+import org.apache.inlong.sort.cdc.debezium.DebeziumSourceFunction;
+import org.apache.inlong.sort.cdc.mysql.source.MySqlSource;
 
 import javax.annotation.Nullable;
-
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -240,6 +238,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .includeIncremental(includeIncremental)
                             .ghostDdlChange(ghostDdlChange)
                             .ghostTableRegex(ghostTableRegex)
+                            .migrateAll(migrateAll)
                             .build();
             return SourceProvider.of(parallelSource);
         } else {


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-8110][Sort] Only whole database migration need table level metric

- Fixes #8110 

### Motivation

Only whole database migration need table level metric. mysql connector DebeziumSoureFunction is right, but parallel read source is not consistent behavior.

### Modifications

Add judge to report table level metric in MySqlRecordEmitter class