### PR TITLE
[INLONG-8549][Sort] Fix incorrect use of maven plugin on integration test among sort-end-to-end-tests

### DIFF
--- a/inlong-sort/sort-end-to-end-tests/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/pom.xml
@@ -179,13 +179,11 @@
 
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${plugin.failsafe.version}</version>
                         <executions>
                             <execution>
                                 <id>end-to-end-tests</id>
-                                <goals>
-                                    <goal>test</goal>
-                                </goals>
                                 <phase>integration-test</phase>
                                 <configuration>
                                     <includes>


### PR DESCRIPTION
- Fixes #8549

### Motivation

Fix incorrect use of maven plugin on integration test among sort-end-to-end-tests

The end-to-end-test use Maven Surefire Plugin to control interation test
However in maven doc https://maven.apache.org/surefire/maven-failsafe-plugin/index.html, maven-failsafe-plugin is the right way to control integration test

Surefire plugin is used for unit test and cannot be applied to --DskipITs=true

### Modifications

use maven-failsafe-plugin for sort-end-to-end-tests

### Documentation

  - Does this pull request introduce a new feature? (no)