### PR TITLE
[INLONG-8601][Sort] Fix NPE in schema.name of Oracle CDC

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sort.cdc.oracle.debezium.table;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
 import org.apache.inlong.sort.cdc.base.debezium.table.AppendMetadataCollector;
 import org.apache.inlong.sort.cdc.base.debezium.table.DeserializationRuntimeConverter;
@@ -38,6 +37,7 @@ import io.debezium.time.NanoTime;
 import io.debezium.time.NanoTimestamp;
 import io.debezium.time.Timestamp;
 import io.debezium.time.ZonedTimestamp;
+import org.apache.commons.lang.StringUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sort.cdc.oracle.debezium.table;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.inlong.sort.cdc.base.debezium.DebeziumDeserializationSchema;
 import org.apache.inlong.sort.cdc.base.debezium.table.AppendMetadataCollector;
 import org.apache.inlong.sort.cdc.base.debezium.table.DeserializationRuntimeConverter;
@@ -292,7 +293,7 @@ public final class RowDataDebeziumDeserializeSchema
 
             @Override
             public Object convert(Object dbzObj, Schema schema) {
-                if (dbzObj instanceof Long) {
+                if (dbzObj instanceof Long && StringUtils.isNotBlank(schema.name())) {
                     // Because Oracle CDC has been shaded, the schema will have the prefix
                     // 'org.apache.inlong.sort.cdc.oracle.shaded' added,
                     // so we need to use `schemaName.endsWith()` to determine the Schema type.
@@ -327,7 +328,7 @@ public final class RowDataDebeziumDeserializeSchema
 
             @Override
             public Object convert(Object dbzObj, Schema schema) {
-                if (dbzObj instanceof Long) {
+                if (dbzObj instanceof Long && StringUtils.isNotBlank(schema.name())) {
                     // Because Oracle CDC has been shaded, the schema will have the prefix
                     // 'org.apache.inlong.sort.cdc.oracle.shaded' added,
                     // so we need to use `schemaName.endsWith()` to determine the Schema type.
@@ -462,7 +463,8 @@ public final class RowDataDebeziumDeserializeSchema
                     // Because Oracle CDC has been shaded, the schema will have the prefix
                     // 'org.apache.inlong.sort.cdc.oracle.shaded' added,
                     // so we need to use `schemaName.endsWith()` to determine the Schema type.
-                    if (schema.name().endsWith(VariableScaleDecimal.LOGICAL_NAME)) {
+                    if (StringUtils.isNotBlank(schema.name())
+                            && schema.name().endsWith(VariableScaleDecimal.LOGICAL_NAME)) {
                         SpecialValueDecimal decimal =
                                 VariableScaleDecimal.toLogical((Struct) dbzObj);
                         bigDecimal = decimal.getDecimalValue().orElse(BigDecimal.ZERO);
@@ -768,8 +770,8 @@ public final class RowDataDebeziumDeserializeSchema
      * @return the extracted data with schema
      */
     private Object getValueWithSchema(Object fieldValue, String schemaName) {
-        if (fieldValue == null) {
-            return null;
+        if (fieldValue == null || StringUtils.isBlank(schemaName)) {
+            return fieldValue;
         }
         // Because Oracle CDC has been shaded, the schema will have the prefix
         // 'org.apache.inlong.sort.cdc.oracle.shaded' added,


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8601][Sort] Fix NPE in schema.name of Oracle CDC

- Fixes #8601 

### Motivation

Some data types have a null `schema.name`, such as INT64, so we need to check whether `schema.name` is null to avoid 
NPE.

<img width="467" alt="企业微信截图_8c978eb3-4cb5-462b-b5d9-a67991574d23" src="https://github.com/apache/inlong/assets/111486498/13563382-9e5d-4212-a861-f6fd7dd6cf6c">


### Modifications

Check whether `schema.name` is nul.
