### PR TITLE
[INLONG-8368][DataProxy] Sink does not have audit data

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
@@ -156,7 +156,6 @@ public class SimplePackProfile extends PackProfile {
         result.put(ConfigConstants.MSG_ENCODE_VER, event.getHeaders().get(ConfigConstants.MSG_ENCODE_VER));
         result.put(EventConstants.HEADER_KEY_VERSION, event.getHeaders().get(EventConstants.HEADER_KEY_VERSION));
         result.put(ConfigConstants.REMOTE_IP_KEY, event.getHeaders().get(ConfigConstants.REMOTE_IP_KEY));
-        result.put(ConfigConstants.PKG_TIME_KEY, event.getHeaders().get(ConfigConstants.PKG_TIME_KEY));
         result.put(ConfigConstants.DATAPROXY_IP_KEY, NetworkUtils.getLocalIp());
         return result;
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -287,7 +287,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         try {
             source.getChannelProcessor().processEvent(event);
             source.fileMetricIncSumStats(StatConstants.EVENT_MSG_V0_POST_SUCCESS);
-            source.fileMetricAddSuccCnt(statsKey, msgCodec.getMsgCount(), 1, msgCodec.getBodyLength());
+            source.fileMetricAddSuccCnt(statsKey, msgCodec.getMsgCount(), 1, event.getBody().length);
             source.addMetric(true, event.getBody().length, event);
             if (msgCodec.isNeedResp() && !msgCodec.isOrderOrProxy()) {
                 msgCodec.setSuccessInfo();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
@@ -235,8 +235,8 @@ public class CodecBinMsg extends AbsV0MsgCodec {
         // build InLong message
         InLongMsg inLongMsg = InLongMsg.newInLongMsg(source.isCompressed(), 4);
         inLongMsg.addMsg(dataBuf.array());
-        long pkgTime = inLongMsg.getCreatetime();
-        Event event = EventBuilder.withBody(inLongMsg.buildArray(), buildEventHeaders(pkgTime));
+        byte[] inlongMsgData = inLongMsg.buildArray();
+        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(inLongMsg.getCreatetime()));
         if (isOrderOrProxy) {
             event = new SinkRspEvent(event, MsgType.MSG_BIN_MULTI_BODY, channel);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
@@ -266,8 +266,8 @@ public class CodecTextMsg extends AbsV0MsgCodec {
             }
             inLongMsg.addMsg(mapJoiner.join(attrMap), bodyData);
         }
-        long pkgTime = inLongMsg.getCreatetime();
-        Event event = EventBuilder.withBody(inLongMsg.buildArray(), buildEventHeaders(pkgTime));
+        byte[] inlongMsgData = inLongMsg.buildArray();
+        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(inLongMsg.getCreatetime()));
         inLongMsg.reset();
         return event;
     }


### PR DESCRIPTION
- Fixes #8368

1. Align message pack construction time
2. Align message length setting
3. Align and construct the necessary field values carried by the MQ message