### PR TITLE
[INLONG-8684][Dashboard] Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//)

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,24 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ Licensed to the Apache Software Foundation (ASF) under one or more
-  ~ contributor license agreements.  See the NOTICE file distributed with
-  ~ this work for additional information regarding copyright ownership.
-  ~ The ASF licenses this file to You under the Apache License, Version 2.0
-  ~ (the "License"); you may not use this file except in compliance with
-  ~ the License.  You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
 <project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
   <component name="IssueNavigationConfiguration">
     <option name="links">
       <list>
@@ -32,5 +13,9 @@
         </IssueNavigationLink>
       </list>
     </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/inlong" vcs="Git" />
   </component>
 </project>

--- a/inlong-dashboard/package-lock.json
+++ b/inlong-dashboard/package-lock.json
@@ -15797,7 +15797,7 @@
       "dev": true
     },
     "vite": {
-      "version": "3.0.9",
+      "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/vite/-/vite-3.0.9.tgz",
       "integrity": "sha512-waYABTM+G6DBTCpYAxvevpG50UOlZuynR0ckTK5PawNVt7ebX6X7wNXHaGIO6wYYFXSM7/WcuFuO2QzhBB6aMw==",
       "dev": true,


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes https://github.com/apache/inlong/issues/8684

### Motivation

To solve the problem that Vite Server Options (server.fs.deny) can be bypassed using double forward-slash (//).

### Modifications

Upgrade vite to version 3.2.7 

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature?  no
 