### PR TITLE
[INLONG-8679][DataProxy] Migrate index-related variables to abstract classes

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -306,7 +306,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
                     msgCodec.getTopicName(), msgCodec.getStrRemoteIP(), msgCodec.getMsgProcType(),
                     msgCodec.getDataTimeMs(), msgCodec.getMsgPkgTime(), 1);
             source.addMetric(false, event.getBody().length, event);
-            if (msgCodec.isNeedResp() && !msgCodec.isOrderOrProxy()) {
+            if (msgCodec.isNeedResp()) {
                 msgCodec.setFailureInfo(DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,
                         strBuff.append("Put event to channel failure: ").append(ex.getMessage()).toString());
                 strBuff.delete(0, strBuff.length());

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/AbsV0MsgCodec.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/AbsV0MsgCodec.java
@@ -62,6 +62,8 @@ public abstract class AbsV0MsgCodec {
     protected String topicName;
     protected String msgSeqId = "";
     protected long uniq = -1L;
+    protected boolean indexMsg = false;
+    protected boolean fileCheckMsg = false;
     protected boolean isOrderOrProxy = false;
     protected String msgProcType = "b2b";
     protected boolean needResp = true;
@@ -87,6 +89,10 @@ public abstract class AbsV0MsgCodec {
 
     public String getErrMsg() {
         return this.errMsg;
+    }
+
+    public boolean isIndexMsg() {
+        return indexMsg;
     }
 
     public boolean isNeedResp() {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
@@ -60,8 +60,6 @@ public class CodecBinMsg extends AbsV0MsgCodec {
     private long dataTimeSec;
     private boolean num2name = false;
     private boolean transNum2Name = false;
-    private boolean indexMsg = false;
-    private boolean fileCheckMsg = false;
     private boolean needTraceMsg = false;
 
     public CodecBinMsg(int totalDataLen, int msgTypeValue,


### PR DESCRIPTION

- Fixes #8679

1. Migrate the fields related to index messages in CodecBinMsg, such as indexMsg and fileCheckMsg, to the abstract class AbsV0MsgCodec
2. Remove unnecessary checks when message delivery to Channel fails