### PR TITLE
[INLONG-8729][DataProxy] Wrong result in the addSendResultMetric function also reports success

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -134,8 +134,10 @@ public class MessageQueueZoneSinkContext extends SinkContext {
     public void addSendResultMetric(PackProfile currentRecord, String mqName, String topic, boolean result,
             long sendTime) {
         if (currentRecord instanceof SimplePackProfile) {
-            AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_SEND_SUCCESS,
-                    ((SimplePackProfile) currentRecord).getEvent());
+            if (result) {
+                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_SEND_SUCCESS,
+                        ((SimplePackProfile) currentRecord).getEvent());
+            }
             return;
         }
         BatchPackProfile batchProfile = (BatchPackProfile) currentRecord;


### PR DESCRIPTION

- Fixes #8729

For SimplePackProfile type messages, only successful operations are counted