### PR TITLE
[INLONG-8436][Sort] Fix the backfill task not running bug in oracle cdc connector

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -134,9 +134,14 @@ public class OracleScanFetchTask implements FetchTask<SourceSplitBase> {
         if (snapshotResult.isCompletedOrSkipped()) {
             final RedoLogSplitReadTask backfillBinlogReadTask =
                     createBackfillRedoLogReadTask(backfillBinlogSplit, sourceFetchContext);
+            final LogMinerOracleOffsetContextLoader loader =
+                    new LogMinerOracleOffsetContextLoader(
+                            ((OracleSourceFetchTaskContext) context).getDbzConnectorConfig());
+            final OracleOffsetContext oracleOffsetContext =
+                    loader.load(backfillBinlogSplit.getStartingOffset().getOffset());
             backfillBinlogReadTask.execute(
-                    new SnapshotBinlogSplitChangeEventSourceContext(),
-                    sourceFetchContext.getOffsetContext());
+                    new SnapshotBinlogSplitChangeEventSourceContext(), oracleOffsetContext);
+            taskRunning = false;
         } else {
             taskRunning = false;
             throw new IllegalStateException(
@@ -284,7 +289,7 @@ public class OracleScanFetchTask implements FetchTask<SourceSplitBase> {
                     "Snapshot step 3 - Determining high watermark {} for split {}",
                     highWatermark,
                     snapshotSplit);
-            ((SnapshotSplitChangeEventSourceContext) (context)).setHighWatermark(lowWatermark);
+            ((SnapshotSplitChangeEventSourceContext) (context)).setHighWatermark(highWatermark);
             dispatcher.dispatchWatermarkEvent(
                     offsetContext.getPartition(), snapshotSplit, highWatermark, WatermarkKind.HIGH);
             return SnapshotResult.completed(ctx.offset);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleStreamFetchTask.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleStreamFetchTask.java
@@ -87,7 +87,7 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
     }
 
     /**
-     * A wrapped task to read all binlog for table and also supports read bounded (from lowWatermark
+     * A wrapped task to read all redo log for table and also supports read bounded (from lowWatermark
      * to highWatermark) binlog.
      */
     public static class RedoLogSplitReadTask extends LogMinerStreamingChangeEventSource {
@@ -130,11 +130,11 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
         @Override
         public void afterHandleScn(OracleOffsetContext offsetContext) {
             super.afterHandleScn(offsetContext);
-            // check do we need to stop for fetch binlog for snapshot split.
+            // check do we need to stop for fetch redo log for snapshot split.
             if (isBoundedRead()) {
                 final RedoLogOffset currentRedoLogOffset =
                         getCurrentRedoLogOffset(offsetContext.getOffset());
-                // reach the high watermark, the binlog fetcher should be finished
+                // reach the high watermark, the redo log fetcher should be finished
                 if (currentRedoLogOffset.isAtOrAfter(redoLogSplit.getEndingOffset())) {
                     // send binlog end event
                     try {
@@ -148,8 +148,8 @@ public class OracleStreamFetchTask implements FetchTask<SourceSplitBase> {
                         errorHandler.setProducerThrowable(
                                 new DebeziumException("Error processing binlog signal event", e));
                     }
-                    // tell fetcher the binlog task finished
-                    ((OracleScanFetchTask.SnapshotBinlogSplitChangeEventSourceContext) context)
+                    // tell fetcher the redo log task finished
+                    ((OracleScanFetchTask.SnapshotStreamSplitChangeEventSourceContext) context)
                             .finished();
                 }
             }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8436][Sort] Fix the backfill task not running bug in oracle cdc connector

- Fixes #8436

### Motivation

Fix the backfill task not running bug in oracle cdc connector.

### Modifications

1. In the `OracleScanFetchTask#doExecute` method, for Snapshot step 3, we need to set the `highWatermark` instead of the `lowWatermark`.

```java
((SnapshotSplitChangeEventSourceContext) (context)).setHighWatermark(highWatermark);
```

2. The `RedoLogSplitReadTask` should use the StartingOffset of `RedoLogSplit` instead of the StartingOffset of `SnapshotSplit`.

```java
            final RedoLogSplitReadTask backfillRedoLogReadReTask =
                    createBackfillRedoLogReadTask(backfillRedoLogSplit, sourceFetchContext);
            final LogMinerOracleOffsetContextLoader loader =
                    new LogMinerOracleOffsetContextLoader(
                            ((OracleSourceFetchTaskContext) context).getDbzConnectorConfig());
            final OracleOffsetContext oracleOffsetContext =
                    loader.load(backfillRedoLogSplit.getStartingOffset().getOffset());
            backfillRedoLogReadReTask.execute(
                    new SnapshotStreamSplitChangeEventSourceContext(), oracleOffsetContext);
```