### PR TITLE
[INLONG-8728][SDK] Optimize the problem of third-party openssl library dependency

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
@@ -24,14 +24,14 @@ project(DataProxySDK)
 # compile level -O2
 set(CMAKE_CXX_FLAGS "-std=c++11 -O2 -g -Wall  -Wsign-compare -Wfloat-equal -fno-strict-aliasing -fPIC -DASIO_STANDALONE")
 
-include_directories(${CMAKE_BINARY_DIR}/third_party/include)
-include_directories(${CMAKE_BINARY_DIR}/third_party/rapidjson/src/rapidjson/include)
+include_directories(${PROJECT_SOURCE_DIR}/third_party/include)
+include_directories(${PROJECT_SOURCE_DIR}/third_party/rapidjson/src/rapidjson/include)
 include_directories(release/inc)
 include_directories(src/base)
 include_directories(src/net)
 
-link_directories(${CMAKE_BINARY_DIR}/third_party/lib)
-link_directories(${CMAKE_BINARY_DIR}/third_party/lib64)
+link_directories(${PROJECT_SOURCE_DIR}/third_party/lib)
+link_directories(${PROJECT_SOURCE_DIR}/third_party/lib64)
 
 add_subdirectory(third_party)
 add_subdirectory(src/base)

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
@@ -28,30 +28,28 @@ include(ExternalProject)
 ExternalProject_Add(
     snappy_proj
     URL https://github.com/google/snappy/archive/1.1.8.tar.gz
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/third_party/
     CMAKE_ARGS
-    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR}
     -DSNAPPY_BUILD_TESTS=OFF
     -DHAVE_LIBLZO2=OFF
     -DCMAKE_CXX_FLAGS=-fPIC
     TEST_BEFORE_INSTALL 0
     BUILD_IN_SOURCE 1
-    )
+)
 
 ExternalProject_Add(
     curl_proj
     URL https://github.com/curl/curl/releases/download/curl-7_78_0/curl-7.78.0.tar.gz
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/third_party/
-    CONFIGURE_COMMAND ./configure --prefix=<INSTALL_DIR> --without-zlib --without-ssl --disable-shared --disable-ldap && make install
+    CONFIGURE_COMMAND ./configure --prefix=${PROJECT_SOURCE_DIR} --without-zlib --without-ssl --disable-shared --disable-ldap && make install
     TEST_BEFORE_INSTALL 0
     BUILD_IN_SOURCE 1
-    )
+)
 
 ExternalProject_Add(
     rapidjson
     PREFIX "rapidjson"
     URL "https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz"
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/third_party/
+    INSTALL_DIR ${PROJECT_SOURCE_DIR}
     CMAKE_ARGS
     -DRAPIDJSON_BUILD_TESTS=OFF
     -DRAPIDJSON_BUILD_DOC=OFF
@@ -60,15 +58,22 @@ ExternalProject_Add(
     BUILD_COMMAND ""
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
-    )
+)
 
 ExternalProject_Add(
-    asio_proj
-    URL https://github.com/chriskohlhoff/asio/archive/asio-1-18-0.tar.gz 
-    INSTALL_DIR ${CMAKE_BINARY_DIR}/third_party/
-    CONFIGURE_COMMAND cd ../asio_proj/asio && ./autogen.sh && ./configure --prefix=<INSTALL_DIR> CFLAGS=-std=c++11 CPPFLAGS=-std=c++11 CXXFLAGS=-std=c++11 && make install
-    TEST_BEFORE_INSTALL 0
-    BUILD_IN_SOURCE 0
-    BUILD_COMMAND "" 
-    INSTALL_COMMAND ""
-    ) 
+    asio
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/asio
+    BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/asio/asio/
+    URL https://github.com/chriskohlhoff/asio/archive/asio-1-28-0.tar.gz
+    CONFIGURE_COMMAND ./autogen.sh
+    COMMAND ./configure --prefix=${PROJECT_SOURCE_DIR}/ CFLAGS=-std=c++11 CPPFLAGS=-std=c++11 CXXFLAGS=-std=c++11 --with-openssl=${PROJECT_SOURCE_DIR}
+)
+
+ExternalProject_Add(
+    openssl
+    URL https://www.openssl.org/source/openssl-1.1.1q.tar.gz
+    CONFIGURE_COMMAND ./config --prefix=${PROJECT_SOURCE_DIR}
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+    BUILD_IN_SOURCE 1
+)


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8728
### Motivation

*The current openssl dependencies cannot be downloaded automatically and need to be installed manually, which is inconvenient.*

### Modifications

*Put the openssl library in the third_party third-party library and install it automatically.*
