### PR TITLE
[INLONG-8252][DataProxy] Adjust default Topic settings from Source to Sink

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
@@ -177,7 +177,12 @@ public class MetaConfigHolder extends ConfigHolder {
     }
 
     public Set<String> getAllTopicName() {
-        Set<String> result = new HashSet<>(defTopics);
+        Set<String> result = new HashSet<>();
+        // add default topics first
+        if (CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
+            result.addAll(CommonConfigHolder.getInstance().getDefTopics());
+        }
+        // add configured topics
         for (IdTopicConfig topicConfig : id2TopicMap.values()) {
             if (topicConfig == null) {
                 continue;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -57,6 +57,7 @@ public class StatConstants {
     public static final java.lang.String EVENT_MSG_BODY_NEGATIVE = "msg.body.negative";
     public static final java.lang.String EVENT_MSG_BODY_UNPRESS_EXP = "msg.body.unpress.exp";
     public static final java.lang.String EVENT_MSG_BODY_OVERMAX = "msg.body.overmax";
+    public static final java.lang.String EVENT_MSG_BODY_TRIP = "msg.body.trip";
     public static final java.lang.String EVENT_MSG_ATTR_NEGATIVE = "msg.attr.negative";
     public static final java.lang.String EVENT_MSG_MAGIC_UNEQUAL = "msg.magic.unequal";
     public static final java.lang.String EVENT_MSG_HB_TOTALLEN_BELOWMIN = "msg.hb.totallen.belowmin";
@@ -76,26 +77,16 @@ public class StatConstants {
     public static final java.lang.String EVENT_MSG_V0_POST_FAILURE = "msg.post.v0.failure";
     public static final java.lang.String EVENT_MSG_V1_POST_SUCCESS = "msg.post.v1.success";
     public static final java.lang.String EVENT_MSG_V1_POST_DROPPED = "msg.post.v1.dropped";
+    // sink
+    public static final java.lang.String EVENT_SINK_CONFIG_TOPIC_MISSING = "sink.topic.missing";
+    public static final java.lang.String EVENT_SINK_DEFAULT_TOPIC_MISSING = "default.topic.empty";
+    public static final java.lang.String EVENT_SINK_DEFAULT_TOPIC_USED = "default.topic.used";
+    public static final java.lang.String EVENT_SINK_PRODUCER_NULL = "sink.producer.null";
+    public static final java.lang.String EVENT_SINK_SEND_EXCEPTION = "sink.send.exception";
 
-    public static final java.lang.String EVENT_SINK_NOUID = "sink.nouid";
-    public static final java.lang.String EVENT_SINK_NOTOPIC = "sink.notopic";
-    public static final java.lang.String EVENT_SINK_NOPRODUCER = "sink.noproducer";
-    public static final java.lang.String EVENT_SINK_SENDEXCEPT = "sink.sendexcept";
     public static final java.lang.String EVENT_SINK_FAILRETRY = "sink.retry";
     public static final java.lang.String EVENT_SINK_FAILDROPPED = "sink.dropped";
     public static final java.lang.String EVENT_SINK_SUCCESS = "sink.success";
     public static final java.lang.String EVENT_SINK_RECEIVEEXCEPT = "sink.rcvexcept";
 
-    public static final java.lang.String METASINK_OTHEREXP = "metasink.otherexp";
-    public static final java.lang.String METASINK_NOSLAVE = "metasink.noslave";
-    public static final java.lang.String METASINK_MSG_NOTOPIC = "metasink.msgnotopic";
-    public static final java.lang.String METASINK_PROCESS_SPEED = "metasink.process.speed";
-    public static final java.lang.String EVENT_OTHEREXP = "socketmsg.otherexp";
-    public static final java.lang.String EVENT_INVALID = "socketmsg.invalid";
-
-    public static final java.lang.String AGENT_MESSAGES_SENT_SUCCESS = "agent.messages.success";
-    public static final java.lang.String AGENT_PACKAGES_SENT_SUCCESS = "agent.packages.success";
-    public static final java.lang.String MSG_COUNTER_KEY = "msgcnt";
-    public static final java.lang.String MSG_PKG_TIME_KEY = "msg.pkg.time";
-    public static final java.lang.String AGENT_MESSAGES_COUNT_PREFIX = "agent.messages.count.";
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/MessageFilter.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/MessageFilter.java
@@ -106,7 +106,7 @@ public class MessageFilter implements Filter {
         // get and check topicName
         String topicName = ConfigManager.getInstance().getTopicName(groupId, streamId);
         if (StringUtils.isBlank(topicName)
-                && !CommonConfigHolder.getInstance().isNoTopicAccept()) {
+                && !CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
             returnRspPackage(resp, req.getCharacterEncoding(),
                     DataProxyErrCode.TOPIC_IS_BLANK.getErrCode(),
                     DataProxyErrCode.TOPIC_IS_BLANK.getErrMsg());

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/SimpleMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/http/SimpleMessageHandler.java
@@ -22,7 +22,6 @@ import org.apache.inlong.common.monitor.MonitorIndexExt;
 import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.common.msg.InLongMsg;
 import org.apache.inlong.common.util.NetworkUtils;
-import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.ConfigManager;
 import org.apache.inlong.dataproxy.consts.AttrConstants;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
@@ -103,13 +102,9 @@ public class SimpleMessageHandler implements MessageHandler {
         // get topicName
         String topicName = configManager.getTopicName(groupId, streamId);
         if (StringUtils.isBlank(topicName)) {
-            if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
-                topicName = "test";
-            } else {
-                throw new MessageProcessException(strBuff
-                        .append("Topic for message is null, inlongGroupId = ")
-                        .append(groupId).append(", inlongStreamId = ").append(streamId).toString());
-            }
+            throw new MessageProcessException(strBuff
+                    .append("Topic for message is null, inlongGroupId = ")
+                    .append(groupId).append(", inlongStreamId = ").append(streamId).toString());
         }
         // get message data time
         final long msgRcvTime = System.currentTimeMillis();
@@ -171,7 +166,7 @@ public class SimpleMessageHandler implements MessageHandler {
         // build metric data item
         longDataTime = longDataTime / 1000 / 60 / 10;
         longDataTime = longDataTime * 1000 * 60 * 10;
-        strBuff.append("http").append(SEP_HASHTAG).append(topicName).append(SEP_HASHTAG)
+        strBuff.append("http").append(SEP_HASHTAG).append(groupId).append(SEP_HASHTAG)
                 .append(streamId).append(SEP_HASHTAG).append(strRemoteIP).append(SEP_HASHTAG)
                 .append(NetworkUtils.getLocalIp()).append(SEP_HASHTAG)
                 .append(evenProcType.getRight()).append(SEP_HASHTAG)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -242,11 +242,11 @@ public class MessageQueueZoneSinkContext extends SinkContext {
             DataProxyErrCode errCode, String errMsg) {
         if (currentRecord.isResend()) {
             dispatchQueue.offer(currentRecord);
-            fileMetricEventInc(StatConstants.EVENT_SINK_FAILRETRY);
+            fileMetricIncSumStats(StatConstants.EVENT_SINK_FAILRETRY);
             this.addSendResultMetric(currentRecord, mqName, topic, false, sendTime);
         } else {
             currentRecord.fail(errCode, errMsg);
-            fileMetricEventInc(StatConstants.EVENT_SINK_FAILDROPPED);
+            fileMetricIncSumStats(StatConstants.EVENT_SINK_FAILDROPPED);
         }
     }
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -381,7 +381,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
             }
             // check topic configure
             if (StringUtils.isEmpty(configTopic)) {
-                if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
+                if (CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
                     configTopic = this.defaultTopic;
                 } else {
                     commonAttrMap.put(AttributeConstants.MESSAGE_PROCESS_ERRCODE,
@@ -518,7 +518,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
                 longDataTime = longDataTime / 1000 / 60 / 10;
                 longDataTime = longDataTime * 1000 * 60 * 10;
                 strBuff.append(protocolType).append(AttrConstants.SEPARATOR)
-                        .append(topicEntry.getKey()).append(AttrConstants.SEPARATOR)
+                        .append(groupId).append(AttrConstants.SEPARATOR)
                         .append(streamIdEntry.getKey()).append(AttrConstants.SEPARATOR)
                         .append(strRemoteIP).append(AttrConstants.SEPARATOR)
                         .append(getLocalIp()).append(AttrConstants.SEPARATOR)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
@@ -153,11 +153,6 @@ public abstract class BaseSource
         Preconditions.checkArgument(StringUtils.isNotBlank(tmpVal),
                 SourceConstants.SRCCXT_MESSAGE_HANDLER_NAME + " config is blank");
         this.messageHandlerName = tmpVal;
-        // get default topic
-        tmpVal = context.getString(SourceConstants.SRCCXT_DEF_TOPIC);
-        if (StringUtils.isNotBlank(tmpVal)) {
-            this.defTopic = tmpVal.trim();
-        }
         // get default attributes
         tmpVal = context.getString(SourceConstants.SRCCXT_DEF_ATTR);
         if (StringUtils.isNotBlank(tmpVal)) {
@@ -365,10 +360,6 @@ public abstract class BaseSource
 
     public String getStrPort() {
         return strPort;
-    }
-
-    public String getDefTopic() {
-        return defTopic;
     }
 
     public String getDefAttr() {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageFactory.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageFactory.java
@@ -34,7 +34,7 @@ public class InLongMessageFactory extends ChannelInitializer<SocketChannel> {
 
     public static final int INLONG_LENGTH_FIELD_OFFSET = 0;
     public static final int INLONG_LENGTH_FIELD_LENGTH = 4;
-    public static final int INLONG_LENGTH_ADJUSTMENT = -4;
+    public static final int INLONG_LENGTH_ADJUSTMENT = 0;
     public static final int INLONG_INITIAL_BYTES_TO_STRIP = 0;
     public static final boolean DEFAULT_FAIL_FAST = true;
     private static final Logger LOG = LoggerFactory.getLogger(InLongMessageFactory.class);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
@@ -75,7 +75,6 @@ public class InLongMessageHandler extends ChannelInboundHandlerAdapter {
     private static final LogCounter logCounter = new LogCounter(10, 100000, 30 * 1000);
 
     private static final int INLONG_MSG_V1 = 1;
-    private static final String DEFAULT_REMOTE_IDC_VALUE = "0";
 
     private static final ConfigManager configManager = ConfigManager.getInstance();
     private final BaseSource source;
@@ -421,14 +420,10 @@ public class InLongMessageHandler extends ChannelInboundHandlerAdapter {
             // get configured topic name
             String topic = configManager.getTopicName(event.getInlongGroupId(), event.getInlongStreamId());
             if (StringUtils.isBlank(topic)) {
-                if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
-                    topic = source.getDefTopic();
-                } else {
-                    source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
-                    source.addMetric(false, event.getBody().length, event);
-                    this.responsePackage(ctx, ProxySdk.ResultCode.ERR_ID_ERROR, packObject);
-                    return;
-                }
+                source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+                source.addMetric(false, event.getBody().length, event);
+                this.responsePackage(ctx, ProxySdk.ResultCode.ERR_ID_ERROR, packObject);
+                return;
             }
             event.setTopic(topic);
             // put to channel

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/SourceConstants.java
@@ -33,8 +33,6 @@ public class SourceConstants {
     public static final String SRCCXT_MSG_FACTORY_NAME = "msg-factory-name";
     // message handler name
     public static final String SRCCXT_MESSAGE_HANDLER_NAME = "message-handler-name";
-    // default topic name
-    public static final String SRCCXT_DEF_TOPIC = "topic";
     // default attributes
     public static final String SRCCXT_DEF_ATTR = "attr";
     // max message length

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
@@ -22,7 +22,6 @@ import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.common.msg.InLongMsg;
 import org.apache.inlong.common.msg.MsgType;
 import org.apache.inlong.dataproxy.base.SinkRspEvent;
-import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.ConfigManager;
 import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.source2.BaseSource;
@@ -149,7 +148,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
             return false;
         }
         // build message seqId
-        this.msgSeqId = strBuff.append(this.topicName)
+        this.msgSeqId = strBuff.append(this.groupId)
                 .append(AttributeConstants.SEPARATOR).append(this.streamId)
                 .append(AttributeConstants.SEPARATOR).append(strRemoteIP)
                 .append("#").append(dataTimeMs).append("#").append(uniq).toString();
@@ -330,15 +329,11 @@ public class CodecBinMsg extends AbsV0MsgCodec {
         // get and check topic configure
         this.topicName = configManager.getTopicName(this.groupId, this.streamId);
         if (StringUtils.isBlank(this.topicName)) {
-            if (CommonConfigHolder.getInstance().isNoTopicAccept()) {
-                this.topicName = source.getDefTopic();
-            } else {
-                source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
-                this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
-                this.errMsg = String.format("Topic not configured for groupId=(%s), streamId=(%s)",
-                        this.groupId, this.streamId);
-                return false;
-            }
+            source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+            this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
+            this.errMsg = String.format("Topic not configured for groupId=(%s), streamId=(%s)",
+                    this.groupId, this.streamId);
+            return false;
         }
         if (StringUtils.isBlank(this.streamId)) {
             this.streamId = "";

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/holder/TestCommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/holder/TestCommonConfigHolder.java
@@ -23,8 +23,6 @@ import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-
 /**
  * Test for {@link CommonConfigHolder}
  */
@@ -35,8 +33,10 @@ public class TestCommonConfigHolder {
         Assert.assertEquals("proxy_inlong5th_sz",
                 CommonConfigHolder.getInstance().getClusterName());
         Assert.assertTrue(CommonConfigHolder.getInstance().isEnableWhiteList());
-        assertEquals("DataProxy",
+        Assert.assertEquals("DataProxy",
                 CommonConfigHolder.getInstance().getProperties().get(MetricListener.KEY_METRIC_DOMAINS));
-        assertEquals(10000, CommonConfigHolder.getInstance().getMetaConfigSyncInvlMs());
+        Assert.assertEquals(10000, CommonConfigHolder.getInstance().getMetaConfigSyncInvlMs());
+        Assert.assertTrue(CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept());
+        Assert.assertTrue(CommonConfigHolder.getInstance().getDefTopics().contains("test2"));
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
+++ b/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
@@ -25,3 +25,8 @@ startup.using.local.meta.file.enable=true
 proxy.enable.whitelist=true
 
 meta.config.sync.interval.ms=10000
+
+# whether to accept messages of unconfigured topics
+id2topic.unconfigured.accept.enable=true
+# the default topic if accept unconfigured topic's message
+id2topic.unconfigured.default.topics= test1 test2 test3


### PR DESCRIPTION

- Fixes #8252

1. Adjust the setting Key of the default Topic;
2. Delete the default Topic setting logic on the Source side;
3. Increase the processing of the default Topic on the Sink side;
4. Adjust the indicator management and log printing frequency
5. Add comments and remove unreferenced KEYs