### PR TITLE
[INLONG-8129][Manager] Add encoding check to the MySQL JDBC URL

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTO.java
@@ -57,8 +57,14 @@ public class MySQLSinkDTO {
 
         {
             put("autoDeserialize=true", "autoDeserialize=false");
+            put("autoDeserialize=yes", "autoDeserialize=false");
+
             put("allowLoadLocalInfile=true", "allowLoadLocalInfile=false");
+            put("allowLoadLocalInfile=yes", "allowLoadLocalInfile=false");
+
             put("allowUrlInLocalInfile=true", "allowUrlInLocalInfile=false");
+            put("allowUrlInLocalInfile=yes", "allowUrlInLocalInfile=false");
+
             put("allowLoadLocalInfileInPath=/", "allowLoadLocalInfileInPath=");
         }
     };

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sink/mysql/MySQLSinkDTOTest.java
@@ -47,6 +47,11 @@ public class MySQLSinkDTOTest {
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
                 originUrl);
+        originUrl = MySQLSinkDTO.filterSensitive(
+                "autoDeserialize=Yes&allowLoadLocalInfile = Yes&autoReconnect=true&allowUrlInLocalInfile=YEs&allowLoadLocalInfileInPath=/");
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
 
         // the sensitive params use url code
         originUrl = MySQLSinkDTO.filterSensitive(
@@ -72,6 +77,18 @@ public class MySQLSinkDTOTest {
         Assertions.assertEquals(
                 "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
                 originUrl);
+
+        originUrl = MySQLSinkDTO.filterSensitive(
+                URLEncoder.encode(
+                        "autoDeserialize=Yes&allowLoadLocalInfile = yes&autoReconnect=true&allowUrlInLocalInfile=YES&allowLoadLocalInfileInPath=/",
+                        "UTF-8"));
+        Assertions.assertEquals(
+                "autoDeserialize=false&allowLoadLocalInfile=false&autoReconnect=true&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=",
+                originUrl);
+
+        originUrl = MySQLSinkDTO.filterSensitive(
+                "autoDeserialize=%59%65%73&allowLoadLocalInfile = yes&allowUrlInLocalInfil%65+=%74%72%75%45&allowLoadLocalInfileInPath=%2F#");
+        Assertions.assertEquals("autoDeserialize=false&allowLoadLocalInfile=false&allowUrlInLocalInfile=false&allowLoadLocalInfileInPath=#", originUrl);
     }
 
     @Test


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8129 

### Motivation

Add a check to the URL encoding of mysql JDBC URL.


### Modifications

1.Add a check to the URL encoding of mysql JDBC URL.

2.Add checks for three unsafe parameters that can cause arbitrary file reading problems. They are
allowLoadLocalInfile, allowUrlInLocalInfile, allowLoadLocalInfileInPath.
