### PR TITLE
[INLONG-8177][Sort] Improve jdbc connector object calculation and fix filesystem connector report dirty data metrics error

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/src/main/java/org/apache/inlong/sort/filesystem/stream/AbstractStreamingWriter.java
@@ -247,7 +247,7 @@ public abstract class AbstractStreamingWriter<IN, OUT> extends AbstractStreamOpe
                 throw new RuntimeException(e);
             }
             if (sinkMetricData != null) {
-                sinkMetricData.invokeWithEstimate(element.getValue());
+                sinkMetricData.invokeDirtyWithEstimate(element.getValue());
             }
             if (dirtySink != null) {
                 DirtyData.Builder<Object> builder = DirtyData.builder();

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/TableMetricStatementExecutor.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/TableMetricStatementExecutor.java
@@ -31,7 +31,6 @@ import org.apache.flink.table.data.RowData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -146,7 +145,7 @@ public final class TableMetricStatementExecutor implements JdbcBatchStatementExe
         int writtenSize = errorPositions.get(0);
         long writtenBytes = 0L;
         if (writtenSize > 0) {
-            writtenBytes = (long) batch.get(0).toString().getBytes(StandardCharsets.UTF_8).length * writtenSize;
+            writtenBytes = CalculateObjectSizeUtils.getDataSize(batch.get(0)) * writtenSize;
         }
         if (!multipleSink) {
             sinkMetricData.invoke(writtenSize, writtenBytes);
@@ -186,7 +185,7 @@ public final class TableMetricStatementExecutor implements JdbcBatchStatementExe
                     sinkMetricData.invokeWithEstimate(rowData);
                 } else {
                     metric[0] += 1;
-                    metric[1] += rowData.toString().getBytes().length;
+                    metric[1] += CalculateObjectSizeUtils.getDataSize(rowData);
                 }
             } catch (Exception e) {
                 st.clearParameters();


### PR DESCRIPTION


### Prepare a Pull Request


- [INLONG-8177][Sort] Improve jdbc connector object calculation and fix filesystem connector report dirty data metrics error


- Fixes #8177 

### Motivation

* Improve jdbc connector object calculation
* Fix filesystem connector report dirty data metrics error

### Modifications

* Modify jdbc connector object calculation
* Modify filesystem connector dirty data metrics report

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
