### PR TITLE
[INLONG-8327][Manager] Add SQLServer field type mapping strategy to improve usability

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
@@ -34,5 +34,5 @@ public class DataNodeType {
     public static final String KUDU = "KUDU";
     public static final String POSTGRESQL = "POSTGRESQL";
     public static final String ORACLE = "ORACLE";
-
+    public static final String SQLSERVER = "SQLSERVER";
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/SQLServerFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/SQLServerFieldTypeStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.fieldtype.strategy;
+
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
+/**
+ * The sqlServer field type mapping strategy
+ */
+public class SQLServerFieldTypeStrategy implements FieldTypeMappingStrategy {
+
+    private final FieldTypeMappingReader reader;
+
+    public SQLServerFieldTypeStrategy() {
+        this.reader = new FieldTypeMappingReader(DataNodeType.SQLSERVER);
+    }
+
+    @Override
+    public String getFieldTypeMapping(String sourceType) {
+        String dataType = StringUtils.substringBefore(sourceType, LEFT_BRACKET).toUpperCase();
+        return reader.getFIELD_TYPE_MAPPING_MAP().getOrDefault(dataType, sourceType.toUpperCase());
+    }
+}

--- a/inlong-manager/manager-common/src/main/resources/sqlserver-field-type-mapping.yaml
+++ b/inlong-manager/manager-common/src/main/resources/sqlserver-field-type-mapping.yaml
@@ -1,0 +1,102 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source.type.to.target.type.converter:
+
+  - source.type: TINYINT
+    target.type: SMALLINT
+
+  - source.type: SMALLINT
+    target.type: SMALLINT
+
+  - source.type: BIGINT
+    target.type: LONG
+
+  - source.type: INT
+    target.type: INT
+
+  - source.type: REAL
+    target.type: FLOAT
+
+  - source.type: FLOAT
+    target.type: FLOAT
+
+  - source.type: NUMERIC
+    target.type: NUMERIC
+
+  - source.type: DECIMAL
+    target.type: DECIMAL
+
+  - source.type: MONEY
+    target.type: DECIMAL
+
+  - source.type: SMALLMONEY
+    target.type: DECIMAL
+
+  - source.type: BOOLEAN
+    target.type: BOOLEAN
+
+  - source.type: BIT
+    target.type: BOOLEAN
+
+  - source.type: DATE
+    target.type: DATE
+
+  - source.type: TIME
+    target.type: TIME
+
+  - source.type: DATETIME
+    target.type: TIMESTAMP
+
+  - source.type: DATETIME2
+    target.type: TIMESTAMP
+
+  - source.type: SMALLDATETIME
+    target.type: TIMESTAMP
+
+  - source.type: TIMESTAMP
+    target.type: TIMESTAMP
+
+  - source.type: DATETIMEOFFSET
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: CHAR
+    target.type: STRING
+
+  - source.type: VARCHAR
+    target.type: STRING
+
+  - source.type: NVARCHAR
+    target.type: STRING
+
+  - source.type: NCHAR
+    target.type: STRING
+
+  - source.type: TEXT
+    target.type: STRING
+
+  - source.type: NTEXT
+    target.type: STRING
+
+  - source.type: XML
+    target.type: STRING
+
+  - source.type: IMAGE
+    target.type: STRING
+
+  - source.type: VARBINARY
+    target.type: STRING

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/SQLServerProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/SQLServerProvider.java
@@ -18,6 +18,8 @@
 package org.apache.inlong.manager.pojo.sort.node.provider;
 
 import org.apache.inlong.manager.common.consts.StreamType;
+import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.SQLServerFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.sink.sqlserver.SQLServerSink;
 import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
 import org.apache.inlong.manager.pojo.sort.node.base.LoadNodeProvider;
@@ -39,6 +41,8 @@ import java.util.Map;
  */
 public class SQLServerProvider implements ExtractNodeProvider, LoadNodeProvider {
 
+    private static final FieldTypeMappingStrategy FIELD_TYPE_MAPPING_STRATEGY = new SQLServerFieldTypeStrategy();
+
     @Override
     public Boolean accept(String streamType) {
         return StreamType.SQLSERVER.equals(streamType);
@@ -47,7 +51,8 @@ public class SQLServerProvider implements ExtractNodeProvider, LoadNodeProvider 
     @Override
     public ExtractNode createExtractNode(StreamNode streamNodeInfo) {
         SQLServerSource source = (SQLServerSource) streamNodeInfo;
-        List<FieldInfo> fieldInfos = parseStreamFieldInfos(source.getFieldList(), source.getSourceName());
+        List<FieldInfo> fieldInfos = parseStreamFieldInfos(source.getFieldList(), source.getSourceName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         Map<String, String> properties = parseProperties(source.getProperties());
 
         return new SqlServerExtractNode(
@@ -71,7 +76,8 @@ public class SQLServerProvider implements ExtractNodeProvider, LoadNodeProvider 
     public LoadNode createLoadNode(StreamNode nodeInfo, Map<String, StreamField> constantFieldMap) {
         SQLServerSink sqlServerSink = (SQLServerSink) nodeInfo;
         Map<String, String> properties = parseProperties(sqlServerSink.getProperties());
-        List<FieldInfo> fieldInfos = parseSinkFieldInfos(sqlServerSink.getSinkFieldList(), sqlServerSink.getSinkName());
+        List<FieldInfo> fieldInfos = parseSinkFieldInfos(sqlServerSink.getSinkFieldList(), sqlServerSink.getSinkName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         List<FieldRelation> fieldRelations = parseSinkFields(sqlServerSink.getSinkFieldList(), constantFieldMap);
 
         return new SqlServerLoadNode(

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -20,10 +20,12 @@ package org.apache.inlong.manager.pojo.sort.util;
 import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.OracleFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.PostgreSQLFieldTypeStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.SQLServerFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.sort.formats.common.IntTypeInfo;
 import org.apache.inlong.sort.formats.common.LocalZonedTimestampTypeInfo;
 import org.apache.inlong.sort.formats.common.ShortTypeInfo;
+import org.apache.inlong.sort.formats.common.StringTypeInfo;
 import org.apache.inlong.sort.formats.common.TypeInfo;
 import org.apache.inlong.sort.protocol.FieldInfo;
 
@@ -69,5 +71,17 @@ public class FieldInfoUtilsTest {
                 "nodeId", new OracleFieldTypeStrategy());
         TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
         Assertions.assertTrue(typeInfo instanceof LocalZonedTimestampTypeInfo);
+    }
+
+    @Test
+    public void testSQLServerFieldTypeInfo() {
+        StreamField streamField = new StreamField();
+        streamField.setIsMetaField(0);
+        streamField.setFieldName("contentXML");
+        streamField.setFieldType("XML");
+        FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
+                "nodeId", new SQLServerFieldTypeStrategy());
+        TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
+        Assertions.assertTrue(typeInfo instanceof StringTypeInfo);
     }
 }


### PR DESCRIPTION
[INLONG-8327][Manager] Add SQLServer field type mapping strategy to improve usability

- Fixes #8327

### Motivation

Inlong SQLServer ExtractNode or LoadNode currently does not support some special field types, add SQLServer field type mapping strategy to mapping to the corresponding type to run correctly