### PR TITLE
[INLONG-8407][Sort] Optimize mongodb cdc to obtain documentKey

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/table/MongoDBConnectorDeserializationSchema.java
@@ -80,7 +80,6 @@ import java.util.Map;
 import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.inlong.sort.cdc.mongodb.debezium.utils.RecordUtils.isDMLOperation;
 
 public class MongoDBConnectorDeserializationSchema
         implements
@@ -145,17 +144,12 @@ public class MongoDBConnectorDeserializationSchema
         Schema valueSchema = record.valueSchema();
 
         OperationType op = operationTypeFor(record);
-        BsonDocument documentKey = new BsonDocument();
-        BsonDocument fullDocument = new BsonDocument();
 
-        if (isDMLOperation(op)) {
-            documentKey =
-                    checkNotNull(
-                            extractBsonDocument(
-                                    value, valueSchema, MongoDBEnvelope.DOCUMENT_KEY_FIELD));
-            fullDocument =
-                    extractBsonDocument(value, valueSchema, MongoDBEnvelope.FULL_DOCUMENT_FIELD);
-        }
+        BsonDocument documentKey =
+                extractBsonDocument(
+                        value, valueSchema, MongoDBEnvelope.DOCUMENT_KEY_FIELD);
+        BsonDocument fullDocument =
+                extractBsonDocument(value, valueSchema, MongoDBEnvelope.FULL_DOCUMENT_FIELD);
 
         switch (op) {
             case INSERT:

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/utils/RecordUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/utils/RecordUtils.java
@@ -127,14 +127,4 @@ public class RecordUtils {
         return null;
     }
 
-    /**
-     * Whether the MongoDB event's operation is a dml operation.
-     */
-    public static boolean isDMLOperation(OperationType op) {
-        if (OperationType.INSERT.equals(op) || OperationType.DELETE.equals(op)
-                || OperationType.UPDATE.equals(op) || OperationType.REPLACE.equals(op)) {
-            return true;
-        }
-        return false;
-    }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/utils/RecordUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/debezium/utils/RecordUtils.java
@@ -18,7 +18,6 @@
 package org.apache.inlong.sort.cdc.mongodb.debezium.utils;
 
 import com.google.common.collect.ImmutableMap;
-import com.mongodb.client.model.changestream.OperationType;
 import io.debezium.connector.AbstractSourceInfo;
 import io.debezium.relational.TableId;
 import org.apache.flink.table.types.logical.ArrayType;


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8407][Sort] Optimize mongodb cdc to obtain documentKey

- Fixes #8407 

### Motivation

The ddl operation of mongodb does not have a documentKey, so we do not need to check whether it is null. We may be able to check whether it is null later.

### Modifications

1. Remove the check that record is DML.
2. Remove the check on whether the documentKey is null.
