### PR TITLE
[INLONG-8279][Sort] Fix NPE when run MySqlLoadSqlParseTest

### DIFF
--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -203,6 +203,12 @@
                     <artifactId>sort-connector-oracle-cdc</artifactId>
                     <version>${project.version}</version>
                     <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>io.debezium</groupId>
+                            <artifactId>debezium-ddl-parser</artifactId>
+                        </exclusion>
+                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.inlong</groupId>


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8279][Sort] Fix NPE when run MySqlLoadSqlParseTest

- Fixes #8279

### Motivation

After filling in the real database connection parameters in `MySqlLoadSqlParseTest#testMySqlLoadSqlParse()`, running the UT occurs NPE. According to the source code, the **debezium-ddl-parser** fails to parse the `varchar(255)` type.

<img width="806" alt="image" src="https://github.com/apache/inlong/assets/111486498/55fd85bf-907d-427a-9850-d8398de5e6d6">

However, when running the MySQL Connector separately instead of the UT, the parsing works correctly. In the UT, there are multiple versions of **debezium-ddl-parser**. By default, version **1.6.4-Final** is used, while MySQL depends on version **1.5.4-Final**. Therefore, we can only exclude the **1.6.4-Final** version from the Oracle Connector for now.

<img width="1046" alt="image" src="https://github.com/apache/inlong/assets/111486498/528bafd7-459c-4ca0-b959-b78a63812270">

### Modifications

Exclude the **1.6.4-Final** version from the Oracle Connector.