### PR TITLE
[INLONG-8690][Security] Upgrade junit version to 4.13.1

### DIFF
--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### [INLONG-8690][Security] Upgrade junit version to 4.13.1 #8690

- Fixes https://github.com/apache/inlong/issues/8690

### Motivation

Work around TemporaryFolder on UNIX-like systems not restricting access to created files, improving the security

### Modifications

Upgrade junit to version 4.13.1 in inlong-tubemq/tubemq-connectors/tubemq-connector-flume/opm.xml

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? no
