### PR TITLE
[INLONG-8791][TubeMQ] Tubemq-client-go lacks log level configuration API

### DIFF
--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
@@ -77,6 +77,7 @@ func NewConsumer(config *config.Config) (Consumer, error) {
 	if err := config.ValidateConsumer(); err != nil {
 		return nil, err
 	}
+	log.SetLogLevel(config.Log.LogLevel)
 	log.Infof("The config of the consumer is %s", config)
 	selector, err := selector.Get("ip")
 	if err != nil {

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
@@ -78,6 +78,8 @@ func NewConsumer(config *config.Config) (Consumer, error) {
 		return nil, err
 	}
 	log.SetLogLevel(config.Log.LogLevel)
+	logConfig := log.GetLogConfig()
+	log.NewLogger(logConfig)
 	log.Infof("The config of the consumer is %s", config)
 	selector, err := selector.Get("ip")
 	if err != nil {

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/client/consumer_impl.go
@@ -78,6 +78,7 @@ func NewConsumer(config *config.Config) (Consumer, error) {
 		return nil, err
 	}
 	log.SetLogLevel(config.Log.LogLevel)
+	log.SetLogPath(config.Log.LogPath)
 	logConfig := log.GetLogConfig()
 	log.NewLogger(logConfig)
 	log.Infof("The config of the consumer is %s", config)

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -143,6 +143,11 @@ type Config struct {
 		// AfterFail is the heartbeat timeout after a heartbeat failure.
 		AfterFail time.Duration
 	}
+
+	Log struct {
+		LogPath  string
+		LogLevel string
+	}
 }
 
 // NewDefaultConfig returns a default config of the client.
@@ -174,6 +179,8 @@ func NewDefaultConfig() *Config {
 	c.Heartbeat.Interval = 10000 * time.Millisecond
 	c.Heartbeat.MaxRetryTimes = 5
 	c.Heartbeat.AfterFail = 60000 * time.Millisecond
+
+	c.Log.LogLevel = "warn"
 
 	return c
 }
@@ -618,5 +625,11 @@ func WithBoundConsume(sessionKey string, sourceCount int, selectBig bool, partOf
 func WithConsumePosition(consumePosition int) Option {
 	return func(c *Config) {
 		c.Consumer.ConsumePosition = consumePosition
+	}
+}
+
+func WithLogLevel(level string) Option {
+	return func(c *Config) {
+		c.Log.LogLevel = level
 	}
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -181,6 +181,7 @@ func NewDefaultConfig() *Config {
 	c.Heartbeat.AfterFail = 60000 * time.Millisecond
 
 	c.Log.LogLevel = "warn"
+	c.Log.LogPath = "../log/tubemq.log"
 
 	return c
 }
@@ -628,8 +629,16 @@ func WithConsumePosition(consumePosition int) Option {
 	}
 }
 
+// WithLogLevel set log level
 func WithLogLevel(level string) Option {
 	return func(c *Config) {
 		c.Log.LogLevel = level
+	}
+}
+
+// WithLogLevel set log path
+func WithLogPath(path string) Option {
+	return func(c *Config) {
+		c.Log.LogPath = path
 	}
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -636,7 +636,7 @@ func WithLogLevel(level string) Option {
 	}
 }
 
-// WithLogLevel set log path
+// WithLogPath set log path
 func WithLogPath(path string) Option {
 	return func(c *Config) {
 		c.Log.LogPath = path

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -44,3 +44,8 @@ var defaultConfig = &OutputConfig{
 func SetLogLevel(level string) {
 	defaultConfig.Level = level
 }
+
+// GetLogConfig get log config
+func GetLogConfig() *OutputConfig {
+	return defaultConfig
+}

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -45,7 +45,7 @@ func SetLogLevel(level string) {
 	defaultConfig.Level = level
 }
 
-// SetLogLevel set log path
+// SetLogPath set log path
 func SetLogPath(path string) {
 	defaultConfig.LogPath = path
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -39,3 +39,8 @@ var defaultConfig = &OutputConfig{
 	MaxAge:     3,
 	Level:      "warn",
 }
+
+// SetLogLevel set log level
+func SetLogLevel(level string) {
+	defaultConfig.Level = level
+}

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -45,6 +45,11 @@ func SetLogLevel(level string) {
 	defaultConfig.Level = level
 }
 
+// SetLogLevel set log path
+func SetLogPath(path string) {
+	defaultConfig.LogPath = path
+}
+
 // GetLogConfig get log config
 func GetLogConfig() *OutputConfig {
 	return defaultConfig


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

cfg := config.New(config.WithConsumerMasters("master"),
		config.WithTopics([]{"topic"}),
		config.WithGroup("group"),
                 config.WithLogLevel("info"),
)
c, err := client.NewConsumer(cfg)

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8791 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
