### PR TITLE
[INLONG-8558][Sort] Use database name in upper case at the OracleTableSourceFactory

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/utils/OracleConnectionUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/utils/OracleConnectionUtils.java
@@ -100,7 +100,7 @@ public class OracleConnectionUtils {
                             String schemaName = rs.getString(1);
                             String tableName = rs.getString(2);
                             TableId tableId =
-                                    new TableId(jdbcConnection.database().toUpperCase(), schemaName, tableName);
+                                    new TableId(jdbcConnection.database(), schemaName, tableName);
                             tableIdSet.add(tableId);
                         }
                     });

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/table/OracleTableSourceFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/table/OracleTableSourceFactory.java
@@ -79,6 +79,11 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         String password = config.get(PASSWORD);
         String databaseName = config.get(DATABASE_NAME);
         checkNotNull(databaseName);
+        // During the incremental phase, Debezium uses the uppercase database name.
+        // However, during the snapshot phase, the database name is user-configurable.
+        // To avoid inconsistencies between the database names in the snapshot and incremental phases,
+        // it is necessary to convert the database name to uppercase when constructing the Oracle Source.
+        // For more details, please refer to: https://github.com/apache/inlong/pull/7865.
         databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/table/OracleTableSourceFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/table/OracleTableSourceFactory.java
@@ -53,6 +53,7 @@ import static com.ververica.cdc.connectors.base.options.SourceOptions.SPLIT_KEY_
 import static com.ververica.cdc.connectors.base.utils.ObjectUtils.doubleCompare;
 import static com.ververica.cdc.connectors.oracle.source.config.OracleSourceOptions.PORT;
 import static com.ververica.cdc.debezium.table.DebeziumOptions.getDebeziumProperties;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
@@ -77,6 +78,8 @@ public class OracleTableSourceFactory implements DynamicTableSourceFactory {
         String username = config.get(USERNAME);
         String password = config.get(PASSWORD);
         String databaseName = config.get(DATABASE_NAME);
+        checkNotNull(databaseName);
+        databaseName = databaseName.toUpperCase();
         String tableName = config.get(TABLE_NAME);
         String schemaName = config.get(SCHEMA_NAME);
         int port = config.get(PORT);


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8558][Sort] Use database name in upper case at the OracleTableSourceFactory

- Fixes #8558 

### Motivation

In the incremental phase, **debezium** has use the uppercase database name, so I believe it is necessary to also do so in the snapshot phase. More details refer for https://github.com/apache/inlong/pull/7865.
Now, I think maybe we should use database name in upper case at the beginning. For example, in the constructor of the Source(OracleTableSourceFactory).

### Modifications

 In the constructor of the Oracle Source(OracleTableSourceFactory), convert the database name to uppercase.