### PR TITLE
[INLONG-8313][Manager] Add Oracle field type mapping strategy to improve usability

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
@@ -33,5 +33,6 @@ public class DataNodeType {
     public static final String REDIS = "REDIS";
     public static final String KUDU = "KUDU";
     public static final String POSTGRESQL = "POSTGRESQL";
+    public static final String ORACLE = "ORACLE";
 
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/OracleFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/OracleFieldTypeStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.fieldtype.strategy;
+
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
+/**
+ * The oracle field type mapping strategy
+ */
+public class OracleFieldTypeStrategy implements FieldTypeMappingStrategy {
+
+    private final FieldTypeMappingReader reader;
+
+    public OracleFieldTypeStrategy() {
+        this.reader = new FieldTypeMappingReader(DataNodeType.ORACLE);
+    }
+
+    @Override
+    public String getFieldTypeMapping(String sourceType) {
+        String dataType = StringUtils.substringBefore(sourceType, LEFT_BRACKET).toUpperCase();
+        return reader.getFIELD_TYPE_MAPPING_MAP().getOrDefault(dataType, sourceType.toUpperCase());
+    }
+}

--- a/inlong-manager/manager-common/src/main/resources/oracle-field-type-mapping.yaml
+++ b/inlong-manager/manager-common/src/main/resources/oracle-field-type-mapping.yaml
@@ -1,0 +1,96 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source.type.to.target.type.converter:
+
+  - source.type: BINARY_FLOAT
+    target.type: FLOAT
+
+  - source.type: FLOAT
+    target.type: FLOAT
+
+  - source.type: BINARY_DOUBLE
+    target.type: DOUBLE
+
+  - source.type: DOUBLE PRECISION
+    target.type: DOUBLE
+
+  - source.type: REAL
+    target.type: DECIMAL
+
+  - source.type: NUMBER
+    target.type: NUMBER
+
+  - source.type: INTEGER
+    target.type: INT
+
+  - source.type: LONG
+    target.type: LONG
+
+  - source.type: INTERVAL DAY TO SECOND
+    target.type: LONG
+
+  - source.type: INTERVAL YEAR TO MONTH
+    target.type: LONG
+
+  - source.type: BOOLEAN
+    target.type: BOOLEAN
+
+  - source.type: DATE
+    target.type: TIMESTAMP
+
+  - source.type: TIMESTAMP
+    target.type: TIMESTAMP
+
+  - source.type: TIMESTAMP WITH TIME ZONE
+    target.type: TIMESTAMP
+
+  - source.type: TIMESTAMP WITH LOCAL TIME ZONE
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: CHAR
+    target.type: STRING
+
+  - source.type: NCHAR
+    target.type: STRING
+
+  - source.type: VARCHAR
+    target.type: STRING
+
+  - source.type: VARCHAR2
+    target.type: STRING
+
+  - source.type: NVARCHAR2
+    target.type: STRING
+
+  - source.type: CLOB
+    target.type: STRING
+
+  - source.type: NCLOB
+    target.type: STRING
+
+  - source.type: XMLTYPE
+    target.type: STRING
+
+  - source.type: SYS.XMLTYPE
+    target.type: STRING
+
+  - source.type: BLOB
+    target.type: VARBINARY
+
+  - source.type: ROWID
+    target.type: VARBINARY

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/OracleProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/OracleProvider.java
@@ -18,6 +18,8 @@
 package org.apache.inlong.manager.pojo.sort.node.provider;
 
 import org.apache.inlong.manager.common.consts.StreamType;
+import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.OracleFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.sink.oracle.OracleSink;
 import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
 import org.apache.inlong.manager.pojo.sort.node.base.LoadNodeProvider;
@@ -42,6 +44,8 @@ import java.util.Map;
  */
 public class OracleProvider implements ExtractNodeProvider, LoadNodeProvider {
 
+    private static final FieldTypeMappingStrategy FIELD_TYPE_MAPPING_STRATEGY = new OracleFieldTypeStrategy();
+
     @Override
     public Boolean accept(String streamType) {
         return StreamType.ORACLE.equals(streamType);
@@ -50,7 +54,8 @@ public class OracleProvider implements ExtractNodeProvider, LoadNodeProvider {
     @Override
     public ExtractNode createExtractNode(StreamNode streamNodeInfo) {
         OracleSource source = (OracleSource) streamNodeInfo;
-        List<FieldInfo> fieldInfos = parseStreamFieldInfos(source.getFieldList(), source.getSourceName());
+        List<FieldInfo> fieldInfos = parseStreamFieldInfos(source.getFieldList(), source.getSourceName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         Map<String, String> properties = parseProperties(source.getProperties());
 
         ScanStartUpMode scanStartupMode = StringUtils.isBlank(source.getScanStartupMode())
@@ -77,7 +82,8 @@ public class OracleProvider implements ExtractNodeProvider, LoadNodeProvider {
     public LoadNode createLoadNode(StreamNode nodeInfo, Map<String, StreamField> constantFieldMap) {
         OracleSink oracleSink = (OracleSink) nodeInfo;
         Map<String, String> properties = parseProperties(oracleSink.getProperties());
-        List<FieldInfo> fieldInfos = parseSinkFieldInfos(oracleSink.getSinkFieldList(), oracleSink.getSinkName());
+        List<FieldInfo> fieldInfos = parseSinkFieldInfos(oracleSink.getSinkFieldList(), oracleSink.getSinkName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         List<FieldRelation> fieldRelations = parseSinkFields(oracleSink.getSinkFieldList(), constantFieldMap);
 
         return new OracleLoadNode(

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -18,9 +18,11 @@
 package org.apache.inlong.manager.pojo.sort.util;
 
 import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.OracleFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.PostgreSQLFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.sort.formats.common.IntTypeInfo;
+import org.apache.inlong.sort.formats.common.LocalZonedTimestampTypeInfo;
 import org.apache.inlong.sort.formats.common.ShortTypeInfo;
 import org.apache.inlong.sort.formats.common.TypeInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
@@ -55,5 +57,17 @@ public class FieldInfoUtilsTest {
                 "nodeId", new MySQLFieldTypeStrategy());
         TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
         Assertions.assertTrue(typeInfo instanceof ShortTypeInfo);
+    }
+
+    @Test
+    public void testOracleFieldTypeInfo() {
+        StreamField streamField = new StreamField();
+        streamField.setIsMetaField(0);
+        streamField.setFieldName("date");
+        streamField.setFieldType("TIMESTAMP WITH LOCAL TIME ZONE");
+        FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
+                "nodeId", new OracleFieldTypeStrategy());
+        TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
+        Assertions.assertTrue(typeInfo instanceof LocalZonedTimestampTypeInfo);
     }
 }


### PR DESCRIPTION
[INLONG-8313][Manager] Add Oracle field type mapping strategy to improve usability

- Fixes #8313

### Motivation

Inlong Oracle ExtractNode or LoadNode currently does not support some special field types, add Oracle field type mapping strategy to mapping to the corresponding type to run correctly