### PR TITLE
[INLONG-8382][Sort] Provide unsupported operation for ddl that is not parseable

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/Operation.java
@@ -34,7 +34,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
         @JsonSubTypes.Type(value = CreateTableOperation.class, name = "createTableOperation"),
         @JsonSubTypes.Type(value = DropTableOperation.class, name = "dropTableOperation"),
         @JsonSubTypes.Type(value = TruncateTableOperation.class, name = "truncateTableOperation"),
-        @JsonSubTypes.Type(value = RenameTableOperation.class, name = "renameTableOperation")
+        @JsonSubTypes.Type(value = RenameTableOperation.class, name = "renameTableOperation"),
+        @JsonSubTypes.Type(value = UnsupportedOperation.class, name = "unsupportedOperation")
 })
 @Data
 @NoArgsConstructor

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/UnsupportedOperation.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/ddl/operations/UnsupportedOperation.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.ddl.operations;
+
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("unsupportedOperation")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class UnsupportedOperation extends Operation {
+
+    @JsonCreator
+    public UnsupportedOperation() {
+        super(OperationType.OTHER);
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/OperationUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/utils/OperationUtils.java
@@ -29,6 +29,7 @@ import org.apache.inlong.sort.protocol.ddl.operations.DropTableOperation;
 import org.apache.inlong.sort.protocol.ddl.operations.Operation;
 import org.apache.inlong.sort.protocol.ddl.operations.RenameTableOperation;
 import org.apache.inlong.sort.protocol.ddl.operations.TruncateTableOperation;
+import org.apache.inlong.sort.protocol.ddl.operations.UnsupportedOperation;
 
 import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
@@ -89,12 +90,12 @@ public class OperationUtils {
             } else if (statement instanceof RenameTableStatement) {
                 return new RenameTableOperation();
             } else {
-                LOG.warn("doesn't support sql {}, statement {}", sql, statement);
+                LOG.error("doesn't support sql {}, statement {}", sql, statement);
             }
         } catch (Exception e) {
-            LOG.error("parse ddl error: {}， set ddl to null", sql, e);
+            LOG.error("parse ddl in sql {} error", sql, e);
         }
-        return null;
+        return new UnsupportedOperation();
     }
 
     /**

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/test/java/org/apache/inlong/sort/cdc/TestOperation.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/test/java/org/apache/inlong/sort/cdc/TestOperation.java
@@ -24,6 +24,7 @@ import org.apache.inlong.sort.protocol.ddl.enums.PositionType;
 import org.apache.inlong.sort.protocol.ddl.expressions.AlterColumn;
 import org.apache.inlong.sort.protocol.ddl.operations.AlterOperation;
 import org.apache.inlong.sort.protocol.ddl.operations.Operation;
+import org.apache.inlong.sort.protocol.ddl.operations.UnsupportedOperation;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -82,6 +83,16 @@ public class TestOperation {
         Assert.assertEquals(alterColumn.getAlterType(), AlterType.CHANGE_COLUMN);
         Assert.assertEquals(alterColumn.getNewColumn().getName(), "c");
         Assert.assertEquals(alterColumn.getOldColumn().getName(), "b");
+    }
+
+    @Test
+    public void testUnsupportedOperation() {
+        String sql = "alter table a drop key 'b'";
+        HashMap<String, Integer> sqlType = new HashMap<>();
+        Operation operation = OperationUtils.generateOperation(sql, sqlType);
+        assert operation != null;
+        Assert.assertTrue(operation instanceof UnsupportedOperation);
+        Assert.assertEquals(operation.getOperationType(), OperationType.OTHER);
     }
 
 }


### PR DESCRIPTION
- Fixes #8382

### Motivation

Provide unsupported operation for ddl that is not parseable

### Modifications

Provide unsupported operation for ddl that is not parseable

### Verifying this change

Run TestOperation testUnsupportedOperation()

### Documentation

  - Does this pull request introduce a new feature? (no)