### PR TITLE
[INLONG-8619][Manager] Remove the inlong role check of internal interfaces

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -119,14 +119,10 @@
         order by modify_time desc
     </select>
     <select id="selectAllDataNodes" resultType="org.apache.inlong.manager.dao.entity.DataNodeEntity">
-        <bind name="_isInlongService" value="LoginUser.InlongService"/>
         select
         <include refid="Base_Column_List"/>
         from data_node
         <where>
-            <if test="_isInlongService == false">
-                tenant = #{tenant,jdbcType=VARCHAR}
-            </if>
             and is_deleted = 0
         </where>
     </select>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -376,7 +376,6 @@
         limit 10
     </select>
     <select id="selectAllGroups" resultType="org.apache.inlong.manager.pojo.sort.standalone.SortSourceGroupInfo">
-        <bind name="_isInlongService" value="LoginUser.InlongService"/>
         select inlong_group_id    as groupId,
                inlong_cluster_tag as clusterTag,
                mq_resource        as mqResource,
@@ -384,9 +383,6 @@
                mq_type            as mqType
         from inlong_group
         <where>
-            <if test="_isInlongService == false">
-               tenant = #{tenant,jdbcType=VARCHAR}
-            </if>
             and is_deleted = 0
         </where>
     </select>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8619 

### Motivation

There is no need to check the role of the internal interface call of config management. 

### Modifications

Remove the INLONG_SERVICE role requirement of **selectAllGroup** method in InlongGroupEntity.xml
Remove the INLONG_SERVICE role requirement of **selectAllDataNodeEntity** method in DataNodeEntity.xml

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
