### PR TITLE
[INLONG-8578][Sort] Fix npe inside outputReadPhaseMetrics in mysql-cdc

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/metrics/MySqlSourceReaderMetrics.java
@@ -148,6 +148,8 @@ public class MySqlSourceReaderMetrics {
      * @param readPhase the readPhase of record
      */
     public void outputReadPhaseMetrics(ReadPhase readPhase) {
-        sourceTableMetricData.outputReadPhaseMetrics(readPhase);
+        if (sourceTableMetricData != null) {
+            sourceTableMetricData.outputReadPhaseMetrics(readPhase);
+        }
     }
 }


### PR DESCRIPTION
- Fixes #8578

### Motivation

Fix npe inside outputReadPhaseMetrics in mysql-cdc

### Modifications

NPE happens when we do not provide metric labels

should check for metricdata before call method 

### Verifying this change

run allmigrate test

### Documentation

  - Does this pull request introduce a new feature? (no)