### PR TITLE
[INLONG-8576][DataProxy] Adjust handling when messages are incomplete

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -79,6 +79,8 @@ public class StatConstants {
     public static final java.lang.String EVENT_MSG_V1_POST_DROPPED = "msg.post.v1.dropped";
     // sink
     public static final java.lang.String EVENT_SINK_EVENT_V1_MALFORMED = "sink.event.v1.malformed";
+    public static final java.lang.String EVENT_SINK_EVENT_TAKE_SUCCESS = "sink.event.take.success";
+    public static final java.lang.String EVENT_SINK_EVENT_TAKE_FAILURE = "sink.event.take.failure";
     public static final java.lang.String EVENT_SINK_EVENT_V1_FILE = "sink.event.v1.file";
     public static final java.lang.String EVENT_SINK_EVENT_V0_FILE = "sink.event.v1.file";
     public static final java.lang.String EVENT_SINK_CONFIG_TOPIC_MISSING = "sink.topic.missing";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
@@ -195,6 +195,7 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable, 
                 tx.commit();
                 return Status.BACKOFF;
             }
+            context.fileMetricIncSumStats(StatConstants.EVENT_SINK_EVENT_TAKE_SUCCESS);
             // ProxyEvent
             if (event instanceof ProxyEvent) {
                 ProxyEvent proxyEvent = (ProxyEvent) event;
@@ -245,6 +246,7 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable, 
             tx.commit();
             return Status.READY;
         } catch (Throwable t) {
+            context.fileMetricIncSumStats(StatConstants.EVENT_SINK_EVENT_TAKE_FAILURE);
             if (logCounter.shouldPrint()) {
                 logger.error("{} process event failed!", this.getName(), t);
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -115,8 +115,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
                 // reset index when buffer is not satisfied.
                 cb.resetReaderIndex();
                 source.fileMetricIncSumStats(StatConstants.EVENT_PKG_READABLE_UNFILLED);
-                throw new Exception("Error msg, buffer is unfilled, readableLength="
-                        + readableLength + ", totalPackLength=" + totalDataLen + " + 4");
+                return;
             }
             // read type
             int msgTypeValue = cb.readByte();


### PR DESCRIPTION

- Fixes #8576

1. Adjust handling when messages are incomplete;
2. Add the indicator statistics of getting messages from Channel