### PR TITLE
[INLONG-8224][Audit] Fix audit-proxy memory leak

### DIFF
--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
@@ -103,6 +103,8 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         } catch (Exception ex) {
             LOGGER.error("extract data error: ", ex);
             throw new IOException(ex);
+        } finally {
+            buf.release();
         }
         if (cmd == null) {
             LOGGER.warn("extract data from received msg is null");
@@ -190,6 +192,8 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
             channel.writeAndFlush(buffer);
             return;
         }
+
+        buffer.release();
 
         String msg = String.format("remote channel=%s is not writable, please check remote client!", channel);
         LOGGER.warn(msg);


### PR DESCRIPTION
### Prepare a Pull Request
- [INLONG-8224][Audit] Fix audit-proxy memory leak
- Fixes #8224

### Motivation

*Fix the problem of netty memory leak.*

### Modifications

*When the use of ByteBuf is completed, release it in time to prevent the memory from being released.*
