### PR TITLE
[INLONG-8169][Manager] Add default tenant "public" if the request does not specify

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/BasicAuth.java
@@ -28,6 +28,9 @@ import java.util.Base64;
 public class BasicAuth {
 
     public static final String BASIC_AUTH_HEADER = "Authorization";
+    public static final String BASIC_AUTH_TENANT_HEADER = "Tenant";
+
+    public static final String DEFAULT_TENANT = "public";
     public static final String BASIC_AUTH_PREFIX = "Basic";
     public static final String BASIC_AUTH_SEPARATOR = " ";
     public static final String BASIC_AUTH_JOINER = ":";

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/InlongManagerMain.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/InlongManagerMain.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.web;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.ServletComponentScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -27,6 +28,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableConfigurationProperties
 @EnableScheduling
 @ComponentScan(basePackages = "org.apache.inlong.manager")
+@ServletComponentScan
 public class InlongManagerMain {
 
     public static void main(String[] args) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/EmptyTenantFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/EmptyTenantFilter.java
@@ -19,7 +19,7 @@ package org.apache.inlong.manager.web.filter;
 
 import org.apache.inlong.manager.web.utils.InlongRequestWrapper;
 
-import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -30,21 +30,19 @@ import javax.servlet.http.HttpServletRequest;
 
 import java.io.IOException;
 
-/**
- * HttpServletRequestFilter
- * Make All
- */
-@Slf4j
-public class HttpServletRequestFilter implements Filter {
+import static org.apache.inlong.common.util.BasicAuth.BASIC_AUTH_TENANT_HEADER;
+import static org.apache.inlong.common.util.BasicAuth.DEFAULT_TENANT;
+
+public class EmptyTenantFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
             throws IOException, ServletException {
-        if (servletRequest instanceof HttpServletRequest) {
-            ServletRequest requestWrapper = new InlongRequestWrapper((HttpServletRequest) servletRequest);
-            filterChain.doFilter(requestWrapper, servletResponse);
-        } else {
-            filterChain.doFilter(servletRequest, servletResponse);
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        String tenant = request.getHeader(BASIC_AUTH_TENANT_HEADER);
+        if (StringUtils.isBlank(tenant)) {
+            ((InlongRequestWrapper) servletRequest).addHeader(BASIC_AUTH_TENANT_HEADER, DEFAULT_TENANT);
         }
+        filterChain.doFilter(servletRequest, servletResponse);
     }
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/EmptyTenantFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/EmptyTenantFilter.java
@@ -33,6 +33,10 @@ import java.io.IOException;
 import static org.apache.inlong.common.util.BasicAuth.BASIC_AUTH_TENANT_HEADER;
 import static org.apache.inlong.common.util.BasicAuth.DEFAULT_TENANT;
 
+/**
+ * Empty tenant filter.
+ * Add default tenant to header if the tenant has not been specified.
+ */
 public class EmptyTenantFilter implements Filter {
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/HttpServletRequestFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/HttpServletRequestFilter.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 
 /**
  * HttpServletRequestFilter
- * Make All
+ * Make all request body modifiable
  */
 @Slf4j
 public class HttpServletRequestFilter implements Filter {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/WebFilterConfig.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/filter/WebFilterConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.filter;
+
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebFilterConfig {
+
+    @Bean
+    public FilterRegistrationBean registerHttpServletRequestFilter() {
+        FilterRegistrationBean<HttpServletRequestFilter> bean = new FilterRegistrationBean<>();
+        bean.setOrder(0);
+        bean.setFilter(new HttpServletRequestFilter());
+        bean.addUrlPatterns("/*");
+        bean.setMatchAfter(false);
+        bean.setName("httpServletRequestFilter");
+        return bean;
+    }
+
+    @Bean
+    public FilterRegistrationBean registerEmptyTenantFilter() {
+        FilterRegistrationBean<EmptyTenantFilter> bean = new FilterRegistrationBean<>();
+        bean.setOrder(1);
+        bean.setFilter(new EmptyTenantFilter());
+        bean.addUrlPatterns("/*");
+        bean.setMatchAfter(false);
+        bean.setName("emptyTenantFilter");
+        return bean;
+    }
+
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
@@ -128,6 +128,11 @@ public class InlongRequestWrapper extends HttpServletRequestWrapper {
         return new BufferedReader(new InputStreamReader(this.getInputStream()));
     }
 
+    @Override
+    public String getHeader(String name) {
+        return this.headers.get(name);
+    }
+
     public void addHeader(String name, String value) {
         headers.put(name, value);
     }

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/filter/EmptyTenantFilterTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/filter/EmptyTenantFilterTest.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.web.filter;
 
 import org.apache.inlong.common.util.BasicAuth;
 import org.apache.inlong.manager.web.WebBaseTest;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
@@ -33,20 +34,22 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
 
+import java.io.IOException;
 
 public class EmptyTenantFilterTest extends WebBaseTest {
 
     @Test
     public void testNoTenant() {
         MockHttpServletRequest req = new MockHttpServletRequest();
-        Servlet servlet = new HttpServlet() {};
+        Servlet servlet = new HttpServlet() {
+        };
         MockHttpServletResponse res = new MockHttpServletResponse();
         HttpServletRequestFilter httpServletRequestFilter = new HttpServletRequestFilter();
         EmptyTenantFilter emptyTenantFilter = new EmptyTenantFilter();
         FilterChecker checker = new FilterChecker(BasicAuth.DEFAULT_TENANT);
-        MockFilterChain filterChain = new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
+        MockFilterChain filterChain =
+                new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
         Assertions.assertDoesNotThrow(() -> filterChain.doFilter(req, res));
     }
 
@@ -55,15 +58,16 @@ public class EmptyTenantFilterTest extends WebBaseTest {
         MockHttpServletRequest req = new MockHttpServletRequest();
         String testTenant = "testTenant";
         req.addHeader(BasicAuth.BASIC_AUTH_TENANT_HEADER, testTenant);
-        Servlet servlet = new HttpServlet() {};
+        Servlet servlet = new HttpServlet() {
+        };
         MockHttpServletResponse res = new MockHttpServletResponse();
         HttpServletRequestFilter httpServletRequestFilter = new HttpServletRequestFilter();
         EmptyTenantFilter emptyTenantFilter = new EmptyTenantFilter();
         FilterChecker checker = new FilterChecker(testTenant);
-        MockFilterChain filterChain = new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
+        MockFilterChain filterChain =
+                new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
         Assertions.assertDoesNotThrow(() -> filterChain.doFilter(req, res));
     }
-
 
     class FilterChecker implements Filter {
 

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/filter/EmptyTenantFilterTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/filter/EmptyTenantFilterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.filter;
+
+import org.apache.inlong.common.util.BasicAuth;
+import org.apache.inlong.manager.web.WebBaseTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+
+public class EmptyTenantFilterTest extends WebBaseTest {
+
+    @Test
+    public void testNoTenant() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        Servlet servlet = new HttpServlet() {};
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        HttpServletRequestFilter httpServletRequestFilter = new HttpServletRequestFilter();
+        EmptyTenantFilter emptyTenantFilter = new EmptyTenantFilter();
+        FilterChecker checker = new FilterChecker(BasicAuth.DEFAULT_TENANT);
+        MockFilterChain filterChain = new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
+        Assertions.assertDoesNotThrow(() -> filterChain.doFilter(req, res));
+    }
+
+    @Test
+    public void testWithTenant() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        String testTenant = "testTenant";
+        req.addHeader(BasicAuth.BASIC_AUTH_TENANT_HEADER, testTenant);
+        Servlet servlet = new HttpServlet() {};
+        MockHttpServletResponse res = new MockHttpServletResponse();
+        HttpServletRequestFilter httpServletRequestFilter = new HttpServletRequestFilter();
+        EmptyTenantFilter emptyTenantFilter = new EmptyTenantFilter();
+        FilterChecker checker = new FilterChecker(testTenant);
+        MockFilterChain filterChain = new MockFilterChain(servlet, httpServletRequestFilter, emptyTenantFilter, checker);
+        Assertions.assertDoesNotThrow(() -> filterChain.doFilter(req, res));
+    }
+
+
+    class FilterChecker implements Filter {
+
+        String targetTenant;
+
+        public FilterChecker(String targetTenant) {
+            this.targetTenant = targetTenant;
+        }
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+            HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+            String tenant = httpServletRequest.getHeader(BasicAuth.BASIC_AUTH_TENANT_HEADER);
+            Assertions.assertEquals(targetTenant, tenant);
+        }
+    }
+}


### PR DESCRIPTION

### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8169 
- Parent #7914 

### Motivation

To support multi-tenancy https://github.com/apache/inlong/issues/7914, all requests need to carry tenant fields in header.
To be compitable with old version, if the requst does not, use "public" tenant.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [x] This change added tests and can be verified as follows: EmptyTenantFilterTest

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
