### PR TITLE
[INLONG-8509][Manager] Optimize preProcessTemplateFileTask in AgentServiceImpl

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -233,7 +233,6 @@
         <include refid="Base_Column_List"/>
         from inlong_group
         where inlong_group_id = #{groupId, jdbcType=VARCHAR}
-        and tenant = #{tenant, jdbcType=VARCHAR}
         and is_deleted = 0
     </select>
     <select id="selectByGroupIdForUpdate" resultMap="BaseResultMap">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -233,6 +233,7 @@
         <include refid="Base_Column_List"/>
         from inlong_group
         where inlong_group_id = #{groupId, jdbcType=VARCHAR}
+        and tenant = #{tenant, jdbcType=VARCHAR}
         and is_deleted = 0
     </select>
     <select id="selectByGroupIdForUpdate" resultMap="BaseResultMap">
@@ -240,6 +241,7 @@
         <include refid="Base_Column_List"/>
         from inlong_group
         where inlong_group_id = #{groupId, jdbcType=VARCHAR}
+        and tenant = #{tenant,jdbcType=VARCHAR}
         and is_deleted = 0 for update
     </select>
     <select id="selectByCondition" resultMap="BaseResultMap"

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -240,7 +240,6 @@
         <include refid="Base_Column_List"/>
         from inlong_group
         where inlong_group_id = #{groupId, jdbcType=VARCHAR}
-        and tenant = #{tenant,jdbcType=VARCHAR}
         and is_deleted = 0 for update
     </select>
     <select id="selectByCondition" resultMap="BaseResultMap"

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -410,7 +410,6 @@ public class AgentServiceImpl implements AgentService {
         Set<GroupStatus> noNeedAddTask = Sets.newHashSet(
                 GroupStatus.SUSPENDED, GroupStatus.SUSPENDING, GroupStatus.DELETING, GroupStatus.DELETED);
         sourceEntities.stream()
-                .filter(sourceEntity -> sourceEntity.getTemplateId() == null) // only apply template task
                 .forEach(sourceEntity -> {
                     InlongGroupEntity groupEntity = groupMapper.selectByGroupId(sourceEntity.getInlongGroupId());
                     if (groupEntity != null && noNeedAddTask.contains(GroupStatus.forCode(groupEntity.getStatus()))) {

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
@@ -71,8 +71,6 @@ class AgentServiceTest extends ServiceBaseTest {
     @Autowired
     private AgentService agentService;
     @Autowired
-    private HeartbeatService heartbeatService;
-    @Autowired
     private InlongGroupEntityMapper groupMapper;
     @Autowired
     private InlongStreamServiceTest streamServiceTest;
@@ -212,12 +210,12 @@ class AgentServiceTest extends ServiceBaseTest {
 
         TaskResult taskResult = agent.pullTask();
         Assertions.assertTrue(taskResult.getCmdConfigs().isEmpty());
-        Assertions.assertEquals(4, taskResult.getDataConfigs().size());
+        Assertions.assertEquals(3, taskResult.getDataConfigs().size());
         Assertions.assertEquals(3, taskResult.getDataConfigs().stream()
                 .filter(dataConfig -> Integer.valueOf(dataConfig.getOp()) == ManagerOpEnum.ADD.getType())
                 .collect(Collectors.toSet())
                 .size());
-        Assertions.assertEquals(1, taskResult.getDataConfigs().stream()
+        Assertions.assertEquals(0, taskResult.getDataConfigs().stream()
                 .filter(dataConfig -> Integer.valueOf(dataConfig.getOp()) == ManagerOpEnum.FROZEN.getType())
                 .collect(Collectors.toSet())
                 .size());
@@ -305,7 +303,7 @@ class AgentServiceTest extends ServiceBaseTest {
         // suspend
         suspendSource(groupStream.getLeft(), groupStream.getRight());
         TaskResult taskResult = agent.pullTask();
-        Assertions.assertEquals(0, taskResult.getDataConfigs().size());
+        Assertions.assertEquals(1, taskResult.getDataConfigs().size());
     }
 
     /**

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
@@ -303,7 +303,7 @@ class AgentServiceTest extends ServiceBaseTest {
         // suspend
         suspendSource(groupStream.getLeft(), groupStream.getRight());
         TaskResult taskResult = agent.pullTask();
-        Assertions.assertEquals(1, taskResult.getDataConfigs().size());
+        Assertions.assertEquals(0, taskResult.getDataConfigs().size());
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-8509][Manager] Optimize preProcessTemplateFileTask in AgentServiceImpl

- Fixes #8509 

### Motivation

In old method, the program will init many stream sources with status 104(Frozen), which will make many dirty records in mysql

### Modifications

Check if node is compile with template stream source when init  sub stream source

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
