### PR TITLE
[INLONG-8305][DataProxy] Optimize HttpPost object creation

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -35,7 +35,6 @@ import org.apache.inlong.dataproxy.utils.HttpUtils;
 
 import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -338,9 +337,7 @@ public class ConfigManager {
             try {
                 url = "http://" + host + ConfigConstants.MANAGER_PATH
                         + ConfigConstants.MANAGER_GET_ALL_CONFIG_PATH;
-                httpPost = new HttpPost(url);
-                httpPost.addHeader(HttpHeaders.CONNECTION, "close");
-                httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+                httpPost = HttpUtils.getHttPost(url);
                 // request body
                 DataProxyConfigRequest request = new DataProxyConfigRequest();
                 request.setClusterName(clusterName);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/heartbeat/HeartbeatManager.java
@@ -23,17 +23,16 @@ import org.apache.inlong.common.heartbeat.AbstractHeartbeatManager;
 import org.apache.inlong.common.heartbeat.GroupHeartbeat;
 import org.apache.inlong.common.heartbeat.HeartbeatMsg;
 import org.apache.inlong.common.heartbeat.StreamHeartbeat;
-import org.apache.inlong.dataproxy.config.AuthUtils;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.ConfigManager;
 import org.apache.inlong.dataproxy.config.holder.SourceReportInfo;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
+import org.apache.inlong.dataproxy.utils.HttpUtils;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpHeaders;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -99,9 +98,7 @@ public class HeartbeatManager implements AbstractHeartbeatManager {
         final String url =
                 "http://" + mgrHostPort + ConfigConstants.MANAGER_PATH + ConfigConstants.MANAGER_HEARTBEAT_REPORT;
         try {
-            HttpPost post = new HttpPost(url);
-            post.addHeader(HttpHeaders.CONNECTION, "close");
-            post.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+            HttpPost post = HttpUtils.getHttPost(url);
             String body = gson.toJson(heartbeat);
             StringEntity stringEntity = new StringEntity(body);
             stringEntity.setContentType("application/json");

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/BaseSource.java
@@ -121,10 +121,10 @@ public abstract class BaseSource
     // send buffer size
     protected int maxSendBufferSize;
     // file metric statistic
-    protected MonitorIndex monitorIndex = null;
+    private MonitorIndex monitorIndex = null;
     private MonitorStats monitorStats = null;
     // metric set
-    protected DataProxyMetricItemSet metricItemSet;
+    private DataProxyMetricItemSet metricItemSet;
 
     public BaseSource() {
         super();
@@ -133,6 +133,7 @@ public abstract class BaseSource
 
     @Override
     public void configure(Context context) {
+        logger.info("{} start to configure context:{}.", this.getName(), context.toString());
         this.context = context;
         this.srcHost = getHostIp(context);
         this.srcPort = getHostPort(context);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/HttpUtils.java
@@ -17,8 +17,12 @@
 
 package org.apache.inlong.dataproxy.utils;
 
+import org.apache.inlong.dataproxy.config.AuthUtils;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 
 import java.io.UnsupportedEncodingException;
@@ -34,4 +38,10 @@ public class HttpUtils {
         return se;
     }
 
+    public static HttpPost getHttPost(String url) {
+        HttpPost httpPost = new HttpPost(url);
+        httpPost.addHeader(HttpHeaders.CONNECTION, "close");
+        httpPost.addHeader(HttpHeaders.AUTHORIZATION, AuthUtils.genBasicAuth());
+        return httpPost;
+    }
 }


### PR DESCRIPTION

- Fixes #8305

Modifications:
1. Construct the HttpPost object creation method getHttPost() in the HttpUtils class;
2. Replace the implementation of creating HttpPost objects in the HeartbeatManager and ConfigManager classes;
3. Add log output printing in BaseSource