### PR TITLE
[INLONG-8294][DataProxy] Optimize the log output in the Sink module

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackProfileCallback.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/BatchPackProfileCallback.java
@@ -28,8 +28,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class BatchPackProfileCallback {
 
-    private AtomicInteger ackingCount;
-    private SourceCallback callback;
+    private final AtomicInteger ackingCount;
+    private final SourceCallback callback;
 
     /**
      * Constructor

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueClusterProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueClusterProducer.java
@@ -31,7 +31,7 @@ import java.util.Set;
  */
 public class MessageQueueClusterProducer implements LifecycleAware {
 
-    public static final Logger LOG = LoggerFactory.getLogger(MessageQueueClusterProducer.class);
+    private static final Logger logger = LoggerFactory.getLogger(MessageQueueClusterProducer.class);
 
     private final String workerName;
     private final CacheClusterConfig config;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneProducer.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneProducer.java
@@ -39,7 +39,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class MessageQueueZoneProducer {
 
-    public static final Logger LOG = LoggerFactory.getLogger(MessageQueueZoneProducer.class);
+    private static final Logger logger = LoggerFactory.getLogger(MessageQueueZoneProducer.class);
     private static final long MAX_RESERVED_TIME = 60 * 1000L;
     private final MessageQueueZoneSink zoneSink;
     private final MessageQueueZoneSinkContext context;
@@ -71,10 +71,10 @@ public class MessageQueueZoneProducer {
      */
     public void start() {
         try {
-            LOG.info("start MessageQueueZoneProducer:{}", zoneSink.getName());
+            logger.info("start MessageQueueZoneProducer:{}", zoneSink.getName());
             this.reloadMetaConfig();
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            logger.error(e.getMessage(), e);
         }
     }
 
@@ -140,7 +140,7 @@ public class MessageQueueZoneProducer {
                 tmpProducer.stop();
             }
         }
-        LOG.info("Clear {}'s expired cluster producer {}", zoneSink.getName(), expired);
+        logger.info("{} cleared expired cluster producer {}", zoneSink.getName(), expired);
     }
 
     /**
@@ -264,17 +264,17 @@ public class MessageQueueZoneProducer {
                 return;
             }
             if (zoneSink.isMqClusterStarted()) {
-                LOG.info("Reload {}'s cluster info, current cluster are {}, removed {}, created {}",
+                logger.info("{} reload cluster info, current cluster are {}, removed {}, created {}",
                         zoneSink.getName(), lastClusterNames, needRmvs, addedItems);
             } else {
                 zoneSink.setMQClusterStarted();
                 ConfigManager.getInstance().setMqClusterReady();
-                LOG.info(
-                        "Reload {}'s cluster info, and updated sink status, current cluster are {}, removed {}, created {}",
+                logger.info(
+                        "{} reload cluster info, and updated sink status, current cluster are {}, removed {}, created {}",
                         zoneSink.getName(), lastClusterNames, needRmvs, addedItems);
             }
         } catch (Throwable e) {
-            LOG.error("Reload cluster info failure", e);
+            logger.error("{} reload cluster info failure", zoneSink.getName(), e);
         }
     }
 
@@ -283,7 +283,7 @@ public class MessageQueueZoneProducer {
         if (curTopicSet.isEmpty() || lastRefreshTopics.equals(curTopicSet)) {
             return;
         }
-        LOG.info("Reload {}'s topics changed, current topics are {}, last topics are {}",
+        logger.info("{} reload topics changed, current topics are {}, last topics are {}",
                 zoneSink.getName(), curTopicSet, lastRefreshTopics);
         lastRefreshTopics.addAll(curTopicSet);
         for (MessageQueueClusterProducer clusterProducer : this.usingClusterMap.values()) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneWorker.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneWorker.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.dataproxy.sink.mq;
 
+import org.apache.inlong.common.monitor.LogCounter;
+
 import org.apache.flume.lifecycle.LifecycleState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,22 +28,24 @@ import org.slf4j.LoggerFactory;
  */
 public class MessageQueueZoneWorker extends Thread {
 
-    public static final Logger LOG = LoggerFactory.getLogger(MessageQueueZoneWorker.class);
-
+    private static final Logger logger = LoggerFactory.getLogger(MessageQueueZoneWorker.class);
+    // log print count
+    private static final LogCounter logCounter = new LogCounter(10, 100000, 30 * 1000);
     private final String workerName;
-    private final MessageQueueZoneSinkContext context;
-
-    private MessageQueueZoneProducer zoneProducer;
+    private final long fetchWaitMs;
+    private final MessageQueueZoneSink mqZoneSink;
+    private final MessageQueueZoneProducer zoneProducer;
     private LifecycleState status;
 
     /**
      * Constructor
      */
-    public MessageQueueZoneWorker(String sinkName, int workerIndex, MessageQueueZoneSinkContext context,
-            MessageQueueZoneProducer zoneProducer) {
+    public MessageQueueZoneWorker(MessageQueueZoneSink mqZoneSink, int workerIndex,
+            long fetchWaitMs, MessageQueueZoneProducer zoneProducer) {
         super();
-        this.workerName = sinkName + "-worker-" + workerIndex;
-        this.context = context;
+        this.mqZoneSink = mqZoneSink;
+        this.workerName = mqZoneSink.getName() + "-worker-" + workerIndex;
+        this.fetchWaitMs = fetchWaitMs;
         this.zoneProducer = zoneProducer;
         this.status = LifecycleState.IDLE;
     }
@@ -70,25 +74,28 @@ public class MessageQueueZoneWorker extends Thread {
      */
     @Override
     public void run() {
-        LOG.info(String.format("start MessageQueueZoneWorker:%s", this.workerName));
+        logger.info("{} start message zone worker", this.workerName);
+        PackProfile profile = null;
         while (status != LifecycleState.STOP) {
-            PackProfile profile = null;
             try {
-                profile = context.getDispatchQueue().pollRecord();
+                profile = this.mqZoneSink.pollDispatchedRecord();
                 if (profile == null) {
                     this.sleepOneInterval();
                     continue;
                 }
                 // send
                 this.zoneProducer.send(profile);
-            } catch (Throwable e) {
-                LOG.error(e.getMessage(), e);
+            } catch (Throwable e1) {
                 if (profile != null) {
-                    context.getDispatchQueue().offer(profile);
+                    this.mqZoneSink.offerDispatchRecord(profile);
+                }
+                if (logCounter.shouldPrint()) {
+                    logger.error("{} send message failure", workerName, e1);
                 }
                 this.sleepOneInterval();
             }
         }
+        logger.info("{} exit message zone worker", this.workerName);
     }
 
     /**
@@ -96,9 +103,11 @@ public class MessageQueueZoneWorker extends Thread {
      */
     private void sleepOneInterval() {
         try {
-            Thread.sleep(context.getProcessInterval());
+            Thread.sleep(fetchWaitMs);
         } catch (InterruptedException e1) {
-            LOG.error(e1.getMessage(), e1);
+            if (logCounter.shouldPrint()) {
+                logger.error("{} wait poll record interrupted", workerName, e1);
+            }
         }
     }
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/PackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/PackProfile.java
@@ -33,8 +33,8 @@ public abstract class PackProfile {
     private final long dispatchTime;
     private final long createTime = System.currentTimeMillis();
     private final String uid;
-    protected long count = 0;
-    protected long size = 0;
+    protected int count = 0;
+    protected int size = 0;
     protected final boolean enableRetryAfterFailure;
     protected final int maxRetries;
     protected int retries = 0;
@@ -96,7 +96,7 @@ public abstract class PackProfile {
      *
      * @return the count
      */
-    public long getCount() {
+    public int getCount() {
         return count;
     }
 
@@ -105,7 +105,7 @@ public abstract class PackProfile {
      *
      * @param count the count to set
      */
-    public void setCount(long count) {
+    public void setCount(int count) {
         this.count = count;
     }
 
@@ -114,7 +114,7 @@ public abstract class PackProfile {
      *
      * @return the size
      */
-    public long getSize() {
+    public int getSize() {
         return size;
     }
 
@@ -123,7 +123,7 @@ public abstract class PackProfile {
      *
      * @param size the size to set
      */
-    public void setSize(long size) {
+    public void setSize(int size) {
         this.size = size;
     }
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/RandomCacheClusterSelector.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/RandomCacheClusterSelector.java
@@ -44,7 +44,7 @@ public class RandomCacheClusterSelector implements CacheClusterSelector, Configu
 
     /**
      * select
-     * @param allClusterList
+     * @param allConfigList
      * @return
      */
     @Override

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
@@ -25,7 +25,6 @@ import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.inlong.dataproxy.base.SinkRspEvent;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.source2.InLongMessageHandler;
-import org.apache.inlong.dataproxy.utils.Constants;
 import org.apache.inlong.sdk.commons.protocol.EventConstants;
 import org.apache.inlong.sdk.commons.protocol.InlongId;
 
@@ -46,10 +45,9 @@ import java.util.Map;
  */
 public class SimplePackProfile extends PackProfile {
 
-    // log print count
-    private static final LogCounter logCounter =
-            new LogCounter(10, 100000, 30 * 1000);
     private static final Logger logger = LoggerFactory.getLogger(SimplePackProfile.class);
+    // log print count
+    private static final LogCounter logCounter = new LogCounter(10, 100000, 30 * 1000);
     private static final long MINUTE_MS = 60L * 1000;
     private boolean needRspEvent = false;
     private Channel channel;
@@ -154,9 +152,10 @@ public class SimplePackProfile extends PackProfile {
      */
     public Map<String, String> getPropsToMQ() {
         Map<String, String> result = new HashMap<>();
-        result.put(Constants.HEADER_KEY_SOURCE_TIME, event.getHeaders().get(AttributeConstants.RCV_TIME));
+        result.put(AttributeConstants.RCV_TIME, event.getHeaders().get(AttributeConstants.RCV_TIME));
         result.put(ConfigConstants.MSG_ENCODE_VER, event.getHeaders().get(ConfigConstants.MSG_ENCODE_VER));
         result.put(EventConstants.HEADER_KEY_VERSION, event.getHeaders().get(EventConstants.HEADER_KEY_VERSION));
+        result.put(ConfigConstants.REMOTE_IP_KEY, event.getHeaders().get(ConfigConstants.REMOTE_IP_KEY));
         result.put(ConfigConstants.DATAPROXY_IP_KEY, NetworkUtils.getLocalIp());
         return result;
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/SizeSemaphore.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/SizeSemaphore.java
@@ -30,7 +30,7 @@ public class SizeSemaphore {
     private int maxSize = 0;
     private int leftSize = 0;
     private Semaphore sizeSemaphore = null;
-    private AtomicInteger leftSemaphore = new AtomicInteger(0);
+    private final AtomicInteger leftSemaphore = new AtomicInteger(0);
 
     /**
      * Constructor


### PR DESCRIPTION

- Fixes #8294

Modifications:
1. Adjust the scope of the log object in the class from Public to private or protected;
2. Modify the log output content, add the Sink object name, and additional prompt information to facilitate the location and search of problem logs
3. Adjust the reference and operation of the dispatchQueue object, concentrate the object in the MessageQueueZoneSink class and encapsulate it with functions to avoid missing operations;
4. Remove the unused reloadTimer implementation in the SinkContext class;
5. Adjust the variable settings of related classes and add parameter setting instructions according to the IDE prompts