### PR TITLE
[INLONG-8341][Sort] MySQL cdc connector can get scale for decimal field

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/MetaDataUtils.java
@@ -57,6 +57,9 @@ public class MetaDataUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetaDataUtils.class);
 
+    private static final String FORMAT_PRECISION = "%s(%d)";
+    private static final String FORMAT_PRECISION_SCALE = "%s(%d, %d)";
+
     /**
      * get sql type from table schema, represents the jdbc data type
      *
@@ -144,12 +147,16 @@ public class MetaDataUtils {
         table.columns()
                 .forEach(
                         column -> {
-                            mysqlType.put(
-                                    column.name(),
-                                    String.format(
-                                            "%s(%d)",
-                                            column.typeName(),
-                                            column.length()));
+                            if (column.scale().isPresent()) {
+                                mysqlType.put(
+                                        column.name(),
+                                        String.format(FORMAT_PRECISION_SCALE,
+                                                column.typeName(), column.length(), column.scale().get()));
+                            } else {
+                                mysqlType.put(
+                                        column.name(),
+                                        String.format(FORMAT_PRECISION, column.typeName(), column.length()));
+                            }
                         });
         return mysqlType;
     }


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8341

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

When MySQL table has decimal(38,10) field, MySQL cdc connector only sends precision 38, but scale 10 is lost.

Refer to `getOracleType` method from [Oracle cdc connector](https://github.com/apache/inlong/blob/b73455a34729d416ee76d0ec22cb6857f5d15ea3/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/table/OracleReadableMetaData.java#L456C38-L456C38) , MySQL cdc connector can also get scale if debezium column  has scale.

### Modifications

*Describe the modifications you've done.*

`getMysqlType` method in `MetaDataUtils` class can get scale if column.scale().isPresent(). 

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
