### PR TITLE
[INLONG-8474][CVE] Unify the version of "hive-exec"

### DIFF
--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -196,7 +196,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-jdbc</artifactId>
-            <version>${hive.version}</version>
+            <version>${hive3x.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.eclipse.jetty.orbit</groupId>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -45,8 +45,6 @@
         <kafka.clients.version>2.7.0</kafka.clients.version>
         <rat.basedir>${basedir}</rat.basedir>
         <hbase.version>2.2.3</hbase.version>
-        <iceberg.hive.version>2.3.7</iceberg.hive.version>
-        <hudi.hive.version>2.3.7</hudi.hive.version>
     </properties>
 
     <dependencyManagement>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <hive3x.version>3.1.3</hive3x.version>
-        <hive2x.version>2.2.4</hive2x.version>
+        <hive2x.version>2.3.4</hive2x.version>
         <orc.core.version>1.4.3</orc.core.version>
         <aircompressor.version>0.8</aircompressor.version>
     </properties>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -31,8 +31,6 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
-        <hive3x.version>3.1.3</hive3x.version>
-        <hive2x.version>2.3.4</hive2x.version>
         <orc.core.version>1.4.3</orc.core.version>
         <aircompressor.version>0.8</aircompressor.version>
     </properties>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
         <hive3x.version>3.1.3</hive3x.version>
-        <hive2x.version>2.2.0</hive2x.version>
+        <hive2x.version>2.2.4</hive2x.version>
         <orc.core.version>1.4.3</orc.core.version>
         <aircompressor.version>0.8</aircompressor.version>
     </properties>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>${hudi.hive.version}</version>
+            <version>${hive2x.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-exec</artifactId>
-            <version>${iceberg.hive.version}</version>
+            <version>${hive2x.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,8 @@
         <fastjson.version>1.2.83</fastjson.version>
 
         <clickhouse-jdbc.version>0.3.1</clickhouse-jdbc.version>
-        <hive.version>3.1.3</hive.version>
+        <hive2x.version>2.3.7</hive2x.version>
+        <hive3x.version>3.1.3</hive3x.version>
         <flume.version>1.10.0</flume.version>
         <hbase.version>2.4.12</hbase.version>
 
@@ -250,7 +251,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-jdbc</artifactId>
-                <version>${hive.version}</version>
+                <version>${hive3x.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>xml-apis</groupId>
@@ -277,7 +278,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-metastore</artifactId>
-                <version>${hive.version}</version>
+                <version>${hive3x.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.logging.log4j</groupId>
@@ -296,7 +297,7 @@
             <dependency>
                 <groupId>org.apache.hive</groupId>
                 <artifactId>hive-exec</artifactId>
-                <version>${hive.version}</version>
+                <version>${hive3x.version}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.pentaho</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
*[INLONG-8474][CVE] Unify the version of "hive-exec"*

- Fixes #8474 

### Motivation

1, unify hive2.x 2.3.7
2, unify hive3. 3.1.3
