### PR TITLE
[INLONG-8309][CVE] Upgrade snappy-java from version 1.1.8.4 to version 1.1.10.1

### DIFF
--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -437,7 +437,7 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_common:0.14.1 - Prometheus Java Span Context Supplier - Common (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (https://github.com/eclipse-ee4j/beanvalidation-api/tree/1.1.0.Final), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine/tree/2.3/velocity-engine-core), (Apache License, Version 2.0)
   org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)

--- a/licenses/inlong-audit/LICENSE
+++ b/licenses/inlong-audit/LICENSE
@@ -520,7 +520,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.projectlombok:lombok:1.18.22 - Project Lombok (https://projectlombok.org), (The MIT License)
   org.slf4j:slf4j-api:1.7.36 - SLF4J API Module (http://www.slf4j.org), (MIT License)
   org.yaml:snakeyaml:1.29 - SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml/src/snakeyaml-1.29/), (Apache License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
 
 
 ========================================================================

--- a/licenses/inlong-dataproxy/LICENSE
+++ b/licenses/inlong-dataproxy/LICENSE
@@ -408,7 +408,7 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_common:0.14.1 - Prometheus Java Span Context Supplier - Common (https://github.com/prometheus/client_java), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry (https://github.com/prometheus/client_java), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java), (The Apache Software License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (http://beanvalidation.org), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine/tree/2.3/velocity-engine-core), (Apache License, Version 2.0)
   org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)

--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -546,7 +546,7 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_otel:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
   org.yaml:snakeyaml:1.30 - SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml/src/snakeyaml-1.30/), (Apache License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   org.springframework.boot:spring-boot:2.6.15 - spring-boot (https://spring.io/projects/spring-boot), (Apache License, Version 2.0)
   org.springframework.boot:spring-boot-autoconfigure:2.6.15 - spring-boot-autoconfigure (https://spring.io/projects/spring-boot), (Apache License, Version 2.0)
   org.springframework.boot:spring-boot-configuration-processor:2.6.15 - spring-boot-configuration-processor (https://spring.io/projects/spring-boot), (Apache License, Version 2.0)

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -952,7 +952,7 @@ The text of each license is the standard Apache 2.0 license.
   org.reflections:reflections:0.10.2 - Reflections (https://github.com/ronmamo/reflections/tree/0.10.2), (The Apache Software License, Version 2.0;  WTFPL)
   org.yaml:snakeyaml:1.17 - SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml/src/v1.17/), (Apache License, Version 2.0)
   org.yaml:snakeyaml:1.26 - SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml/src/v1.26/), (Apache License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   com.tdunning:t-digest:3.2 - T-Digest (https://github.com/tdunning/t-digest/tree/t-digest-3.2), (The Apache Software License, Version 2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (http://beanvalidation.org), (The Apache Software License, Version 2.0)
   com.fasterxml.woodstox:woodstox-core:5.0.3 - Woodstox (https://github.com/FasterXML/woodstox/tree/woodstox-core-5.0.3), (The Apache License, Version 2.0)

--- a/licenses/inlong-sort-standalone/LICENSE
+++ b/licenses/inlong-sort-standalone/LICENSE
@@ -482,7 +482,7 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_otel:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry (https://github.com/prometheus/client_java/tree/parent-0.14.1/simpleclient_tracer/simpleclient_tracer_otel), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java/tree/parent-0.14.1/simpleclient_tracer/simpleclient_tracer_otel_agent), (The Apache Software License, Version 2.0)
   org.yaml:snakeyaml:1.17 - SnakeYAML (https://bitbucket.org/snakeyaml/snakeyaml/src/v1.17/), (Apache License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (The Apache Software License, Version 2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (The Apache Software License, Version 2.0)
   com.tdunning:t-digest:3.2 - T-Digest (https://github.com/tdunning/t-digest), (The Apache Software License, Version 2.0)
   com.tencentcloudapi.cls:tencentcloud-cls-sdk-java:1.0.9 - tencentcloud-cls-sdk-java (https://github.com/TencentCloud/tencentcloud-cls-sdk-java/tree/v1.0.9), (Apache License, Version 2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (http://beanvalidation.org), (The Apache Software License, Version 2.0)

--- a/licenses/inlong-sort/LICENSE
+++ b/licenses/inlong-sort/LICENSE
@@ -399,7 +399,7 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_common:0.14.1 - Prometheus Java Span Context Supplier - Common (https://github.com/prometheus/client_java/tree/parent-0.14.1/simpleclient_tracer/simpleclient_tracer_common), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry (https://github.com/prometheus/client_java/tree/parent-0.14.1/simpleclient_tracer/simpleclient_tracer_otel), (The Apache Software License, Version 2.0)
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java/tree/parent-0.14.1/simpleclient_tracer/simpleclient_tracer_otel_agent), (The Apache Software License, Version 2.0)
-  org.xerial.snappy:snappy-java:1.1.8.4 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
+  org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
 
 
 ========================================================================

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <elasticsearch7.version>7.9.2</elasticsearch7.version>
         <shiro.version>1.10.1</shiro.version>
 
-        <snappy.version>1.1.8.4</snappy.version>
+        <snappy.version>1.1.10.1</snappy.version>
         <protobuf.version>3.19.6</protobuf.version>
         <bytebuddy.version>1.12.9</bytebuddy.version>
         <reflections.version>0.10.2</reflections.version>


### PR DESCRIPTION
### Prepare a Pull Request

-INLONG-8309][Other]Upgrade org.xerial.snappy:snappy-java from version 1.1.8.4 to version 1.1.10.1

- Fixes #8309 

### Motivation

![image](https://github.com/apache/inlong/assets/18047329/51b852ef-bdaf-4e34-878a-2bc0e8ceae83)


### Modifications

*Upgrade org.xerial.snappy:snappy-java from version 1.1.8.4 to version 1.1.10.1*
