### PR TITLE
[INLONG-8639][SDK] Improve send failed logic

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
@@ -334,6 +334,11 @@ type closeReq struct {
 	doneCh chan struct{}
 }
 
+type sendFailedBatchReq struct {
+	batch *batchReq
+	retry bool
+}
+
 func getWorkerIndex(workerID string) int {
 	if workerID == "" {
 		return -1


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-8639][DataProxy][Golang SDK] Improve send failed logic

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8639

### Motivation

When send failed, delete batch and retry in a same gorotine.

### Modifications

When send failed, delete batch and retry in a same gorotine.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
