### PR TITLE
[INLONG-8481][Sort] Fix unit test for sort-core in flink-1.15

### DIFF
--- a/.github/workflows/ci_ut_flink15.yml
+++ b/.github/workflows/ci_ut_flink15.yml
@@ -60,7 +60,7 @@ jobs:
           CI: false
 
       - name: Unit test for Flink 1.15 with Maven
-        run: mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core  -Pv1.15
+        run: mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core -Pv1.15
         env:
           CI: false
 

--- a/.github/workflows/ci_ut_flink15.yml
+++ b/.github/workflows/ci_ut_flink15.yml
@@ -60,7 +60,7 @@ jobs:
           CI: false
 
       - name: Unit test for Flink 1.15 with Maven
-        run: mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core -DfailIfNoTests=false -Pv1.15
+        run: mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core  -Pv1.15
         env:
           CI: false
 

--- a/.github/workflows/ci_ut_flink15.yml
+++ b/.github/workflows/ci_ut_flink15.yml
@@ -15,7 +15,8 @@
 # limitations under the License.
 #
 
-name: InLong Unit Test For Flink 1.15
+name:
+  InLong Unit Test For Flink 1.15
 
 on:
   push:
@@ -59,7 +60,7 @@ jobs:
           CI: false
 
       - name: Unit test for Flink 1.15 with Maven
-        run: mvn --update-snapshots -e -V test -Dtest="*" -pl inlong-sort/sort-core
+        run: mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core -DfailIfNoTests=false -Pv1.15
         env:
           CI: false
 

--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -252,6 +252,20 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${plugin.surefire.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>org.apache.inlong.sort.function.*</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/inlong-sort/sort-formats/format-json-v1.15/pom.xml
+++ b/inlong-sort/sort-formats/format-json-v1.15/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.basedir}</inlong.root.dir>
         <flink.version>1.15.4</flink.version>
-        <flink.shaded.guava.version>18.0-13.0</flink.shaded.guava.version>
+        <flink.shaded.guava.version>30.1.1-jre-15.0</flink.shaded.guava.version>
     </properties>
 
     <dependencies>

--- a/inlong-sort/sort-formats/format-json-v1.15/src/main/java/org/apache/inlong/sort/formats/json/utils/FormatJsonUtil.java
+++ b/inlong-sort/sort-formats/format-json-v1.15/src/main/java/org/apache/inlong/sort/formats/json/utils/FormatJsonUtil.java
@@ -21,7 +21,7 @@ import org.apache.flink.formats.common.TimestampFormat;
 import org.apache.flink.formats.json.JsonFormatOptions.MapNullKeyMode;
 import org.apache.flink.formats.json.RowDataToJsonConverters;
 import org.apache.flink.formats.json.RowDataToJsonConverters.RowDataToJsonConverter;
-import org.apache.flink.shaded.guava18.com.google.common.collect.ImmutableMap;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;

--- a/inlong-sort/sort-formats/pom.xml
+++ b/inlong-sort/sort-formats/pom.xml
@@ -37,9 +37,7 @@
         <module>format-kv</module>
         <module>format-inlongmsg-base</module>
         <module>format-inlongmsg-csv</module>
-        <module>format-json-v1.13</module>
         <module>format-inlongmsg-pb</module>
-        <module>format-json-v1.15</module>
     </modules>
 
     <properties>
@@ -211,5 +209,23 @@
         <connection>git@git.code.oa.com:flink/flink-formats.git</connection>
         <url>https://git.code.oa.com/flink/flink-formats</url>
     </scm>
+
+    <profiles>
+        <profile>
+            <id>v1.13</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>format-json-v1.13</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>v1.15</id>
+            <modules>
+                <module>format-json-v1.15</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
- Fixes #8481

### Motivation

Fix unit test for sort-core in flink-1.15

### Modifications

1\

change the test code to 

mvn --update-snapshots -e -V clean test -am -pl inlong-sort/sort-core -DfailIfNoTests=false -Pv1.15

when using -pl to specify a module, we should use -am to compile the related modules 

Also should specify the profile

2\

sort-core test on flink 1.15 do not have most connectors for flink1.15 so the connectors parser tests should be removed

3\

for flink 1.15 guava version should be 

30.1.x
--


<br class="Apple-interchange-newline">
<img width="417" alt="image" src="https://github.com/apache/inlong/assets/26538404/2dabb13a-8a78-4ba2-ad2a-f34419ec3237">

### Verifying this change

run test

### Documentation

  - Does this pull request introduce a new feature? (no)