### PR TITLE
[INLONG-8602][Sort] Fix StackOverflowError of Oracle CDC

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -797,38 +797,17 @@ public final class RowDataDebeziumDeserializeSchema
 
     @Override
     public void deserialize(SourceRecord record, Collector<RowData> out) throws Exception {
-        Envelope.Operation op = Envelope.operationFor(record);
-        Struct value = (Struct) record.value();
-        Schema valueSchema = record.valueSchema();
-        if (op == Envelope.Operation.CREATE || op == Envelope.Operation.READ) {
-            GenericRowData insert = extractAfterRow(value, valueSchema, null);
-            validator.validate(insert, RowKind.INSERT);
-            insert.setRowKind(RowKind.INSERT);
-            emit(record, insert, null, out);
-        } else if (op == Envelope.Operation.DELETE) {
-            GenericRowData delete = extractBeforeRow(value, valueSchema, null);
-            validator.validate(delete, RowKind.DELETE);
-            delete.setRowKind(RowKind.DELETE);
-            emit(record, delete, null, out);
-        } else {
-            if (!appendSource) {
-                GenericRowData before = extractBeforeRow(value, valueSchema, null);
-                validator.validate(before, RowKind.UPDATE_BEFORE);
-                before.setRowKind(RowKind.UPDATE_BEFORE);
-                emit(record, before, null, out);
-            }
-
-            GenericRowData after = extractAfterRow(value, valueSchema, null);
-            validator.validate(after, RowKind.UPDATE_AFTER);
-            after.setRowKind(RowKind.UPDATE_AFTER);
-            emit(record, after, null, out);
-        }
+        extractRowAndEmitRecord(record, out, null);
     }
 
     @Override
     public void deserialize(SourceRecord record, Collector<RowData> out,
             TableChange tableSchema)
             throws Exception {
+        extractRowAndEmitRecord(record, out, tableSchema);
+    }
+
+    private void extractRowAndEmitRecord(SourceRecord record, Collector<RowData> out, TableChange tableSchema) throws Exception {
         Envelope.Operation op = Envelope.operationFor(record);
         Struct value = (Struct) record.value();
         Schema valueSchema = record.valueSchema();

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/debezium/table/RowDataDebeziumDeserializeSchema.java
@@ -807,7 +807,8 @@ public final class RowDataDebeziumDeserializeSchema
         extractRowAndEmitRecord(record, out, tableSchema);
     }
 
-    private void extractRowAndEmitRecord(SourceRecord record, Collector<RowData> out, TableChange tableSchema) throws Exception {
+    private void extractRowAndEmitRecord(SourceRecord record, Collector<RowData> out, TableChange tableSchema)
+            throws Exception {
         Envelope.Operation op = Envelope.operationFor(record);
         Struct value = (Struct) record.value();
         Schema valueSchema = record.valueSchema();


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8602][Sort] Fix StackOverflowError of Oracle CDC

- Fixes #8602 

### Motivation

**DebeziumDeserializationSchema** has three methods:

- `void deserialize(SourceRecord record, Collector<T> out)`
- `default void deserialize(SourceRecord record, Collector<T> out, TableChanges.TableChange tableSchema)`
- `default void deserialize(SourceRecord record, Collector<T> out, Boolean isStreamingPhase)`

**RowDataDebeziumDeserializeSchema** is an implementation of **DebeziumDeserializationSchema**. When calling the `RowDataDebeziumDeserializeSchema.deserialize(SourceRecord record, Collector<RowData> out)` method, it invokes the `deserialize(record, out)` method, as shown in the code below:

```java
    @Override
    public void deserialize(SourceRecord record, Collector<RowData> out) throws Exception {
        deserialize(record, out);
    }
```

This results in a recursive call, causing StackOverflowError like #8602.

In fact, we need to call the `deserialize(SourceRecord record, Collector<RowData> out, TableChange tableSchema)` method. Previously, we could use `deserialize(record, out, null)`, but later the `deserialize(SourceRecord record, Collector<T> out, Boolean isStreamingPhase)` method was added, which conflicts with the `deserialize(SourceRecord record, Collector<RowData> out, TableChange tableSchema)` method.

<img width="1292" alt="image" src="https://github.com/apache/inlong/assets/111486498/30166ee1-5f67-47cd-be58-43bbf8820341">

Therefore, we must override the `deserialize(SourceRecord record, Collector<RowData> out, TableChange tableSchema)` method.

### Modifications

Override the `RowDataDebeziumDeserializeSchema.deserialize(SourceRecord record, Collector<RowData> out, TableChange tableSchema)` 
