### PR TITLE
[INLONG-8286][TubeMQ] Supports the return package type when querying messages

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
@@ -557,23 +557,19 @@ public class BrokerServiceServer implements BrokerReadService, BrokerWriteServic
                         .append(topicName).append(")!\"}");
                 return sb;
             } else {
-                List<String> transferMessageList = new ArrayList<>();
                 List<TransferedMessage> tmpMsgList = getMessageResult.transferedMessageList;
                 List<Message> messageList = DataConverterUtil.convertMessage(topicName, tmpMsgList);
-                int startPos = Math.max(messageList.size() - msgCount, 0);
-                for (; startPos < messageList.size(); startPos++) {
-                    String msgItem = new String(
-                            Base64.encodeBase64(messageList.get(startPos).getData()));
-                    transferMessageList.add(msgItem);
-                }
                 int i = 0;
+                int startPos = Math.max(messageList.size() - msgCount, 0);
                 sb.append("{\"result\":true,\"errCode\":200,\"errMsg\":\"Success!\",\"dataSet\":[");
-                for (String msgData : transferMessageList) {
+                for (; startPos < messageList.size(); startPos++) {
                     if (i > 0) {
                         sb.append(",");
                     }
-                    sb.append("{\"index\":").append(i++)
-                            .append(",\"data\":\"").append(msgData).append("\"}");
+                    sb.append("{\"index\":").append(i++).append(",\"data\":\"")
+                            .append(new String(Base64.encodeBase64(messageList.get(startPos).getData())))
+                            .append("\",\"attr\":\"").append(messageList.get(startPos).getAttribute())
+                            .append("\"}");
                 }
                 sb.append("]}");
                 return sb;


### PR DESCRIPTION

- Fixes #8286

Add the "attr" field to the return result of the admin_snapshot_message method to carry the attribute information of the Message