### PR TITLE
[INLONG-8173][Sort] Fix the NPE problem when adding new columns

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergSchemaChangeHelper.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergSchemaChangeHelper.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sort.iceberg.schema;
 
+import org.apache.iceberg.types.Types;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.DirtyType;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
@@ -122,7 +123,7 @@ public class IcebergSchemaChangeHelper extends SchemaChangeHelper {
         }
     }
 
-    public void doAddColumn(List<AlterColumn> alterColumns, TableIdentifier tableId) {
+    private void doAddColumn(List<AlterColumn> alterColumns, TableIdentifier tableId) {
         List<TableChange> tableChanges = new ArrayList<>();
         Table table = catalog.loadTable(tableId);
         Transaction transaction = table.newTransaction();
@@ -130,9 +131,17 @@ public class IcebergSchemaChangeHelper extends SchemaChangeHelper {
         alterColumns.forEach(alterColumn -> {
             Column column = alterColumn.getNewColumn();
             LogicalType dataType = dynamicSchemaFormat.sqlType2FlinkType(column.getJdbcType());
-            TableChange.ColumnPosition position =
-                    column.getPosition().getPositionType() == PositionType.FIRST ? TableChange.ColumnPosition.first()
-                            : TableChange.ColumnPosition.after(column.getName());
+            TableChange.ColumnPosition position;
+            if (column.getPosition() != null && column.getPosition().getColumnName() != null) {
+                position =
+                        column.getPosition().getPositionType() == PositionType.FIRST
+                                ? TableChange.ColumnPosition.first()
+                                : TableChange.ColumnPosition.after(column.getPosition().getColumnName());
+            } else {
+                List<Types.NestedField> columns = table.schema().columns();
+                Types.NestedField lastField = columns.get(columns.size() - 1);
+                position = TableChange.ColumnPosition.after(lastField.name());
+            }
             TableChange.AddColumn addColumn = new TableChange.AddColumn(new String[]{column.getName()},
                     dataType, column.isNullable(), column.getComment(), position);
             tableChanges.add(addColumn);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergSchemaChangeHelper.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergSchemaChangeHelper.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sort.iceberg.schema;
 
-import org.apache.iceberg.types.Types;
 import org.apache.inlong.sort.base.dirty.DirtySinkHelper;
 import org.apache.inlong.sort.base.dirty.DirtyType;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
@@ -44,6 +43,7 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -177,10 +177,10 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         }
         this.dirtySinkHelper.open(new Configuration());
         this.schemaChangeHelper = new IcebergSchemaChangeHelper(dynamicSchemaFormat,
-                enableSchemaChange, enableSchemaChange ? SchemaChangeUtils.deserialize(schemaChangePolicies) : null,
-                multipleSinkOption.getDatabasePattern(), multipleSinkOption.getTablePattern(),
-                multipleSinkOption.getSchemaUpdatePolicy(), metricData, dirtySinkHelper,
-                catalog, asNamespaceCatalog);
+                enableSchemaChange, enableSchemaChange ? SchemaChangeUtils.deserialize(schemaChangePolicies)
+                : Collections.emptyMap(), multipleSinkOption.getDatabasePattern(),
+                multipleSinkOption.getTablePattern(), multipleSinkOption.getSchemaUpdatePolicy(), metricData,
+                dirtySinkHelper, catalog, asNamespaceCatalog);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -178,7 +178,8 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         this.dirtySinkHelper.open(new Configuration());
         this.schemaChangeHelper = new IcebergSchemaChangeHelper(dynamicSchemaFormat,
                 enableSchemaChange, enableSchemaChange ? SchemaChangeUtils.deserialize(schemaChangePolicies)
-                : Collections.emptyMap(), multipleSinkOption.getDatabasePattern(),
+                        : Collections.emptyMap(),
+                multipleSinkOption.getDatabasePattern(),
                 multipleSinkOption.getTablePattern(), multipleSinkOption.getSchemaUpdatePolicy(), metricData,
                 dirtySinkHelper, catalog, asNamespaceCatalog);
     }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes https://github.com/apache/inlong/issues/8173

### Motivation
When Column#position may be null, the doAddColumn method may throw NPE:
https://github.com/apache/inlong/blob/a38bab22169a06010c54b0d27ed3b40656c667e6/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergSchemaChangeHelper.java#L134-L136

### Modifications
When Column#position is null, append to the last column by default.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
