### PR TITLE
[INLONG-8157][CI] Support execute mvn commands in any submodule

### DIFF
--- a/inlong-agent/agent-common/pom.xml
+++ b/inlong-agent/agent-common/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-agent</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>agent-common</artifactId>
     <name>Apache InLong - Agent Common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-agent/agent-core/pom.xml
+++ b/inlong-agent/agent-core/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-agent</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>agent-core</artifactId>
     <name>Apache InLong - Agent Core</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-agent/agent-docker/pom.xml
+++ b/inlong-agent/agent-docker/pom.xml
@@ -27,8 +27,13 @@
         <artifactId>inlong-agent</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>agent-docker</artifactId>
     <name>Apache InLong - Agent Docker</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-agent/agent-plugins/pom.xml
+++ b/inlong-agent/agent-plugins/pom.xml
@@ -25,10 +25,12 @@
         <artifactId>inlong-agent</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>agent-plugins</artifactId>
     <name>Apache InLong - Agent Plugins</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
         <debezium.version>1.8.0.Final</debezium.version>
     </properties>
 

--- a/inlong-agent/agent-release/pom.xml
+++ b/inlong-agent/agent-release/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-agent</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>agent-release</artifactId>
     <name>Apache InLong - Agent Release</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-agent/pom.xml
+++ b/inlong-agent/pom.xml
@@ -25,6 +25,7 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-agent</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - Agent</name>
@@ -36,4 +37,9 @@
         <module>agent-release</module>
         <module>agent-docker</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
+
 </project>

--- a/inlong-audit/audit-common/pom.xml
+++ b/inlong-audit/audit-common/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-audit</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>audit-common</artifactId>
     <name>Apache InLong - Audit Common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-audit/audit-docker/pom.xml
+++ b/inlong-audit/audit-docker/pom.xml
@@ -28,6 +28,10 @@
     <artifactId>audit-docker</artifactId>
     <name>Apache InLong - Audit Docker</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-audit/audit-proxy/pom.xml
+++ b/inlong-audit/audit-proxy/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-audit</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>audit-proxy</artifactId>
     <name>Apache InLong - Audit Proxy</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-audit/audit-release/pom.xml
+++ b/inlong-audit/audit-release/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-audit</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>audit-release</artifactId>
     <name>Apache InLong - Audit Release</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-audit/audit-sdk/pom.xml
+++ b/inlong-audit/audit-sdk/pom.xml
@@ -18,7 +18,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
@@ -26,8 +25,11 @@
     </parent>
 
     <artifactId>audit-sdk</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Audit SDK</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-audit/audit-store/pom.xml
+++ b/inlong-audit/audit-store/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-audit</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>audit-store</artifactId>
     <name>Apache InLong - Audit store</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-audit/pom.xml
+++ b/inlong-audit/pom.xml
@@ -25,7 +25,7 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>inlong-audit</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - Audit</name>
@@ -38,6 +38,10 @@
         <module>audit-release</module>
         <module>audit-docker</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-common/pom.xml
+++ b/inlong-common/pom.xml
@@ -25,9 +25,13 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-common</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-dashboard/pom.xml
+++ b/inlong-dashboard/pom.xml
@@ -25,9 +25,14 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-dashboard</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - Dashboard</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <build>
         <plugins>

--- a/inlong-dataproxy/dataproxy-dist/pom.xml
+++ b/inlong-dataproxy/dataproxy-dist/pom.xml
@@ -30,6 +30,10 @@
     <packaging>pom</packaging>
     <name>Apache InLong - DataProxy Dist</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/inlong-dataproxy/dataproxy-docker/pom.xml
+++ b/inlong-dataproxy/dataproxy-docker/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-dataproxy</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dataproxy-docker</artifactId>
     <name>Apache InLong - DataProxy Docker</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-dataproxy/dataproxy-source/pom.xml
+++ b/inlong-dataproxy/dataproxy-source/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-dataproxy</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dataproxy-source</artifactId>
     <name>Apache InLong - DataProxy Source</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-dataproxy/pom.xml
+++ b/inlong-dataproxy/pom.xml
@@ -25,6 +25,7 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-dataproxy</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - DataProxy</name>
@@ -34,6 +35,10 @@
         <module>dataproxy-dist</module>
         <module>dataproxy-docker</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-distribution/pom.xml
+++ b/inlong-distribution/pom.xml
@@ -29,6 +29,10 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Distribution</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/inlong-manager/manager-client-examples/pom.xml
+++ b/inlong-manager/manager-client-examples/pom.xml
@@ -23,8 +23,13 @@
         <artifactId>inlong-manager</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>manager-client-examples</artifactId>
     <name>Apache InLong - Manager Client Examples</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-manager/manager-client-tools/pom.xml
+++ b/inlong-manager/manager-client-tools/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-client-tools</artifactId>
     <name>Apache InLong - Manager Client Tools</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/manager-client/pom.xml
+++ b/inlong-manager/manager-client/pom.xml
@@ -23,8 +23,13 @@
         <artifactId>inlong-manager</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>manager-client</artifactId>
     <name>Apache InLong - Manager Client</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-manager/manager-common/pom.xml
+++ b/inlong-manager/manager-common/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-common</artifactId>
     <name>Apache InLong - Manager Common</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/manager-dao/pom.xml
+++ b/inlong-manager/manager-dao/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-dao</artifactId>
     <name>Apache InLong - Manager DAO</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -27,8 +27,13 @@
         <artifactId>inlong-manager</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>manager-docker</artifactId>
     <name>Apache InLong - Manager Docker</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <!-- copy manager-web.tar.gz to the manager-docker/target path -->

--- a/inlong-manager/manager-plugins/pom.xml
+++ b/inlong-manager/manager-plugins/pom.xml
@@ -18,7 +18,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
@@ -27,6 +26,10 @@
 
     <artifactId>manager-plugins</artifactId>
     <name>Apache InLong - Manager Plugins</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-manager/manager-pojo/pom.xml
+++ b/inlong-manager/manager-pojo/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-pojo</artifactId>
     <name>Apache InLong - Manager Pojo</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/manager-service/pom.xml
+++ b/inlong-manager/manager-service/pom.xml
@@ -18,7 +18,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
@@ -27,6 +26,10 @@
 
     <artifactId>manager-service</artifactId>
     <name>Apache InLong - Manager Service</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-manager/manager-test/pom.xml
+++ b/inlong-manager/manager-test/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-test</artifactId>
     <name>Apache InLong - Manager Test</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/inlong-manager/manager-web/pom.xml
+++ b/inlong-manager/manager-web/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-web</artifactId>
     <name>Apache InLong - Manager Web</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/manager-workflow/pom.xml
+++ b/inlong-manager/manager-workflow/pom.xml
@@ -27,6 +27,10 @@
     <artifactId>manager-workflow</artifactId>
     <name>Apache InLong - Manager Workflow</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-manager/pom.xml
+++ b/inlong-manager/pom.xml
@@ -23,6 +23,7 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-manager</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - Manager</name>
@@ -41,6 +42,10 @@
         <module>manager-web</module>
         <module>manager-docker</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sdk/dataproxy-sdk/pom.xml
+++ b/inlong-sdk/dataproxy-sdk/pom.xml
@@ -25,9 +25,13 @@
         <artifactId>inlong-sdk</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>dataproxy-sdk</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - DataProxy SDK</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sdk/pom.xml
+++ b/inlong-sdk/pom.xml
@@ -35,6 +35,10 @@
         <module>dataproxy-sdk</module>
     </modules>
 
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.flume</groupId>

--- a/inlong-sdk/sdk-common/pom.xml
+++ b/inlong-sdk/sdk-common/pom.xml
@@ -25,9 +25,13 @@
         <artifactId>inlong-sdk</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>sdk-common</artifactId>
     <name>Apache InLong - SDK Common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sdk/sort-sdk/pom.xml
+++ b/inlong-sdk/sort-sdk/pom.xml
@@ -30,6 +30,10 @@
 
     <name>Apache InLong - Sort SDK</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -25,6 +25,7 @@
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-sort-standalone</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Standalone</name>
@@ -34,6 +35,10 @@
         <module>sort-standalone-source</module>
         <module>sort-standalone-dist</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort-standalone/sort-standalone-common/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-common/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-sort-standalone</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>sort-standalone-common</artifactId>
     <name>Apache InLong - Sort Standalone Common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort-standalone/sort-standalone-dist/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-dist/pom.xml
@@ -30,6 +30,10 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Standalone Dist</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/inlong-sort-standalone/sort-standalone-source/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-source/pom.xml
@@ -25,8 +25,13 @@
         <artifactId>inlong-sort-standalone</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>sort-standalone-source</artifactId>
     <name>Apache InLong - Sort Standalone Source</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -20,15 +20,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>inlong-sort</artifactId>
     <packaging>pom</packaging>
-
     <name>Apache InLong - Sort</name>
 
     <modules>
@@ -40,7 +39,9 @@
         <module>sort-end-to-end-tests</module>
         <module>sort-flink</module>
     </modules>
+
     <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
         <debezium.version>1.5.4.Final</debezium.version>
         <kafka.clients.version>2.7.0</kafka.clients.version>
         <rat.basedir>${basedir}</rat.basedir>
@@ -48,6 +49,7 @@
         <iceberg.hive.version>2.3.7</iceberg.hive.version>
         <hudi.hive.version>2.3.7</hudi.hive.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/inlong-sort/sort-api/pom.xml
+++ b/inlong-sort/sort-api/pom.xml
@@ -20,19 +20,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-api</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Api</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
         <!-- deploy this module to repo -->
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
@@ -43,7 +41,6 @@
             <artifactId>sort-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/inlong-sort/sort-common/pom.xml
+++ b/inlong-sort/sort-common/pom.xml
@@ -20,19 +20,17 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-common</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Common</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
         <!-- deploy this module to repo -->
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>

--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -20,17 +20,18 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-core</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Core</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-dist/pom.xml
+++ b/inlong-sort/sort-dist/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>sort-dist</artifactId>
     <name>Apache InLong - Sort Dist</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-sort/sort-end-to-end-tests/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/pom.xml
@@ -23,11 +23,14 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-end-to-end-tests</artifactId>
     <name>Apache InLong - Sort End to End Tests</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/base/pom.xml
+++ b/inlong-sort/sort-flink/base/pom.xml
@@ -25,8 +25,11 @@
     </parent>
 
     <artifactId>sort-connector-base</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-base</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
 

--- a/inlong-sort/sort-flink/cdc-base/pom.xml
+++ b/inlong-sort/sort-flink/cdc-base/pom.xml
@@ -25,11 +25,13 @@
     </parent>
 
     <artifactId>sort-connector-cdc-base</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-cdc-base</name>
 
-    <dependencies>
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
+    <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-connector-base</artifactId>
@@ -52,7 +54,6 @@
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-shaded-jackson</artifactId>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/inlong-sort/sort-flink/pom.xml
+++ b/inlong-sort/sort-flink/pom.xml
@@ -30,6 +30,10 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Flink</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <profiles>
         <profile>
             <id>flink-all-version</id>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
@@ -36,6 +36,7 @@
     </modules>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
         <flink.version>1.13.5</flink.version>
         <flink.connector.mongodb.cdc.version>2.3.0</flink.connector.mongodb.cdc.version>
         <flink.connector.redis>1.1.0</flink.connector.redis>
@@ -53,6 +54,7 @@
         <sqlserver.jdbc.version>7.2.2.jre8</sqlserver.jdbc.version>
         <thrift.version>0.9.3</thrift.version>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <!-- flink connector-->

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
@@ -23,13 +23,12 @@
         <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <artifactId>sort-connector-doris</artifactId>
 
+    <artifactId>sort-connector-doris</artifactId>
     <name>Apache InLong - Sort-connector-doris</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
     </properties>
 
     <dependencies>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
@@ -25,8 +25,11 @@
     </parent>
 
     <artifactId>sort-connector-elasticsearch6</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-elasticsearch6</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
@@ -25,8 +25,11 @@
     </parent>
 
     <artifactId>sort-connector-elasticsearch7</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-elasticsearch7</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
@@ -25,8 +25,11 @@
     </parent>
 
     <artifactId>sort-connector-elasticsearch-base</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-elasticsearch-base</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
@@ -26,8 +26,11 @@
     </parent>
 
     <artifactId>sort-connector-filesystem</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-filesystem</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
@@ -26,10 +26,10 @@
     </parent>
 
     <artifactId>sort-connector-hbase</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-hbase</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <zookeeper.version>3.4.14</zookeeper.version>
     </properties>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -27,8 +27,11 @@
     </parent>
 
     <artifactId>sort-connector-hive</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-hive</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
@@ -26,10 +26,10 @@
     </parent>
 
     <artifactId>sort-connector-hudi</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-hudi</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <stax2-api.version>4.2.1</stax2-api.version>
         <guava.version>31.0.1-jre</guava.version>
         <woodstox-core.version>5.3.0</woodstox-core.version>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
@@ -26,8 +26,11 @@
     </parent>
 
     <artifactId>sort-connector-iceberg</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-iceberg</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
@@ -27,8 +27,11 @@
     </parent>
 
     <artifactId>sort-connector-jdbc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-jdbc</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
@@ -27,8 +27,11 @@
     </parent>
 
     <artifactId>sort-connector-kafka</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-kafka</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
@@ -26,10 +26,11 @@
     </parent>
 
     <artifactId>sort-connector-kudu</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-kudu</name>
 
-    <properties />
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
@@ -26,10 +26,10 @@
     </parent>
 
     <artifactId>sort-connector-mongodb-cdc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-mongodb-cdc</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <debezium.version>1.6.4.Final</debezium.version>
     </properties>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
@@ -20,7 +20,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
@@ -28,8 +27,11 @@
     </parent>
 
     <artifactId>sort-connector-mysql-cdc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-mysql-cdc</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
@@ -26,10 +26,10 @@
     </parent>
 
     <artifactId>sort-connector-oracle-cdc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-oracle-cdc</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <debezium.version>1.6.4.Final</debezium.version>
     </properties>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
@@ -24,7 +24,6 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-connectors-v1.13</artifactId>
@@ -56,6 +55,10 @@
         <module>hudi</module>
         <module>kudu</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
@@ -26,8 +26,11 @@
     </parent>
 
     <artifactId>sort-connector-postgres-cdc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-postgres-cdc</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
@@ -27,8 +27,11 @@
     </parent>
 
     <artifactId>sort-connector-pulsar</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-pulsar</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -25,11 +25,13 @@
     </parent>
 
     <artifactId>sort-connector-redis</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-redis</name>
 
-    <dependencies>
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
+    <dependencies>
         <dependency>
             <groupId>org.apache.bahir</groupId>
             <artifactId>flink-connector-redis_${flink.scala.binary.version}</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
@@ -26,8 +26,11 @@
     </parent>
 
     <artifactId>sort-connector-sqlserver-cdc</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-sqlserver-cdc</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
@@ -23,13 +23,12 @@
         <artifactId>sort-connectors-v1.13</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <artifactId>sort-connector-starrocks</artifactId>
 
+    <artifactId>sort-connector-starrocks</artifactId>
     <name>Apache InLong - Sort-connector-starrocks</name>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <starrocks-connector.version>1.2.3</starrocks-connector.version>
     </properties>
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
@@ -26,8 +26,12 @@
     </parent>
 
     <artifactId>sort-connector-tubemq</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort-connector-tubemq</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-flink-dependencies/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>sort-flink-dependencies-v1.13</artifactId>
     <name>Apache InLong - Sort Flink Dependencies v1.13</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
         <!--flink 1.13.5-->
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/pom.xml
@@ -36,6 +36,7 @@
     </modules>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
         <flink.version>1.15.4</flink.version>
         <debezium.version>2.0.1.Final</debezium.version>
         <flink.connector.mongodb.cdc.version>2.3.0</flink.connector.mongodb.cdc.version>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
@@ -30,4 +30,8 @@
     <packaging>pom</packaging>
     <name>Apache InLong - Sort Connectors v1.15</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
 </project>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
@@ -27,8 +27,11 @@
     </parent>
 
     <artifactId>sort-flink-dependencies-v1.15</artifactId>
-
     <name>Apache InLong - Sort Flink Dependencies v1.15</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <!--flink 1.15.4-->

--- a/inlong-sort/sort-formats/format-base/pom.xml
+++ b/inlong-sort/sort-formats/format-base/pom.xml
@@ -19,19 +19,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>sort-format-base</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-base</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-formats/format-common/pom.xml
+++ b/inlong-sort/sort-formats/format-common/pom.xml
@@ -19,19 +19,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>sort-format-common</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-common</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-formats/format-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-csv/pom.xml
@@ -19,19 +19,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>sort-format-csv</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-csv</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -86,6 +86,7 @@
         </dependency>
 
     </dependencies>
+
     <profiles>
         <!-- Create SQL Client uber jars by default -->
         <profile>

--- a/inlong-sort/sort-formats/format-inlongmsg-base/pom.xml
+++ b/inlong-sort/sort-formats/format-inlongmsg-base/pom.xml
@@ -19,22 +19,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-format-inlongmsg-base</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-inlongmsg-base</name>
 
-    <dependencies>
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
+    <dependencies>
         <!-- core dependencies -->
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-sort/sort-formats/format-inlongmsg-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-inlongmsg-csv/pom.xml
@@ -19,24 +19,22 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>sort-format-inlongmsg-csv</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-inlongmsg-csv</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
-
         <!-- core dependencies -->
-
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-format-common</artifactId>

--- a/inlong-sort/sort-formats/format-inlongmsg-pb/pom.xml
+++ b/inlong-sort/sort-formats/format-inlongmsg-pb/pom.xml
@@ -19,22 +19,21 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-format-inlongmsg-pb</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-inlongmsg-pb</name>
 
-    <dependencies>
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
+    <dependencies>
         <!-- core dependencies -->
         <dependency>
             <groupId>org.apache.inlong</groupId>

--- a/inlong-sort/sort-formats/format-json/pom.xml
+++ b/inlong-sort/sort-formats/format-json/pom.xml
@@ -19,19 +19,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-format-json</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-json</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-sort/sort-formats/format-kv/pom.xml
+++ b/inlong-sort/sort-formats/format-kv/pom.xml
@@ -19,24 +19,22 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
     </parent>
 
     <artifactId>sort-format-kv</artifactId>
-    <packaging>jar</packaging>
     <name>Apache InLong - Sort Format-kv</name>
 
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
     <dependencies>
-
         <!-- core dependencies -->
-
         <dependency>
             <groupId>org.apache.inlong</groupId>
             <artifactId>sort-format-common</artifactId>

--- a/inlong-sort/sort-formats/pom.xml
+++ b/inlong-sort/sort-formats/pom.xml
@@ -19,14 +19,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
-
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>sort-formats</artifactId>
@@ -45,6 +42,7 @@
     </modules>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
         <flink.forkCount>1C</flink.forkCount>
         <flink.reuseForks>true</flink.reuseForks>
         <log4j.configurationfile>log4j2-test.properties</log4j.configurationfile>

--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -25,7 +25,6 @@
         <version>1.8.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.apache.inlong</groupId>
     <artifactId>inlong-tubemq</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ</name>
@@ -39,6 +38,10 @@
         <module>tubemq-manager</module>
         <module>tubemq-docker</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <build>
         <plugins>

--- a/inlong-tubemq/tubemq-client/pom.xml
+++ b/inlong-tubemq/tubemq-client/pom.xml
@@ -22,11 +22,15 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-client</artifactId>
     <name>Apache InLong - TubeMQ Client</name>
     <description>Client functionality for TubeMQ</description>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-connectors/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/pom.xml
@@ -22,16 +22,21 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-connectors</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Connectors</name>
+
     <modules>
         <module>tubemq-connector-flink</module>
         <module>tubemq-connector-flume</module>
         <module>tubemq-connector-spark</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flink/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flink/pom.xml
@@ -23,10 +23,12 @@
         <artifactId>tubemq-connectors</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>tubemq-connector-flink</artifactId>
     <name>Apache InLong - TubeMQ Connectors-flink</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
         <flink.version>1.13.5</flink.version>
         <scala.binary.version>2.11</scala.binary.version>
     </properties>

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
@@ -27,6 +27,7 @@
     <name>Apache InLong - TubeMQ Connectors-flume</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
         <flume.version>1.9.0</flume.version>
         <mockito.version>1.9.0</mockito.version>
         <junit.version>4.11</junit.version>

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-spark/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-spark/pom.xml
@@ -23,8 +23,13 @@
         <artifactId>tubemq-connectors</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
+
     <artifactId>tubemq-connector-spark</artifactId>
     <name>Apache InLong - TubeMQ Connectors-spark</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-core/pom.xml
+++ b/inlong-tubemq/tubemq-core/pom.xml
@@ -22,11 +22,15 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-core</artifactId>
     <name>Apache InLong - TubeMQ Core</name>
     <description>Core functionality for InLong TubeMQ</description>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-docker/pom.xml
+++ b/inlong-tubemq/tubemq-docker/pom.xml
@@ -22,17 +22,22 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-docker</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Docker</name>
+
     <modules>
         <module>tubemq-all</module>
         <module>tubemq-build</module>
         <module>tubemq-cpp</module>
         <module>tubemq-manager</module>
     </modules>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-docker/tubemq-all/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/pom.xml
@@ -27,10 +27,14 @@
         <artifactId>tubemq-docker</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>tubemq-all</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Docker All</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-docker/tubemq-build/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-build/pom.xml
@@ -27,10 +27,14 @@
         <artifactId>tubemq-docker</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>tubemq-build</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Docker Build</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <profiles>
         <profile>

--- a/inlong-tubemq/tubemq-docker/tubemq-cpp/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-cpp/pom.xml
@@ -27,10 +27,14 @@
         <artifactId>tubemq-docker</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>tubemq-cpp</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Docker Build C++ SDK Client</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <profiles>
         <profile>

--- a/inlong-tubemq/tubemq-docker/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-manager/pom.xml
@@ -27,10 +27,14 @@
         <artifactId>tubemq-docker</artifactId>
         <version>1.8.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.apache.inlong</groupId>
+
     <artifactId>tubemq-manager-docker</artifactId>
     <packaging>pom</packaging>
     <name>Apache InLong - TubeMQ Docker Manager</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-example/pom.xml
+++ b/inlong-tubemq/tubemq-example/pom.xml
@@ -22,11 +22,15 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-example</artifactId>
     <name>Apache InLong - TubeMQ Example</name>
     <description>Example for InLong TubeMQ</description>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -22,12 +22,13 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
+
     <artifactId>tubemq-manager</artifactId>
     <name>Apache InLong - TubeMQ Manager</name>
 
     <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
         <docker.image.prefix>springboot-docker</docker.image.prefix>
     </properties>
 

--- a/inlong-tubemq/tubemq-server/pom.xml
+++ b/inlong-tubemq/tubemq-server/pom.xml
@@ -22,12 +22,15 @@
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
         <version>1.8.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>tubemq-server</artifactId>
     <name>Apache InLong - TubeMQ Server</name>
     <description>Server functionality for InLong TubeMQ</description>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,9 @@
     </modules>
 
     <properties>
+        <!-- the root directory of the inlong project -->
+        <inlong.root.dir>${project.basedir}</inlong.root.dir>
+
         <project.build.encoding>UTF-8</project.build.encoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -1284,6 +1287,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
@@ -1291,10 +1295,10 @@
                 <configuration>
                     <java>
                         <eclipse>
-                            <file>codestyle/spotless_inlong_formatter.xml</file>
+                            <file>${inlong.root.dir}/codestyle/spotless_inlong_formatter.xml</file>
                         </eclipse>
                         <licenseHeader>
-                            <file>codestyle/license-header</file>
+                            <file>${inlong.root.dir}/codestyle/license-header</file>
                         </licenseHeader>
 
                         <importOrder>
@@ -1342,14 +1346,16 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>compile-format</id>
+                        <id>compile-apply-format</id>
                         <goals>
+                            <!-- apply the format when compile the project  -->
                             <goal>apply</goal>
                         </goals>
                         <phase>compile</phase>
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
@@ -1358,6 +1364,7 @@
                     <!-- here add configures -->
                 </configuration>
             </plugin>
+
             <plugin>
                 <groupId>org.apache.rat</groupId>
                 <artifactId>apache-rat-plugin</artifactId>
@@ -1464,6 +1471,7 @@
             </plugin>
         </plugins>
     </build>
+
     <url>https://github.com/apache/inlong</url>
     <inceptionYear>2013</inceptionYear>
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8157

### Motivation

Support execute Maven commands in any submodule.

### Modifications

First, I use the `directory-maven-plugin` plugin to obtain the root path of the project, and then I can successfully execute commands such as `mvn compile` in the submodule.

But soon I found that the life cycle of this plug-in cannot be associated with the `mvn spotless:check / apply` command, that is, when executing `mvn spotless:check / apply`, an error will be reported saying that `${inlong.root.dir}` cannot be found this variable.

Finally, I refer to the practice of the Apache Avro community[1] and define the same variable in each pom.xml. Although it is a bit troublesome, this way I can successfully use the `mvn` commands (like `mvn compile`) and the `mvn spotless` commands in the submodule.

> [1] Usage in Apache Avro: 
>   https://github.com/healchow/avro/blob/master/lang/java/pom.xml?#L37
>   https://github.com/healchow/avro/blob/master/lang/java/pom.xml?#L306

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)