### PR TITLE
[INLONG-8716][TubeMQ] set error code 0 when it works

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
@@ -561,7 +561,7 @@ public class BrokerServiceServer implements BrokerReadService, BrokerWriteServic
                 List<Message> messageList = DataConverterUtil.convertMessage(topicName, tmpMsgList);
                 int i = 0;
                 int startPos = Math.max(messageList.size() - msgCount, 0);
-                sb.append("{\"result\":true,\"errCode\":200,\"errMsg\":\"Success!\",\"dataSet\":[");
+                sb.append("{\"result\":true,\"errCode\":0,\"errMsg\":\"Success!\",\"dataSet\":[");
                 for (; startPos < messageList.size(); startPos++) {
                     if (i > 0) {
                         sb.append(",");


### PR DESCRIPTION
- Fixes #8716

Adjust the errCode value of the outer layer of the API, and successfully unify it to 0