### PR TITLE
[INLONG-8409][SDK] Data sending fails but dataproxy-sdk-cpp returns success

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/release/demo/send_demo.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/release/demo/send_demo.cc
@@ -39,7 +39,7 @@ int call_back_func(const char *inlong_group_id, const char *inlong_stream_id, co
 
 int main(int argc, char const *argv[])
 {
-    if (2 != argc)
+    if ( argc <2)
     {
         cout << "USAGE: ./send_demo ../config/config_example.json" << endl;
         return 0;
@@ -54,8 +54,13 @@ int main(int argc, char const *argv[])
     cout << "---->start sdk successfully" << endl;
 
     int count = 1000;
-    string inlong_group_id = "test_20220727_86";
-    string inlong_stream_id = "test_20220727_86_str_17";
+    string inlong_group_id = "test_cpp_sdk_20230404";
+    string inlong_stream_id = "stream1";
+    if ( 4 == argc) {
+        inlong_group_id = argv[2];
+        inlong_stream_id = argv[3];
+    }
+    cout << "inlong_group_id: "<<inlong_group_id<<"inlong_stream_id:"<<inlong_stream_id << endl;
     string msg = "this is a test ttttttttttttttt; eiwhgreuhg jfdiowaehgorerlea; test end";
 
     // step2. send
@@ -68,40 +73,6 @@ int main(int argc, char const *argv[])
                  << " ";
         }
     }
-
-    string bad_groupid="test_wrong_groupid";
-    int32_t bad_res=tc_api_send(bad_groupid.c_str(), inlong_stream_id.c_str(), msg.c_str(), msg.length(), call_back_func);
-    cout << endl << "send bad inlong_group_id res:"<<bad_res;
-
-    cout << endl
-         << "---->start tc_api_send_ext" << endl;
-    for (size_t i = 0; i < count; i++)
-    {
-        auto time_now = chrono::system_clock::now();
-        auto duration_in_ms = chrono::duration_cast<chrono::milliseconds>(time_now.time_since_epoch());
-        auto dt = duration_in_ms.count();
-        if (tc_api_send_ext(inlong_group_id.c_str(), inlong_stream_id.c_str(), msg.c_str(), msg.length(), dt, call_back_func))
-        {
-            cout << "tc_api_send_ext error;"
-                 << " ";
-        }
-    }
-
-    cout << endl
-         << "---->start tc_api_send_base" << endl;
-    for (size_t i = 0; i < count; i++)
-    {
-        auto time_now = chrono::system_clock::now();
-        auto duration_in_ms = chrono::duration_cast<chrono::milliseconds>(time_now.time_since_epoch());
-        auto dt = duration_in_ms.count();
-        if (tc_api_send_base(inlong_group_id.c_str(), inlong_stream_id.c_str(), msg.c_str(), msg.length(), dt, "127.0.0.1"))
-        {
-            cout << "tc_api_send_base error;"
-                 << " ";
-        }
-    }
-
-    // std::this_thread::sleep_for(std::chrono::minutes(2));
 
     // step3. close
     if (tc_api_close(1000))

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/base/sdk_constant.h
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/base/sdk_constant.h
@@ -96,6 +96,8 @@ namespace dataproxy_sdk
         static const char kBasicAuthJoiner[] = ":";
         static const char kProtocolType [] = "TCP";
 
+        static const uint32_t kMaxAttrLen = 2048;
+
     } // namespace constants
 
 } // namespace dataproxy_sdk

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/net/socket_connection.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/net/socket_connection.cc
@@ -347,6 +347,10 @@ namespace dataproxy_sdk
         recv_buf_->Skip(body_len);
         LOG_TRACE("body_len is %d, and skip body");
         uint32_t attr_len = recv_buf_->ReadUint32();
+        if (attr_len > constants::kMaxAttrLen) {
+            LOG_ERROR("attr_len(%d) > kMaxAttrLen(%d)", attr_len, constants::kMaxAttrLen);
+            return false;
+        }
         char attr[attr_len + 1];
         memset(attr, 0x0, attr_len + 1);
         strncpy(attr, recv_buf_->data(), attr_len);
@@ -373,6 +377,10 @@ namespace dataproxy_sdk
     {
         uint32_t uniq = recv_buf_->ReadUint32();
         uint16_t attr_len = recv_buf_->ReadUint16();
+        if (attr_len > constants::kMaxAttrLen) {
+            LOG_ERROR("attr_len(%d) > kMaxAttrLen(%d)", attr_len, constants::kMaxAttrLen);
+            return false;
+        }
         char attr[attr_len + 1];
         memset(attr, 0x0, attr_len + 1);
         strncpy(attr, recv_buf_->data(), attr_len);

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/net/socket_connection.h
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/net/socket_connection.h
@@ -118,6 +118,7 @@ namespace dataproxy_sdk
     bool parseBinaryAck(uint32_t total_len);   
     bool parseBinaryHB(uint32_t total_len);
     uint32_t parseAttr(char *attr, int32_t attr_len);
+    int parseErrorCode(char *attr, int32_t attr_len);
   };
 
 } // namespace dataproxy_sdk


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8409

### Motivation

*When reporting data to DataProxy through dataproxy-sdk-cpp, after DataProxy returns an error, dataproxy-sdk-cpp still counts successfully*

### Modifications

*According to the latest dp return packet protocol, the errorcode is analyzed and judged.*
