### PR TITLE
[INLONG-8170][DataProxy] Add inlong_cluster and inlong_cluster_node tables

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
@@ -30,6 +30,7 @@ import org.apache.inlong.dataproxy.config.pojo.CacheClusterConfig;
 import org.apache.inlong.dataproxy.config.pojo.CacheType;
 import org.apache.inlong.dataproxy.config.pojo.DataType;
 import org.apache.inlong.dataproxy.config.pojo.IdTopicConfig;
+import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.sdk.commons.protocol.InlongId;
 
 import com.google.gson.Gson;
@@ -54,8 +55,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
-import static org.apache.inlong.dataproxy.consts.ConfigConstants.KEY_NAMESPACE;
 
 /**
  * Json to object
@@ -333,6 +332,7 @@ public class MetaConfigHolder extends ConfigHolder {
         String groupId;
         String streamId;
         String topicName;
+        String tenant;
         String nameSpace;
         for (InLongIdObject idObject : inLongIds) {
             if (idObject == null
@@ -359,7 +359,8 @@ public class MetaConfigHolder extends ConfigHolder {
             if (index >= 0) {
                 topicName = topicName.substring(index + 1).trim();
             }
-            nameSpace = idObject.getParams().getOrDefault(KEY_NAMESPACE, "");
+            tenant = idObject.getParams().getOrDefault(ConfigConstants.KEY_TENANT, "");
+            nameSpace = idObject.getParams().getOrDefault(ConfigConstants.KEY_NAMESPACE, "");
             if (mqType.equals(CacheType.TUBE)) {
                 if (StringUtils.isNotBlank(nameSpace)) {
                     topicName = nameSpace;
@@ -371,7 +372,7 @@ public class MetaConfigHolder extends ConfigHolder {
             }
             IdTopicConfig tmpConfig = new IdTopicConfig();
             tmpConfig.setInlongGroupIdAndStreamId(groupId, streamId);
-            tmpConfig.setNameSpace(nameSpace);
+            tmpConfig.setTenantAndNameSpace(tenant, nameSpace);
             tmpConfig.setTopicName(topicName);
             tmpConfig.setParams(idObject.getParams());
             tmpConfig.setDataType(DataType.convert(
@@ -384,7 +385,7 @@ public class MetaConfigHolder extends ConfigHolder {
                     && tmpTopicConfigMap.get(tmpConfig.getInlongGroupId()) == null) {
                 IdTopicConfig tmpConfig2 = new IdTopicConfig();
                 tmpConfig2.setInlongGroupIdAndStreamId(groupId, "");
-                tmpConfig2.setNameSpace(nameSpace);
+                tmpConfig.setTenantAndNameSpace(tenant, nameSpace);
                 tmpConfig2.setTopicName(topicName);
                 tmpConfig2.setDataType(tmpConfig.getDataType());
                 tmpConfig2.setFieldDelimiter(tmpConfig.getFieldDelimiter());

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/pojo/IdTopicConfig.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/pojo/IdTopicConfig.java
@@ -19,6 +19,7 @@ package org.apache.inlong.dataproxy.config.pojo;
 
 import org.apache.inlong.sdk.commons.protocol.InlongId;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 import java.util.HashMap;
@@ -29,16 +30,22 @@ import java.util.Map;
  */
 public class IdTopicConfig {
 
+    private static final String DEFAULT_PULSAR_TENANT = "public";
     private String uid;
     private String inlongGroupId;
     private String inlongStreamid;
     private String topicName;
+    private String tenant;
     private String nameSpace;
     private DataType dataType = DataType.TEXT;
     private String fieldDelimiter = "|";
     private String fileDelimiter = "\n";
 
     private Map<String, String> params = new HashMap<>();
+
+    public IdTopicConfig() {
+
+    }
 
     /**
      * get uid
@@ -78,16 +85,23 @@ public class IdTopicConfig {
 
     public String getPulsarTopicName(String clusterTenant, String clusterNameSpace) {
         StringBuilder builder = new StringBuilder(256);
-        if (clusterTenant != null) {
-            builder.append(clusterTenant).append("/");
+        // build tenant
+        if (StringUtils.isBlank(tenant)) {
+            if (StringUtils.isBlank(clusterTenant)) {
+                builder.append(DEFAULT_PULSAR_TENANT).append("/");
+            } else {
+                builder.append(clusterTenant).append("/");
+            }
+        } else {
+            builder.append(tenant).append("/");
         }
-        String namespace = clusterNameSpace;
-        if (namespace == null) {
-            namespace = this.nameSpace;
+        // build name space
+        if (StringUtils.isBlank(this.nameSpace)) {
+            builder.append(clusterNameSpace).append("/");
+        } else {
+            builder.append(this.nameSpace).append("/");
         }
-        if (namespace != null) {
-            builder.append(namespace).append("/");
-        }
+        // build topic name
         return builder.append(topicName).toString();
     }
 
@@ -164,18 +178,13 @@ public class IdTopicConfig {
     }
 
     /**
-     * get nameSpace
-     * @return the nameSpace
-     */
-    public String getNameSpace() {
-        return nameSpace;
-    }
-
-    /**
-     * set nameSpace
+     * set tenant and nameSpace
+     *
+     * @param tenant  the tenant to set
      * @param nameSpace the nameSpace to set
      */
-    public void setNameSpace(String nameSpace) {
+    public void setTenantAndNameSpace(String tenant, String nameSpace) {
+        this.tenant = tenant;
         this.nameSpace = nameSpace;
     }
 


### PR DESCRIPTION

- Fixes #8170

1. Adjust the implementation logic of IdTopicConfig.getPulsarTopicName(): first obtain the tenant carried by IdTopicConfig, if the value is not set, the incoming clusterTenant shall prevail, if the clusterTenant is not set, set the default value "public"; second obtain the namespace carried by IdTopicConfig, if the value is not set, the incoming clusterNameSpace shall prevail, this namespace value must exist, so no default value is set.
2. Adjust the tenant and namespace acquisition method in the IdTopicConfig object