### PR TITLE
[INLONG-8596][Sort] Fix bugs and reformat code in Iceberg dynamic switching between append and upsert

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -165,7 +165,7 @@ public final class Constants {
 
     public static final String GHOST_TAG = "/* gh-ost */";
 
-    public static final String META_INCREMENTAL = "meta.incremental";
+    public static final String META_INCREMENTAL = "incremental_inlong";
 
     public static final ConfigOption<String> INLONG_METRIC =
             ConfigOptions.key("inlong.metric.labels")
@@ -248,7 +248,8 @@ public final class Constants {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("The option 'switch.append.upsert.enable' "
-                            + "is used to switch between append and upsert, default is 'false'.");
+                            + "is used when sink connector switch between append and upsert mode, "
+                            + "default is 'false'.");
 
     public static final ConfigOption<SchemaUpdateExceptionPolicy> SINK_MULTIPLE_SCHEMA_UPDATE_POLICY =
             ConfigOptions.key("sink.multiple.schema-update.policy")

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/IcebergTableSink.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/IcebergTableSink.java
@@ -121,11 +121,12 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
         List<String> equalityColumns = tableSchema.getPrimaryKey()
                 .map(UniqueConstraint::getColumns)
                 .orElseGet(ImmutableList::of);
-
+        LOG.info("iceberg sink running with equality columns {}", equalityColumns);
         final ReadableConfig tableOptions = Configuration.fromMap(catalogTable.getOptions());
         boolean multipleSink = tableOptions.get(SINK_MULTIPLE_ENABLE);
         boolean schemaChange = tableOptions.get(SINK_SCHEMA_CHANGE_ENABLE);
         String schemaChangePolicies = tableOptions.getOptional(SINK_SCHEMA_CHANGE_POLICIES).orElse(null);
+        LOG.info("iceberg sink running with policy {}", tableOptions.get(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY));
         if (multipleSink) {
             return (DataStreamSinkProvider) dataStream -> FlinkSink.forRowData(dataStream)
                     .overwrite(overwrite)

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergModeSwitchHelper.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/IcebergModeSwitchHelper.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.iceberg.schema;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.RowType.RowField;
+
+import java.util.List;
+
+import static org.apache.flink.table.api.DataTypes.FIELD;
+import static org.apache.flink.table.api.DataTypes.ROW;
+
+/**
+ * this class helps to manipulate iceberg table schema
+ * when SWITCH_APPEND_UPSERT_ENABLE equals to true
+ */
+public class IcebergModeSwitchHelper {
+
+    private final RowType tableSchemaRowType;
+    private final RowDataConverter rowDataConverter;
+    private final int incrementalFieldIndex;
+    public static final String META_INCREMENTAL = "incremental_inlong";
+    public static final int DEFAULT_META_INDEX = -1;
+
+    public IcebergModeSwitchHelper(RowType tableSchemaRowType, int incrementalFieldIndex) {
+        this.tableSchemaRowType = tableSchemaRowType;
+        this.rowDataConverter = new RowDataConverter(tableSchemaRowType.getChildren());
+        this.incrementalFieldIndex = incrementalFieldIndex;
+    }
+
+    /**
+     * remove incremental field from rowData
+     * @param rowData input row data
+     * @return row data without incremental field
+     */
+    public RowData removeIncrementalField(RowData rowData) {
+        if (incrementalFieldIndex == DEFAULT_META_INDEX) {
+            return rowData;
+        }
+        GenericRowData newRowData = new GenericRowData(tableSchemaRowType.getFieldCount() - 1);
+        for (int i = 0, j = 0; i < tableSchemaRowType.getFieldCount(); i++) {
+            if (i != incrementalFieldIndex) {
+                newRowData.setField(j++, rowDataConverter.get(rowData, i));
+            }
+        }
+        return newRowData;
+    }
+
+    /**
+     * remove incremental field from table schema
+     * @param requestedSchema input table schema
+     * @return table schema without incremental field
+     */
+    public static DataType filterOutMetaField(TableSchema requestedSchema) {
+        DataTypes.Field[] fields = requestedSchema.getTableColumns().stream()
+                .filter(column -> !META_INCREMENTAL.equals(column.getName()))
+                .map(column -> FIELD(column.getName(), column.getType()))
+                .toArray(DataTypes.Field[]::new);
+        return ROW(fields).notNull();
+    }
+
+    /**
+     * get incremental field index
+     * @param tableSchema input table schema
+     * @return incremental field index
+     */
+    public static int getMetaFieldIndex(TableSchema tableSchema) {
+        RowType rowType = (RowType) tableSchema.toRowDataType().getLogicalType();
+        List<RowField> fields = rowType.getFields();
+        int metaFieldIndex = DEFAULT_META_INDEX;
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField rowField = fields.get(i);
+            if (META_INCREMENTAL.equals(rowField.getName())) {
+                metaFieldIndex = i;
+                break;
+            }
+        }
+        return metaFieldIndex;
+    }
+
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/RowDataConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/schema/RowDataConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.iceberg.schema;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.util.List;
+
+import static org.apache.inlong.sort.base.Constants.SWITCH_APPEND_UPSERT_ENABLE;
+
+/**
+ * used in iceberg running in {@link SWITCH_APPEND_UPSERT_ENABLE}
+ */
+public class RowDataConverter {
+
+    private final RowData.FieldGetter[] fieldGetter;
+
+    public RowDataConverter(List<LogicalType> types) {
+        this.fieldGetter = new RowData.FieldGetter[types.size()];
+
+        for (int i = 0; i < types.size(); ++i) {
+            this.fieldGetter[i] = RowData.createFieldGetter(types.get(i), i);
+        }
+
+    }
+
+    public Object get(RowData struct, int index) {
+        return this.fieldGetter[index].getFieldOrNull(struct);
+    }
+
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RowDataTaskWriterFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/RowDataTaskWriterFactory.java
@@ -37,6 +37,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.ArrayUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -45,6 +47,8 @@ import java.util.List;
  * Add an option `sink.ignore.changelog` to support insert-only mode without equalityFieldIds.
  */
 public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RowDataTaskWriterFactory.class);
 
     private final Table table;
     private final Schema schema;
@@ -56,9 +60,8 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
     private final List<Integer> equalityFieldIds;
     private boolean upsert;
     private boolean appendMode;
+    private FileAppenderFactory<RowData> appenderFactory;
     private final boolean miniBatchMode;
-    private final FileAppenderFactory<RowData> appenderFactory;
-
     private transient OutputFileFactory outputFileFactory;
 
     public RowDataTaskWriterFactory(Table table,
@@ -80,19 +83,24 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
         this.equalityFieldIds = equalityFieldIds;
         this.upsert = upsert;
         this.appendMode = appendMode;
+        this.appenderFactory = createRowDataFileAppenderFactory(table, flinkSchema,
+                equalityFieldIds, upsert, appendMode);
         this.miniBatchMode = miniBatchMode;
+    }
 
+    private FileAppenderFactory<RowData> createRowDataFileAppenderFactory(Table table,
+            RowType flinkSchema, List<Integer> equalityFieldIds, boolean upsert, boolean appendMode) {
         if (equalityFieldIds == null || equalityFieldIds.isEmpty() || appendMode) {
-            this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec);
+            return new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec);
         } else if (upsert) {
             // In upsert mode, only the new row is emitted using INSERT row kind. Therefore, any column of the inserted
             // row may differ from the deleted row other than the primary key fields, and the delete file must contain
             // values that are correct for the deleted row. Therefore, only write the equality delete fields.
-            this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
+            return new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
                     ArrayUtil.toIntArray(equalityFieldIds),
                     TypeUtil.select(schema, Sets.newHashSet(equalityFieldIds)), null);
         } else {
-            this.appenderFactory = new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
+            return new FlinkAppenderFactory(schema, flinkSchema, table.properties(), spec,
                     ArrayUtil.toIntArray(equalityFieldIds), schema, null);
         }
     }
@@ -107,8 +115,8 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
         this.upsert = false;
     }
 
-    public boolean isAppendMode() {
-        return equalityFieldIds == null || equalityFieldIds.isEmpty() || appendMode;
+    public boolean isUpsert() {
+        return upsert;
     }
 
     @Override
@@ -124,9 +132,11 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
         if (equalityFieldIds == null || equalityFieldIds.isEmpty() || appendMode) {
             // Initialize a task writer to write INSERT only.
             if (spec.isUnpartitioned()) {
+                LOGGER.info("Create an unPartitioned append writer for table {}.", table.name());
                 return new UnpartitionedWriter<>(
                         spec, format, appenderFactory, outputFileFactory, io, targetFileSizeBytes);
             } else {
+                LOGGER.info("Create a partitioned append writer for table {}.", table.name());
                 if (miniBatchMode) {
                     return new RowDataGroupedPartitionedFanoutWriter(spec, format, appenderFactory, outputFileFactory,
                             io, targetFileSizeBytes, schema, flinkSchema);
@@ -138,9 +148,11 @@ public class RowDataTaskWriterFactory implements TaskWriterFactory<RowData> {
         } else {
             // Initialize a task writer to write both INSERT and equality DELETE.
             if (spec.isUnpartitioned()) {
+                LOGGER.info("Create an unPartitioned upsert delta writer for table {}.", table.name());
                 return new UnpartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
                         targetFileSizeBytes, schema, flinkSchema, equalityFieldIds, upsert);
             } else {
+                LOGGER.info("Create a partitioned upsert delta writer for table {}.", table.name());
                 if (miniBatchMode) {
                     return new GroupedPartitionedDeltaWriter(spec, format, appenderFactory, outputFileFactory, io,
                             targetFileSizeBytes, schema, flinkSchema, equalityFieldIds, upsert);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -426,10 +426,8 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
                 recordWithSchema.setRowCount(rowCount.get());
                 recordWithSchema.setRowSize(rowSize.get());
                 JsonNode originalData = recordWithSchema.getOriginalData();
-                boolean incremental = Optional.ofNullable(originalData.get(INCREMENTAL))
-                        .map(node -> node.asBoolean())
-                        .orElse(false);
-                recordWithSchema.setIncremental(incremental);
+                recordWithSchema.setIncremental(Optional.ofNullable(originalData.get(INCREMENTAL))
+                        .map(JsonNode::asBoolean).orElse(false));
                 output.collect(new StreamRecord<>(recordWithSchema));
             } else {
                 if (SchemaUpdateExceptionPolicy.LOG_WITH_IGNORE == multipleSinkOption

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleFileCommiter.java
@@ -317,6 +317,7 @@ public class IcebergSingleFileCommiter extends IcebergProcessFunction<WriteResul
             continuousEmptyCheckpoints = 0;
         }
         // remove already committed snapshot manifest info
+
         pendingMap.keySet().forEach(deltaManifestsMap::remove);
         pendingMap.clear();
 


### PR DESCRIPTION
- Fixes #8596 

### Motivation

There are some minor errors in https://github.com/apache/inlong/pull/8238

1、the cache write result should be cleared after emitting
2、the streaming task should work in append mode when switch enabled
3、the writing data should not be binaryRowdata but be GenericRowdata, this can be done using a rowdataConverter

### Modifications

1、cache write result be cleared after emitting
2、the streaming task work in append mode when switch enabled
3、use a rowdataConverter to convert binaryData to GenericRowdata

### Verifying this change

<img width="1317" alt="image" src="https://github.com/apache/inlong/assets/26538404/d128d091-7e4b-45f6-84c5-f08d0013900c">

<img width="1336" alt="image" src="https://github.com/apache/inlong/assets/26538404/3e980d87-c909-4694-8592-b85523177e4c">
