### PR TITLE
[INLONG-8667][Sort] Fix the class name error in OracleSnapshotContext

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleScanFetchTask.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleScanFetchTask.java
@@ -298,14 +298,14 @@ public class OracleScanFetchTask implements FetchTask<SourceSplitBase> {
         @Override
         protected SnapshotContext prepare(ChangeEventSourceContext changeEventSourceContext)
                 throws Exception {
-            return new MySqlSnapshotContext();
+            return new OracleSnapshotContext();
         }
 
-        private static class MySqlSnapshotContext
+        private static class OracleSnapshotContext
                 extends
                     RelationalSnapshotChangeEventSource.RelationalSnapshotContext {
 
-            public MySqlSnapshotContext() throws SQLException {
+            public OracleSnapshotContext() throws SQLException {
                 super("");
             }
         }


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8667][Sort] Fix the class name error in OracleSnapshotContext

- Fixes #8667 

### Motivation

In Oracle CDC, this should be `OracleSnapshotContext`, not `MySqlSnapshotContext`.

<img width="1063" alt="image" src="https://github.com/apache/inlong/assets/111486498/f7a791b4-bb9d-44b5-8345-6553731631e8">


### Modifications

Rename `MySqlSnapshotContext` to `OracleSnapshotContext`.
