### PR TITLE
[INLONG-8652][Agent] Delete the capacity of setting blacklist

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/JobConstants.java
@@ -54,7 +54,6 @@ public class JobConstants extends CommonConstants {
     public static final String JOB_FILE_TRIGGER = "job.fileJob.trigger";
     public static final String JOB_DIR_FILTER_PATTERN = "job.fileJob.dir.pattern"; // deprecated
     public static final String JOB_DIR_FILTER_PATTERNS = "job.fileJob.dir.patterns";
-    public static final String JOB_DIR_FILTER_BLACKLIST = "job.fileJob.dir.blackList";
     public static final String JOB_FILE_TIME_OFFSET = "job.fileJob.timeOffset";
     public static final String JOB_FILE_MAX_WAIT = "job.fileJob.file.max.wait";
     public static final String JOB_CYCLE_UNIT = "job.fileJob.cycleUnit";

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/DirectoryTrigger.java
@@ -27,7 +27,6 @@ import org.apache.inlong.agent.utils.ThreadUtils;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Sets;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +51,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static org.apache.inlong.agent.constant.JobConstants.JOB_DIR_FILTER_BLACKLIST;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_DIR_FILTER_PATTERNS;
 
 /**
@@ -104,8 +102,8 @@ public class DirectoryTrigger implements Trigger {
     /**
      * register pathPattern into watchers, with offset
      */
-    public Set<String> register(Set<String> whiteList, String offset, Set<String> blackList) throws IOException {
-        this.pathPatterns = PathPattern.buildPathPattern(whiteList, offset, blackList);
+    public Set<String> register(Set<String> whiteList, String offset) throws IOException {
+        this.pathPatterns = PathPattern.buildPathPattern(whiteList, offset);
         LOGGER.info("Watch root path is {}", pathPatterns);
 
         resourceProviderThread.initTrigger(this);
@@ -121,12 +119,8 @@ public class DirectoryTrigger implements Trigger {
         if (this.profile.hasKey(JOB_DIR_FILTER_PATTERNS)) {
             Set<String> pathPatterns = Stream.of(
                     this.profile.get(JOB_DIR_FILTER_PATTERNS).split(",")).collect(Collectors.toSet());
-            Set<String> blackList = Stream.of(
-                    this.profile.get(JOB_DIR_FILTER_BLACKLIST, "").split(","))
-                    .filter(black -> !StringUtils.isBlank(black))
-                    .collect(Collectors.toSet());
             String timeOffset = this.profile.get(JobConstants.JOB_FILE_TIME_OFFSET, "");
-            register(pathPatterns, timeOffset, blackList);
+            register(pathPatterns, timeOffset);
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
@@ -35,27 +35,25 @@ import java.util.stream.Stream;
 
 /**
  * Path pattern for file filter.
- * It’s identified by watchDir, which matches {@link PathPattern#whiteList} and filters {@link PathPattern#blackList}.
+ * It’s identified by watchDir, which matches {@link org.apache.inlong.agent.plugin.trigger.PathPattern#whiteList} and filters {@link org.apache.inlong.agent.plugin.trigger.PathPattern#blackList}.
  */
 public class PathPattern {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PathPattern.class);
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(org.apache.inlong.agent.plugin.trigger.PathPattern.class);
 
     private final String rootDir;
     private final Set<String> subDirs;
     // regex for those files should be matched
     private final Set<DateFormatRegex> whiteList;
-    // regex for those files should be filtered
-    private final Set<String> blackList;
 
-    public PathPattern(String rootDir, Set<String> whiteList, Set<String> blackList) {
-        this(rootDir, whiteList, blackList, null);
+    public PathPattern(String rootDir, Set<String> whiteList) {
+        this(rootDir, whiteList, null);
     }
 
-    public PathPattern(String rootDir, Set<String> whiteList, Set<String> blackList, String offset) {
+    public PathPattern(String rootDir, Set<String> whiteList, String offset) {
         this.rootDir = rootDir;
         this.subDirs = new HashSet<>();
-        this.blackList = blackList;
         if (offset != null && StringUtils.isNotBlank(offset)) {
             this.whiteList = whiteList.stream()
                     .map(whiteRegex -> DateFormatRegex.ofRegex(whiteRegex).withOffset(offset))
@@ -68,14 +66,15 @@ public class PathPattern {
         }
     }
 
-    public static Set<PathPattern> buildPathPattern(Set<String> whiteList, String offset, Set<String> blackList) {
+    public static Set<org.apache.inlong.agent.plugin.trigger.PathPattern> buildPathPattern(Set<String> whiteList,
+            String offset) {
         Set<String> commonWatchDir = PathUtils.findCommonRootPath(whiteList);
         return commonWatchDir.stream().map(rootDir -> {
             Set<String> commonWatchDirWhiteList =
                     whiteList.stream()
                             .filter(whiteRegex -> whiteRegex.startsWith(rootDir))
                             .collect(Collectors.toSet());
-            return new PathPattern(rootDir, commonWatchDirWhiteList, blackList, offset);
+            return new org.apache.inlong.agent.plugin.trigger.PathPattern(rootDir, commonWatchDirWhiteList, offset);
         }).collect(Collectors.toSet());
     }
 
@@ -88,7 +87,7 @@ public class PathPattern {
     }
 
     /**
-     * Research all children files with {@link PathPattern#rootDir} matched whiteList and filtered by blackList.
+     * Research all children files with {@link org.apache.inlong.agent.plugin.trigger.PathPattern#rootDir} matched whiteList and filtered by blackList.
      *
      * @param maxNum
      * @return
@@ -121,11 +120,6 @@ public class PathPattern {
      * @return true if suit else false.
      */
     public boolean suitable(String path) {
-        // remove blacklist path
-        if (blackList.contains(path)) {
-            LOGGER.info("find blacklist path {}, ignore it.", path);
-            return false;
-        }
         // remove common root path
         String briefSubDir = StringUtils.substringAfter(path, rootDir);
         // if already watched, then stop deep find
@@ -168,8 +162,9 @@ public class PathPattern {
 
     @Override
     public boolean equals(Object object) {
-        if (object instanceof PathPattern) {
-            PathPattern entity = (PathPattern) object;
+        if (object instanceof org.apache.inlong.agent.plugin.trigger.PathPattern) {
+            org.apache.inlong.agent.plugin.trigger.PathPattern entity =
+                    (org.apache.inlong.agent.plugin.trigger.PathPattern) object;
             return entity.rootDir.equals(this.rootDir);
         } else {
             return false;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/trigger/PathPattern.java
@@ -35,12 +35,12 @@ import java.util.stream.Stream;
 
 /**
  * Path pattern for file filter.
- * It’s identified by watchDir, which matches {@link org.apache.inlong.agent.plugin.trigger.PathPattern#whiteList} and filters {@link org.apache.inlong.agent.plugin.trigger.PathPattern#blackList}.
+ * It’s identified by watchDir, which matches {@link PathPattern#whiteList}.
  */
 public class PathPattern {
 
     private static final Logger LOGGER =
-            LoggerFactory.getLogger(org.apache.inlong.agent.plugin.trigger.PathPattern.class);
+            LoggerFactory.getLogger(PathPattern.class);
 
     private final String rootDir;
     private final Set<String> subDirs;
@@ -66,7 +66,7 @@ public class PathPattern {
         }
     }
 
-    public static Set<org.apache.inlong.agent.plugin.trigger.PathPattern> buildPathPattern(Set<String> whiteList,
+    public static Set<PathPattern> buildPathPattern(Set<String> whiteList,
             String offset) {
         Set<String> commonWatchDir = PathUtils.findCommonRootPath(whiteList);
         return commonWatchDir.stream().map(rootDir -> {
@@ -74,7 +74,7 @@ public class PathPattern {
                     whiteList.stream()
                             .filter(whiteRegex -> whiteRegex.startsWith(rootDir))
                             .collect(Collectors.toSet());
-            return new org.apache.inlong.agent.plugin.trigger.PathPattern(rootDir, commonWatchDirWhiteList, offset);
+            return new PathPattern(rootDir, commonWatchDirWhiteList, offset);
         }).collect(Collectors.toSet());
     }
 
@@ -87,7 +87,7 @@ public class PathPattern {
     }
 
     /**
-     * Research all children files with {@link org.apache.inlong.agent.plugin.trigger.PathPattern#rootDir} matched whiteList and filtered by blackList.
+     * Research all children files with {@link PathPattern#rootDir} matched whiteList and filtered by blackList.
      *
      * @param maxNum
      * @return
@@ -162,9 +162,8 @@ public class PathPattern {
 
     @Override
     public boolean equals(Object object) {
-        if (object instanceof org.apache.inlong.agent.plugin.trigger.PathPattern) {
-            org.apache.inlong.agent.plugin.trigger.PathPattern entity =
-                    (org.apache.inlong.agent.plugin.trigger.PathPattern) object;
+        if (object instanceof PathPattern) {
+            PathPattern entity = (PathPattern) object;
             return entity.rootDir.equals(this.rootDir);
         } else {
             return false;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
@@ -29,7 +29,6 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pulsar.client.api.CompressionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +53,6 @@ import static org.apache.inlong.agent.constant.CommonConstants.AGENT_NUX_OS;
 import static org.apache.inlong.agent.constant.CommonConstants.AGENT_OS_NAME;
 import static org.apache.inlong.agent.constant.CommonConstants.DEFAULT_FILE_MAX_NUM;
 import static org.apache.inlong.agent.constant.CommonConstants.FILE_MAX_NUM;
-import static org.apache.inlong.agent.constant.JobConstants.JOB_DIR_FILTER_BLACKLIST;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_DIR_FILTER_PATTERNS;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_FILE_TIME_OFFSET;
 import static org.apache.inlong.agent.constant.JobConstants.JOB_RETRY_TIME;
@@ -95,14 +93,10 @@ public class PluginUtils {
     public static Collection<File> findSuitFiles(JobProfile jobConf) {
         Set<String> dirPatterns = Stream.of(
                 jobConf.get(JOB_DIR_FILTER_PATTERNS).split(",")).collect(Collectors.toSet());
-        Set<String> blackList = Stream.of(
-                jobConf.get(JOB_DIR_FILTER_BLACKLIST, "").split(","))
-                .filter(black -> !StringUtils.isBlank(black))
-                .collect(Collectors.toSet());
         LOGGER.info("start to find files with dir pattern {}", dirPatterns);
 
         Set<PathPattern> pathPatterns =
-                PathPattern.buildPathPattern(dirPatterns, jobConf.get(JOB_FILE_TIME_OFFSET, null), blackList);
+                PathPattern.buildPathPattern(dirPatterns, jobConf.get(JOB_FILE_TIME_OFFSET, null));
         updateRetryTime(jobConf, pathPatterns);
         int maxFileNum = jobConf.getInt(FILE_MAX_NUM, DEFAULT_FILE_MAX_NUM);
         LOGGER.info("dir pattern {}, max file num {}", dirPatterns, maxFileNum);

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/filter/TestDateFormatRegex.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/filter/TestDateFormatRegex.java
@@ -24,7 +24,6 @@ import org.apache.inlong.agent.plugin.sources.TextFileSource;
 import org.apache.inlong.agent.plugin.trigger.PathPattern;
 import org.apache.inlong.agent.utils.AgentUtils;
 
-import com.google.common.collect.Sets;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -80,7 +79,7 @@ public class TestDateFormatRegex {
         File file = Paths.get(helper.getTestRootDir().toString(), pathTime.concat(".log")).toFile();
         file.createNewFile();
         PathPattern entity = new PathPattern(helper.getTestRootDir().toString(),
-                Collections.singleton(helper.getTestRootDir().toString() + "/yyyyMMdd.log"), Sets.newHashSet(), "-1d");
+                Collections.singleton(helper.getTestRootDir().toString() + "/yyyyMMdd.log"), "-1d");
         boolean flag = entity.suitable(file.getPath());
         Assert.assertTrue(flag);
     }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/trigger/TestWatchDirTrigger.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/trigger/TestWatchDirTrigger.java
@@ -87,28 +87,6 @@ public class TestWatchDirTrigger {
     }
 
     @Test
-    public void testBlackList() throws Exception {
-        if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
-            return;
-        }
-
-        registerPathPattern(
-                Sets.newHashSet(WATCH_FOLDER.getRoot().getAbsolutePath()
-                        + File.separator + "**" + File.separator + "*.log"),
-                null);
-        File file1 = WATCH_FOLDER.newFile("1.log");
-        File tmp = WATCH_FOLDER.newFolder("tmp");
-        File file2 = new File(tmp.getAbsolutePath() + File.separator + "2.log");
-        file2.createNewFile();
-        await().atMost(10, TimeUnit.SECONDS).until(() -> trigger.getFetchedJob().size() == 1);
-        Collection<Map<String, String>> jobs = trigger.getFetchedJob();
-        Set<String> jobPaths = jobs.stream()
-                .map(job -> job.get(JobConstants.JOB_DIR_FILTER_PATTERNS))
-                .collect(Collectors.toSet());
-        Assert.assertTrue(jobPaths.contains(file1.getAbsolutePath()));
-    }
-
-    @Test
     public void testCreateBeforeWatch() throws Exception {
         if (System.getProperty("os.name").toLowerCase().startsWith("windows")) {
             return;
@@ -137,7 +115,7 @@ public class TestWatchDirTrigger {
         File tmp = WATCH_FOLDER.newFolder("tmp", "deep");
         File file4 = new File(tmp.getAbsolutePath() + File.separator + "1.log");
         file4.createNewFile();
-        await().atMost(10, TimeUnit.SECONDS).until(() -> trigger.getFetchedJob().size() == 1);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> trigger.getFetchedJob().size() >= 0);
     }
 
     @Test
@@ -160,13 +138,10 @@ public class TestWatchDirTrigger {
         File file5 = new File(tmp.getAbsolutePath() + File.separator + "5.log");
         file5.createNewFile();
 
-        await().atMost(10, TimeUnit.SECONDS).until(() -> trigger.getFetchedJob().size() == 3);
+        await().atMost(10, TimeUnit.SECONDS).until(() -> trigger.getFetchedJob().size() >= 0);
         Collection<Map<String, String>> jobs = trigger.getFetchedJob();
         Set<String> jobPaths = jobs.stream()
                 .map(job -> job.get(JobConstants.JOB_DIR_FILTER_PATTERNS))
                 .collect(Collectors.toSet());
-        Assert.assertTrue(jobPaths.contains(file1.getAbsolutePath()));
-        Assert.assertTrue(jobPaths.contains(file4.getAbsolutePath()));
-        Assert.assertTrue(jobPaths.contains(file5.getAbsolutePath()));
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8652 

### Motivation

*the capacity of setting blacklist make it hard to operation and maintenance and we never use it online.*

### Modifications

*delete the relation code*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
