### PR TITLE
[INLONG-8642][Audit] Remove the audit commons-text dependency

### DIFF
--- a/inlong-audit/pom.xml
+++ b/inlong-audit/pom.xml
@@ -56,6 +56,12 @@
         <dependency>
             <groupId>org.apache.flume</groupId>
             <artifactId>flume-ng-node</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.flume</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8642

### Motivation

*Remove the audit commons-text dependency, because audit does not use it, but this library will trigger security issues.*

### Modifications

*Remove the commons-text in the audit pom.*
