### PR TITLE
[INLONG-8556][Manager] Optimize the location of the manager-plugins-flink jar package

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/assembly/assembly.xml
+++ b/inlong-manager/manager-plugins/base/src/main/assembly/assembly.xml
@@ -60,6 +60,7 @@
                 <include>flink-*.jar</include>
                 <include>sort-flink-*.jar</include>
                 <include>scala-*.jar</include>
+                <include>manager-plugins-flink-v1.13.jar</include>
             </includes>
         </fileSet>
 
@@ -71,6 +72,7 @@
                 <include>flink-*.jar</include>
                 <include>sort-flink-*.jar</include>
                 <include>scala-*.jar</include>
+                <include>manager-plugins-flink-v1.15.jar</include>
             </includes>
         </fileSet>
     </fileSets>

--- a/inlong-manager/manager-web/assembly.xml
+++ b/inlong-manager/manager-web/assembly.xml
@@ -66,6 +66,7 @@
                 <exclude>*scala*.jar</exclude>
                 <exclude>flink-*.jar</exclude>
                 <exclude>sort-flink-*.jar</exclude>
+                <exclude>manager-plugins-flink-*.jar</exclude>
             </excludes>
         </fileSet>
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8556 

### Motivation

The jar packages of manager-plugin-flink1.13 and manager-plugin-flink1.15 cannot exist at the same time when inlong-manager is running.

### Modifications

- Remove manager-plugins-flink-v1.13.jar and manager-plugins-flink-v1.15.jar from the inlong-manager lib directory.
- Add manager-plugins-flink-v1.13.jar to the inlong-manager/plugins/flink-v1.13 directory.
- Add manager-plugins-flink-v1.15.jar to the inlong-manager/plugins/flink-v1.15 directory.

