### PR TITLE
[INLONG-8783][Sort] Mysql connector jdbc version should be compatible with mysql-cdc version

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
@@ -48,6 +48,9 @@
         <flink.connector.postgres.cdc.version>2.2.1</flink.connector.postgres.cdc.version>
         <flink.connector.sqlserver.cdc.version>2.2.1</flink.connector.sqlserver.cdc.version>
         <flink.pulsar.version>1.13.6.2</flink.pulsar.version>
+        <!-- specify mysql connector version because we are using cdc 2.2 -->
+        <!-- see also in https://github.com/ververica/flink-cdc-connectors/issues/627 -->
+        <mysql-connector-java.version>8.0.21</mysql-connector-java.version>
         <flink.protobuf.version>2.7.6</flink.protobuf.version>
         <flink.connector.oracle.cdc.version>2.3.0</flink.connector.oracle.cdc.version>
         <flink.connector.doris.version>1.0.3</flink.connector.doris.version>
@@ -100,6 +103,11 @@
                 <groupId>com.ververica</groupId>
                 <artifactId>flink-connector-mysql-cdc</artifactId>
                 <version>${flink.connector.mysql.cdc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql-connector-java.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8783 

### Motivation

Mysql connector jdbc version should be compatible with mysql-cdc version

### Modifications

Specify mysql driver version to 8.0.21

### Verifying this change

![image](https://github.com/apache/inlong/assets/26538404/cc1fcc8a-ac40-481c-a110-a239bd709eec)


