### PR TITLE
[INLONG-8681][Security] Upgrade io.netty:netty-handler to version 4.1.94

### DIFF
--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -415,7 +415,7 @@ The text of each license is the standard Apache 2.0 license.
   io.netty:netty-buffer:4.1.72.Final - Netty/Buffer (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
   io.netty:netty-codec:4.1.72.Final - Netty/Codec (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
   io.netty:netty-common:4.1.72.Final - Netty/Common (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
-  io.netty:netty-handler:4.1.72.Final - Netty/Handler (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
+  io.netty:netty-handler:4.1.94.Final - Netty/Handler (https://github.com/netty/netty/tree/netty-4.1.94.Final), (Apache License, Version 2.0)
   io.netty:netty-resolver:4.1.72.Final - Netty/Resolver (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
   io.netty:netty-transport:4.1.72.Final - Netty/Transport (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)
   io.netty:netty-transport-classes-epoll:4.1.72.Final - Netty/Transport/Classes/Epoll (https://github.com/netty/netty/tree/netty-4.1.72.Final), (Apache License, Version 2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <testcontainers.version>1.17.2</testcontainers.version>
         <docker.organization>inlong</docker.organization>
 
-        <netty.version>4.1.72.Final</netty.version>
+        <netty.version>4.1.94.Final</netty.version>
         <jboss.netty.version>3.10.6.Final</jboss.netty.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.4</spark.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes https://github.com/apache/inlong/issues/8681

### Motivation

The SniHandler can allocate up to 16MB of heap for each channel during the TLS handshake. When the handler orthe channel does not have an idle timeout, it can be used to make a TCP server using the SniHandler to allocate
16MB of heap.

### Modifications

Upgrade io.netty:netty-handler to version 4.1.94 and edit licenses/inlong-agent/LICENSE

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
