### PR TITLE
[INLONG-8649][Agent] Fix the proxysink thread leaks when the dataproxy sdk init failed

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -183,10 +183,10 @@ public class ProxySink extends AbstractSink {
         messageFilter = initMessageFilter(jobConf);
         fieldSplitter = jobConf.get(CommonConstants.FIELD_SPLITTER, DEFAULT_FIELD_SPLITTER).getBytes(
                 StandardCharsets.UTF_8);
-        executorService.execute(flushCache());
         senderManager = new SenderManager(jobConf, inlongGroupId, sourceName);
         try {
             senderManager.Start();
+            executorService.execute(flushCache());
         } catch (Throwable ex) {
             LOGGER.error("error while init sender for group id {}", inlongGroupId);
             ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);


### PR DESCRIPTION
fix bug: proxysink thread leaks when the dataproxy sdk init failed

### Prepare a Pull Request

- Fixes #8649 

### Motivation

*proxysink thread leaks when the dataproxy sdk init failed*

### Modifications

*start the thread after the sender has manager start*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
