### PR TITLE
[INLONG-8212][DataProxy] Improve HTTP related message handling

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/DataProxyErrCode.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/DataProxyErrCode.java
@@ -26,10 +26,17 @@ public enum DataProxyErrCode {
 
     SUCCESS(0, "Ok"),
 
-    SINK_SERVICE_UNREADY(1, "Service not ready"),
+    SINK_SERVICE_UNREADY(1, "Service sink not ready"),
     SERVICE_CLOSED(2, "Service closed"),
     CONF_SERVICE_UNREADY(3, "Configure Service not ready"),
     ILLEGAL_VISIT_IP(10, "Illegal visit ip"),
+
+    HTTP_DECODE_REQ_FAILURE(31, "Decode request failure"),
+    HTTP_UNSUPPORTED_METHOD(32, "Un-supported method"),
+    HTTP_REQ_URI_BLANK(33, "Request uri is blank"),
+    HTTP_DECODE_REQ_URI_FAILURE(34, "Decode uri failure"),
+    HTTP_UNSUPPORTED_SERVICE_URI(35, "Un-supported service uri"),
+    HTTP_UNSUPPORTED_CONTENT_TYPE(36, "Un-supported content type"),
 
     FIELD_VALUE_NOT_EQUAL(95, "Field value not equal"),
     UNCOMPRESS_DATA_ERROR(96, "Uncompress data error"),

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/HttpAttrConst.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/HttpAttrConst.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.dataproxy.consts;
+
+/**
+ * Http Attribute constants
+ */
+public class HttpAttrConst {
+
+    public static final String KEY_SRV_URL_HEARTBEAT = "/dataproxy/heartbeat";
+    public static final String KEY_SRV_URL_REPORT_MSG = "/dataproxy/message";
+    public static final String KEY_URL_FAVICON_ICON = "/favicon.ico";
+
+    public static final String KEY_GROUP_ID = "groupId";
+    public static final String KEY_STREAM_ID = "streamId";
+    public static final String KEY_BODY = "body";
+    public static final String KEY_DATA_TIME = "dt";
+    public static final String KEY_MESSAGE_COUNT = "cnt";
+    public static final String KEY_CHARSET = "charset";
+    public static final String VAL_DEF_CHARSET = "UTF-8";
+    public static final String RET_CNT_TYPE = "application/json;charset=utf-8";
+
+}

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -19,15 +19,30 @@ package org.apache.inlong.dataproxy.consts;
 
 public class StatConstants {
 
-    public static final java.lang.String EVENT_SERVICE_CLOSED = "source.srvclosed";
-    public static final java.lang.String EVENT_SERVICE_UNREADY = "sink.unready";
-    public static final java.lang.String EVENT_VISITIP_ILLEGAL = "links.illegal";
-    public static final java.lang.String EVENT_NOTOPIC = "config.notopic";
+    public static final java.lang.String EVENT_SERVICE_CLOSED = "service.closed";
+    public static final java.lang.String EVENT_SERVICE_SINK_UNREADY = "service.sink.unready";
+    // visit
+    public static final java.lang.String EVENT_VISIT_ILLEGAL = "visit.illegal";
+    public static final java.lang.String EVENT_VISIT_OVERMAX = "visit.overmax";
+    public static final java.lang.String EVENT_VISIT_LINKIN = "visit.linkin";
+    public static final java.lang.String EVENT_VISIT_LINKOUT = "visit.linkout";
+    public static final java.lang.String EVENT_VISIT_EXCEPTION = "visit.exception";
+    // configure
+    public static final java.lang.String EVENT_CONFIG_TOPIC_MISSING = "config.topic.missing";
     // source
-    public static final java.lang.String EVENT_LINKS_OVERMAX = "links.overmax";
-    public static final java.lang.String EVENT_LINKS_IN = "links.linkin";
-    public static final java.lang.String EVENT_LINKS_OUT = "links.linkout";
-    public static final java.lang.String EVENT_LINKS_EXCEPTION = "links.exception";
+    public static final java.lang.String EVENT_MSG_DECODE_FAIL = "msg.decode.failure";
+    public static final java.lang.String EVENT_MSG_METHOD_INVALID = "msg.method.invalid";
+    public static final java.lang.String EVENT_MSG_PATH_INVALID = "msg.path.invalid";
+    public static final java.lang.String EVENT_MSG_CONTYPE_INVALID = "msg.content.invalid";
+    public static final java.lang.String EVENT_MSG_GROUPID_MISSING = "msg.groupid.missing";
+    public static final java.lang.String EVENT_MSG_STREAMID_MISSING = "msg.streamid.missing";
+    public static final java.lang.String EVENT_MSG_BODY_MISSING = "msg.body.missing";
+    public static final java.lang.String EVENT_MSG_BODY_BLANK = "msg.body.blank";
+    public static final java.lang.String EVENT_MSG_BODY_OVERMAX = "msg.body.overmax";
+    public static final java.lang.String EVENT_MSG_HB_SUCCESS = "msg.hb.success";
+    public static final java.lang.String EVENT_MSG_POST_SUCCESS = "msg.post.success";
+    public static final java.lang.String EVENT_MSG_POST_FAILURE = "msg.post.failure";
+
     public static final java.lang.String EVENT_EMPTY = "socketmsg.empty";
     public static final java.lang.String EVENT_OVERMAXLEN = "socketmsg.overmaxlen";
     public static final java.lang.String EVENT_NOTEQUALLEN = "socketmsg.notequallen";
@@ -46,20 +61,6 @@ public class StatConstants {
     public static final java.lang.String EVENT_POST_SUCCESS = "socketmsg.success";
     public static final java.lang.String EVENT_POST_DROPPED = "socketmsg.dropped";
     // http
-    public static final java.lang.String EVENT_HTTP_DECFAIL = "httpmsg.decfailure";
-    public static final java.lang.String EVENT_HTTP_INVALIDMETHOD = "httpmsg.invmethod";
-    public static final java.lang.String EVENT_HTTP_BLANKURI = "httpmsg.blankuri";
-    public static final java.lang.String EVENT_HTTP_URIDECFAIL = "httpmsg.decurifail";
-    public static final java.lang.String EVENT_HTTP_INVALIDURI = "httpmsg.invuri";
-    public static final java.lang.String EVENT_HTTP_ILLEGAL_VISIT = "httpmsg.illegal";
-    public static final java.lang.String EVENT_HTTP_HB_SUCCESS = "httphb.success";
-    public static final java.lang.String EVENT_HTTP_WITHOUTGROUPID = "httpmsg.wogroupid";
-    public static final java.lang.String EVENT_HTTP_WITHOUTSTREAMID = "httpmsg.wostreamid";
-    public static final java.lang.String EVENT_HTTP_NOBODY = "httpmsg.nobody";
-    public static final java.lang.String EVENT_HTTP_EMPTYBODY = "httpmsg.emptybody";
-    public static final java.lang.String EVENT_HTTP_BODYOVERMAXLEN = "httpmsg.bodyovermax";
-    public static final java.lang.String EVENT_HTTP_POST_SUCCESS = "httpmsg.success";
-    public static final java.lang.String EVENT_HTTP_POST_DROPPED = "httpmsg.dropped";
 
     public static final java.lang.String EVENT_SINK_NOUID = "sink.nouid";
     public static final java.lang.String EVENT_SINK_NOTOPIC = "sink.notopic";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
@@ -117,7 +117,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
                 return true;
             }
         } catch (Exception ex) {
-            log.error("reportHeartbeat failed for url {}", url, ex);
+            log.error("reportHeartbeat failed for url {}, exception message is {}", url, ex.getMessage());
         }
         return false;
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
@@ -107,8 +107,7 @@ public class AuditUtils {
      */
     public static long getLogTime(Event event) {
         if (event != null) {
-            Map<String, String> headers = event.getHeaders();
-            return getLogTime(headers);
+            return getLogTime(event.getHeaders());
         }
         return System.currentTimeMillis();
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
@@ -106,16 +106,16 @@ public class TubeHandler implements MessageQueueHandler {
     }
 
     @Override
-    public void publishTopic(Set<String> topicSet) {
-        if (this.producer == null || topicSet == null || topicSet.isEmpty()) {
+    public void publishTopic(Set<String> newTopicSet) {
+        if (this.producer == null || newTopicSet == null || newTopicSet.isEmpty()) {
             return;
         }
         Set<String> published;
         try {
-            published = producer.publish(topicSet);
-            topicSet.addAll(published);
+            published = producer.publish(newTopicSet);
+            this.topicSet.addAll(newTopicSet);
             LOG.info("Publish topics to {}, need publish are {}, published are {}",
-                    this.clusterName, topicSet, published);
+                    this.clusterName, newTopicSet, published);
         } catch (Throwable e) {
             LOG.warn("Publish topics to {} failure", this.clusterName, e);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SimpleHttpSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SimpleHttpSource.java
@@ -47,6 +47,7 @@ public class SimpleHttpSource extends BaseSource implements Configurable {
 
     public SimpleHttpSource() {
         super();
+        ConfigManager.getInstance().regIPVisitConfigChgCallback(this);
     }
 
     @Override

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SimpleTcpSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SimpleTcpSource.java
@@ -18,15 +18,12 @@
 package org.apache.inlong.dataproxy.source2;
 
 import org.apache.inlong.dataproxy.config.ConfigManager;
-import org.apache.inlong.dataproxy.config.holder.ConfigUpdateCallback;
-import org.apache.inlong.dataproxy.utils.AddressUtils;
 import org.apache.inlong.dataproxy.utils.ConfStringUtils;
 import org.apache.inlong.dataproxy.utils.EventLoopUtil;
 
 import com.google.common.base.Preconditions;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBufAllocator;
-import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import org.apache.flume.Context;
@@ -35,12 +32,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
-import java.util.Iterator;
 
 /**
  * Simple tcp source
  */
-public class SimpleTcpSource extends BaseSource implements Configurable, ConfigUpdateCallback {
+public class SimpleTcpSource extends BaseSource implements Configurable {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleTcpSource.class);
 
@@ -121,34 +117,6 @@ public class SimpleTcpSource extends BaseSource implements Configurable, ConfigU
     @Override
     public String getProtocolName() {
         return SourceConstants.SRC_PROTOCOL_TYPE_TCP;
-    }
-
-    @Override
-    public void update() {
-        // check current all links
-        if (ConfigManager.getInstance().needChkIllegalIP()) {
-            int cnt = 0;
-            Channel channel;
-            String strRemoteIP;
-            long startTime = System.currentTimeMillis();
-            Iterator<Channel> iterator = allChannels.iterator();
-            while (iterator.hasNext()) {
-                channel = iterator.next();
-                strRemoteIP = AddressUtils.getChannelRemoteIP(channel);
-                if (strRemoteIP == null) {
-                    continue;
-                }
-                if (ConfigManager.getInstance().isIllegalIP(strRemoteIP)) {
-                    channel.disconnect();
-                    channel.close();
-                    allChannels.remove(channel);
-                    cnt++;
-                    logger.error(strRemoteIP + " is Illegal IP, so disconnect it !");
-                }
-            }
-            logger.info("Source {} channel check, disconnects {} Illegal channels, waist {} ms",
-                    getName(), cnt, (System.currentTimeMillis() - startTime));
-        }
     }
 
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
@@ -268,7 +268,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
             confGroupId = configManager.getGroupIdNameByNum(strGroupIdNum);
             if (StringUtils.isBlank(confGroupId)) {
                 if (configManager.isGroupIdNumConfigEmpty()) {
-                    source.fileMetricEventInc(StatConstants.EVENT_SERVICE_UNREADY);
+                    source.fileMetricEventInc(StatConstants.EVENT_SERVICE_SINK_UNREADY);
                     this.errCode = DataProxyErrCode.CONF_SERVICE_UNREADY;
                     this.errMsg = "GroupId-Mapping configuration is null";
                 } else {
@@ -300,7 +300,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
                 confStreamId = configManager.getStreamIdNameByIdNum(strGroupIdNum, strStreamIdNum);
                 if (StringUtils.isBlank(confStreamId)) {
                     if (configManager.isStreamIdNumConfigEmpty()) {
-                        source.fileMetricEventInc(StatConstants.EVENT_SERVICE_UNREADY);
+                        source.fileMetricEventInc(StatConstants.EVENT_SERVICE_SINK_UNREADY);
                         this.errCode = DataProxyErrCode.CONF_SERVICE_UNREADY;
                         this.errMsg = "StreamId-Mapping configuration is null";
                     } else {
@@ -338,7 +338,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
             if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
                 this.topicName = source.getDefTopic();
             } else {
-                source.fileMetricEventInc(StatConstants.EVENT_NOTOPIC);
+                source.fileMetricEventInc(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
                 this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
                 this.errMsg = String.format("Topic is null for inlongGroupId=(%s), inlongStreamId=(%s)",
                         this.groupId, this.streamId);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecTextMsg.java
@@ -148,7 +148,7 @@ public class CodecTextMsg extends AbsV0MsgCodec {
             if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
                 tmpTopicName = source.getDefTopic();
             } else {
-                source.fileMetricEventInc(StatConstants.EVENT_NOTOPIC);
+                source.fileMetricEventInc(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
                 this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
                 this.errMsg = String.format(
                         "Topic is null for inlongGroupId=(%s), inlongStreamId=(%s)", tmpGroupId, tmpStreamId);


### PR DESCRIPTION

- Fixes #8212 


1. Adjust the implementation of InLongHttpMsgHandler, use QueryStringDecoder to parse the fields in the request; add content data processing of POST requests; adjust abnormal IP inspection processing, and gather HTTP-related constants in the same file
2. Adjust the name of HTTP-related indicator statistics Key;
3. Adjust the log output level, delete the information that does not need to be printed frequently,
4. Other detailed revisions