### PR TITLE
[INLONG-8725][DataProxy] Cache file metric output switch value at usage location

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/SinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/common/SinkContext.java
@@ -66,6 +66,7 @@ public class SinkContext {
     // file metric statistic
     protected MonitorIndex monitorIndex = null;
     private MonitorStats monitorStats = null;
+    private final boolean enableFileMetric;
 
     /**
      * Constructor
@@ -78,6 +79,7 @@ public class SinkContext {
         this.maxThreads = sinkContext.getInteger(KEY_MAX_THREADS, 10);
         this.processInterval = sinkContext.getInteger(KEY_PROCESSINTERVAL, 100);
         this.reloadInterval = sinkContext.getLong(KEY_RELOADINTERVAL, 60000L);
+        this.enableFileMetric = CommonConfigHolder.getInstance().isEnableFileMetric();
         //
         this.metricItemSet = new DataProxyMetricItemSet(sinkName);
         MetricRegister.register(this.metricItemSet);
@@ -88,7 +90,7 @@ public class SinkContext {
      */
     public void start() {
         // init monitor logic
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             this.monitorIndex = new MonitorIndex(CommonConfigHolder.getInstance().getFileMetricSinkOutName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec() * 1000L,
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
@@ -107,7 +109,7 @@ public class SinkContext {
      */
     public void close() {
         // stop file statistic index
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             if (monitorIndex != null) {
                 monitorIndex.stop();
             }
@@ -118,21 +120,20 @@ public class SinkContext {
     }
 
     public void fileMetricIncSumStats(String eventKey) {
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             monitorStats.incSumStats(eventKey);
         }
     }
 
     public void fileMetricIncWithDetailStats(String eventKey, String detailInfoKey) {
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             monitorStats.incSumStats(eventKey);
             monitorStats.incDetailStats(eventKey + "#" + detailInfoKey);
         }
     }
 
     public void fileMetricAddSuccStats(PackProfile profile, String topic, String brokerIP) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()
-                || !(profile instanceof SimplePackProfile)) {
+        if (!enableFileMetric || !(profile instanceof SimplePackProfile)) {
             return;
         }
         fileMetricIncStats((SimplePackProfile) profile, true,
@@ -140,8 +141,7 @@ public class SinkContext {
     }
 
     public void fileMetricAddFailStats(PackProfile profile, String topic, String brokerIP, String detailKey) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()
-                || !(profile instanceof SimplePackProfile)) {
+        if (!enableFileMetric || !(profile instanceof SimplePackProfile)) {
             return;
         }
         fileMetricIncStats((SimplePackProfile) profile, false,
@@ -149,8 +149,7 @@ public class SinkContext {
     }
 
     public void fileMetricAddExceptStats(PackProfile profile, String topic, String brokerIP, String detailKey) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()
-                || !(profile instanceof SimplePackProfile)) {
+        if (!enableFileMetric || !(profile instanceof SimplePackProfile)) {
             return;
         }
         fileMetricIncStats((SimplePackProfile) profile, false,

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
@@ -128,10 +128,13 @@ public abstract class BaseSource
     private MonitorStats monitorStats = null;
     // metric set
     private DataProxyMetricItemSet metricItemSet;
+    // whether enable file metric
+    protected boolean enableFileMetric;
 
     public BaseSource() {
         super();
         allChannels = new DefaultChannelGroup("DefaultChannelGroup", GlobalEventExecutor.INSTANCE);
+        this.enableFileMetric = CommonConfigHolder.getInstance().isEnableFileMetric();
     }
 
     @Override
@@ -256,7 +259,7 @@ public abstract class BaseSource
                 CommonConfigHolder.getInstance().getClusterName(), this.cachedSrcName, String.valueOf(srcPort));
         MetricRegister.register(metricItemSet);
         // init monitor logic
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             this.monitorIndex = new MonitorIndex(CommonConfigHolder.getInstance().getFileMetricSourceOutName(),
                     CommonConfigHolder.getInstance().getFileMetricStatInvlSec() * 1000L,
                     CommonConfigHolder.getInstance().getFileMetricStatCacheCnt());
@@ -304,7 +307,7 @@ public abstract class BaseSource
             this.workerGroup.shutdownGracefully();
         }
         // stop file statistic index
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             if (monitorIndex != null) {
                 monitorIndex.stop();
             }
@@ -409,13 +412,13 @@ public abstract class BaseSource
     }
 
     public void fileMetricIncSumStats(String eventKey) {
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             monitorStats.incSumStats(eventKey);
         }
     }
 
     public void fileMetricIncDetailStats(String eventKey) {
-        if (CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (enableFileMetric) {
             monitorStats.incDetailStats(eventKey);
         }
     }
@@ -436,7 +439,7 @@ public abstract class BaseSource
     private void fileMetricIncStats(StringBuilder strBuff, boolean isSucc, String groupId,
             String streamId, String topicName, String clientIP, String msgProcType,
             long dt, long pkgTime, int cnt, int packCnt, long packSize, int failCnt) {
-        if (!CommonConfigHolder.getInstance().isEnableFileMetric()) {
+        if (!enableFileMetric) {
             return;
         }
         String tenMinsDt = DateTimeUtils.ms2yyyyMMddHHmmTenMins(dt);


### PR DESCRIPTION

- Fixes #8725

1. Cache file metrics output values in BaseSource
2. Cache file indicator output value in SinkContext
3. Optimize the implementation of the responseV0Msg function of the SimplePackProfile class, adjust the parameter name and code block placement