### PR TITLE
[INLONG-8332][DataProxy] Return original content for MSG_ORIGINAL_RETURN type messages

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -302,12 +302,12 @@ public class MessageQueueZoneSinkContext extends SinkContext {
         if (packProfile instanceof SimplePackProfile) {
             SimplePackProfile simpleProfile = (SimplePackProfile) packProfile;
             StringBuilder statsKey = new StringBuilder(512)
-                    .append(sinkName).append(AttrConstants.SEPARATOR)
-                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEPARATOR)
-                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEPARATOR)
-                    .append(topic).append(AttrConstants.SEPARATOR)
-                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEPARATOR)
-                    .append(remoteId).append(AttrConstants.SEPARATOR)
+                    .append(sinkName).append(AttrConstants.SEP_HASHTAG)
+                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEP_HASHTAG)
+                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEP_HASHTAG)
+                    .append(topic).append(AttrConstants.SEP_HASHTAG)
+                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEP_HASHTAG)
+                    .append(remoteId).append(AttrConstants.SEP_HASHTAG)
                     .append(simpleProfile.getProperties().get(ConfigConstants.PKG_TIME_KEY));
             monitorIndex.addFailStats(statsKey.toString(), 1);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/AbsV0MsgCodec.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/AbsV0MsgCodec.java
@@ -56,6 +56,7 @@ public abstract class AbsV0MsgCodec {
     protected int msgCount;
     protected String origAttr = "";
     protected byte[] bodyData;
+    protected byte[] origBody = null;
     protected long dataTimeMs;
     protected String groupId;
     protected String streamId = "";
@@ -142,6 +143,10 @@ public abstract class AbsV0MsgCodec {
 
     public String getStrRemoteIP() {
         return strRemoteIP;
+    }
+
+    public byte[] getOrigBody() {
+        return origBody;
     }
 
     public long getMsgRcvTime() {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source2/v0msg/CodecTextMsg.java
@@ -71,6 +71,10 @@ public class CodecTextMsg extends AbsV0MsgCodec {
         // extract body bytes
         this.bodyData = new byte[bodyLen];
         cb.getBytes(msgHeadPos + TXT_MSG_BODY_OFFSET, this.bodyData, 0, bodyLen);
+        if (MsgType.MSG_ORIGINAL_RETURN.equals(MsgType.valueOf(msgType))) {
+            this.origBody = new byte[bodyLen];
+            System.arraycopy(this.bodyData, 0, this.origBody, 0, bodyLen);
+        }
         // get attribute length
         int attrLen = cb.getInt(msgHeadPos + TXT_MSG_BODY_OFFSET + bodyLen);
         if (attrLen < 0) {


### PR DESCRIPTION

- Fixes #8332

1. Save the original body content of the MSG_ORIGINAL_RETURN request, and carry the original body content when returning the response message;
2. Fix the wrong symbol "&" on the Sink side to "#"