### PR TITLE
[INLONG-8768][TubeMQ] Add restart-manager.sh to inlong-tubemq-manager

### DIFF
--- a/inlong-tubemq/tubemq-manager/bin/restart-manager.sh
+++ b/inlong-tubemq/tubemq-manager/bin/restart-manager.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env sh
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Get the directory of the restart-manager.sh script
+SCRIPT_DIR=$(dirname "$0")
+
+# Stop the manager
+"$SCRIPT_DIR/stop-manager.sh"
+
+# Sleep for a few seconds to ensure the manager is stopped
+sleep 2
+
+# Start the manager
+"$SCRIPT_DIR/start-manager.sh"
+
+echo "TubeMQ Manager restarted."


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8768 

### Motivation

**New restart-manager script for fast restart implementation and quick changes to the manager configuration.**

### Modifications

**Add restart-manager.sh to inlong-tubemq-manager/bin**

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
