### PR TITLE
[INLONG-8563][Manager] Opitmize the permission check of tenant-related operation

### DIFF
--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongStreamEntityMapper.xml
@@ -246,12 +246,6 @@
             <if test="request.inlongGroupId != null and request.inlongGroupId != ''">
                 and stream.inlong_group_id = #{request.inlongGroupId, jdbcType=VARCHAR}
             </if>
-            <if test="request.isAdminRole == false">
-                and (
-                find_in_set(#{request.currentUser, jdbcType=VARCHAR}, grp.in_charges)
-                or find_in_set(#{request.currentUser, jdbcType=VARCHAR}, grp.followers)
-                )
-            </if>
             <if test="request.keyword != null and request.keyword != ''">
                 and (
                 stream.inlong_stream_id like CONCAT('%', #{request.keyword}, '%')
@@ -266,9 +260,6 @@
                 <foreach collection="request.statusList" item="status" index="index" open="(" close=")" separator=",">
                     #{status}
                 </foreach>
-            </if>
-            <if test="request.inCharge != null and request.inCharge != ''">
-                and find_in_set(#{request.inCharge, jdbcType=VARCHAR}, grp.in_charges)
             </if>
         </where>
         <choose>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/InlongConsumeServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/consume/InlongConsumeServiceImpl.java
@@ -34,7 +34,6 @@ import org.apache.inlong.manager.pojo.consume.InlongConsumeInfo;
 import org.apache.inlong.manager.pojo.consume.InlongConsumePageRequest;
 import org.apache.inlong.manager.pojo.consume.InlongConsumeRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
-import org.apache.inlong.manager.service.user.UserService;
 
 import com.github.pagehelper.Page;
 import com.github.pagehelper.PageHelper;
@@ -66,8 +65,6 @@ public class InlongConsumeServiceImpl implements InlongConsumeService {
     private InlongConsumeEntityMapper consumeMapper;
     @Autowired
     private InlongConsumeOperatorFactory consumeOperatorFactory;
-    @Autowired
-    private UserService userService;
 
     @Override
     public Integer save(InlongConsumeRequest request, String operator) {
@@ -142,8 +139,6 @@ public class InlongConsumeServiceImpl implements InlongConsumeService {
             LOGGER.error("inlong consume not found with id={}", id);
             throw new BusinessException(ErrorCodeEnum.CONSUME_NOT_FOUND);
         }
-        userService.checkUser(entity.getInCharges(), currentUser,
-                "Current user does not have permission to get inlong consume");
 
         InlongConsumeOperator consumeOperator = consumeOperatorFactory.getInstance(entity.getMqType());
         InlongConsumeInfo consumeInfo = consumeOperator.getFromEntity(entity);
@@ -200,8 +195,6 @@ public class InlongConsumeServiceImpl implements InlongConsumeService {
         Integer consumeId = request.getId();
         InlongConsumeEntity existEntity = consumeMapper.selectById(consumeId);
         Preconditions.expectNotNull(existEntity, "inlong consume not exist with id " + consumeId);
-        userService.checkUser(existEntity.getInCharges(), operator,
-                "Current user does not have permission to update inlong consume");
 
         if (!Objects.equals(existEntity.getVersion(), request.getVersion())) {
             LOGGER.error(String.format("inlong consume has already updated, id=%s, curVersion=%s",
@@ -250,8 +243,6 @@ public class InlongConsumeServiceImpl implements InlongConsumeService {
         Preconditions.expectNotNull(id, "inlong consume id cannot be null");
         InlongConsumeEntity entity = consumeMapper.selectById(id);
         Preconditions.expectNotNull(entity, "inlong consume not exist with id " + id);
-        userService.checkUser(entity.getInCharges(), operator,
-                "Current user does not have permission to delete inlong consume");
 
         entity.setIsDeleted(id);
         entity.setStatus(ConsumeStatus.DELETED.getCode());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/WorkflowApproverServiceImpl.java
@@ -29,7 +29,6 @@ import org.apache.inlong.manager.pojo.workflow.ApproverPageRequest;
 import org.apache.inlong.manager.pojo.workflow.ApproverRequest;
 import org.apache.inlong.manager.pojo.workflow.ApproverResponse;
 import org.apache.inlong.manager.service.core.WorkflowApproverService;
-import org.apache.inlong.manager.service.user.UserService;
 import org.apache.inlong.manager.workflow.core.ProcessDefinitionService;
 import org.apache.inlong.manager.workflow.definition.UserTask;
 import org.apache.inlong.manager.workflow.definition.WorkflowProcess;
@@ -61,8 +60,6 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
     private WorkflowApproverEntityMapper approverMapper;
     @Autowired
     private ProcessDefinitionService processDefinitionService;
-    @Autowired
-    private UserService userService;
 
     @Override
     public Integer save(ApproverRequest request, String operator) {
@@ -98,9 +95,6 @@ public class WorkflowApproverServiceImpl implements WorkflowApproverService {
             LOGGER.error("workflow approver not found by id={}", id);
             throw new BusinessException(ErrorCodeEnum.WORKFLOW_APPROVER_NOT_FOUND);
         }
-
-        userService.checkUser(approverEntity.getApprovers(), operator,
-                "Current user does not have permission to get this workflow approver info");
 
         return CommonBeanUtils.copyProperties(approverEntity, ApproverResponse::new);
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeServiceImpl.java
@@ -31,7 +31,6 @@ import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 import org.apache.inlong.manager.pojo.node.DataNodePageRequest;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 import org.apache.inlong.manager.pojo.user.UserInfo;
-import org.apache.inlong.manager.service.user.UserService;
 
 import com.github.pagehelper.Page;
 import com.github.pagehelper.PageHelper;
@@ -58,8 +57,6 @@ public class DataNodeServiceImpl implements DataNodeService {
     private DataNodeEntityMapper dataNodeMapper;
     @Autowired
     private DataNodeOperatorFactory operatorFactory;
-    @Autowired
-    private UserService userService;
 
     @Override
     public Integer save(DataNodeRequest request, String operator) {
@@ -114,8 +111,6 @@ public class DataNodeServiceImpl implements DataNodeService {
             LOGGER.error("data node not found by id={}", id);
             throw new BusinessException("data node not found");
         }
-        userService.checkUser(entity.getInCharges(), currentUser,
-                "Current user does not have permission to get data node info");
         String dataNodeType = entity.getType();
         DataNodeOperator dataNodeOperator = operatorFactory.getInstance(dataNodeType);
         DataNodeInfo dataNodeInfo = dataNodeOperator.getFromEntity(entity);
@@ -129,9 +124,6 @@ public class DataNodeServiceImpl implements DataNodeService {
         if (entity == null) {
             throw new BusinessException(ErrorCodeEnum.DATA_NODE_NOT_FOUND);
         }
-        // only the person in charges can query
-        userService.checkUser(entity.getInCharges(), opInfo.getName(),
-                "Current user does not have permission to get data node info");
         DataNodeOperator dataNodeOperator = operatorFactory.getInstance(entity.getType());
         return dataNodeOperator.getFromEntity(entity);
     }
@@ -191,9 +183,6 @@ public class DataNodeServiceImpl implements DataNodeService {
             throw new BusinessException(ErrorCodeEnum.RECORD_NOT_FOUND,
                     String.format("data node record not found by id=%d", request.getId()));
         }
-        userService.checkUser(curEntity.getInCharges(), operator,
-                "Current user does not have permission to update data node info");
-
         // check whether modify unmodifiable parameters
         chkUnmodifiableParams(curEntity, request);
 
@@ -230,8 +219,6 @@ public class DataNodeServiceImpl implements DataNodeService {
             LOGGER.error(errMsg);
             throw new BusinessException(errMsg);
         }
-        userService.checkUser(entity.getInCharges(), operator,
-                "Current user does not have permission to update data node info");
         request.setId(entity.getId());
         Boolean result = this.update(request, operator);
         LOGGER.info("success to update data node by key: {}", request);
@@ -243,8 +230,6 @@ public class DataNodeServiceImpl implements DataNodeService {
         DataNodeEntity entity = dataNodeMapper.selectById(id);
         Preconditions.expectNotNull(entity, ErrorCodeEnum.DATA_NODE_NOT_FOUND,
                 ErrorCodeEnum.DATA_NODE_NOT_FOUND.getMessage());
-        userService.checkUser(entity.getInCharges(), operator,
-                "Current user does not have permission to delete data node info");
         return delete(entity, operator);
     }
 
@@ -253,8 +238,6 @@ public class DataNodeServiceImpl implements DataNodeService {
         DataNodeEntity entity = dataNodeMapper.selectById(id);
         Preconditions.expectNotNull(entity, ErrorCodeEnum.DATA_NODE_NOT_FOUND,
                 ErrorCodeEnum.DATA_NODE_NOT_FOUND.getMessage());
-        userService.checkUser(entity.getInCharges(), opInfo.getName(),
-                "Current user does not have permission to delete data node info");
         // delete record
         entity.setIsDeleted(entity.getId());
         entity.setModifier(opInfo.getName());
@@ -303,8 +286,6 @@ public class DataNodeServiceImpl implements DataNodeService {
         DataNodeEntity entity = dataNodeMapper.selectByUniqueKey(name, type);
         Preconditions.expectNotNull(entity, ErrorCodeEnum.DATA_NODE_NOT_FOUND,
                 ErrorCodeEnum.DATA_NODE_NOT_FOUND.getMessage());
-        userService.checkUser(entity.getInCharges(), operator,
-                "Current user does not have permission to delete data node info");
         return delete(entity, operator);
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
@@ -44,7 +44,6 @@ import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.manager.pojo.user.UserInfo;
 import org.apache.inlong.manager.service.group.GroupCheckService;
-import org.apache.inlong.manager.service.user.UserService;
 
 import com.github.pagehelper.Page;
 import com.github.pagehelper.PageHelper;
@@ -90,8 +89,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
     private StreamSourceFieldEntityMapper sourceFieldMapper;
     @Autowired
     private GroupCheckService groupCheckService;
-    @Autowired
-    private UserService userService;
 
     @Override
     @Transactional(rollbackFor = Throwable.class, propagation = Propagation.REQUIRES_NEW)
@@ -102,8 +99,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
         // Check if it can be added
         String groupId = request.getInlongGroupId();
         InlongGroupEntity groupEntity = groupCheckService.checkGroupStatus(groupId, operator);
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         String streamId = request.getInlongStreamId();
         String sourceName = request.getSourceName();
         List<StreamSourceEntity> existList = sourceMapper.selectByRelatedId(groupId, streamId, sourceName);
@@ -134,9 +129,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", request.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // get stream information
         InlongStreamEntity streamEntity = streamMapper.selectByIdentifier(
                 request.getInlongGroupId(), request.getInlongStreamId());
@@ -196,9 +188,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
         if (groupEntity == null) {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         StreamSourceOperator sourceOperator = operatorFactory.getInstance(entity.getSourceType());
         return sourceOperator.getFromEntity(entity);
     }
@@ -338,8 +327,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", groupEntity.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         StreamSourceOperator sourceOperator = operatorFactory.getInstance(request.getSourceType());
         // Remove id in sourceField when save
         List<StreamField> streamFields = request.getFieldList();
@@ -363,9 +350,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.ILLEGAL_RECORD_FIELD_VALUE,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", request.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // check inlong group status
         GroupStatus status = GroupStatus.forCode(groupEntity.getStatus());
         if (GroupStatus.notAllowedUpdate(status)) {
@@ -408,8 +392,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", entity.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         SourceStatus curStatus = SourceStatus.forCode(entity.getStatus());
         SourceStatus nextStatus = SourceStatus.TO_BE_ISSUED_DELETE;
@@ -453,9 +435,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", entity.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // check record status
         boolean isTemplateSource = CollectionUtils.isNotEmpty(sourceMapper.selectByTemplateId(id));
         SourceStatus curStatus = SourceStatus.forCode(entity.getStatus());
@@ -513,8 +492,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", entity.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         StreamSourceOperator sourceOperator = operatorFactory.getInstance(entity.getSourceType());
         SourceRequest sourceRequest = new SourceRequest();
@@ -536,8 +513,6 @@ public class StreamSourceServiceImpl implements StreamSourceService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", entity.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         StreamSourceOperator sourceOperator = operatorFactory.getInstance(entity.getSourceType());
         SourceRequest sourceRequest = new SourceRequest();

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamProcessService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamProcessService.java
@@ -32,7 +32,6 @@ import org.apache.inlong.manager.pojo.user.UserInfo;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
 import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
 import org.apache.inlong.manager.service.group.InlongGroupService;
-import org.apache.inlong.manager.service.user.UserService;
 import org.apache.inlong.manager.service.workflow.WorkflowService;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -73,8 +72,6 @@ public class InlongStreamProcessService {
     private InlongStreamService streamService;
     @Autowired
     private WorkflowService workflowService;
-    @Autowired
-    private UserService userService;
 
     /**
      * Create stream in synchronous/asynchronous way.
@@ -89,9 +86,6 @@ public class InlongStreamProcessService {
             throw new BusinessException(String.format("group status=%s not support start stream"
                     + " for groupId=%s", groupStatus, groupId));
         }
-
-        // only the person in charges can start process
-        userService.checkUser(groupInfo.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         InlongStreamInfo streamInfo = streamService.get(groupId, streamId);
         Preconditions.expectNotNull(streamInfo, ErrorCodeEnum.STREAM_NOT_FOUND.getMessage());
@@ -137,9 +131,6 @@ public class InlongStreamProcessService {
                     + " for groupId=%s", groupStatus, groupId));
         }
 
-        // only the person in charges can suspend process
-        userService.checkUser(groupInfo.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
-
         InlongStreamInfo streamInfo = streamService.get(groupId, streamId);
         Preconditions.expectNotNull(streamInfo, ErrorCodeEnum.STREAM_NOT_FOUND.getMessage());
         StreamStatus status = StreamStatus.forCode(streamInfo.getStatus());
@@ -181,8 +172,6 @@ public class InlongStreamProcessService {
             throw new BusinessException(
                     String.format("group status=%s not support restart stream for groupId=%s", groupStatus, groupId));
         }
-        // only the person in charges can restart process
-        userService.checkUser(groupInfo.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         InlongStreamInfo streamInfo = streamService.get(groupId, streamId);
         Preconditions.expectNotNull(streamInfo, ErrorCodeEnum.STREAM_NOT_FOUND.getMessage());
@@ -223,9 +212,6 @@ public class InlongStreamProcessService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     ErrorCodeEnum.GROUP_NOT_FOUND.getMessage() + " : " + groupId);
         }
-
-        // only the person in charges can delete process
-        userService.checkUser(groupInfo.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         GroupStatus groupStatus = GroupStatus.forCode(groupInfo.getStatus());
         if (GroupStatus.notAllowedTransition(groupStatus, GroupStatus.DELETING)) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamServiceImpl.java
@@ -58,7 +58,6 @@ import org.apache.inlong.manager.service.resource.queue.QueueResourceOperator;
 import org.apache.inlong.manager.service.resource.queue.QueueResourceOperatorFactory;
 import org.apache.inlong.manager.service.sink.StreamSinkService;
 import org.apache.inlong.manager.service.source.StreamSourceService;
-import org.apache.inlong.manager.service.user.UserService;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -130,8 +129,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
     @Autowired
     private ObjectMapper objectMapper;
     @Autowired
-    private UserService userService;
-    @Autowired
     @Lazy
     private QueueResourceOperatorFactory queueOperatorFactory;
     @Autowired
@@ -186,9 +183,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         if (entity == null) {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
-        // only the person in charges can query
-        userService.checkUser(entity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // Add/modify/delete is not allowed under temporary inlong group status
         GroupStatus curState = GroupStatus.forCode(entity.getStatus());
         if (GroupStatus.isTempStatus(curState)) {
@@ -266,9 +260,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         if (entity == null) {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
-        // only the person in charges can query
-        userService.checkUser(entity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // get stream information
         InlongStreamEntity streamEntity = streamMapper.selectByIdentifier(groupId, streamId);
         if (streamEntity == null) {
@@ -297,9 +288,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
 
-        // only the person in charges can query
-        userService.checkUser(entity.getInCharges(), operator,
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // get stream information
         InlongStreamEntity streamEntity = streamMapper.selectByIdentifier(groupId, streamId);
         if (streamEntity == null) {
@@ -478,9 +466,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
 
-        // only the person in charges can query
-        userService.checkUser(entity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // Add/modify/delete is not allowed under temporary inlong group status
         GroupStatus curState = GroupStatus.forCode(entity.getStatus());
         if (GroupStatus.isTempStatus(curState)) {
@@ -611,9 +596,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
         if (groupEntity == null) {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // Add/modify/delete is not allowed under temporary inlong group status
         GroupStatus curState = GroupStatus.forCode(groupEntity.getStatus());
         if (GroupStatus.isTempStatus(curState)) {
@@ -1004,8 +986,6 @@ public class InlongStreamServiceImpl implements InlongStreamService {
     @Override
     public List<BriefMQMessage> listMessages(String groupId, String streamId, Integer messageCount, String operator) {
         InlongGroupEntity groupEntity = groupMapper.selectByGroupId(groupId);
-        // check user
-        userService.checkUser(groupEntity.getInCharges(), operator, ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         InlongGroupOperator instance = groupOperatorFactory.getInstance(groupEntity.getMqType());
         InlongGroupInfo groupInfo = instance.getFromEntity(groupEntity);
         InlongStreamInfo inlongStreamInfo = get(groupId, streamId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/transform/StreamTransformServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/transform/StreamTransformServiceImpl.java
@@ -111,9 +111,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", request.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // check inlong group status
         GroupStatus status = GroupStatus.forCode(groupEntity.getStatus());
         if (GroupStatus.notAllowedUpdate(status)) {
@@ -151,8 +148,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", groupId));
         }
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         // query result
         List<StreamTransformEntity> entityList = transformMapper.selectByCondition(request);
@@ -179,8 +174,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", entity.getInlongGroupId()));
         }
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
 
         Map<Integer, List<StreamField>> fieldInfoMap = fieldEntities.stream()
                 .map(transformFieldEntity -> {
@@ -213,8 +206,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", groupId));
         }
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // query result
         List<StreamTransformEntity> entityList = transformMapper.selectByRelatedId(groupId, streamId, null);
         if (CollectionUtils.isEmpty(entityList)) {
@@ -261,9 +252,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", request.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // check inlong group status
         GroupStatus status = GroupStatus.forCode(groupEntity.getStatus());
         if (GroupStatus.notAllowedUpdate(status)) {
@@ -327,9 +315,6 @@ public class StreamTransformServiceImpl implements StreamTransformService {
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
                     String.format("InlongGroup does not exist with InlongGroupId=%s", request.getInlongGroupId()));
         }
-        // only the person in charges can query
-        userService.checkUser(groupEntity.getInCharges(), opInfo.getName(),
-                ErrorCodeEnum.GROUP_PERMISSION_DENIED.getMessage());
         // check inlong group status
         GroupStatus status = GroupStatus.forCode(groupEntity.getStatus());
         if (GroupStatus.notAllowedUpdate(status)) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserService.java
@@ -82,13 +82,4 @@ public interface UserService {
      */
     void login(UserLoginRequest req);
 
-    /**
-     * Check the given user is the admin or is one of the in charges.
-     *
-     * @param inCharges incharge list
-     * @param user current user name
-     * @param errMsg error message
-     */
-    void checkUser(String inCharges, String user, String errMsg);
-
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
@@ -354,10 +354,6 @@ public class UserServiceImpl implements UserService {
         loginLockStatusMap.put(username, userLoginLockStatus);
     }
 
-    public void checkUser(String inCharges, String user, String errMsg) {
-
-    }
-
     public void removeInChargeForGroup(String user, String operator) {
         InlongGroupPageRequest pageRequest = new InlongGroupPageRequest();
         pageRequest.setCurrentUser(user);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
@@ -355,10 +355,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public void checkUser(String inCharges, String user, String errMsg) {
-        UserEntity userEntity = userMapper.selectByName(user);
-        boolean isInCharge = Preconditions.inSeparatedString(user, inCharges, InlongConstants.COMMA);
-        Preconditions.expectTrue(isInCharge
-                || TenantUserTypeEnum.TENANT_ADMIN.getCode().equals(userEntity.getAccountType()), errMsg);
+
     }
 
     public void removeInChargeForGroup(String user, String operator) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
@@ -29,7 +29,6 @@ import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 import org.apache.inlong.manager.pojo.node.DataNodePageRequest;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
-import org.apache.inlong.manager.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.service.node.DataNodeService;
 import org.apache.inlong.manager.service.operationlog.OperationLog;
 
@@ -37,8 +36,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
-import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -64,7 +61,6 @@ public class DataNodeController {
     @PostMapping(value = "/node/save")
     @ApiOperation(value = "Save node")
     @OperationLog(operation = OperationType.CREATE)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody DataNodeRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(dataNodeService.save(request, currentUser));
@@ -90,7 +86,6 @@ public class DataNodeController {
     @PostMapping(value = "/node/update")
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update data node")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody DataNodeRequest request) {
         String username = LoginUserUtils.getLoginUser().getName();
         return Response.success(dataNodeService.update(request, username));
@@ -99,7 +94,6 @@ public class DataNodeController {
     @PostMapping(value = "/node/updateByKey")
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update data node by key")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<UpdateResult> updateByKey(
             @Validated(UpdateByKeyValidation.class) @RequestBody DataNodeRequest request) {
         String username = LoginUserUtils.getLoginUser().getName();
@@ -110,7 +104,6 @@ public class DataNodeController {
     @ApiOperation(value = "Delete data node by id")
     @OperationLog(operation = OperationType.DELETE)
     @ApiImplicitParam(name = "id", value = "Data node ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> delete(@PathVariable Integer id) {
         return Response.success(dataNodeService.delete(id, LoginUserUtils.getLoginUser().getName()));
     }
@@ -122,7 +115,6 @@ public class DataNodeController {
             @ApiImplicitParam(name = "name", value = "Data node name", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "type", value = "Data node type", dataTypeClass = String.class, required = true)
     })
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> deleteByKey(@RequestParam String name, @RequestParam String type) {
         return Response.success(dataNodeService.deleteByKey(name, type,
                 LoginUserUtils.getLoginUser().getName()));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -46,7 +46,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
@@ -213,7 +212,7 @@ public class InlongClusterController {
     @ApiOperation(value = "Delete cluster by id")
     @OperationLog(operation = OperationType.DELETE)
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> delete(@PathVariable Integer id) {
         return Response.success(clusterService.delete(id, LoginUserUtils.getLoginUser().getName()));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongConsumeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongConsumeController.java
@@ -28,7 +28,6 @@ import org.apache.inlong.manager.pojo.consume.InlongConsumeInfo;
 import org.apache.inlong.manager.pojo.consume.InlongConsumePageRequest;
 import org.apache.inlong.manager.pojo.consume.InlongConsumeRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
-import org.apache.inlong.manager.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
 import org.apache.inlong.manager.service.consume.InlongConsumeProcessService;
 import org.apache.inlong.manager.service.consume.InlongConsumeService;
@@ -37,8 +36,6 @@ import org.apache.inlong.manager.service.operationlog.OperationLog;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
-import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -66,7 +63,6 @@ public class InlongConsumeController {
     @RequestMapping(value = "/consume/save", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.CREATE)
     @ApiOperation(value = "Save inlong consume")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@RequestBody InlongConsumeRequest request) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(consumeService.save(request, operator));
@@ -97,7 +93,6 @@ public class InlongConsumeController {
     @PostMapping("/consume/update")
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update inlong consume")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> update(@Validated(UpdateValidation.class) @RequestBody InlongConsumeRequest request) {
         return Response.success(consumeService.update(request, LoginUserUtils.getLoginUser().getName()));
     }
@@ -106,7 +101,6 @@ public class InlongConsumeController {
     @OperationLog(operation = OperationType.DELETE)
     @ApiOperation(value = "Delete inlong consume by ID")
     @ApiImplicitParam(name = "id", value = "Inlong consume ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> delete(@PathVariable(name = "id") Integer id) {
         return Response.success(consumeService.delete(id, LoginUserUtils.getLoginUser().getName()));
     }
@@ -115,7 +109,6 @@ public class InlongConsumeController {
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Start inlong consume process")
     @ApiImplicitParam(name = "id", value = "Inlong consume ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<WorkflowResult> startProcess(@PathVariable(name = "id") Integer id) {
         String username = LoginUserUtils.getLoginUser().getName();
         return Response.success(consumeProcessService.startProcess(id, username));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -32,7 +32,6 @@ import org.apache.inlong.manager.pojo.group.InlongGroupResetRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
-import org.apache.inlong.manager.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
 import org.apache.inlong.manager.service.group.InlongGroupProcessService;
 import org.apache.inlong.manager.service.group.InlongGroupService;
@@ -41,8 +40,6 @@ import org.apache.inlong.manager.service.operationlog.OperationLog;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
-import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -73,7 +70,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/save", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.CREATE)
     @ApiOperation(value = "Save inlong group")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<String> save(@Validated(SaveValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupService.save(groupRequest, operator));
@@ -132,7 +128,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/update", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update inlong group")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<String> update(@Validated(UpdateValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupService.update(groupRequest, operator));
@@ -142,7 +137,6 @@ public class InlongGroupController {
     @ApiOperation(value = "Delete inlong group info")
     @OperationLog(operation = OperationType.DELETE)
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> delete(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.deleteProcess(groupId, operator));
@@ -152,7 +146,6 @@ public class InlongGroupController {
     @ApiOperation(value = "Delete inlong group info")
     @OperationLog(operation = OperationType.DELETE)
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<String> deleteAsync(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.deleteProcessAsync(groupId, operator));
@@ -161,7 +154,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/startProcess/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Start inlong approval process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<WorkflowResult> startProcess(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.startProcess(groupId, operator));
@@ -170,7 +162,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/suspendProcess/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Suspend inlong group process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<WorkflowResult> suspendProcess(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.suspendProcess(groupId, operator));
@@ -179,7 +170,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/restartProcess/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Restart inlong group process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<WorkflowResult> restartProcess(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.restartProcess(groupId, operator));
@@ -188,7 +178,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/suspendProcessAsync/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Suspend inlong group process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<String> suspendProcessAsync(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.suspendProcessAsync(groupId, operator));
@@ -197,7 +186,6 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/restartProcessAsync/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Restart inlong group process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<String> restartProcessAsync(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.restartProcessAsync(groupId, operator));
@@ -205,7 +193,6 @@ public class InlongGroupController {
 
     @PostMapping(value = "/group/reset")
     @ApiOperation(value = "Reset group status when group is in CONFIG_ING|SUSPENDING|RESTARTING|DELETING")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> reset(@RequestBody @Validated InlongGroupResetRequest request) {
         String operator = LoginUserUtils.getLoginUser().getName();
         return Response.success(groupProcessOperation.resetGroupStatus(request, operator));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
@@ -63,7 +63,7 @@ public class InlongTenantController {
     @RequestMapping(value = "/tenant/save", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.CREATE)
     @ApiOperation(value = "Save inlong tenant")
-    @RequiresRoles(logical = Logical.OR, value = {INLONG_ADMIN})
+    @RequiresRoles(INLONG_ADMIN)
     public Response<Integer> save(@Validated @RequestBody InlongTenantRequest request) {
         return Response.success(tenantService.save(request));
     }
@@ -77,7 +77,7 @@ public class InlongTenantController {
     @RequestMapping(value = "/tenant/update", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update inlong tenant")
-    @RequiresRoles(logical = Logical.OR, value = {INLONG_ADMIN})
+    @RequiresRoles(INLONG_ADMIN)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody InlongTenantRequest request) {
         return Response.success(tenantService.update(request));
     }
@@ -85,7 +85,7 @@ public class InlongTenantController {
     @RequestMapping(value = "/tenant/delete/{name}", method = RequestMethod.GET)
     @ApiOperation(value = "Delete inlong tenant by name")
     @ApiImplicitParam(name = "name", dataTypeClass = String.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {INLONG_ADMIN})
+    @RequiresRoles(INLONG_ADMIN)
     public Response<Boolean> delete(@PathVariable String name) {
         return Response.success(tenantService.delete(name));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantRoleController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantRoleController.java
@@ -68,7 +68,7 @@ public class InlongTenantRoleController {
     }
 
     @RequestMapping(value = "/role/tenant/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update tenant role")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> update(@Validated @RequestBody TenantRoleRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
 
     @PostMapping("/user/listAll")
     @ApiOperation(value = "List all users")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN})
     public Response<PageResult<UserInfo>> list(@RequestBody UserRequest request) {
         return Response.success(userService.list(request));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
@@ -32,6 +32,7 @@ import org.apache.inlong.manager.service.operationlog.OperationLog;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -56,7 +57,7 @@ public class WorkflowApproverController {
     @PostMapping("/workflow/approver/save")
     @OperationLog(operation = OperationType.CREATE)
     @ApiOperation(value = "Save approver info")
-    @RequiresRoles(value = UserRoleCode.TENANT_ADMIN)
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@RequestBody ApproverRequest config) {
         return Response.success(workflowApproverService.save(config, LoginUserUtils.getLoginUser().getName()));
     }
@@ -80,7 +81,7 @@ public class WorkflowApproverController {
     @PostMapping("/workflow/approver/update")
     @OperationLog(operation = OperationType.UPDATE)
     @ApiOperation(value = "Update approver info")
-    @RequiresRoles(value = UserRoleCode.TENANT_ADMIN)
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> update(@RequestBody ApproverRequest request) {
         return Response.success(workflowApproverService.update(request, LoginUserUtils.getLoginUser().getName()));
     }
@@ -89,7 +90,7 @@ public class WorkflowApproverController {
     @OperationLog(operation = OperationType.DELETE)
     @ApiOperation(value = "Delete approver by ID")
     @ApiImplicitParam(name = "id", value = "Workflow approver ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(value = UserRoleCode.TENANT_ADMIN)
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> delete(@PathVariable Integer id) {
         workflowApproverService.delete(id, LoginUserUtils.getLoginUser().getName());
         return Response.success(true);

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenDataNodeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenDataNodeController.java
@@ -27,15 +27,12 @@ import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 import org.apache.inlong.manager.pojo.node.DataNodePageRequest;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
-import org.apache.inlong.manager.pojo.user.UserRoleCode;
 import org.apache.inlong.manager.service.node.DataNodeService;
 import org.apache.inlong.manager.service.operationlog.OperationLog;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
-import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -79,7 +76,6 @@ public class OpenDataNodeController {
     @PostMapping(value = "/node/save")
     @ApiOperation(value = "Save node")
     @OperationLog(operation = OperationType.CREATE)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody DataNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -89,7 +85,6 @@ public class OpenDataNodeController {
     @PostMapping(value = "/node/update")
     @ApiOperation(value = "Update data node")
     @OperationLog(operation = OperationType.UPDATE)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody DataNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.REQUEST_IS_EMPTY);
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -100,7 +95,6 @@ public class OpenDataNodeController {
     @ApiOperation(value = "Delete data node by id")
     @OperationLog(operation = OperationType.DELETE)
     @ApiImplicitParam(name = "id", value = "Data node ID", dataTypeClass = Integer.class, required = true)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> delete(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "data node id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);


### PR DESCRIPTION

### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8563 

### Motivation

1. All users can operate all resources under their tenant.
2. Only tenant admins can add/delete one user into/from theirs tenant

So we need to remove all **@RequeireRoles** annotation from resources controller like InlongGroup, InlongStream, dataNode etc.
Some shared resources like InlongCluster should be restriced under **INLONG_ADMIN**

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
