### PR TITLE
[INLONG-7900][Sort] Support partition by primary key when upsert single table of Kafka 

### DIFF
--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/DynamicKafkaSerializationSchema.java
@@ -37,6 +37,10 @@ import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.base.format.JsonDynamicSchemaFormat;
 import org.apache.inlong.sort.base.metric.sub.SinkTopicMetricData;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink.WritableMetadata;
+import org.apache.inlong.sort.protocol.enums.SchemaChangePolicy;
+import org.apache.inlong.sort.protocol.enums.SchemaChangeType;
+import org.apache.inlong.sort.util.SchemaChangeUtils;
+import org.apache.inlong.sort.kafka.partitioner.SingleTablePrimaryKeyPartitioner;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,10 +88,10 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
      */
     private final int[] metadataPositions;
     private final String sinkMultipleFormat;
-    private boolean multipleSink;
-    private JsonDynamicSchemaFormat jsonDynamicSchemaFormat;
     private final DirtyOptions dirtyOptions;
     private final @Nullable DirtySink<Object> dirtySink;
+    private boolean multipleSink;
+    private JsonDynamicSchemaFormat jsonDynamicSchemaFormat;
     private int[] partitions;
 
     private int parallelInstanceId;
@@ -129,10 +133,6 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
         this.dirtySink = dirtySink;
     }
 
-    public void setMetricData(SinkTopicMetricData metricData) {
-        this.metricData = metricData;
-    }
-
     static RowData createProjectedRow(
             RowData consumedRow, RowKind kind, RowData.FieldGetter[] fieldGetters) {
         final int arity = fieldGetters.length;
@@ -141,6 +141,10 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
             genericRowData.setField(fieldPos, fieldGetters[fieldPos].getFieldOrNull(consumedRow));
         }
         return genericRowData;
+    }
+
+    public void setMetricData(SinkTopicMetricData metricData) {
+        this.metricData = metricData;
     }
 
     @Override
@@ -161,6 +165,10 @@ class DynamicKafkaSerializationSchema implements KafkaSerializationSchema<RowDat
             multipleSink = true;
             jsonDynamicSchemaFormat =
                     (JsonDynamicSchemaFormat) DynamicSchemaFormatFactory.getFormat(sinkMultipleFormat);
+        }
+
+        if (partitioner instanceof SingleTablePrimaryKeyPartitioner) {
+            ((SingleTablePrimaryKeyPartitioner<?>) partitioner).setValueFieldGetters(valueFieldGetters);
         }
     }
 

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/SingleTablePrimaryKeyPartitioner.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/partitioner/SingleTablePrimaryKeyPartitioner.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.kafka.partitioner;
+
+import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.RowData.FieldGetter;
+import org.apache.flink.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * The PrimaryKey Partitioner is used to extract primary key from single table messages:
+ *
+ * @param <T>
+ */
+public class SingleTablePrimaryKeyPartitioner<T> extends FlinkKafkaPartitioner<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SingleTablePrimaryKeyPartitioner.class);
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * schema entry names which will be used to extract fields from schema for hashing.
+     */
+    private String partitionKey;
+
+    /**
+     * If a partitionNumber is specified, then use this number directly instead.
+     */
+    private int partitionNumber = -1;
+
+    /**
+     * the fieldnames of the schema
+     */
+    private String[] fieldNames;
+
+    /**
+     * the value field getters used to extract rowdata
+     */
+    private FieldGetter[] valueFieldGetters;
+
+    @Override
+    public void open(int parallelInstanceId, int parallelInstances) {
+        super.open(parallelInstanceId, parallelInstances);
+    }
+
+    /**
+     * precondition: record is of rowData Type, schema and partitionKey are not null
+     */
+    @Override
+    public int partition(T record, byte[] key, byte[] value, String targetTopic, int[] partitions) {
+        Preconditions.checkArgument(
+                partitions != null && partitions.length > 0,
+                "Partitions of the target topic is empty.");
+        // parse the partition key fields
+        return getPartition((RowData) record, partitions);
+    }
+
+    public void setPartitionKey(String partitionKey) {
+        this.partitionKey = partitionKey;
+    }
+
+    /**
+     * input: rowdata,  partitions
+     * output: the hashed partition number
+     */
+    private int getPartition(RowData data, int[] partitions) {
+        if (partitionNumber >= 0) {
+            return partitionNumber;
+        }
+        List<Integer> pos = getFieldPos();
+        // parse out the List<String> from partitionkey and then get list of positions in schema.
+        long hashCode = 0;
+        for (int i : pos) {
+            Object fieldValue = valueFieldGetters[i].getFieldOrNull(data);
+            if (fieldValue != null) {
+                hashCode += fieldValue.hashCode();
+            }
+        }
+        return partitions[((int) ((hashCode & Integer.MAX_VALUE) % partitions.length))];
+    }
+
+    /**
+     * output: integer list of partitionKeys' corresponding positions within schema
+     */
+    private List<Integer> getFieldPos() {
+        // the positions of the partition keys.
+        List<Integer> positions = new ArrayList<>();
+        if (partitionKey == null) {
+            LOG.error("primaryKeyPartioner:failed to fetch partitionKey");
+            return positions;
+        }
+        // a map storing field names and their position in the schema
+        HashMap<String, Integer> map = new HashMap<>();
+        String[] keys = partitionKey.split(",");
+        for (int i = 0; i < fieldNames.length; i++) {
+            map.put(fieldNames[i], i);
+        }
+        for (String key : keys) {
+            positions.add(map.get(key));
+        }
+        return positions;
+    }
+
+    @SuppressWarnings("deprecation")
+    public void setSchema(TableSchema schema) {
+        this.fieldNames = schema.getFieldNames();
+    }
+
+    public void setPartitionNumber(String partitionNumber) {
+        // partition Number is optional parameter and not always needed, so it can be null.
+        if (partitionNumber != null) {
+            this.partitionNumber = Integer.parseInt(partitionNumber);
+        }
+    }
+
+    public void setValueFieldGetters(FieldGetter[] fieldGetters) {
+        this.valueFieldGetters = fieldGetters;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof SingleTablePrimaryKeyPartitioner;
+    }
+
+    @Override
+    public int hashCode() {
+        return SingleTablePrimaryKeyPartitioner.class.hashCode();
+    }
+}

--- a/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
+++ b/inlong-sort/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicTableFactory.java
@@ -32,6 +32,7 @@ import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartiti
 import org.apache.flink.streaming.connectors.kafka.table.KafkaOptions;
 import org.apache.flink.streaming.connectors.kafka.table.KafkaSinkSemantic;
 import org.apache.flink.streaming.connectors.kafka.table.SinkBufferFlushMode;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -57,6 +58,10 @@ import org.apache.inlong.sort.base.dirty.utils.DirtySinkFactoryUtils;
 import org.apache.inlong.sort.base.format.DynamicSchemaFormatFactory;
 import org.apache.inlong.sort.kafka.KafkaDynamicSink;
 import org.apache.inlong.sort.kafka.partitioner.RawDataHashPartitioner;
+import org.apache.inlong.sort.protocol.enums.SchemaChangePolicy;
+import org.apache.inlong.sort.protocol.enums.SchemaChangeType;
+import org.apache.inlong.sort.util.SchemaChangeUtils;
+import org.apache.inlong.sort.kafka.partitioner.SingleTablePrimaryKeyPartitioner;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
@@ -68,6 +73,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FIELDS_PREFIX;
 import static org.apache.flink.streaming.connectors.kafka.table.KafkaOptions.KEY_FORMAT;
@@ -103,6 +109,11 @@ import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
 import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
+import static org.apache.inlong.sort.base.Constants.SINK_SCHEMA_CHANGE_POLICIES;
+import static org.apache.inlong.sort.base.Constants.SINK_SCHEMA_CHANGE_ENABLE;
+import static org.apache.inlong.sort.base.Constants.PATTERN_PARTITION_MAP;
+import static org.apache.inlong.sort.base.Constants.PATTERN_PARTITION_MAP;
+import static org.apache.inlong.sort.base.Constants.SINK_MULTIPLE_FORMAT;
 import static org.apache.inlong.sort.kafka.table.KafkaOptions.KAFKA_IGNORE_ALL_CHANGELOG;
 
 /**
@@ -117,12 +128,18 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
     public static final String IDENTIFIER = "kafka-inlong";
 
     public static final String SINK_PARTITIONER_VALUE_RAW_HASH = "raw-hash";
+    public static final String SINK_PARTITIONER_VALUE_PRIMARY_KEY = "primaryKey";
+    public static final String SINK_PARTITIONER_VALUE_INLONG_FIXED_PARTITION = "inlong-fixed-partition";
 
     public static final ConfigOption<String> SINK_MULTIPLE_PARTITION_PATTERN =
             ConfigOptions.key("sink.multiple.partition-pattern")
                     .stringType()
-                    .noDefaultValue()
-                    .withDescription("option 'sink.multiple.partition-pattern' used when the partitioner is raw-hash.");
+                    .noDefaultValue();
+
+    public static final ConfigOption<String> SINK_FIXED_IDENTIFIER =
+            ConfigOptions.key("sink.fixed.identifier")
+                    .stringType()
+                    .defaultValue("-1");
 
     private static final Set<String> SINK_SEMANTIC_ENUMS =
             new HashSet<>(
@@ -240,14 +257,33 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
     }
 
     private Optional<FlinkKafkaPartitioner<RowData>> getFlinkKafkaPartitioner(
-            ReadableConfig tableOptions, ClassLoader classLoader) {
-        if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
+            ReadableConfig tableOptions, ClassLoader classLoader, TableSchema schema) {
+        if (tableOptions.getOptional(SINK_PARTITIONER).isPresent() && SINK_PARTITIONER_VALUE_INLONG_FIXED_PARTITION
+                .equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
+            InLongFixedPartitionPartitioner<RowData> inLongFixedPartitionPartitioner =
+                    new InLongFixedPartitionPartitioner<>(tableOptions.getOptional(PATTERN_PARTITION_MAP)
+                            .orElse(null),
+                            tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
+                                    .orElse(null));
+            inLongFixedPartitionPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT)
+                    .orElse(null));
+            return Optional.of(inLongFixedPartitionPartitioner);
+        } else if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
                 && SINK_PARTITIONER_VALUE_RAW_HASH.equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
             RawDataHashPartitioner<RowData> rawHashPartitioner = new RawDataHashPartitioner<>();
             rawHashPartitioner.setSinkMultipleFormat(tableOptions.getOptional(SINK_MULTIPLE_FORMAT).orElse(null));
             rawHashPartitioner.setPartitionPattern(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
                     .orElse(null));
             return Optional.of(rawHashPartitioner);
+        } else if (tableOptions.getOptional(SINK_PARTITIONER).isPresent()
+                && SINK_PARTITIONER_VALUE_PRIMARY_KEY.equals(tableOptions.getOptional(SINK_PARTITIONER).get())) {
+            SingleTablePrimaryKeyPartitioner<RowData> primaryKeyPartitioner = new SingleTablePrimaryKeyPartitioner<>();
+            // the pattern is different from the ${} pattern, it is a truncated string of schema fields.
+            primaryKeyPartitioner.setPartitionNumber(tableOptions.getOptional(SINK_FIXED_IDENTIFIER).orElse(null));
+            primaryKeyPartitioner.setPartitionKey(tableOptions.getOptional(SINK_MULTIPLE_PARTITION_PATTERN)
+                    .orElse(null));
+            primaryKeyPartitioner.setSchema(schema);
+            return Optional.of(primaryKeyPartitioner);
         }
         Optional<FlinkKafkaPartitioner<RowData>> partitioner = KafkaOptions
                 .getFlinkKafkaPartitioner(tableOptions, classLoader);
@@ -313,6 +349,11 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
         options.add(AUDIT_KEYS);
         options.add(SINK_MULTIPLE_FORMAT);
         options.add(SINK_MULTIPLE_PARTITION_PATTERN);
+        options.add(PATTERN_PARTITION_MAP);
+        options.add(DATASOURCE_PARTITION_MAP);
+        options.add(SINK_SCHEMA_CHANGE_ENABLE);
+        options.add(SINK_SCHEMA_CHANGE_POLICIES);
+        options.add(SINK_FIXED_IDENTIFIER);
         return options;
     }
 
@@ -442,7 +483,8 @@ public class KafkaDynamicTableFactory implements DynamicTableSourceFactory, Dyna
                 tableOptions.get(TOPIC).get(0),
                 getKafkaProperties(context.getCatalogTable().getOptions()),
                 context.getCatalogTable(),
-                getFlinkKafkaPartitioner(tableOptions, context.getClassLoader()).orElse(null),
+                getFlinkKafkaPartitioner(tableOptions, context.getClassLoader(),
+                        context.getCatalogTable().getSchema()).orElse(null),
                 getSinkSemantic(tableOptions),
                 parallelism,
                 inlongMetric,


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7900 

### Motivation
See issue.

### Modifications
Added PrimaryKeyPartitioner, and made modifications to support upsert-kafka


### Verifying this change
1. execute the sql in the issue again
2. create a kafka-mysql task to consume all the messages back to mysql

the mysql table fluctuated from 1000-2000 rows, and in the end it reduced to 0 rows, so I assume that the issue has been solved, since if it is still round robin, some update queries will be unordered, and it is unlikely that 3890 remaining records can be reduced to 0. The format used is json, for canal-json/avro/csv, I only tested that the primaryKey partitition is in effect and there are no errors. 
