### PR TITLE
[INLONG-8701][TubeMQ] Fix Master dashboard respond always true when some operation complete

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
@@ -88,6 +88,20 @@ public class WebParameterUtils {
         return sBuffer.append("],\"count\":").append(totalCnt).append("}");
     }
 
+    public static void buildFailWithDataRetBegin(StringBuilder sBuffer,int errCode, String errMsg){
+        sBuffer.append("{\"result\":true,\"errCode\":")
+                .append(errCode)
+                .append(",\"errMsg\":\"Happens one err at least:")
+                .append(errMsg)
+                .append("\",\"data\":[");
+    }
+
+    public static void buildFailWithDataRetEnd(StringBuilder sBuffer, int totalCnt){
+        sBuffer.append("],\"count\":")
+                .append(totalCnt)
+                .append("}");
+    }
+
     /**
      * Parse the parameter value required for add update and delete
      *

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/utils/WebParameterUtils.java
@@ -59,33 +59,33 @@ public class WebParameterUtils {
     private static final List<String> allowedDelUnits = Arrays.asList("s", "m", "h");
     private static final List<Integer> allowedPriorityVal = Arrays.asList(1, 2, 3);
 
-    public static StringBuilder buildFailResult(StringBuilder sBuffer, String errMsg) {
-        return sBuffer.append("{\"result\":false,\"errCode\":400,\"errMsg\":\"")
+    public static void buildFailResult(StringBuilder sBuffer, String errMsg) {
+        sBuffer.append("{\"result\":false,\"errCode\":400,\"errMsg\":\"")
                 .append(errMsg).append("\"}");
     }
 
-    public static StringBuilder buildFailResultWithBlankData(int errcode, String errMsg,
+    public static void buildFailResultWithBlankData(int errcode, String errMsg,
             StringBuilder sBuffer) {
-        return sBuffer.append("{\"result\":false,\"errCode\":").append(errcode)
+        sBuffer.append("{\"result\":false,\"errCode\":").append(errcode)
                 .append(",\"errMsg\":\"").append(errMsg).append("\",\"data\":[]}");
     }
 
-    public static StringBuilder buildSuccessResult(StringBuilder sBuffer) {
-        return sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"OK\",\"data\":[]}");
+    public static void buildSuccessResult(StringBuilder sBuffer) {
+        sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"OK\",\"data\":[]}");
     }
 
-    public static StringBuilder buildSuccessResult(StringBuilder sBuffer, String appendInfo) {
-        return sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"")
+    public static void buildSuccessResult(StringBuilder sBuffer, String appendInfo) {
+        sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"")
                 .append(appendInfo).append("\",\"data\":[]}");
     }
 
-    public static StringBuilder buildSuccessWithDataRetBegin(StringBuilder sBuffer) {
-        return sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"OK\",\"data\":[");
+    public static void buildSuccessWithDataRetBegin(StringBuilder sBuffer) {
+        sBuffer.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"OK\",\"data\":[");
     }
 
-    public static StringBuilder buildSuccessWithDataRetEnd(
+    public static void buildSuccessWithDataRetEnd(
             StringBuilder sBuffer, int totalCnt) {
-        return sBuffer.append("],\"count\":").append(totalCnt).append("}");
+        sBuffer.append("],\"count\":").append(totalCnt).append("}");
     }
 
     public static void buildFailWithDataRetBegin(StringBuilder sBuffer,int errCode, String errMsg){

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebBrokerConfHandler.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/master/web/handler/WebBrokerConfHandler.java
@@ -1045,18 +1045,34 @@ public class WebBrokerConfHandler extends AbstractWebHandler {
     private StringBuilder buildRetInfo(List<BrokerProcessResult> retInfo,
             StringBuilder sBuffer) {
         int totalCnt = 0;
-        WebParameterUtils.buildSuccessWithDataRetBegin(sBuffer);
+        StringBuilder actionMiddleProxy = new StringBuilder();
+        boolean isSussess = true;
+        int errCode = 0;
+        String errInfo = "";
         for (BrokerProcessResult entry : retInfo) {
             if (totalCnt++ > 0) {
-                sBuffer.append(",");
+                actionMiddleProxy.append(",");
             }
-            sBuffer.append("{\"brokerId\":").append(entry.getBrokerId())
+            actionMiddleProxy.append("{\"brokerId\":").append(entry.getBrokerId())
                     .append(",\"brokerIp\":\"").append(entry.getBrokerIp())
                     .append("\",\"success\":").append(entry.isSuccess())
                     .append(",\"errCode\":").append(entry.getErrCode())
                     .append(",\"errInfo\":\"").append(entry.getErrMsg()).append("\"}");
+            if (isSussess && !entry.isSuccess()){
+                isSussess = false;
+                errInfo = entry.getErrMsg();
+                errCode = entry.getErrCode();
+            }
         }
-        WebParameterUtils.buildSuccessWithDataRetEnd(sBuffer, totalCnt);
+        if (isSussess) {
+            WebParameterUtils.buildSuccessWithDataRetBegin(sBuffer);
+            sBuffer.append(actionMiddleProxy);
+            WebParameterUtils.buildSuccessWithDataRetEnd(sBuffer, totalCnt);
+        }else{
+            WebParameterUtils.buildFailWithDataRetBegin(sBuffer, errCode, errInfo);
+            sBuffer.append(actionMiddleProxy);
+            WebParameterUtils.buildFailWithDataRetEnd(sBuffer,totalCnt);
+        }
         return sBuffer;
     }
 


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8701 

### Motivation

Fix Master dashboard respond always true when some operation complete

### Modifications

- Add dealing with error logic
- refactor some unnecessary func ret

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
