### PR TITLE
[INLONG-8490][Manager] Duplicate queried audit data according to all fields

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/AuditEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/AuditEntityMapper.xml
@@ -42,12 +42,16 @@
 
     <select id="sumByLogTs" resultMap="SumByLogTsResultMap">
         select date_format(log_ts, #{format, jdbcType=VARCHAR}) as log_ts, sum(`count`) as total, sum(`delay`) as total_delay
-        from apache_inlong_audit.audit_data
-        where inlong_group_id = #{groupId,jdbcType=VARCHAR}
-          and inlong_stream_id = #{streamId,jdbcType=VARCHAR}
-          and audit_id = #{auditId,jdbcType=VARCHAR}
-          and log_ts &gt;= #{sDate, jdbcType=VARCHAR}
-          and log_ts &lt; #{eDate, jdbcType=VARCHAR}
+        from (
+            select ip, docker_id, thread_id, sdk_ts, packet_id, log_ts, inlong_group_id, inlong_stream_id, audit_id, `count`, `size`, `delay`
+            from apache_inlong_audit.audit_data
+            where inlong_group_id = #{groupId,jdbcType=VARCHAR}
+              and inlong_stream_id = #{streamId,jdbcType=VARCHAR}
+              and audit_id = #{auditId,jdbcType=VARCHAR}
+              and log_ts &gt;= #{sDate, jdbcType=VARCHAR}
+              and log_ts &lt; #{eDate, jdbcType=VARCHAR}
+            group by ip, docker_id, thread_id, sdk_ts, packet_id, log_ts, inlong_group_id, inlong_stream_id, audit_id, `count`, `size`, `delay`
+            ) as sub
         group by log_ts
         order by log_ts
     </select>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/AuditEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/AuditEntityMapper.xml
@@ -38,19 +38,19 @@
     <resultMap id="SumByLogTsResultMap" type="java.util.Map">
         <result column="log_ts" property="logTs" jdbcType="VARCHAR"/>
         <result column="total" property="total" jdbcType="BIGINT"/>
+        <result column="total_delay" property="totalDelay" jdbcType="BIGINT"/>
     </resultMap>
 
     <select id="sumByLogTs" resultMap="SumByLogTsResultMap">
         select date_format(log_ts, #{format, jdbcType=VARCHAR}) as log_ts, sum(`count`) as total, sum(`delay`) as total_delay
         from (
-            select ip, docker_id, thread_id, sdk_ts, packet_id, log_ts, inlong_group_id, inlong_stream_id, audit_id, `count`, `size`, `delay`
+            select distinct ip, docker_id, thread_id, sdk_ts, packet_id, log_ts, inlong_group_id, inlong_stream_id, audit_id, `count`, `size`, `delay`
             from apache_inlong_audit.audit_data
             where inlong_group_id = #{groupId,jdbcType=VARCHAR}
               and inlong_stream_id = #{streamId,jdbcType=VARCHAR}
               and audit_id = #{auditId,jdbcType=VARCHAR}
               and log_ts &gt;= #{sDate, jdbcType=VARCHAR}
               and log_ts &lt; #{eDate, jdbcType=VARCHAR}
-            group by ip, docker_id, thread_id, sdk_ts, packet_id, log_ts, inlong_group_id, inlong_stream_id, audit_id, `count`, `size`, `delay`
             ) as sub
         group by log_ts
         order by log_ts

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
@@ -265,7 +265,7 @@ public class AuditServiceImpl implements AuditService {
                     AuditInfo vo = new AuditInfo();
                     vo.setLogTs((String) s.get("logTs"));
                     vo.setCount(((BigDecimal) s.get("total")).longValue());
-                    vo.setDelay(((BigDecimal) s.get("total_delay")).longValue());
+                    vo.setCount(((BigDecimal) s.get("totalDelay")).longValue());
                     return vo;
                 }).collect(Collectors.toList());
                 result.add(new AuditVO(auditId, auditSet,
@@ -382,7 +382,7 @@ public class AuditServiceImpl implements AuditService {
 
         // Query results are duplicated according to all fields.
         String subQuery = new SQL()
-                .SELECT("ip", "docker_id", "thread_id", "sdk_ts", "packet_id", "log_ts", "inlong_group_id",
+                .SELECT_DISTINCT("ip", "docker_id", "thread_id", "sdk_ts", "packet_id", "log_ts", "inlong_group_id",
                         "inlong_stream_id", "audit_id", "count", "size", "delay")
                 .FROM("audit_data")
                 .WHERE("inlong_group_id = ?")
@@ -390,8 +390,6 @@ public class AuditServiceImpl implements AuditService {
                 .WHERE("audit_id = ?")
                 .WHERE("log_ts >= ?")
                 .WHERE("log_ts < ?")
-                .GROUP_BY("ip", "docker_id", "thread_id", "sdk_ts", "packet_id", "log_ts", "inlong_group_id",
-                        "inlong_stream_id", "audit_id", "count", "size", "delay")
                 .toString();
 
         String sql = new SQL()


### PR DESCRIPTION
### Prepare a Pull Request
*[INLONG-8490][Manager] Duplicate queried audit data according to all fields*

- Fixes #8490 

### Motivation

*Network problems may lead to repeated transmission of audit data. At present, the data found by audit is only queried according to several query conditions, and then the total_count and total_delay are counted according to log_ts. However, there may be duplicate data in the found data, which will cause the total_count and total_delay to be greater than the true value.*
![image](https://github.com/apache/inlong/assets/53897686/ea5d6a55-31c6-4580-8fe5-321c7fa742ac)

### Modifications

*When querying "clickhouse" and "mysql", duplicate sentences were added. This deduplication operation is based on all fields of audit_data. Therefore, we can ensure that the queried audit data is not repeated, and that the total_count and total_delay of statistics are correct.*


