### PR TITLE
[INLONG-8753][Audit] Separate commons-text from org.apache.flume

### DIFF
--- a/inlong-audit/pom.xml
+++ b/inlong-audit/pom.xml
@@ -64,6 +64,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.flume</groupId>
             <artifactId>flume-ng-sdk</artifactId>
         </dependency>

--- a/inlong-dataproxy/pom.xml
+++ b/inlong-dataproxy/pom.xml
@@ -74,7 +74,16 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flume</groupId>

--- a/inlong-sdk/pom.xml
+++ b/inlong-sdk/pom.xml
@@ -47,6 +47,17 @@
         <dependency>
             <groupId>org.apache.flume</groupId>
             <artifactId>flume-ng-node</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flume</groupId>

--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -62,7 +62,16 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${commons.text.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flume</groupId>

--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -387,6 +387,7 @@ The text of each license is the standard Apache 2.0 license.
   org.apache.flume:flume-ng-node:1.9.0 - Flume NG Node (https://github.com/apache/flume/tree/flume-1.9/flume-ng-node), (The Apache Software License, Version 2.0)
   org.apache.flume:flume-ng-sdk:1.9.0 - Flume NG SDK (https://github.com/apache/flume/tree/flume-1.9/flume-ng-sdk), (The Apache Software License, Version 2.0)
   org.apache.flume.flume-ng-channels:flume-spillable-memory-channel:1.9.0 - Flume NG Spillable Memory channel (https://github.com/apache/flume/tree/flume-1.9/flume-ng-channels/flume-spillable-memory-channel), (The Apache Software License, Version 2.0)
+  org.apache.commons:commons-text:1.10.0 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
   com.google.code.gson:gson:2.8.6 - Gson (https://github.com/google/gson/gson), (Apache 2.0)
   com.google.guava:guava:32.1.2-jre - Guava: Google Core Libraries for Java (https://github.com/google/guava), (Apache License, Version 2.0)
   org.apache.httpcomponents:httpclient:4.5.13 - Apache HttpClient (http://hc.apache.org/httpcomponents-client), (Apache License, Version 2.0)

--- a/licenses/inlong-audit/LICENSE
+++ b/licenses/inlong-audit/LICENSE
@@ -382,6 +382,7 @@ The text of each license is the standard Apache 2.0 license.
   org.apache.flume:flume-ng-node:1.9.0 - Flume NG Node (https://github.com/apache/flume/tree/flume-1.9/flume-ng-node), (The Apache Software License, Version 2.0)
   org.apache.flume:flume-ng-sdk:1.9.0 - Flume NG SDK (https://github.com/apache/flume/tree/flume-1.9/flume-ng-sdk), (The Apache Software License, Version 2.0)
   org.apache.flume.flume-ng-channels:flume-spillable-memory-channel:1.9.0 - Flume NG Spillable Memory channel (https://github.com/apache/flume/tree/flume-1.9/flume-ng-channels/flume-spillable-memory-channel), (The Apache Software License, Version 2.0)
+  org.apache.commons:commons-text:1.10.0 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
   com.google.code.gson:gson:2.8.6 - Gson (https://github.com/google/gson/gson), (Apache 2.0)
   com.google.guava:guava:32.1.2-jre - Guava: Google Core Libraries for Java (https://github.com/google/guava), (Apache License, Version 2.0)
   com.zaxxer:HikariCP:4.0.3 - HikariCP (https://github.com/brettwooldridge/HikariCP/tree/HikariCP-4.0.3), (The Apache Software License, Version 2.0)

--- a/licenses/inlong-dataproxy/LICENSE
+++ b/licenses/inlong-dataproxy/LICENSE
@@ -373,6 +373,7 @@ The text of each license is the standard Apache 2.0 license.
   org.apache.flume:flume-ng-node:1.10.0 - Flume NG Node (https://github.com/apache/flume/tree/flume-1.10.0/flume-ng-node), (The Apache Software License, Version 2.0)
   org.apache.flume:flume-ng-sdk:1.10.0 - Flume NG SDK (https://github.com/apache/flume/tree/flume-1.10.0/flume-ng-sdk), (The Apache Software License, Version 2.0)
   org.apache.flume.flume-ng-channels:flume-spillable-memory-channel:1.10.0 - Flume NG Spillable Memory channel (https://github.com/apache/flume/tree/flume-1.10.0/flume-ng-channels/flume-spillable-memory-channel), (The Apache Software License, Version 2.0)
+  org.apache.commons:commons-text:1.10.0 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
   com.google.code.gson:gson:2.8.6 - Gson (https://github.com/google/gson/gson), (Apache 2.0)
   com.google.guava:guava:-jre - Guava: Google Core Libraries for Java (https://github.com/google/guava), (Apache License, Version 2.0)
   org.apache.httpcomponents:httpclient:4.5.13 - Apache HttpClient (https://hc.apache.org/httpcomponents-client-4.5.x), (Apache License, Version 2.0)

--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -377,7 +377,7 @@ The text of each license is the standard Apache 2.0 license.
   commons-logging:commons-logging:1.2 - Commons Logging (https://commons.apache.org/proper/commons-logging/), (The Apache Software License, Version 2.0)
   commons-net:commons-net:3.1 - Commons Net (https://commons.apache.org/proper/commons-net/), (The Apache Software License, Version 2.0)
   commons-pool:commons-pool:1.5.4 - Commons Pool (https://commons.apache.org/proper/commons-pool/), (The Apache Software License, Version 2.0)
-  org.apache.commons:commons-text:1.9 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
+  org.apache.commons:commons-text:1.10.0 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
   com.typesafe:config:1.3.3 - config (https://github.com/lightbend/config/tree/v1.3.3), (Apache License, Version 2.0)
   com.squareup.retrofit2:converter-jackson:2.9.0 - Retrofit (https://github.com/square/retrofit) (Apache License, Version 2.0)
   org.apache.curator:curator-client:2.13.0 - Curator Client (https://curator.apache.org/curator-client), (The Apache Software License, Version 2.0)

--- a/licenses/inlong-sort-standalone/LICENSE
+++ b/licenses/inlong-sort-standalone/LICENSE
@@ -397,6 +397,7 @@ The text of each license is the standard Apache 2.0 license.
   org.apache.flume:flume-ng-node:1.9.0 - Flume NG Node (https://github.com/apache/flume/tree/flume-1.9/flume-ng-node), (The Apache Software License, Version 2.0)
   org.apache.flume:flume-ng-sdk:1.9.0 - Flume NG SDK (https://github.com/apache/flume/tree/flume-1.9/flume-ng-sdk), (The Apache Software License, Version 2.0)
   org.apache.flume.flume-ng-channels:flume-spillable-memory-channel:1.9.0 - Flume NG Spillable Memory channel (https://github.com/apache/flume/tree/flume-1.9/flume-ng-channels/flume-spillable-memory-channel), (The Apache Software License, Version 2.0)
+  org.apache.commons:commons-text:1.10.0 - Apache Commons Text (https://commons.apache.org/proper/commons-text), (Apache License, Version 2.0)
   de.ruedigermoeller:fst:2.50 - fst (https://github.com/RuedigerMoeller/fast-serialization/tree/v2.50), (Apache License 2.0)
   org.apache.geronimo.specs:geronimo-jcache_1.0_spec:1.0-alpha-1 - Apache Geronimo JCache Spec 1.0 (http://geronimo.apache.org/maven/specs/geronimo-jcache_1.0_spec/1.0-alpha-1), (The Apache Software License, Version 2.0)
   com.google.code.gson:gson:2.8.6 - Gson (https://github.com/google/gson/gson), (Apache 2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,7 @@
         <commons.lang3.version>3.11</commons.lang3.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.collections4.version>4.3</commons.collections4.version>
+        <commons.text.version>1.10.0</commons.text.version>
 
         <guava.version>32.1.2-jre</guava.version>
         <lombok.version>1.18.22</lombok.version>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8753

### Motivation

*Separate commons-text from org.apache.flume, because flume uses the old version of commons-text, there will be security issues*

### Modifications

*Separate commons-text from org.apache.flume.*
