### PR TITLE
[INLONG-8372][Sort] MySQL connector supports uploading flink job delay metrics

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -62,6 +62,11 @@ public final class Constants {
     public static final String NUM_BYTES_IN_PER_SECOND = "numBytesInPerSecond";
 
     public static final String NUM_RECORDS_IN_PER_SECOND = "numRecordsInPerSecond";
+
+    public static final String CURRENT_FETCH_EVENT_TIME_LAG = "currentFetchEventTimeLag";
+
+    public static final String CURRENT_EMIT_EVENT_TIME_LAG = "currentEmitEventTimeLag";
+
     /**
      * Timestamp when the read phase changed
      */

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricData.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.base.metric;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.MetricGroup;
@@ -113,6 +114,20 @@ public interface MetricData {
             inlongMetricGroup = inlongMetricGroup.addGroup(label.getKey(), label.getValue());
         }
         return inlongMetricGroup.meter(metricName, new MeterView(counter, TIME_SPAN_IN_SECONDS));
+    }
+
+    /**
+     * Register a gauge metric
+     *
+     * @param metricName The gauge name
+     * @return Gauge of registered
+     */
+    default Gauge registerGauge(String metricName, Gauge gauge) {
+        MetricGroup inlongMetricGroup = getMetricGroup();
+        for (Map.Entry<String, String> label : getLabels().entrySet()) {
+            inlongMetricGroup = inlongMetricGroup.addGroup(label.getKey(), label.getValue());
+        }
+        return inlongMetricGroup.gauge(metricName, gauge);
     }
 
 }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.base.metric;
 import org.apache.inlong.audit.AuditOperator;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.SimpleCounter;
@@ -29,6 +30,8 @@ import org.slf4j.LoggerFactory;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.inlong.sort.base.Constants.CURRENT_EMIT_EVENT_TIME_LAG;
+import static org.apache.inlong.sort.base.Constants.CURRENT_FETCH_EVENT_TIME_LAG;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN_FOR_METER;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN_PER_SECOND;
@@ -54,6 +57,29 @@ public class SourceMetricData implements MetricData {
     private AuditOperator auditOperator;
     private List<Integer> auditKeys;
 
+    /**
+     * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
+     * record fetched into the source operator.
+     */
+    private Gauge currentFetchEventTimeLag;
+    /**
+     * currentEmitEventTimeLag = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the
+     * source operator.
+     */
+    private Gauge currentEmitEventTimeLag;
+
+    /**
+     * fetchDelay = FetchTime - messageTimestamp, where the FetchTime is the time the
+     * record fetched into the source operator.
+     */
+    private volatile long fetchDelay = 0L;
+
+    /**
+     * emitDelay = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the
+     * source operator.
+     */
+    private volatile long emitDelay = 0L;
+
     public SourceMetricData(MetricOption option, MetricGroup metricGroup) {
         this.metricGroup = metricGroup;
         this.labels = option.getLabels();
@@ -70,6 +96,8 @@ public class SourceMetricData implements MetricData {
                 registerMetricsForNumRecordsInForMeter(new ThreadSafeCounter());
                 registerMetricsForNumBytesInPerSecond();
                 registerMetricsForNumRecordsInPerSecond();
+                registerMetricsForCurrentFetchEventTimeLag();
+                registerMetricsForCurrentEmitEventTimeLag();
                 break;
         }
 
@@ -160,6 +188,14 @@ public class SourceMetricData implements MetricData {
         numBytesInPerSecond = registerMeter(NUM_BYTES_IN_PER_SECOND, this.numBytesInForMeter);
     }
 
+    public void registerMetricsForCurrentFetchEventTimeLag() {
+        currentFetchEventTimeLag = registerGauge(CURRENT_FETCH_EVENT_TIME_LAG, (Gauge<Long>) this::getFetchDelay);
+    }
+
+    public void registerMetricsForCurrentEmitEventTimeLag() {
+        currentEmitEventTimeLag = registerGauge(CURRENT_EMIT_EVENT_TIME_LAG, (Gauge<Long>) this::getEmitDelay);
+    }
+
     public Counter getNumRecordsIn() {
         return numRecordsIn;
     }
@@ -184,6 +220,14 @@ public class SourceMetricData implements MetricData {
         return numBytesInForMeter;
     }
 
+    public long getFetchDelay() {
+        return fetchDelay;
+    }
+
+    public long getEmitDelay() {
+        return emitDelay;
+    }
+
     @Override
     public MetricGroup getMetricGroup() {
         return metricGroup;
@@ -198,12 +242,35 @@ public class SourceMetricData implements MetricData {
         outputMetrics(1, getDataSize(data));
     }
 
+    public void outputMetricsWithEstimate(Object data, long fetchDelay, long emitDelay) {
+        outputMetrics(1, getDataSize(data));
+        this.fetchDelay = fetchDelay;
+        this.emitDelay = emitDelay;
+    }
+
     public void outputMetricsWithEstimate(Object data, long dataTime) {
         outputMetrics(1, getDataSize(data), dataTime);
     }
 
     public void outputMetrics(long rowCountSize, long rowDataSize) {
         outputDefaultMetrics(rowCountSize, rowDataSize);
+
+        if (auditOperator != null) {
+            for (Integer key : auditKeys) {
+                auditOperator.add(
+                        key,
+                        getGroupId(),
+                        getStreamId(),
+                        System.currentTimeMillis(),
+                        rowCountSize,
+                        rowDataSize);
+            }
+
+        }
+    }
+
+    public void outputMetrics(long rowCountSize, long rowDataSize, long fetchDelay, long emitDelay) {
+        outputDefaultMetrics(rowCountSize, rowDataSize, fetchDelay, emitDelay);
 
         if (auditOperator != null) {
             for (Integer key : auditKeys) {
@@ -253,6 +320,12 @@ public class SourceMetricData implements MetricData {
         }
     }
 
+    private void outputDefaultMetrics(long rowCountSize, long rowDataSize, long fetchDelay, long emitDelay) {
+        outputDefaultMetrics(rowCountSize, rowDataSize);
+        this.fetchDelay = fetchDelay;
+        this.emitDelay = emitDelay;
+    }
+
     @Override
     public String toString() {
         return "SourceMetricData{"
@@ -264,6 +337,8 @@ public class SourceMetricData implements MetricData {
                 + ", numBytesInForMeter=" + numBytesInForMeter.getCount()
                 + ", numRecordsInPerSecond=" + numRecordsInPerSecond.getRate()
                 + ", numBytesInPerSecond=" + numBytesInPerSecond.getRate()
+                + ", currentFetchEventTimeLag=" + currentFetchEventTimeLag.getValue()
+                + ", currentEmitEventTimeLag=" + currentEmitEventTimeLag.getValue()
                 + ", auditOperator=" + auditOperator
                 + '}';
     }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/sub/SourceTableMetricData.java
@@ -24,6 +24,7 @@ import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
 import org.apache.inlong.sort.base.metric.MetricState;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.base.metric.phase.ReadPhaseMetricData;
+import org.apache.inlong.sort.base.util.CalculateObjectSizeUtils;
 
 import com.google.common.collect.Maps;
 import org.apache.commons.lang3.StringUtils;
@@ -165,6 +166,28 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
      * output metrics with estimate
      *
      * @param database the database name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param data the data of record
+     * @param fetchDelay fetchDelay = FetchTime - messageTimestamp, where the FetchTime is the time the record fetched into the source operator.
+     * @param emitDelay emitDelay = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the source operator.
+     */
+    public void outputMetricsWithEstimate(String database, String table, boolean isSnapshotRecord, Object data,
+            long fetchDelay, long emitDelay) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(table)) {
+            outputMetricsWithEstimate(data, fetchDelay, emitDelay);
+            // output read phase metric
+            outputReadPhaseMetrics((isSnapshotRecord) ? ReadPhase.SNAPSHOT_PHASE : ReadPhase.INCREASE_PHASE);
+            return;
+        }
+        // output sub source metric
+        outputMetricsWithEstimate(new String[]{database, table}, isSnapshotRecord, data, fetchDelay, emitDelay);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param database the database name of record
      * @param schema the schema name of record
      * @param table the table name of record
      * @param isSnapshotRecord is it snapshot record
@@ -174,6 +197,27 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
             boolean isSnapshotRecord, Object data) {
         if (StringUtils.isBlank(database) || StringUtils.isBlank(schema) || StringUtils.isBlank(table)) {
             outputMetricsWithEstimate(data);
+            return;
+        }
+        // output sub source metric
+        outputMetricsWithEstimate(new String[]{database, schema, table}, isSnapshotRecord, data);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param database the database name of record
+     * @param schema the schema name of record
+     * @param table the table name of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param data the data of record
+     * @param fetchDelay fetchDelay = FetchTime - messageTimestamp, where the FetchTime is the time the record fetched into the source operator.
+     * @param emitDelay emitDelay = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the source operator.
+     */
+    public void outputMetricsWithEstimate(String database, String schema, String table,
+            boolean isSnapshotRecord, Object data, long fetchDelay, long emitDelay) {
+        if (StringUtils.isBlank(database) || StringUtils.isBlank(schema) || StringUtils.isBlank(table)) {
+            outputMetricsWithEstimate(data, fetchDelay, emitDelay);
             return;
         }
         // output sub source metric
@@ -205,6 +249,39 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
         long rowDataSize = data.toString().getBytes(StandardCharsets.UTF_8).length;
         this.outputMetrics(rowCountSize, rowDataSize);
         subSourceMetricData.outputMetrics(rowCountSize, rowDataSize);
+
+        // output read phase metric
+        outputReadPhaseMetrics((isSnapshotRecord) ? ReadPhase.SNAPSHOT_PHASE : ReadPhase.INCREASE_PHASE);
+    }
+
+    /**
+     * output metrics with estimate
+     *
+     * @param recordSchemaInfoArray the schema info of record
+     * @param isSnapshotRecord is it snapshot record
+     * @param data the data of record
+     * @param fetchDelay fetchDelay = FetchTime - messageTimestamp, where the FetchTime is the time the record fetched into the source operator.
+     * @param emitDelay emitDelay = EmitTime - messageTimestamp, where the EmitTime is the time the record leaves the source operator.
+     */
+    public void outputMetricsWithEstimate(String[] recordSchemaInfoArray, boolean isSnapshotRecord, Object data,
+            long fetchDelay, long emitDelay) {
+        if (recordSchemaInfoArray == null) {
+            outputMetricsWithEstimate(data, fetchDelay, emitDelay);
+            return;
+        }
+        String identify = String.join(Constants.SEMICOLON, recordSchemaInfoArray);
+        SourceMetricData subSourceMetricData;
+        if (subSourceMetricMap.containsKey(identify)) {
+            subSourceMetricData = subSourceMetricMap.get(identify);
+        } else {
+            subSourceMetricData = buildSubSourceMetricData(recordSchemaInfoArray, this);
+            subSourceMetricMap.put(identify, subSourceMetricData);
+        }
+        // source metric and sub source metric output metrics
+        long rowCountSize = 1L;
+        long rowDataSize = CalculateObjectSizeUtils.getDataSize(data);
+        this.outputMetrics(rowCountSize, rowDataSize, fetchDelay, emitDelay);
+        subSourceMetricData.outputMetrics(rowCountSize, rowDataSize, fetchDelay, emitDelay);
 
         // output read phase metric
         outputReadPhaseMetrics((isSnapshotRecord) ? ReadPhase.SNAPSHOT_PHASE : ReadPhase.INCREASE_PHASE);
@@ -259,6 +336,12 @@ public class SourceTableMetricData extends SourceMetricData implements SourceSub
         return "SourceTableMetricData{"
                 + "numRecordsIn=" + getNumRecordsIn().getCount()
                 + ", numBytesIn=" + getNumBytesIn().getCount()
+                + ", numRecordsInForMeter=" + getNumRecordsInForMeter().getCount()
+                + ", numBytesInForMeter=" + getNumBytesInForMeter().getCount()
+                + ", numRecordsInPerSecond=" + getNumRecordsInPerSecond().getRate()
+                + ", numBytesInPerSecond=" + getNumBytesInPerSecond().getRate()
+                + ", currentFetchEventTimeLag=" + getFetchDelay()
+                + ", currentEmitEventTimeLag=" + getEmitDelay()
                 + ", readPhaseMetricDataMap=" + readPhaseMetricDataMap
                 + ", subSourceMetricMap=" + subSourceMetricMap
                 + '}';

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -108,7 +108,8 @@ public class MySqlSourceReaderMetrics {
 
     public void outputMetrics(String database, String table, boolean isSnapshotRecord, Object data) {
         if (sourceTableMetricData != null) {
-            sourceTableMetricData.outputMetricsWithEstimate(database, table, isSnapshotRecord, data);
+            sourceTableMetricData.outputMetricsWithEstimate(database, table, isSnapshotRecord, data, fetchDelay,
+                    emitDelay);
         }
     }
 


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-8372][Sort] MySQL connector supports uploading flink job delay metrics

- Fixes #8372

### Motivation

Now mysql cdc connector has two [delay metrics](https://github.com/ververica/flink-cdc-connectors/blob/ba5fcbc97b46bbe57a2937622afa1562885beed8/flink-connector-mysql-cdc/src/main/java/com/ververica/cdc/connectors/mysql/source/metrics/MySqlSourceReaderMetrics.java#L52C36-L52C36): `currentFetchEventTimeLag` and `currentEmitEventTimeLag`. 

We could know if mysql cdc connector can follow MySQL binlog in time by this two metrics. The higher values ,the delay is severer.

Inlong metrics don't contain these now.

### Modifications

1. `MetricData` has `registerGauge` method which is used for registering a gauge metric.

2. `SourceMetricData` has two new `Gauge` parameters: `currentFetchEventTimeLag` and `currentEmitEventTimeLag`. It also has two long parameters `fetchDelay` and `emitDelay` which is set by every source connector.  `currentFetchEventTimeLag` and `currentEmitEventTimeLag` read `fetchDelay` and `emitDelay` value and upload them to Inlong metric system.

3. `SourceMetricData` and `SourceTableMetricData` classes have some new overriding methods which have two long parameters. Every source connector could update their delay metrics by invoking these methods.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
