### PR TITLE
[INLONG-8121][Manager] Supports cluster node status management in the case of multiple manager nodes

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ComponentHeartbeatEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ComponentHeartbeatEntityMapper.java
@@ -38,6 +38,16 @@ public interface ComponentHeartbeatEntityMapper {
 
     List<ComponentHeartbeatEntity> selectByCondition(@Param("request") HeartbeatPageRequest request);
 
+    /**
+     * Get the heartbeat by heartbeat interval
+     *
+     * @param component component type
+     * @param instance component address
+     * @param beforeSeconds the modified time was beforeSeconds seconds ago
+     */
+    ComponentHeartbeatEntity selectTimeOutHeartBeat(@Param("component") String component,
+            @Param("instance") String instance, @Param("beforeSeconds") Long beforeSeconds);
+
     int deleteByPrimaryKey(Integer id);
 
 }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ComponentHeartbeatEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ComponentHeartbeatEntityMapper.xml
@@ -77,6 +77,15 @@
         order by modify_time desc
     </select>
 
+    <select id="selectTimeOutHeartBeat" resultType="org.apache.inlong.manager.dao.entity.ComponentHeartbeatEntity">
+        select
+        <include refid="Base_Column_List"/>
+        from component_heartbeat
+        where component = #{component, jdbcType=VARCHAR}
+        and instance = #{instance,jdbcType=VARCHAR}
+        and modify_time &gt;= DATE_ADD(NOW(), INTERVAL -#{beforeSeconds, jdbcType=INTEGER} SECOND)
+    </select>
+
     <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
         delete
         from component_heartbeat

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
@@ -228,6 +228,8 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
             }
         }
         // If the manager has multiple nodes, need to determine that the heartbeat is updated
+        // heartbeatInterval() is the reporting interval of cluster nodes, multiplied by two to prevent network
+        // fluctuations
         ComponentHeartbeatEntity componentHeartbeatEntity = componentHeartbeatMapper.selectTimeOutHeartBeat(
                 componentHeartbeat.getComponentType(), componentHeartbeat.getIp(), heartbeatInterval() * 2L);
         if (componentHeartbeatEntity != null) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
@@ -17,28 +17,6 @@
 
 package org.apache.inlong.manager.service.heartbeat;
 
-import org.apache.inlong.common.enums.NodeSrvStatus;
-import org.apache.inlong.common.heartbeat.AbstractHeartbeatManager;
-import org.apache.inlong.common.heartbeat.ComponentHeartbeat;
-import org.apache.inlong.common.heartbeat.HeartbeatMsg;
-import org.apache.inlong.manager.common.consts.InlongConstants;
-import org.apache.inlong.manager.common.enums.ClusterStatus;
-import org.apache.inlong.manager.common.enums.ClusterType;
-import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
-import org.apache.inlong.manager.common.enums.NodeStatus;
-import org.apache.inlong.manager.common.util.JsonUtils;
-import org.apache.inlong.manager.common.util.Preconditions;
-import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
-import org.apache.inlong.manager.dao.entity.InlongClusterNodeEntity;
-import org.apache.inlong.manager.dao.mapper.InlongClusterEntityMapper;
-import org.apache.inlong.manager.dao.mapper.InlongClusterNodeEntityMapper;
-import org.apache.inlong.manager.dao.mapper.StreamSourceEntityMapper;
-import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
-import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
-import org.apache.inlong.manager.pojo.cluster.agent.AgentClusterNodeDTO;
-import org.apache.inlong.manager.service.cluster.InlongClusterOperator;
-import org.apache.inlong.manager.service.cluster.InlongClusterOperatorFactory;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -51,13 +29,35 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.common.enums.NodeSrvStatus;
+import org.apache.inlong.common.heartbeat.AbstractHeartbeatManager;
+import org.apache.inlong.common.heartbeat.ComponentHeartbeat;
+import org.apache.inlong.common.heartbeat.HeartbeatMsg;
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.common.enums.ClusterStatus;
+import org.apache.inlong.manager.common.enums.ClusterType;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.NodeStatus;
+import org.apache.inlong.manager.common.util.JsonUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.ComponentHeartbeatEntity;
+import org.apache.inlong.manager.dao.entity.InlongClusterEntity;
+import org.apache.inlong.manager.dao.entity.InlongClusterNodeEntity;
+import org.apache.inlong.manager.dao.mapper.ComponentHeartbeatEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongClusterEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongClusterNodeEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StreamSourceEntityMapper;
+import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
+import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
+import org.apache.inlong.manager.pojo.cluster.agent.AgentClusterNodeDTO;
+import org.apache.inlong.manager.service.cluster.InlongClusterOperator;
+import org.apache.inlong.manager.service.cluster.InlongClusterOperatorFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -87,6 +87,8 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
     private InlongClusterNodeEntityMapper clusterNodeMapper;
     @Autowired
     private StreamSourceEntityMapper sourceMapper;
+    @Autowired
+    private ComponentHeartbeatEntityMapper componentHeartbeatMapper;
 
     @Value("${cluster.heartbeat.interval:30}")
     private Long heartbeatIntervalFactor;
@@ -222,6 +224,13 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
             if (protocolTypes.length < ports.length) {
                 protocolTypes = null;
             }
+        }
+        // If the manager has multiple nodes, need to determine that the heartbeat is updated
+        ComponentHeartbeatEntity componentHeartbeatEntity = componentHeartbeatMapper.selectTimeOutHeartBeat(
+                componentHeartbeat.getComponentType(), componentHeartbeat.getIp(), heartbeatInterval() * 2L);
+        if (componentHeartbeatEntity != null) {
+            heartbeatCache.put(componentHeartbeat, heartbeat);
+            return;
         }
 
         for (int i = 0; i < ports.length; i++) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/heartbeat/HeartbeatManager.java
@@ -17,18 +17,6 @@
 
 package org.apache.inlong.manager.service.heartbeat;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.RemovalCause;
-import com.github.benmanes.caffeine.cache.Scheduler;
-import com.google.common.base.Joiner;
-import com.google.gson.Gson;
-import lombok.Getter;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.common.enums.NodeSrvStatus;
 import org.apache.inlong.common.heartbeat.AbstractHeartbeatManager;
 import org.apache.inlong.common.heartbeat.ComponentHeartbeat;
@@ -52,12 +40,26 @@ import org.apache.inlong.manager.pojo.cluster.ClusterNodeRequest;
 import org.apache.inlong.manager.pojo.cluster.agent.AgentClusterNodeDTO;
 import org.apache.inlong.manager.service.cluster.InlongClusterOperator;
 import org.apache.inlong.manager.service.cluster.InlongClusterOperatorFactory;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.google.common.base.Joiner;
+import com.google.gson.Gson;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;

--- a/inlong-manager/manager-web/src/main/resources/application-dev.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-dev.properties
@@ -87,7 +87,7 @@ data.cleansing.batchSize=100
 sort.enable.zookeeper=false
 
 # cluster node timeout interval of heartbeat unit: second, the interval multiplied by 5 represents the true heartbeat timeout interval
-cluster.heartbeat.interval=30
+cluster.heartbeat.interval=6
 
 # If turned on, synchronizing change the source status when the agent heartbeat times out
 source.update.enabled=false

--- a/inlong-manager/manager-web/src/main/resources/application-prod.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-prod.properties
@@ -86,7 +86,7 @@ data.cleansing.batchSize=100
 sort.enable.zookeeper=false
 
 # cluster node timeout interval of heartbeat unit: second, the interval multiplied by 5 represents the true heartbeat timeout interval
-cluster.heartbeat.interval=30
+cluster.heartbeat.interval=6
 
 # If turned on, synchronizing change the source status when the agent heartbeat times out
 source.update.enabled=false

--- a/inlong-manager/manager-web/src/main/resources/application-test.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-test.properties
@@ -87,7 +87,7 @@ data.cleansing.batchSize=100
 sort.enable.zookeeper=false
 
 # cluster node timeout interval of heartbeat unit: second, the interval multiplied by 5 represents the true heartbeat timeout interval
-cluster.heartbeat.interval=30
+cluster.heartbeat.interval=6
 
 # If turned on, synchronizing change the source status when the agent heartbeat times out
 source.update.enabled=false


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8121 

### Motivation

Supports cluster node status management in the case of multiple manager nodes.

The state management of the cluster nodes in the current manager is achieved through caching.

If the manager has multiple nodes, the cluster node status in the database will be refreshed to `heartbeat timeout` when the cache in any manager becomes invalid.

Therefore, when the cache fails, need to check whether the current cluster node is normal according to whether the current heartbeat information is expired.
### Modifications

Supports cluster node status management in the case of multiple manager nodes.

