### PR TITLE
[INLONG-8421][Manager] Fix NPE when disable OpenApi auth

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/openapi/OpenAPIFilter.java
@@ -88,8 +88,8 @@ public class OpenAPIFilter implements Filter {
     }
 
     private SecretToken parseBasicAuth(HttpServletRequest servletRequest) {
-        // return empty token if openapi auth is disable. The realm will pass the request and use default user.
-        if (openAPIAuthEnabled) {
+        // return empty token if openapi auth is disabled. The realm will pass the request and use default user.
+        if (!openAPIAuthEnabled) {
             return new SecretToken();
         }
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8421 

### Motivation

To fix null point exception when disable OpenApi auth.
![image](https://github.com/apache/inlong/assets/45282474/1131de39-4447-42f3-b84c-4898884961e8)


### Modifications

Fix the condition error.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature?  no
