### PR TITLE
[INLONG-8671][Manager] Fix no method parameter of form data in POST request

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/HttpContextUtils.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/HttpContextUtils.java
@@ -74,6 +74,7 @@ public class HttpContextUtils {
                 }
             }
         }
+        paramMap.putAll(request.getParameterMap());
         return paramMap;
     }
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/utils/InlongRequestWrapper.java
@@ -51,9 +51,14 @@ public class InlongRequestWrapper extends HttpServletRequestWrapper {
 
     public InlongRequestWrapper(HttpServletRequest request) {
         super(request);
-        this.bodyParams = HttpContextUtils.getBodyString(request);
         this.params = HttpContextUtils.getParameterMap(request);
+        this.bodyParams = HttpContextUtils.getBodyString(request);
         this.headers = HttpContextUtils.getHeaderMapAll(request);
+    }
+
+    @Override
+    public int getContentLength() {
+        return bodyParams.length();
     }
 
     @Override


### PR DESCRIPTION

### Prepare a Pull Request

- Fixes #8671

### Motivation

<img width="1415" alt="image" src="https://github.com/apache/inlong/assets/45282474/798b0830-dd0b-439c-9d04-bd04fde0dcef">
Find no method parameter data iff the request is POST method and use x-www-form-urlencoded format.

This bug is due to the InlongRequestWrapper only parse the data in query string as the parameters.
But in HTTP standards, the x-www-form-urlencoded format with POST method request should parse the body as the parameters too.

### Modifications

1. Parse parameterMap as HTTP standard first.
2. Adjust the order of parameter parsing and body parsing.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
