### PR TITLE
[INLONG-8611][Manager] Add full link trace based on Opentelemetry

### DIFF
--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -17,6 +17,15 @@
 #
 
 
+# Opentelemetry startup parameter configuration
+export OTEL_SERVICE_NAME=inlong_agent
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
+export OTEL_VERSION=v1.28.0
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_RESOURCE_ATTRIBUTES=
 
 #project directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
@@ -60,4 +69,11 @@ if [[ $JMX_ENABLED == 1 ]]; then
   export AGENT_ARGS="$AGENT_JVM_ARGS $AGENT_RMI_ARGS -cp $CLASSPATH -Dagent.home=$BASE_DIR"
 else
   export AGENT_ARGS="$AGENT_JVM_ARGS -cp $CLASSPATH -Dagent.home=$BASE_DIR"
+fi
+
+# Opentelemetry java agent path
+JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
+DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
+if [ ! -f "$JAVA_AGENT" ]; then
+    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
 fi

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -23,7 +23,7 @@ export OTEL_TRACES_EXPORTER=otlp
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
-export OTEL_VERSION=v1.28.0
+export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
@@ -72,8 +72,4 @@ else
 fi
 
 # Opentelemetry java agent path
-JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
-DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
-if [ ! -f "$JAVA_AGENT" ]; then
-    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
-fi
+JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -19,10 +19,6 @@
 
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_agent
-export OTEL_TRACES_EXPORTER=otlp
-export OTEL_METRICS_EXPORTER=otlp
-export OTEL_LOGS_EXPORTER=otlp
-export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
 export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -68,4 +68,4 @@ else
 fi
 
 # Opentelemetry java agent path
-OTEL_JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+OTEL_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -68,4 +68,4 @@ else
 fi
 
 # Opentelemetry java agent path
-JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+OTEL_JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-agent/bin/agent.sh
+++ b/inlong-agent/bin/agent.sh
@@ -46,7 +46,7 @@ function start_agent() {
     echo "agent is running."
     exit 1
   fi
-  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${JAVA_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_JAVA_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
 }
 
 # stop agent

--- a/inlong-agent/bin/agent.sh
+++ b/inlong-agent/bin/agent.sh
@@ -46,7 +46,7 @@ function start_agent() {
     echo "agent is running."
     exit 1
   fi
-  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_JAVA_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
 }
 
 # stop agent

--- a/inlong-agent/bin/agent.sh
+++ b/inlong-agent/bin/agent.sh
@@ -46,7 +46,7 @@ function start_agent() {
     echo "agent is running."
     exit 1
   fi
-  nohup ${JAVA} ${AGENT_ARGS} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${JAVA_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
 }
 
 # stop agent

--- a/inlong-agent/conf/log4j2.xml
+++ b/inlong-agent/conf/log4j2.xml
@@ -20,7 +20,7 @@
 <configuration status="WARN" monitorInterval="30">
     <Properties>
         <property name="basePath">${sys:agent.home}/logs</property>
-        <property name="log_pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} -%5p ${PID:-} [%30.30t] %-30.30C{1.}:%L %m%n</property>
+        <property name="log_pattern">[%X{trace_id} %X{span_id}] %d{yyyy-MM-dd HH:mm:ss.SSS} -%5p ${PID:-} [%30.30t] %-30.30C{1.}:%L %m%n</property>
         <property name="every_file_date">1</property>
         <property name="every_file_size">1G</property>
         <property name="output_log_level">INFO</property>

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -203,14 +203,6 @@ in the classpath.
 EOF
 }
 
-
-# Opentelemetry java agent path
-JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
-DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
-if [ ! -f "$JAVA_AGENT" ]; then
-    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
-fi
-
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_dataproxy
 export OTEL_TRACES_EXPORTER=otlp
@@ -221,6 +213,12 @@ export OTEL_VERSION=v1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
+# Opentelemetry java agent path
+JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
+DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
+if [ ! -f "$JAVA_AGENT" ]; then
+    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
+fi
 
 run_flume() {
   local FLUME_APPLICATION_CLASS

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -27,6 +27,15 @@ DATA_PROXY_AGENT_CLASS="org.apache.inlong.dataproxy.node.Application"
 FLUME_AVRO_CLIENT_CLASS="org.apache.flume.client.avro.AvroCLIClient"
 FLUME_VERSION_CLASS="org.apache.flume.tools.VersionInfo"
 
+# Opentelemetry startup parameter configuration
+export OTEL_SERVICE_NAME=inlong_dataproxy
+export OTEL_VERSION=1.28.0
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_RESOURCE_ATTRIBUTES=
+
+# Opentelemetry java agent path
+OTEL_JAVA_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+
 CLEAN_FLAG=1
 ################################
 # functions
@@ -215,7 +224,7 @@ run_flume() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     set -x
   fi
-  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${JAVA_AGENT} -cp "$DATAPROXY_CLASSPATH" \
+  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_JAVA_AGENT} -cp "$DATAPROXY_CLASSPATH" \
       -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
 }
 
@@ -402,12 +411,3 @@ else
   error "This message should never appear" 1
 fi
 exit 0
-
-# Opentelemetry startup parameter configuration
-export OTEL_SERVICE_NAME=inlong_dataproxy
-export OTEL_VERSION=1.28.0
-export OTEL_EXPORTER_OTLP_ENDPOINT=
-export OTEL_RESOURCE_ATTRIBUTES=
-
-# Opentelemetry java agent path
-JAVA_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -31,7 +31,7 @@ CLEAN_FLAG=1
 ################################
 # functions
 ################################
-
+BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 info() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     local msg=$1
@@ -203,6 +203,25 @@ in the classpath.
 EOF
 }
 
+
+# Opentelemetry java agent path
+JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
+DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
+if [ ! -f "$JAVA_AGENT" ]; then
+    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
+fi
+
+# Opentelemetry startup parameter configuration
+export OTEL_SERVICE_NAME=inlong_dataproxy
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
+export OTEL_VERSION=v1.28.0
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_RESOURCE_ATTRIBUTES=
+
+
 run_flume() {
   local FLUME_APPLICATION_CLASS
 
@@ -216,7 +235,7 @@ run_flume() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     set -x
   fi
-  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -cp "$DATAPROXY_CLASSPATH" \
+  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${JAVA_AGENT} -cp "$DATAPROXY_CLASSPATH" \
       -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
 }
 

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -209,16 +209,12 @@ export OTEL_TRACES_EXPORTER=otlp
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
-export OTEL_VERSION=v1.28.0
+export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
 # Opentelemetry java agent path
-JAVA_AGENT="${BASE_DIR}/bin/opentelemetry-javaagent.jar"
-DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
-if [ ! -f "$JAVA_AGENT" ]; then
-    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
-fi
+JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 run_flume() {
   local FLUME_APPLICATION_CLASS

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -205,10 +205,6 @@ EOF
 
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_dataproxy
-export OTEL_TRACES_EXPORTER=otlp
-export OTEL_METRICS_EXPORTER=otlp
-export OTEL_LOGS_EXPORTER=otlp
-export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
 export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -34,7 +34,7 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
 # Opentelemetry java agent path
-OTEL_JAVA_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+OTEL_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 CLEAN_FLAG=1
 ################################
@@ -224,7 +224,7 @@ run_flume() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     set -x
   fi
-  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_JAVA_AGENT} -cp "$DATAPROXY_CLASSPATH" \
+  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_AGENT} -cp "$DATAPROXY_CLASSPATH" \
       -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
 }
 

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -31,7 +31,6 @@ CLEAN_FLAG=1
 ################################
 # functions
 ################################
-BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 info() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     local msg=$1
@@ -202,15 +201,6 @@ in the classpath.
 
 EOF
 }
-
-# Opentelemetry startup parameter configuration
-export OTEL_SERVICE_NAME=inlong_dataproxy
-export OTEL_VERSION=1.28.0
-export OTEL_EXPORTER_OTLP_ENDPOINT=
-export OTEL_RESOURCE_ATTRIBUTES=
-
-# Opentelemetry java agent path
-JAVA_AGENT="${BASE_DIR}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 run_flume() {
   local FLUME_APPLICATION_CLASS
@@ -412,3 +402,12 @@ else
   error "This message should never appear" 1
 fi
 exit 0
+
+# Opentelemetry startup parameter configuration
+export OTEL_SERVICE_NAME=inlong_dataproxy
+export OTEL_VERSION=1.28.0
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_RESOURCE_ATTRIBUTES=
+
+# Opentelemetry java agent path
+JAVA_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-dataproxy/conf/log4j2.xml
+++ b/inlong-dataproxy/conf/log4j2.xml
@@ -20,7 +20,7 @@
 <configuration status="WARN" monitorInterval="30" packages="org.apache.inlong.dataproxy.config">
     <Properties>
         <property name="basePath">${sys:dataproxy.log.path}</property>
-        <property name="log_pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} -%5p ${PID:-} [%15.15t] %-30.30C{1.}:%L %mask %n</property>
+        <property name="log_pattern">[%X{trace_id} %X{span_id}] %d{yyyy-MM-dd HH:mm:ss.SSS} -%5p ${PID:-} [%15.15t] %-30.30C{1.}:%L %mask %n</property>
         <property name="every_file_date">1</property>
         <property name="every_file_size">1G</property>
         <property name="output_log_level">DEBUG</property>

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -92,13 +92,6 @@ JAVA_OPT="${JAVA_OPT} -XX:+IgnoreUnrecognizedVMOptions -XX:+UseConcMarkSweepGC -
 # Remote debugger
 #JAVA_OPT="${JAVA_OPT} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8081"
 
-# Opentelemetry java agent path
-JAVA_AGENT="${BASE_PATH}/bin/opentelemetry-javaagent.jar"
-DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
-if [ ! -f "$JAVA_AGENT" ]; then
-    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
-fi
-
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_manager
 export OTEL_TRACES_EXPORTER=otlp
@@ -108,6 +101,13 @@ export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
 export OTEL_VERSION=v1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
+
+# Opentelemetry java agent path
+JAVA_AGENT="${BASE_PATH}/bin/opentelemetry-javaagent.jar"
+DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
+if [ ! -f "$JAVA_AGENT" ]; then
+    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
+fi
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
 nohup java ${JAVA_OPT} -javaagent:${JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -98,16 +98,12 @@ export OTEL_TRACES_EXPORTER=otlp
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
-export OTEL_VERSION=v1.28.0
+export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
 # Opentelemetry java agent path
-JAVA_AGENT="${BASE_PATH}/bin/opentelemetry-javaagent.jar"
-DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
-if [ ! -f "$JAVA_AGENT" ]; then
-    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
-fi
+JAVA_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
 nohup java ${JAVA_OPT} -javaagent:${JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -92,8 +92,25 @@ JAVA_OPT="${JAVA_OPT} -XX:+IgnoreUnrecognizedVMOptions -XX:+UseConcMarkSweepGC -
 # Remote debugger
 #JAVA_OPT="${JAVA_OPT} -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8081"
 
+# Opentelemetry java agent path
+JAVA_AGENT="${BASE_PATH}/bin/opentelemetry-javaagent.jar"
+DOWNLOAD_URL="https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/${OTEL_VERSION}/opentelemetry-javaagent.jar"
+if [ ! -f "$JAVA_AGENT" ]; then
+    wget -O "$JAVA_AGENT" "$DOWNLOAD_URL"
+fi
+
+# Opentelemetry startup parameter configuration
+export OTEL_SERVICE_NAME=inlong_manager
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
+export OTEL_VERSION=v1.28.0
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_RESOURCE_ATTRIBUTES=
+
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
-nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
+nohup java ${JAVA_OPT} -javaagent:${JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
 
 # Print the startup log
 STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -99,10 +99,10 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
 # Opentelemetry java agent path
-OTEL_JAVA_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+OTEL_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
-nohup java ${JAVA_OPT} -javaagent:${OTEL_JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
+nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
 
 # Print the startup log
 STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -94,10 +94,6 @@ JAVA_OPT="${JAVA_OPT} -XX:+IgnoreUnrecognizedVMOptions -XX:+UseConcMarkSweepGC -
 
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_manager
-export OTEL_TRACES_EXPORTER=otlp
-export OTEL_METRICS_EXPORTER=otlp
-export OTEL_LOGS_EXPORTER=otlp
-export OTEL_INSTRUMENTATION_PULSAR_ENABLED=false
 export OTEL_VERSION=1.28.0
 export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -99,10 +99,10 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=
 export OTEL_RESOURCE_ATTRIBUTES=
 
 # Opentelemetry java agent path
-JAVA_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+OTEL_JAVA_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
-nohup java ${JAVA_OPT} -javaagent:${JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
+nohup java ${JAVA_OPT} -javaagent:${OTEL_JAVA_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
 
 # Print the startup log
 STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/ResponseWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/ResponseWrapper.java
@@ -25,6 +25,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Response wrapper
+ * Used to wrap HttpServletResponse, and do some extra processing or recording when getting the response data.
+ */
 public class ResponseWrapper extends HttpServletResponseWrapper {
 
     private final ByteArrayOutputStream buffer;
@@ -48,11 +52,11 @@ public class ResponseWrapper extends HttpServletResponseWrapper {
         return writer;
     }
 
-    public byte[] getResponseData() throws IOException {
-        flushBuffer();
-        return buffer.toByteArray();
-    }
-
+    /**
+     * Gets the string form of response data.
+     * @return Return the string form of response data.
+     * @throws IOException
+     */
     public String getContent() throws IOException {
         flushBuffer();
         return buffer.toString();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/ResponseWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/ResponseWrapper.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.trace;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class ResponseWrapper extends HttpServletResponseWrapper {
+
+    private final ByteArrayOutputStream buffer;
+    private final ServletOutputStream out;
+    private final PrintWriter writer;
+
+    public ResponseWrapper(HttpServletResponse response) throws IOException {
+        super(response);
+        buffer = new ByteArrayOutputStream();
+        out = new WrapperOutputStream(buffer, response);
+        writer = new WrapperWriter(buffer, response);
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        return out;
+    }
+
+    @Override
+    public PrintWriter getWriter() {
+        return writer;
+    }
+
+    public byte[] getResponseData() throws IOException {
+        flushBuffer();
+        return buffer.toByteArray();
+    }
+
+    public String getContent() throws IOException {
+        flushBuffer();
+        return buffer.toString();
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/TraceFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/TraceFilter.java
@@ -48,6 +48,11 @@ public class TraceFilter implements Filter {
     private static final String CLUSTER_NAME = "clusterName";
     private static final String CLUSTER_TAG = "clusterTag";
     private static final String INLONG_STREAM = "inlongStreamId";
+    private static final String TRACE_ID = "trace-id";
+    private static final String REQUEST = "request";
+    private static final String BODY = "body";
+    private static final String URI = "URI";
+    private static final String RESPONSE = "response";
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
@@ -69,11 +74,11 @@ public class TraceFilter implements Filter {
         ResponseWrapper responseWrapper = new ResponseWrapper(response);
         Span span = Span.current();
         addAttributes(inlongRequestWrapper.getContent(), request);
-        span.addEvent("request", Attributes.builder().put("body", inlongRequestWrapper.getContent())
-                .put("URI", request.getRequestURI()).build());
-        response.addHeader("trace-id", span.getSpanContext().getTraceId());
+        span.addEvent(REQUEST, Attributes.builder().put(BODY, inlongRequestWrapper.getContent())
+                .put(URI, request.getRequestURI()).build());
+        response.addHeader(TRACE_ID, span.getSpanContext().getTraceId());
         filterChain.doFilter(inlongRequestWrapper, responseWrapper);
-        span.addEvent("response", Attributes.builder().put("body", responseWrapper.getContent()).build());
+        span.addEvent(RESPONSE, Attributes.builder().put(BODY, responseWrapper.getContent()).build());
     }
 
     private void addAttributes(String body, HttpServletRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/TraceFilter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/TraceFilter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.trace;
+
+import org.apache.inlong.manager.common.util.JsonUtils;
+import org.apache.inlong.manager.web.utils.InlongRequestWrapper;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.apache.shiro.web.servlet.ShiroHttpServletRequest;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+@Aspect
+@Component
+@Slf4j
+public class TraceFilter implements Filter {
+
+    private static final String INLONG_GROUP_ID = "inlongGroupId";
+    private static final String CLUSTER_NAME = "clusterName";
+    private static final String CLUSTER_TAG = "clusterTag";
+    private static final String INLONG_STREAM = "inlongStreamId";
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+            throws IOException, ServletException {
+        HttpServletRequest request = (HttpServletRequest) servletRequest;
+        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        InlongRequestWrapper inlongRequestWrapper;
+        if (request instanceof ShiroHttpServletRequest) {
+            ShiroHttpServletRequest shiroWrapper = (ShiroHttpServletRequest) request;
+            inlongRequestWrapper = (InlongRequestWrapper) shiroWrapper.getRequest();
+        } else if (request instanceof InlongRequestWrapper) {
+            inlongRequestWrapper = (InlongRequestWrapper) request;
+        } else {
+            String errMsg = "request should be one of ShiroHttpServletRequest or InlongRequestWrapper type";
+            log.error(errMsg);
+            response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, errMsg);
+            return;
+        }
+        ResponseWrapper responseWrapper = new ResponseWrapper(response);
+        Span span = Span.current();
+        addAttributes(inlongRequestWrapper.getContent(), request);
+        span.addEvent("request", Attributes.builder().put("body", inlongRequestWrapper.getContent())
+                .put("URI", request.getRequestURI()).build());
+        response.addHeader("trace-id", span.getSpanContext().getTraceId());
+        filterChain.doFilter(inlongRequestWrapper, responseWrapper);
+        span.addEvent("response", Attributes.builder().put("body", responseWrapper.getContent()).build());
+    }
+
+    private void addAttributes(String body, HttpServletRequest request) {
+        try {
+            JsonNode jsonNode = JsonUtils.parseTree(body);
+            addParamInBody(jsonNode, INLONG_GROUP_ID);
+            addParamInBody(jsonNode, CLUSTER_NAME);
+            addParamInBody(jsonNode, CLUSTER_TAG);
+            addParamInBody(jsonNode, INLONG_STREAM);
+            addParamInURI(request, INLONG_GROUP_ID);
+            addParamInURI(request, CLUSTER_NAME);
+            addParamInURI(request, CLUSTER_TAG);
+            addParamInURI(request, INLONG_STREAM);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+
+    private void addParamInBody(JsonNode jsonNode, String paramName) {
+        JsonNode nodeValue = jsonNode.get(paramName);
+        if (nodeValue != null) {
+            Span.current().setAttribute(paramName, nodeValue.asText());
+        }
+    }
+
+    private void addParamInURI(HttpServletRequest request, String paramName) {
+        String param = request.getParameter(paramName);
+        if (StringUtils.isNotBlank(param)) {
+            Span.current().setAttribute(paramName, param);
+        }
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.OutputStream;
+
 @Slf4j
 public class WrapperOutputStream extends ServletOutputStream {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.trace;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.catalina.connector.CoyoteOutputStream;
 
 import javax.servlet.ServletOutputStream;
@@ -25,7 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 import java.io.OutputStream;
-
+@Slf4j
 public class WrapperOutputStream extends ServletOutputStream {
 
     private OutputStream innerOut;
@@ -45,7 +46,7 @@ public class WrapperOutputStream extends ServletOutputStream {
         try {
             return response.getOutputStream().isReady();
         } catch (IOException e) {
-            e.printStackTrace();
+            log.error("got exception when check if  the output stream is ready", e);
         }
         return false;
     }
@@ -56,7 +57,7 @@ public class WrapperOutputStream extends ServletOutputStream {
             try {
                 ((CoyoteOutputStream) response.getOutputStream()).setWriteListener(listener);
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("got exception when set write listener", e);
             }
         }
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
@@ -27,6 +27,10 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * Wrapper output stream
+ * When writing character data, write the data into the output stream of OutputStream and HttpServletResponse object at the same time.
+ */
 @Slf4j
 public class WrapperOutputStream extends ServletOutputStream {
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperOutputStream.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.trace;
+
+import org.apache.catalina.connector.CoyoteOutputStream;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class WrapperOutputStream extends ServletOutputStream {
+
+    private OutputStream innerOut;
+    private HttpServletResponse response;
+
+    public WrapperOutputStream(OutputStream innerOut, HttpServletResponse response) {
+        super();
+        this.response = response;
+        this.innerOut = innerOut;
+    }
+
+    @Override
+    public boolean isReady() {
+        if (response == null) {
+            return false;
+        }
+        try {
+            return response.getOutputStream().isReady();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    @Override
+    public void setWriteListener(WriteListener listener) {
+        if (response != null) {
+            try {
+                ((CoyoteOutputStream) response.getOutputStream()).setWriteListener(listener);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        if (response != null) {
+            response.getOutputStream().write(b);
+        }
+        innerOut.write(b);
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.trace;
+
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class WrapperWriter extends PrintWriter {
+
+    private HttpServletResponse response;
+    ByteArrayOutputStream output;
+
+    public WrapperWriter(ByteArrayOutputStream out, HttpServletResponse response) {
+        super(out);
+        this.response = response;
+        this.output = out;
+    }
+
+    @Override
+    public void write(int b) {
+        super.write(b);
+        try {
+            response.getWriter().write(b);
+        } catch (IOException e) {
+            e.printStackTrace();
+            this.setError();
+        }
+    }
+
+    @Override
+    public void write(String s, int off, int len) {
+        super.write(s, off, len);
+        try {
+            response.getWriter().write(s, off, len);
+        } catch (IOException e) {
+            e.printStackTrace();
+            this.setError();
+        }
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
@@ -23,6 +23,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * Wrapper Writer
+ * When writing character data, write the data into the output stream of ByteArrayOutputStream and HttpServletResponse object at the same time.
+ */
 public class WrapperWriter extends PrintWriter {
 
     private HttpServletResponse response;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/trace/WrapperWriter.java
@@ -35,10 +35,10 @@ public class WrapperWriter extends PrintWriter {
     }
 
     @Override
-    public void write(int b) {
-        super.write(b);
+    public void write(int c) {
+        super.write(c);
         try {
-            response.getWriter().write(b);
+            response.getWriter().write(c);
         } catch (IOException e) {
             e.printStackTrace();
             this.setError();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
@@ -158,5 +158,8 @@ public class InlongRequestWrapper extends HttpServletRequestWrapper {
     public void addParameter(String name, String value) {
         params.put(name, new String[]{value});
     }
+    public String getContent() {
+        return bodyParams;
+    }
 
 }

--- a/inlong-manager/manager-web/src/main/resources/log4j2.xml
+++ b/inlong-manager/manager-web/src/main/resources/log4j2.xml
@@ -20,7 +20,7 @@
 <configuration status="WARN" monitorInterval="30" packages="org.apache.inlong.manager.web.config">
     <properties>
         <property name="basePath">logs</property>
-        <property name="log_pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} -%5p [%5.30t] %-30.30C{1.}:%L - %mask %n</property>
+        <property name="log_pattern">[%X{trace_id} %X{span_id}] %d{yyyy-MM-dd HH:mm:ss.SSS} -%5p [%5.30t] %-30.30C{1.}:%L - %mask %n</property>
         <property name="every_file_date">1</property>
         <property name="every_file_size">1G</property>
         <property name="rolling_max">50</property>

--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,7 @@
         <jedis.version>2.9.0</jedis.version>
         <poi.version>5.2.3</poi.version>
         <woodstox-core.version>5.4.0</woodstox-core.version>
+        <otel.version>1.28.0</otel.version>
     </properties>
 
     <dependencyManagement>
@@ -210,7 +211,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.24.0</version>
+                <version>${otel.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -1267,55 +1268,12 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-trace</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-exporter-otlp-logs</artifactId>
-            <version>1.24.0-alpha</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-semconv</artifactId>
-            <version>1.24.0-alpha</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
-            <version>1.24.0-alpha</version>
-        </dependency>
-        <dependency>
-            <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-extension-annotations</artifactId>
-            <version>1.18.0</version>
+            <version>${otel.version}</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry.javaagent</groupId>
             <artifactId>opentelemetry-javaagent</artifactId>
-            <version>1.24.0</version>
+            <version>${otel.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,8 +201,8 @@
         <tomcat.version>8.5.53</tomcat.version>
         <jedis.version>2.9.0</jedis.version>
         <poi.version>5.2.3</poi.version>
-        <woodstox-core.version>5.4.0</woodstox-core.version>
         <otel.version>1.28.0</otel.version>
+        <woodstox-core.version>5.4.0</woodstox-core.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--opentelemetry-->
+            <dependency>
+                <groupId>io.opentelemetry</groupId>
+                <artifactId>opentelemetry-bom</artifactId>
+                <version>1.24.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <!-- flume dependency -->
             <dependency>
                 <groupId>org.apache.flume</groupId>
@@ -1253,6 +1261,63 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <dependencies>
+        <!--opentelemetry-->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-trace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-logging-otlp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp-logs</artifactId>
+            <version>1.24.0-alpha</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.24.0-alpha</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-autoconfigure</artifactId>
+            <version>1.24.0-alpha</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-extension-annotations</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry.javaagent</groupId>
+            <artifactId>opentelemetry-javaagent</artifactId>
+            <version>1.24.0</version>
+        </dependency>
+    </dependencies>
 
     <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1276,7 +1276,6 @@
             <version>${otel.version}</version>
         </dependency>
     </dependencies>
-
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
### Prepare a Pull Request

- Title Example: [INLONG-8611][Manager] Add full link trace.

- Fixes #8611 

### Motivation

*Inlong lacks observability, which is not conducive to link tracking and error location.*

### Modifications
Oentelemetry java agent is introduced for link embedding, collection and reporting, and span log is added to realize keyword search. It mainly includes the following functions:
- Opentelemetry java agent has automatically collected some fixed attributes for each span. In order to better meet the needs of inlong's link tracking, we have added some special attributes for span. Such as inlongGroupId, inlongstream, clusterName, clusterTag. Enter "key = value", for example, "inlongGroupId=test-group", and relevant links will be found. 
![image](https://github.com/apache/inlong/assets/53897686/8642a45e-e2b6-4a72-a6fc-191971ffbbd4)

- Whether each response succeeds or fails, the trace id of its link can be found in the response header.
![image](https://github.com/apache/inlong/assets/53897686/2d4aa3e5-37eb-400a-a012-fecb201c3625)

- An event log is added to the span of the link portal, which shows the request and response contents of the current request.
![image](https://github.com/apache/inlong/assets/53897686/28af44dc-4cc1-4a15-9deb-623940de9f43)

- In the output log, if the log belongs to a link, trace id and span id will be printed when the log is printed. 
![image](https://github.com/apache/inlong/assets/53897686/7ce683c7-b465-41c0-b316-8dd1e0b1365a)


