### PR TITLE
[INLONG-8315][Audit] Filter out illegal data that is more than 7 days old (configurable)

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
@@ -70,4 +70,6 @@ public class ConfigConstants {
     public static final String MANAGER_PATH = "/inlong/manager/openapi";
 
     public static final String MANAGER_GET_CONFIG_PATH = "/audit/getConfig";
+
+    public static final String MSGVALID = "msg.valid.threshold";
 }

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageFactory.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageFactory.java
@@ -41,6 +41,7 @@ public class ServerMessageFactory extends ChannelInitializer<SocketChannel> {
     private ServiceDecoder serviceDecoder;
     private String messageHandlerName;
     private int maxConnections = Integer.MAX_VALUE;
+    private final long msgValidThreshold;
     private int maxMsgLength;
     private String name;
 
@@ -57,7 +58,7 @@ public class ServerMessageFactory extends ChannelInitializer<SocketChannel> {
      */
     public ServerMessageFactory(AbstractSource source,
             ChannelGroup allChannels, ServiceDecoder serviceDecoder,
-            String messageHandlerName, Integer maxMsgLength, Integer maxCons, String name) {
+            String messageHandlerName, Integer maxMsgLength, Integer maxCons, Long msgValid, String name) {
         this.source = source;
         this.processor = source.getChannelProcessor();
         this.allChannels = allChannels;
@@ -66,6 +67,7 @@ public class ServerMessageFactory extends ChannelInitializer<SocketChannel> {
         this.name = name;
         this.maxConnections = maxCons;
         this.maxMsgLength = maxMsgLength;
+        this.msgValidThreshold = msgValid;
     }
 
     @Override
@@ -83,10 +85,10 @@ public class ServerMessageFactory extends ChannelInitializer<SocketChannel> {
 
                 Constructor<?> ctor =
                         clazz.getConstructor(AbstractSource.class, ServiceDecoder.class,
-                                ChannelGroup.class, Integer.class);
+                                ChannelGroup.class, Integer.class, Long.class);
 
                 ChannelInboundHandlerAdapter messageHandler = (ChannelInboundHandlerAdapter) ctor
-                        .newInstance(source, serviceDecoder, allChannels, maxConnections);
+                        .newInstance(source, serviceDecoder, allChannels, maxConnections, msgValidThreshold);
 
                 ch.pipeline().addLast("messageHandler", messageHandler);
             } catch (Exception e) {

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
@@ -47,6 +47,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 /**
  * Server message handler
  */
+
 public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ServerMessageHandler.class);
@@ -56,13 +57,15 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
     private final ChannelProcessor processor;
     private final ServiceDecoder serviceDecoder;
     private final int maxConnections;
+    private final long msgValidThreshold;
 
     public ServerMessageHandler(AbstractSource source, ServiceDecoder serviceDecoder,
-            ChannelGroup allChannels, Integer maxCons) {
+            ChannelGroup allChannels, Integer maxCons, Long msgValidThreshold) {
         this.processor = source.getChannelProcessor();
         this.serviceDecoder = serviceDecoder;
         this.allChannels = allChannels;
         this.maxConnections = maxCons;
+        this.msgValidThreshold = msgValidThreshold;
     }
 
     @Override
@@ -147,6 +150,12 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         List<AuditMessageBody> bodyList = auditRequest.getMsgBodyList();
         int errorMsgBody = 0;
         for (AuditMessageBody auditMessageBody : bodyList) {
+            long msgDays = messageDays(auditMessageBody.getLogTs());
+            if (msgDays >= this.msgValidThreshold) {
+                LOGGER.info("Discard the data as it is from" + msgDays +
+                        "days ago . Note: Only data with a log timestamp less than 7 days is considered valid.");
+                continue;
+            }
             AuditData auditData = new AuditData();
             auditData.setIp(auditRequest.getMsgHeader().getIp());
             auditData.setThreadId(auditRequest.getMsgHeader().getThreadId());
@@ -180,6 +189,13 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         }
 
         return reply;
+    }
+
+    public long messageDays(long logTs) {
+        long ONE_DAY_MS = 24 * 60 * 60 * 1000;
+        long currentTime = System.currentTimeMillis();
+        long timeDiff = currentTime - logTs;
+        return timeDiff / ONE_DAY_MS;
     }
 
     @Override

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
@@ -58,6 +58,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
     private final ServiceDecoder serviceDecoder;
     private final int maxConnections;
     private final long msgValidThreshold;
+    private final long ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
     public ServerMessageHandler(AbstractSource source, ServiceDecoder serviceDecoder,
             ChannelGroup allChannels, Integer maxCons, Long msgValidThreshold) {
@@ -192,7 +193,6 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
     }
 
     public long messageDays(long logTs) {
-        long ONE_DAY_MS = 24 * 60 * 60 * 1000;
         long currentTime = System.currentTimeMillis();
         long timeDiff = currentTime - logTs;
         return timeDiff / ONE_DAY_MS;

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -67,6 +67,9 @@ audit.kafka.topic=inlong-audit
 audit.kafka.consumer.name=inlong-audit-consumer
 audit.kafka.group.id=audit-consumer-group
 
+#message's valid threshold config
+msg.valid.threshold=7
+
 # es config
 elasticsearch.host=127.0.0.1
 elasticsearch.port=9200


### PR DESCRIPTION
### Prepare a Pull Request

- Title Example: [INLONG-8315][Audit] Filter out illegal data that is more than 7 days old (configurable)

- Fixes #8315 

### Motivation
Currently, there are some data that cannot be sent normally due to various reasons. These data will be retried continuously, which affects the online data. Therefore, we define these data that cannot be sent normally as illegal data and discard them. We assume that data with a log time more than seven days ago is illegal data by default.

### Modifications
I filtered out the data with a log time of seven days ago (by default), and configured the time to decide when to discard the data.
