### PR TITLE
[INLONG-8267][DataProxy] Add the control of whether to retry and the count of retries for the failure message

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -87,6 +87,7 @@ public class StatConstants {
     public static final java.lang.String EVENT_SINK_FAILRETRY = "sink.retry";
     public static final java.lang.String EVENT_SINK_FAILDROPPED = "sink.dropped";
     public static final java.lang.String EVENT_SINK_SUCCESS = "sink.success";
+    public static final java.lang.String EVENT_SINK_FAILURE = "sink.failure";
     public static final java.lang.String EVENT_SINK_RECEIVEEXCEPT = "sink.rcvexcept";
 
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/TubeUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/TubeUtils.java
@@ -67,9 +67,8 @@ public class TubeUtils {
             message.putSystemHeader(headers.get(Constants.INLONG_STREAM_ID),
                     DateTimeUtils.ms2yyyyMMddHHmm(dataTimeL));
         } else {
-            long dataTimeL = Long.parseLong(headers.get(AttributeConstants.DATA_TIME));
             message.putSystemHeader(headers.get(AttributeConstants.STREAM_ID),
-                    DateTimeUtils.ms2yyyyMMddHHmm(dataTimeL));
+                    headers.get(ConfigConstants.PKG_TIME_KEY));
         }
         Map<String, String> extraAttrMap = MessageUtils.getXfsAttrs(headers, pkgVersion);
         for (Map.Entry<String, String> entry : extraAttrMap.entrySet()) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackManager.java
@@ -54,18 +54,18 @@ public class BatchPackManager {
     private final long dispatchTimeout;
     private final long maxPackCount;
     private final long maxPackSize;
-    private BufferQueue<PackProfile> dispatchQueue;
-    private ConcurrentHashMap<String, PackProfile> profileCache = new ConcurrentHashMap<>();
+    private final BufferQueue<PackProfile> dispatchQueue;
+    private final ConcurrentHashMap<String, PackProfile> profileCache = new ConcurrentHashMap<>();
     // flag that manager need to output overtime data.
-    private AtomicBoolean needOutputOvertimeData = new AtomicBoolean(false);
-    private AtomicLong inCounter = new AtomicLong(0);
-    private AtomicLong outCounter = new AtomicLong(0);
+    private final AtomicBoolean needOutputOvertimeData = new AtomicBoolean(false);
+    private final AtomicLong inCounter = new AtomicLong(0);
+    private final AtomicLong outCounter = new AtomicLong(0);
 
     /**
      * Constructor
      * 
-     * @param context
-     * @param dispatchQueue
+     * @param context the process context
+     * @param dispatchQueue  the batch queue
      */
     public BatchPackManager(Context context, BufferQueue<PackProfile> dispatchQueue) {
         this.dispatchQueue = dispatchQueue;
@@ -76,7 +76,7 @@ public class BatchPackManager {
 
     /**
      * addEvent
-     * @param event
+     * @param event the event to add
      */
     public void addEvent(ProxyEvent event) {
         // parse
@@ -106,7 +106,7 @@ public class BatchPackManager {
 
     /**
      * addPackEvent
-     * @param packEvent
+     * @param packEvent  the event need to add
      */
     public void addPackEvent(ProxyPackEvent packEvent) {
         String eventUid = packEvent.getUid();
@@ -142,7 +142,7 @@ public class BatchPackManager {
 
     /**
      * addSimpleEvent
-     * @param event
+     * @param event  the event need to add
      */
     public void addSimpleEvent(SimpleEvent event) {
         Map<String, String> headers = event.getHeaders();
@@ -162,7 +162,6 @@ public class BatchPackManager {
     /**
      * outputOvertimeData
      * 
-     * @return
      */
     public void outputOvertimeData() {
         if (!needOutputOvertimeData.getAndSet(false)) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackProfile.java
@@ -37,10 +37,10 @@ public class BatchPackProfile extends PackProfile {
     /**
      * Constructor
      *
-     * @param uid
-     * @param inlongGroupId
-     * @param inlongStreamId
-     * @param dispatchTime
+     * @param uid   the inlong id
+     * @param inlongGroupId   the group id
+     * @param inlongStreamId  the stream id
+     * @param dispatchTime    the dispatch time
      */
     public BatchPackProfile(String uid, String inlongGroupId, String inlongStreamId, long dispatchTime) {
         super(uid, inlongGroupId, inlongStreamId, dispatchTime);
@@ -49,10 +49,10 @@ public class BatchPackProfile extends PackProfile {
     /**
      * addEvent
      * 
-     * @param  event
-     * @param  maxPackCount
-     * @param  maxPackSize
-     * @return
+     * @param  event   the event to added
+     * @param  maxPackCount   the max package count to cached
+     * @param  maxPackSize    the max package size to cached
+     * @return  whether added the event
      */
     public boolean addEvent(Event event, long maxPackCount, long maxPackSize) {
         long eventLength = event.getBody().length;
@@ -94,7 +94,6 @@ public class BatchPackProfile extends PackProfile {
 
     /**
      * fail
-     * @return
      */
     public void fail(DataProxyErrCode errCode, String errMsg) {
         if (callback != null) {
@@ -104,10 +103,12 @@ public class BatchPackProfile extends PackProfile {
 
     /**
      * isResend
-     * @return
+     * @return  whether resend message
      */
     public boolean isResend() {
-        return callback == null;
+        return callback == null
+                && enableRetryAfterFailure
+                && (maxRetries < 0 || ++retries <= maxRetries);
     }
 
     /**

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -18,7 +18,10 @@
 package org.apache.inlong.dataproxy.sink.mq;
 
 import org.apache.inlong.common.enums.DataProxyErrCode;
+import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
+import org.apache.inlong.dataproxy.consts.AttrConstants;
+import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
 import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
@@ -28,6 +31,7 @@ import org.apache.inlong.sdk.commons.protocol.ProxySdk.INLONG_COMPRESSED_TYPE;
 
 import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.conf.Configurable;
@@ -271,5 +275,44 @@ public class MessageQueueZoneSinkContext extends SinkContext {
                     strSelectorClass, t.getMessage(), t);
         }
         return null;
+    }
+
+    public void fileMetricAddSuccCnt(PackProfile packProfile, String topic, String remoteId) {
+        if (!CommonConfigHolder.getInstance().isEnableFileMetric()) {
+            return;
+        }
+        if (packProfile instanceof SimplePackProfile) {
+            SimplePackProfile simpleProfile = (SimplePackProfile) packProfile;
+            StringBuilder statsKey = new StringBuilder(512)
+                    .append(sinkName).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEPARATOR)
+                    .append(topic).append(AttrConstants.SEPARATOR)
+                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEPARATOR)
+                    .append(remoteId).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getProperties().get(ConfigConstants.PKG_TIME_KEY));
+            monitorIndex.addSuccStats(statsKey.toString(), NumberUtils.toInt(
+                    simpleProfile.getProperties().get(ConfigConstants.MSG_COUNTER_KEY), 1),
+                    1, simpleProfile.getSize());
+        }
+    }
+
+    public void fileMetricAddFailCnt(PackProfile packProfile, String topic, String remoteId) {
+        if (!CommonConfigHolder.getInstance().isEnableFileMetric()) {
+            return;
+        }
+
+        if (packProfile instanceof SimplePackProfile) {
+            SimplePackProfile simpleProfile = (SimplePackProfile) packProfile;
+            StringBuilder statsKey = new StringBuilder(512)
+                    .append(sinkName).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEPARATOR)
+                    .append(topic).append(AttrConstants.SEPARATOR)
+                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEPARATOR)
+                    .append(remoteId).append(AttrConstants.SEPARATOR)
+                    .append(simpleProfile.getProperties().get(ConfigConstants.PKG_TIME_KEY));
+            monitorIndex.addFailStats(statsKey.toString(), 1);
+        }
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/PackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/PackProfile.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.dataproxy.sink.mq;
 
 import org.apache.inlong.common.enums.DataProxyErrCode;
+import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 
 import org.apache.flume.Event;
 
@@ -34,20 +35,24 @@ public abstract class PackProfile {
     private final String uid;
     protected long count = 0;
     protected long size = 0;
-
+    protected final boolean enableRetryAfterFailure;
+    protected final int maxRetries;
+    protected int retries = 0;
     /**
      * Constructor
      *
-     * @param uid
-     * @param inlongGroupId
-     * @param inlongStreamId
-     * @param dispatchTime
+     * @param uid  the inlong id
+     * @param inlongGroupId   the group id
+     * @param inlongStreamId  the stream id
+     * @param dispatchTime the dispatch time
      */
     public PackProfile(String uid, String inlongGroupId, String inlongStreamId, long dispatchTime) {
         this.uid = uid;
         this.inlongGroupId = inlongGroupId;
         this.inlongStreamId = inlongStreamId;
         this.dispatchTime = dispatchTime;
+        this.enableRetryAfterFailure = CommonConfigHolder.getInstance().isEnableSendRetryAfterFailure();
+        this.maxRetries = CommonConfigHolder.getInstance().getMaxRetriesAfterFailure();
     }
 
     /**
@@ -80,7 +85,7 @@ public abstract class PackProfile {
     /**
      * getDispatchTime
      * 
-     * @return
+     * @return the dispatch time
      */
     public long getDispatchTime() {
         return dispatchTime;
@@ -125,8 +130,8 @@ public abstract class PackProfile {
     /**
      * isTimeout
      *
-     * @param  createThreshold
-     * @return
+     * @param  createThreshold  the creation threshold
+     * @return whether time out
      */
     public boolean isTimeout(long createThreshold) {
         return createThreshold >= createTime;
@@ -139,23 +144,22 @@ public abstract class PackProfile {
 
     /**
      * fail
-     * @return
      */
     public abstract void fail(DataProxyErrCode errCode, String errMsg);
 
     /**
      * isResend
-     * @return
+     * @return whether resend message
      */
     public abstract boolean isResend();
 
     /**
      * addEvent
      *
-     * @param  event
-     * @param  maxPackCount
-     * @param  maxPackSize
-     * @return
+     * @param  event   the event need to add
+     * @param  maxPackCount   the max package count
+     * @param  maxPackSize    the max package size
+     * @return whether add success
      */
     public abstract boolean addEvent(Event event, long maxPackCount, long maxPackSize);
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
@@ -53,10 +53,10 @@ public class SimplePackProfile extends PackProfile {
 
     /**
      * Constructor
-     * @param uid
-     * @param inlongGroupId
-     * @param inlongStreamId
-     * @param dispatchTime
+     * @param uid   the inlong id
+     * @param inlongGroupId   the group id
+     * @param inlongStreamId  the stream id
+     * @param dispatchTime    the received time
      */
     public SimplePackProfile(String uid, String inlongGroupId, String inlongStreamId, long dispatchTime) {
         super(uid, inlongGroupId, inlongStreamId, dispatchTime);
@@ -80,7 +80,9 @@ public class SimplePackProfile extends PackProfile {
 
     @Override
     public boolean isResend() {
-        return !needRspEvent;
+        return !needRspEvent
+                && enableRetryAfterFailure
+                && (maxRetries < 0 || ++retries <= maxRetries);
     }
 
     @Override
@@ -101,9 +103,9 @@ public class SimplePackProfile extends PackProfile {
     }
 
     /**
-     * create
-     * @param event
-     * @return
+     * create simple pack profile
+     * @param event  the event to process
+     * @return  the package profile
      */
     public static SimplePackProfile create(Event event) {
         Map<String, String> headers = event.getHeaders();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
@@ -295,7 +295,7 @@ public class InLongMessageHandler extends ChannelInboundHandlerAdapter {
             }
         } catch (Throwable ex) {
             source.fileMetricIncSumStats(StatConstants.EVENT_MSG_V0_POST_FAILURE);
-            source.fileMetricAddFailCnt(statsKey, msgCodec.getMsgCount());
+            source.fileMetricAddFailCnt(statsKey, 1);
             source.addMetric(false, event.getBody().length, event);
             if (msgCodec.isNeedResp() && !msgCodec.isOrderOrProxy()) {
                 msgCodec.setFailureInfo(DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/httpMsg/InLongHttpMsgHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/httpMsg/InLongHttpMsgHandler.java
@@ -332,6 +332,7 @@ public class InLongHttpMsgHandler extends SimpleChannelInboundHandler<FullHttpRe
                 .append(AttributeConstants.KEY_VALUE_SEPARATOR).append(msgRcvTime);
         inLongMsg.addMsg(strBuff.toString(), body.getBytes(HttpAttrConst.VAL_DEF_CHARSET));
         byte[] inlongMsgData = inLongMsg.buildArray();
+        long pkgTime = inLongMsg.getCreatetime();
         inLongMsg.reset();
         strBuff.delete(0, strBuff.length());
         // build flume event
@@ -344,6 +345,7 @@ public class InLongHttpMsgHandler extends SimpleChannelInboundHandler<FullHttpRe
         eventHeaders.put(ConfigConstants.MSG_COUNTER_KEY, strMsgCount);
         eventHeaders.put(ConfigConstants.MSG_ENCODE_VER, InLongMsgVer.INLONG_V0.getName());
         eventHeaders.put(AttributeConstants.RCV_TIME, String.valueOf(msgRcvTime));
+        eventHeaders.put(ConfigConstants.PKG_TIME_KEY, DateTimeUtils.ms2yyyyMMddHHmm(pkgTime));
         Event event = EventBuilder.withBody(inlongMsgData, eventHeaders);
         // build metric data item
         dataTime = dataTime / 1000 / 60 / 10;
@@ -366,7 +368,7 @@ public class InLongHttpMsgHandler extends SimpleChannelInboundHandler<FullHttpRe
             return true;
         } catch (Throwable ex) {
             source.fileMetricIncSumStats(StatConstants.EVENT_MSG_V0_POST_FAILURE);
-            source.fileMetricAddFailCnt(statsKey, intMsgCnt);
+            source.fileMetricAddFailCnt(statsKey, 1);
             source.addMetric(false, event.getBody().length, event);
             sendErrorMsg(ctx, DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,
                     strBuff.append("Put event to channel failure: ").append(ex.getMessage()).toString());

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecBinMsg.java
@@ -272,7 +272,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
                 }
                 return false;
             }
-            if (StringUtils.isNotBlank(this.groupId) && !this.groupId.equalsIgnoreCase(confGroupId)) {
+            if (StringUtils.isNotBlank(this.groupId) && !this.groupId.equals(confGroupId)) {
                 source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_GROUP_IDNUM_INCONSTANT);
                 this.errCode = DataProxyErrCode.GROUPID_OR_STREAMID_INCONSTANT;
                 this.errMsg = String.format(
@@ -305,7 +305,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
                     }
                     return false;
                 }
-                if (StringUtils.isNotBlank(this.streamId) && !this.streamId.equalsIgnoreCase(confStreamId)) {
+                if (StringUtils.isNotBlank(this.streamId) && !this.streamId.equals(confStreamId)) {
                     source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_STREAM_IDNUM_INCONSTANT);
                     this.errCode = DataProxyErrCode.GROUPID_OR_STREAMID_INCONSTANT;
                     this.errMsg = String.format(

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/holder/TestCommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/config/holder/TestCommonConfigHolder.java
@@ -38,5 +38,8 @@ public class TestCommonConfigHolder {
         Assert.assertEquals(10000, CommonConfigHolder.getInstance().getMetaConfigSyncInvlMs());
         Assert.assertTrue(CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept());
         Assert.assertTrue(CommonConfigHolder.getInstance().getDefTopics().contains("test2"));
+        Assert.assertTrue(CommonConfigHolder.getInstance().isEnableSendRetryAfterFailure());
+        Assert.assertEquals(2, CommonConfigHolder.getInstance().getMaxRetriesAfterFailure());
     }
+
 }

--- a/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
+++ b/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
@@ -30,3 +30,7 @@ meta.config.sync.interval.ms=10000
 id2topic.unconfigured.accept.enable=true
 # the default topic if accept unconfigured topic's message
 id2topic.unconfigured.default.topics= test1 test2 test3
+# whether to retry send after sent failure
+send.retry.after.failure = true
+# max retries after sent failure
+max.retries.after.failure=2


### PR DESCRIPTION

- Fixes #8267

1. Add the control of whether to retry the message sending failure and the maximum number of retries;
2. Adjust the index output when message outputting to MQ;
3. Add documentation comments and minor adjustments