### PR TITLE
[INLONG-8443][Manager] Add ClickHouse field type mapping strategy to improve usability

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/ClickHouseFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/ClickHouseFieldTypeStrategy.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
 
 /**
- * The clickHouse field type mapping strategy
+ * The ClickHouse field type mapping strategy
  */
 public class ClickHouseFieldTypeStrategy implements FieldTypeMappingStrategy {
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/ClickHouseFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/ClickHouseFieldTypeStrategy.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.fieldtype.strategy;
+
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
+/**
+ * The clickHouse field type mapping strategy
+ */
+public class ClickHouseFieldTypeStrategy implements FieldTypeMappingStrategy {
+
+    private final FieldTypeMappingReader reader;
+
+    public ClickHouseFieldTypeStrategy() {
+        this.reader = new FieldTypeMappingReader(DataNodeType.CLICKHOUSE);
+    }
+
+    @Override
+    public String getFieldTypeMapping(String sourceType) {
+        String dataType = StringUtils.substringBefore(sourceType, LEFT_BRACKET).toUpperCase();
+        return reader.getFIELD_TYPE_MAPPING_MAP().getOrDefault(dataType, sourceType.toUpperCase());
+    }
+}

--- a/inlong-manager/manager-common/src/main/resources/clickhouse-field-type-mapping.yaml
+++ b/inlong-manager/manager-common/src/main/resources/clickhouse-field-type-mapping.yaml
@@ -1,0 +1,87 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source.type.to.target.type.converter:
+
+  - source.type: INT8
+    target.type: TINYINT
+
+  - source.type: INT16
+    target.type: SMALLINT
+
+  - source.type: INT32
+    target.type: INT
+
+  - source.type: INT64
+    target.type: LONG
+
+  - source.type: UINT8
+    target.type: TINYINT
+
+  - source.type: UINT16
+    target.type: SMALLINT
+
+  - source.type: UINT32
+    target.type: INT
+
+  - source.type: UINT64
+    target.type: LONG
+
+  - source.type: DECIMAL
+    target.type: DECIMAL
+
+  - source.type: DECIMAL32
+    target.type: DECIMAL
+
+  - source.type: DECIMAL64
+    target.type: DECIMAL
+
+  - source.type: DECIMAL128
+    target.type: DECIMAL
+
+  - source.type: STRING
+    target.type: STRING
+
+  - source.type: UUID
+    target.type: STRING
+
+  - source.type: FIXEDSTRING
+    target.type: STRING
+
+  - source.type: DATE
+    target.type: DATE
+
+  - source.type: DATE32
+    target.type: DATE
+
+  - source.type: DATETIME
+    target.type: TIMESTAMP
+
+  - source.type: DATETIME64
+    target.type: TIMESTAMP
+
+  - source.type: FLOAT32
+    target.type: FLOAT
+
+  - source.type: FLOAT64
+    target.type: DOUBLE
+
+  - source.type: BOOLEAN
+    target.type: BOOLEAN
+
+  - source.type: BOOL
+    target.type: BOOLEAN

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/ClickHouseProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/ClickHouseProvider.java
@@ -18,6 +18,8 @@
 package org.apache.inlong.manager.pojo.sort.node.provider;
 
 import org.apache.inlong.manager.common.consts.SinkType;
+import org.apache.inlong.manager.common.fieldtype.strategy.ClickHouseFieldTypeStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
 import org.apache.inlong.manager.pojo.sink.ck.ClickHouseSink;
 import org.apache.inlong.manager.pojo.sort.node.base.LoadNodeProvider;
 import org.apache.inlong.manager.pojo.stream.StreamField;
@@ -35,6 +37,8 @@ import java.util.Map;
  */
 public class ClickHouseProvider implements LoadNodeProvider {
 
+    private static final FieldTypeMappingStrategy FIELD_TYPE_MAPPING_STRATEGY = new ClickHouseFieldTypeStrategy();
+
     @Override
     public Boolean accept(String sinkType) {
         return SinkType.CLICKHOUSE.equals(sinkType);
@@ -44,7 +48,8 @@ public class ClickHouseProvider implements LoadNodeProvider {
     public LoadNode createLoadNode(StreamNode nodeInfo, Map<String, StreamField> constantFieldMap) {
         ClickHouseSink streamSink = (ClickHouseSink) nodeInfo;
         Map<String, String> properties = parseProperties(streamSink.getProperties());
-        List<FieldInfo> fieldInfos = parseSinkFieldInfos(streamSink.getSinkFieldList(), streamSink.getSinkName());
+        List<FieldInfo> fieldInfos = parseSinkFieldInfos(streamSink.getSinkFieldList(), streamSink.getSinkName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         List<FieldRelation> fieldRelations = parseSinkFields(streamSink.getSinkFieldList(), constantFieldMap);
         return new ClickHouseLoadNode(
                 streamSink.getSinkName(),

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -17,12 +17,14 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
+import org.apache.inlong.manager.common.fieldtype.strategy.ClickHouseFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MongoDBFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.OracleFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.PostgreSQLFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.SQLServerFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.stream.StreamField;
+import org.apache.inlong.sort.formats.common.ByteTypeInfo;
 import org.apache.inlong.sort.formats.common.IntTypeInfo;
 import org.apache.inlong.sort.formats.common.LocalZonedTimestampTypeInfo;
 import org.apache.inlong.sort.formats.common.ShortTypeInfo;
@@ -96,5 +98,17 @@ public class FieldInfoUtilsTest {
                 "nodeId", new MongoDBFieldTypeStrategy());
         TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
         Assertions.assertTrue(typeInfo instanceof StringTypeInfo);
+    }
+
+    @Test
+    public void testClickHouseFieldTypeInfo() {
+        StreamField streamField = new StreamField();
+        streamField.setIsMetaField(0);
+        streamField.setFieldName("age");
+        streamField.setFieldType("uint8");
+        FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
+                "nodeId", new ClickHouseFieldTypeStrategy());
+        TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
+        Assertions.assertTrue(typeInfo instanceof ByteTypeInfo);
     }
 }


### PR DESCRIPTION
[INLONG-8443][Manager] Add ClickHouse field type mapping strategy to improve usability

- Fixes #8443

### Motivation

Inlong ClickHouse ExtractNode or LoadNode currently does not support some special field types, add ClickHouse field type mapping strategy to mapping to the corresponding type to run correctly