### PR TITLE
[INLONG-8597][DataProxy] Adjust the format of the metric output to the file

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -78,6 +78,7 @@ public class ConfigConstants {
     public static final String REMOTE_IP_KEY = "srcIp";
     public static final String DATAPROXY_IP_KEY = "dpIp";
     public static final String MSG_ENCODE_VER = "msgEnType";
+    public static final String MSG_SEND_TIME = "st";
     public static final String REMOTE_IDC_KEY = "idc";
     public static final String MSG_COUNTER_KEY = "msgcnt";
     public static final String PKG_COUNTER_KEY = "pkgcnt";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/stats/MonitorIndex.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/stats/MonitorIndex.java
@@ -34,7 +34,8 @@ import java.util.concurrent.atomic.LongAdder;
 public class MonitorIndex extends AbsStatsDaemon {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MonitorIndex.class);
-
+    // Indicator record format version
+    private static final String INDEX_RECORD_VER = "v1";
     private static final AtomicLong RECODE_ID = new AtomicLong(0);
     private final StatsUnit[] statsUnits = new StatsUnit[2];
 
@@ -134,7 +135,7 @@ public class MonitorIndex extends AbsStatsDaemon {
                 if (entry == null || entry.getKey() == null || entry.getValue() == null) {
                     continue;
                 }
-                LOGGER.info("{}#{}_{}#{}#{}", this.statsName, printTime,
+                LOGGER.info("{}#{}#{}_{}#{}={}", this.statsName, INDEX_RECORD_VER, printTime,
                         RECODE_ID.incrementAndGet(), entry.getKey(), entry.getValue().toString());
                 printCnt++;
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/TubeUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/TubeUtils.java
@@ -17,8 +17,6 @@
 
 package org.apache.inlong.dataproxy.sink.common;
 
-import org.apache.inlong.common.enums.DataProxyMsgEncType;
-import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.dataproxy.config.pojo.MQClusterConfig;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.utils.Constants;
@@ -62,14 +60,9 @@ public class TubeUtils {
         Map<String, String> headers = event.getHeaders();
         Message message = new Message(topicName, event.getBody());
         String pkgVersion = headers.get(ConfigConstants.MSG_ENCODE_VER);
-        if (DataProxyMsgEncType.MSG_ENCODE_TYPE_PB.getStrId().equalsIgnoreCase(pkgVersion)) {
-            long dataTimeL = Long.parseLong(headers.get(ConfigConstants.PKG_TIME_KEY));
-            message.putSystemHeader(headers.get(Constants.INLONG_STREAM_ID),
-                    DateTimeUtils.ms2yyyyMMddHHmm(dataTimeL));
-        } else {
-            message.putSystemHeader(headers.get(AttributeConstants.STREAM_ID),
-                    headers.get(ConfigConstants.PKG_TIME_KEY));
-        }
+        long dataTimeL = Long.parseLong(headers.get(ConfigConstants.PKG_TIME_KEY));
+        message.putSystemHeader(headers.get(Constants.INLONG_STREAM_ID),
+                DateTimeUtils.ms2yyyyMMddHHmm(dataTimeL));
         Map<String, String> extraAttrMap = MessageUtils.getXfsAttrs(headers, pkgVersion);
         for (Map.Entry<String, String> entry : extraAttrMap.entrySet()) {
             message.setAttrKeyVal(entry.getKey(), entry.getValue());

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -18,10 +18,7 @@
 package org.apache.inlong.dataproxy.sink.mq;
 
 import org.apache.inlong.common.enums.DataProxyErrCode;
-import org.apache.inlong.common.util.NetworkUtils;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
-import org.apache.inlong.dataproxy.consts.AttrConstants;
-import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.metrics.DataProxyMetricItem;
 import org.apache.inlong.dataproxy.metrics.audit.AuditUtils;
@@ -30,7 +27,6 @@ import org.apache.inlong.sdk.commons.protocol.ProxySdk.INLONG_COMPRESSED_TYPE;
 
 import org.apache.commons.lang.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.apache.flume.conf.Configurable;
@@ -274,42 +270,4 @@ public class MessageQueueZoneSinkContext extends SinkContext {
         return null;
     }
 
-    public void fileMetricAddSuccCnt(PackProfile packProfile, String topic, String remoteId) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()) {
-            return;
-        }
-        if (packProfile instanceof SimplePackProfile) {
-            SimplePackProfile simpleProfile = (SimplePackProfile) packProfile;
-            StringBuilder statsKey = new StringBuilder(512)
-                    .append(sinkName).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEP_HASHTAG)
-                    .append(topic).append(AttrConstants.SEP_HASHTAG)
-                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEP_HASHTAG)
-                    .append(remoteId).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getProperties().get(ConfigConstants.PKG_TIME_KEY));
-            monitorIndex.addSuccStats(statsKey.toString(), NumberUtils.toInt(
-                    simpleProfile.getProperties().get(ConfigConstants.MSG_COUNTER_KEY), 1),
-                    1, simpleProfile.getSize());
-        }
-    }
-
-    public void fileMetricAddFailCnt(PackProfile packProfile, String topic, String remoteId) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()) {
-            return;
-        }
-
-        if (packProfile instanceof SimplePackProfile) {
-            SimplePackProfile simpleProfile = (SimplePackProfile) packProfile;
-            StringBuilder statsKey = new StringBuilder(512)
-                    .append(sinkName).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getInlongGroupId()).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getInlongStreamId()).append(AttrConstants.SEP_HASHTAG)
-                    .append(topic).append(AttrConstants.SEP_HASHTAG)
-                    .append(NetworkUtils.getLocalIp()).append(AttrConstants.SEP_HASHTAG)
-                    .append(remoteId).append(AttrConstants.SEP_HASHTAG)
-                    .append(simpleProfile.getProperties().get(ConfigConstants.PKG_TIME_KEY));
-            monitorIndex.addFailStats(statsKey.toString(), 1);
-        }
-    }
 }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/SimplePackProfile.java
@@ -148,11 +148,13 @@ public class SimplePackProfile extends PackProfile {
     /**
      * get required properties sent to MQ
      *
+     * @param sendTime  send time
      * @return the properties
      */
-    public Map<String, String> getPropsToMQ() {
+    public Map<String, String> getPropsToMQ(long sendTime) {
         Map<String, String> result = new HashMap<>();
         result.put(AttributeConstants.RCV_TIME, event.getHeaders().get(AttributeConstants.RCV_TIME));
+        result.put(ConfigConstants.MSG_SEND_TIME, String.valueOf(sendTime));
         result.put(ConfigConstants.MSG_ENCODE_VER, event.getHeaders().get(ConfigConstants.MSG_ENCODE_VER));
         result.put(EventConstants.HEADER_KEY_VERSION, event.getHeaders().get(EventConstants.HEADER_KEY_VERSION));
         result.put(ConfigConstants.REMOTE_IP_KEY, event.getHeaders().get(ConfigConstants.REMOTE_IP_KEY));

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -23,7 +23,6 @@ import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.common.msg.MsgType;
 import org.apache.inlong.dataproxy.config.CommonConfigHolder;
 import org.apache.inlong.dataproxy.config.ConfigManager;
-import org.apache.inlong.dataproxy.consts.AttrConstants;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.source.v0msg.AbsV0MsgCodec;
@@ -31,7 +30,6 @@ import org.apache.inlong.dataproxy.source.v0msg.CodecBinMsg;
 import org.apache.inlong.dataproxy.source.v0msg.CodecTextMsg;
 import org.apache.inlong.dataproxy.source.v1msg.InlongTcpSourceCallback;
 import org.apache.inlong.dataproxy.utils.AddressUtils;
-import org.apache.inlong.dataproxy.utils.DateTimeUtils;
 import org.apache.inlong.sdk.commons.protocol.EventUtils;
 import org.apache.inlong.sdk.commons.protocol.ProxyEvent;
 import org.apache.inlong.sdk.commons.protocol.ProxyPackEvent;
@@ -271,30 +269,21 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         }
         // build InLong event.
         Event event = msgCodec.encEventPackage(source, channel);
-        // build metric data item
-        long longDataTime = msgCodec.getDataTimeMs() / 1000 / 60 / 10;
-        longDataTime = longDataTime * 1000 * 60 * 10;
-        String statsKey = strBuff.append(source.getProtocolName()).append(AttrConstants.SEP_HASHTAG)
-                .append(msgCodec.getGroupId()).append(AttrConstants.SEP_HASHTAG)
-                .append(msgCodec.getStreamId()).append(AttrConstants.SEP_HASHTAG)
-                .append(msgCodec.getStrRemoteIP()).append(AttrConstants.SEP_HASHTAG)
-                .append(source.getSrcHost()).append(AttrConstants.SEP_HASHTAG)
-                .append(msgCodec.getMsgProcType()).append(AttrConstants.SEP_HASHTAG)
-                .append(DateTimeUtils.ms2yyyyMMddHHmm(longDataTime)).append(AttrConstants.SEP_HASHTAG)
-                .append(DateTimeUtils.ms2yyyyMMddHHmm(msgCodec.getMsgRcvTime())).toString();
-        strBuff.delete(0, strBuff.length());
         try {
             source.getChannelProcessor().processEvent(event);
-            source.fileMetricIncSumStats(StatConstants.EVENT_MSG_V0_POST_SUCCESS);
-            source.fileMetricAddSuccCnt(statsKey, msgCodec.getMsgCount(), 1, event.getBody().length);
+            source.fileMetricAddSuccStats(strBuff, msgCodec.getGroupId(), msgCodec.getStreamId(),
+                    msgCodec.getTopicName(), msgCodec.getStrRemoteIP(), msgCodec.getMsgProcType(),
+                    msgCodec.getDataTimeMs(), msgCodec.getMsgPkgTime(), msgCodec.getMsgCount(), 1,
+                    event.getBody().length);
             source.addMetric(true, event.getBody().length, event);
             if (msgCodec.isNeedResp() && !msgCodec.isOrderOrProxy()) {
                 msgCodec.setSuccessInfo();
                 responseV0Msg(channel, msgCodec, strBuff);
             }
         } catch (Throwable ex) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_MSG_V0_POST_FAILURE);
-            source.fileMetricAddFailCnt(statsKey, 1);
+            source.fileMetricAddFailStats(strBuff, msgCodec.getGroupId(), msgCodec.getStreamId(),
+                    msgCodec.getTopicName(), msgCodec.getStrRemoteIP(), msgCodec.getMsgProcType(),
+                    msgCodec.getDataTimeMs(), msgCodec.getMsgPkgTime(), 1);
             source.addMetric(false, event.getBody().length, event);
             if (msgCodec.isNeedResp() && !msgCodec.isOrderOrProxy()) {
                 msgCodec.setFailureInfo(DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/AbsV0MsgCodec.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/AbsV0MsgCodec.java
@@ -23,7 +23,6 @@ import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.dataproxy.consts.ConfigConstants;
 import org.apache.inlong.dataproxy.consts.StatConstants;
 import org.apache.inlong.dataproxy.source.BaseSource;
-import org.apache.inlong.dataproxy.utils.DateTimeUtils;
 import org.apache.inlong.sdk.commons.protocol.EventConstants;
 
 import com.google.common.base.Joiner;
@@ -66,6 +65,7 @@ public abstract class AbsV0MsgCodec {
     protected boolean isOrderOrProxy = false;
     protected String msgProcType = "b2b";
     protected boolean needResp = true;
+    protected long msgPkgTime;
 
     public AbsV0MsgCodec(int totalDataLen, int msgTypeValue,
             long msgRcvTime, String strRemoteIP) {
@@ -115,6 +115,10 @@ public abstract class AbsV0MsgCodec {
 
     public long getDataTimeMs() {
         return this.dataTimeMs;
+    }
+
+    public long getMsgPkgTime() {
+        return msgPkgTime;
     }
 
     public String getGroupId() {
@@ -219,7 +223,7 @@ public abstract class AbsV0MsgCodec {
         return true;
     }
 
-    protected Map<String, String> buildEventHeaders(long pkgTime) {
+    protected Map<String, String> buildEventHeaders(BaseSource source) {
         // build headers
         Map<String, String> headers = new HashMap<>();
         headers.put(AttributeConstants.GROUP_ID, groupId);
@@ -227,6 +231,7 @@ public abstract class AbsV0MsgCodec {
         headers.put(ConfigConstants.TOPIC_KEY, topicName);
         headers.put(AttributeConstants.DATA_TIME, String.valueOf(dataTimeMs));
         headers.put(ConfigConstants.REMOTE_IP_KEY, strRemoteIP);
+        headers.put(ConfigConstants.DATAPROXY_IP_KEY, source.getSrcHost());
         headers.put(ConfigConstants.MSG_COUNTER_KEY, String.valueOf(msgCount));
         headers.put(ConfigConstants.MSG_ENCODE_VER,
                 DataProxyMsgEncType.MSG_ENCODE_TYPE_INLONGMSG.getStrId());
@@ -234,7 +239,7 @@ public abstract class AbsV0MsgCodec {
                 DataProxyMsgEncType.MSG_ENCODE_TYPE_INLONGMSG.getStrId());
         headers.put(AttributeConstants.RCV_TIME, String.valueOf(msgRcvTime));
         headers.put(AttributeConstants.UNIQ_ID, String.valueOf(uniq));
-        headers.put(ConfigConstants.PKG_TIME_KEY, DateTimeUtils.ms2yyyyMMddHHmm(pkgTime));
+        headers.put(ConfigConstants.PKG_TIME_KEY, String.valueOf(msgPkgTime));
         // add extra key-value information
         if (!needResp) {
             headers.put(AttributeConstants.MESSAGE_IS_ACK, "false");

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
@@ -236,7 +236,8 @@ public class CodecBinMsg extends AbsV0MsgCodec {
         InLongMsg inLongMsg = InLongMsg.newInLongMsg(source.isCompressed(), 4);
         inLongMsg.addMsg(dataBuf.array());
         byte[] inlongMsgData = inLongMsg.buildArray();
-        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(inLongMsg.getCreatetime()));
+        msgPkgTime = inLongMsg.getCreatetime();
+        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(source));
         if (isOrderOrProxy) {
             event = new SinkRspEvent(event, MsgType.MSG_BIN_MULTI_BODY, channel);
         }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
@@ -267,7 +267,8 @@ public class CodecTextMsg extends AbsV0MsgCodec {
             inLongMsg.addMsg(mapJoiner.join(attrMap), bodyData);
         }
         byte[] inlongMsgData = inLongMsg.buildArray();
-        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(inLongMsg.getCreatetime()));
+        msgPkgTime = inLongMsg.getCreatetime();
+        Event event = EventBuilder.withBody(inlongMsgData, buildEventHeaders(source));
         inLongMsg.reset();
         return event;
     }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/DateTimeUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/utils/DateTimeUtils.java
@@ -38,4 +38,18 @@ public class DateTimeUtils {
                 LocalDateTime.ofInstant(Instant.ofEpochMilli(timestamp), defZoneId);
         return DATE_FORMATTER.format(localDateTime);
     }
+
+    /**
+     * convert ms value to ten minute level 'yyyyMMddHHmm' string
+     *
+     * @param timestamp The millisecond value of the specified time
+     * @return the time string in ten-minute format yyyyMMddHHmmss
+     */
+    public static String ms2yyyyMMddHHmmTenMins(long timestamp) {
+        long longDataTime = timestamp / 1000 / 60 / 10;
+        LocalDateTime localDateTime = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(longDataTime * 1000 * 60 * 10), defZoneId);
+        return DATE_FORMATTER.format(localDateTime);
+    }
+
 }


### PR DESCRIPTION

- Fixes #8597

1. Adjust the output format of the index.log indicator, add version information, and separate keys and values with "=", and adjust the output position of some fields;
2. For the output indicators on the Sink side, add groupId, streamId information, and dt time;
3. Optimize and adjust the implementation logic of the indicator output function on the Source and Sink sides
4. Add sending time information to the message sent to MQ