### PR TITLE
[INLONG-8323][DataProxy] Add Topic detailed information output when Producer is null

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
@@ -156,6 +156,7 @@ public class SimplePackProfile extends PackProfile {
         result.put(ConfigConstants.MSG_ENCODE_VER, event.getHeaders().get(ConfigConstants.MSG_ENCODE_VER));
         result.put(EventConstants.HEADER_KEY_VERSION, event.getHeaders().get(EventConstants.HEADER_KEY_VERSION));
         result.put(ConfigConstants.REMOTE_IP_KEY, event.getHeaders().get(ConfigConstants.REMOTE_IP_KEY));
+        result.put(ConfigConstants.PKG_TIME_KEY, event.getHeaders().get(ConfigConstants.PKG_TIME_KEY));
         result.put(ConfigConstants.DATAPROXY_IP_KEY, NetworkUtils.getLocalIp());
         return result;
     }
@@ -189,6 +190,14 @@ public class SimplePackProfile extends PackProfile {
                 if (StringUtils.isNotEmpty(errMsg)) {
                     strBuff.append(AttributeConstants.SEPARATOR).append(AttributeConstants.MESSAGE_PROCESS_ERRMSG)
                             .append(AttributeConstants.KEY_VALUE_SEPARATOR).append(errMsg);
+                }
+            }
+            String origAttr = event.getHeaders().getOrDefault(ConfigConstants.DECODER_ATTRS, "");
+            if (StringUtils.isNotEmpty(origAttr)) {
+                if (strBuff.length() > 0) {
+                    strBuff.append(AttributeConstants.SEPARATOR).append(origAttr);
+                } else {
+                    strBuff.append(origAttr);
                 }
             }
             // build and send response message

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/kafka/KafkaHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/kafka/KafkaHandler.java
@@ -146,7 +146,7 @@ public class KafkaHandler implements MessageQueueHandler {
             }
             // create producer failed
             if (producer == null) {
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_PRODUCER_NULL);
+                sinkContext.fileMetricIncWithDetailStats(StatConstants.EVENT_SINK_PRODUCER_NULL, topic);
                 sinkContext.processSendFail(profile, clusterName, topic, 0, DataProxyErrCode.PRODUCER_IS_NULL, "");
                 return false;
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/pulsar/PulsarHandler.java
@@ -253,7 +253,7 @@ public class PulsarHandler implements MessageQueueHandler {
             }
             // create producer failed
             if (producer == null) {
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_PRODUCER_NULL);
+                sinkContext.fileMetricIncWithDetailStats(StatConstants.EVENT_SINK_PRODUCER_NULL, producerTopic);
                 sinkContext.processSendFail(profile, clusterName, producerTopic, 0,
                         DataProxyErrCode.PRODUCER_IS_NULL, "");
                 return false;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
@@ -211,7 +211,7 @@ public class TubeHandler implements MessageQueueHandler {
             }
             // create producer failed
             if (producer == null) {
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_PRODUCER_NULL);
+                sinkContext.fileMetricIncWithDetailStats(StatConstants.EVENT_SINK_PRODUCER_NULL, topic);
                 sinkContext.processSendFail(profile, clusterName, topic, 0,
                         DataProxyErrCode.PRODUCER_IS_NULL, "");
                 return false;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/InLongMessageHandler.java
@@ -469,9 +469,9 @@ public class InLongMessageHandler extends ChannelInboundHandlerAdapter {
                 strBuff.append(AttributeConstants.SEPARATOR).append(AttributeConstants.MESSAGE_PROCESS_ERRMSG)
                         .append(AttributeConstants.KEY_VALUE_SEPARATOR).append(msgObj.getErrMsg());
             }
-            if (StringUtils.isNotEmpty(msgObj.getAttr())) {
-                strBuff.append(AttributeConstants.SEPARATOR).append(msgObj.getAttr());
-            }
+        }
+        if (StringUtils.isNotEmpty(msgObj.getAttr())) {
+            strBuff.append(AttributeConstants.SEPARATOR).append(msgObj.getAttr());
         }
         // build and send response message
         ByteBuf retData;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/AbsV0MsgCodec.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/AbsV0MsgCodec.java
@@ -242,6 +242,9 @@ public abstract class AbsV0MsgCodec {
         if (StringUtils.isNotEmpty(proxySend)) {
             headers.put(AttributeConstants.MESSAGE_PROXY_SEND, proxySend);
         }
+        if (isOrderOrProxy) {
+            headers.put(ConfigConstants.DECODER_ATTRS, this.origAttr);
+        }
         String partitionKey = attrMap.get(AttributeConstants.MESSAGE_PARTITION_KEY);
         if (StringUtils.isNotEmpty(partitionKey)) {
             headers.put(AttributeConstants.MESSAGE_PARTITION_KEY, partitionKey);


### PR DESCRIPTION
- Fixes #8323

1. Add the corresponding Topic output when the Producer is null;
2. Add attribute information to the return message to facilitate error location