### PR TITLE
[INLONG-8594][Sort] Fix SourceRecord range check of MongoDB CDC

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/fetch/MongoDBFetchTaskContext.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/cdc/mongodb/source/reader/fetch/MongoDBFetchTaskContext.java
@@ -130,7 +130,7 @@ public class MongoDBFetchTaskContext implements FetchTask.Context {
         BsonDocument splitKeys = (BsonDocument) splitStart[0];
         String firstKey = splitKeys.getFirstKey();
         BsonValue keyValue = documentKey.get(firstKey);
-        BsonValue lowerBound = ((BsonDocument) splitEnd[1]).get(firstKey);
+        BsonValue lowerBound = ((BsonDocument) splitStart[1]).get(firstKey);
         BsonValue upperBound = ((BsonDocument) splitEnd[1]).get(firstKey);
 
         // for all range


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8594][Sort] Fix SourceRecord range check of MongoDB CDC

- Fixes #8594 

### Motivation

When change record is chunk range of snapshot phase, MongoDB cannot output the record. The method `MongoDBFetchTaskContext#isRecordBetween` is not work.

<img width="1005" alt="image" src="https://github.com/apache/inlong/assets/111486498/9ba6ac90-f4cb-4866-9b06-897b017083ba">

<img width="1088" alt="image" src="https://github.com/apache/inlong/assets/111486498/37e96227-f072-4caf-8d3e-0dcc1ddc2d17">



### Modifications

Fix `MongoDBFetchTaskContext#isRecordBetween` checking function.
