### PR TITLE
[INLONG-8797][Manager][Sort] Support multiple audit ids for data sync

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -127,6 +127,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             List<String> auditIds = new ArrayList<>();
             for (StreamSink sink : sinks) {
                 auditIds.add(auditService.getAuditId(sink.getSinkType(), false));
+                auditIds.add(auditService.getAuditId(sink.getSinkType(), true));
             }
             for (StreamSource source : sources) {
                 source.setFieldList(inlongStream.getFieldList());

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/IcebergTableSink.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/IcebergTableSink.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.IGNORE_ALL_CHANGELOG;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
@@ -133,7 +134,8 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
             return (DataStreamSinkProvider) dataStream -> FlinkSink.forRowData(dataStream)
                     .overwrite(overwrite)
                     .appendMode(tableOptions.get(IGNORE_ALL_CHANGELOG))
-                    .metric(tableOptions.get(INLONG_METRIC), tableOptions.get(INLONG_AUDIT))
+                    .metric(tableOptions.get(INLONG_METRIC), tableOptions.get(INLONG_AUDIT),
+                            tableOptions.get(AUDIT_KEYS))
                     .catalogLoader(catalogLoader)
                     .tableSchema(tableSchema)
                     .multipleSink(tableOptions.get(SINK_MULTIPLE_ENABLE))
@@ -164,7 +166,8 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
                     .equalityFieldColumns(equalityColumns)
                     .overwrite(overwrite)
                     .appendMode(tableOptions.get(IGNORE_ALL_CHANGELOG))
-                    .metric(tableOptions.get(INLONG_METRIC), tableOptions.get(INLONG_AUDIT))
+                    .metric(tableOptions.get(INLONG_METRIC), tableOptions.get(INLONG_AUDIT),
+                            tableOptions.get(AUDIT_KEYS))
                     .dirtyOptions(dirtyOptions)
                     .dirtySink(dirtySink)
                     .action(actionsProvider)

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/DynamicSchemaHandleOperator.java
@@ -118,6 +118,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
     // metric
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private @Nullable transient SinkTableMetricData metricData;
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
@@ -135,7 +136,8 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
             String auditHostAndPorts,
             boolean enableSchemaChange,
             String schemaChangePolicies,
-            boolean autoCreateTableWhenSnapshot) {
+            boolean autoCreateTableWhenSnapshot,
+            String auditKeys) {
         this.catalogLoader = catalogLoader;
         this.multipleSinkOption = multipleSinkOption;
         this.inlongMetric = inlongMetric;
@@ -144,6 +146,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
         this.schemaChangePolicies = schemaChangePolicies;
         this.enableSchemaChange = enableSchemaChange;
         this.autoCreateTableWhenSnapshot = autoCreateTableWhenSnapshot;
+        this.auditKeys = auditKeys;
     }
 
     @SuppressWarnings("unchecked")
@@ -174,6 +177,7 @@ public class DynamicSchemaHandleOperator extends AbstractStreamOperator<RecordWi
                 .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
                 .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
                 .withRegisterMetric(RegisteredMetric.ALL)
+                .withAuditKeys(auditKeys)
                 .build();
         if (metricOption != null) {
             metricData = new SinkTableMetricData(metricOption, getRuntimeContext().getMetricGroup());

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergMultipleStreamWriter.java
@@ -102,6 +102,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
     // metric
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private final DirtyOptions dirtyOptions;
     private @Nullable final DirtySink<Object> dirtySink;
 
@@ -123,7 +124,8 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
             @Nullable DirtySink<Object> dirtySink,
             RowType tableSchemaRowType,
             int metaFieldIndex,
-            boolean switchAppendUpsertEnable) {
+            boolean switchAppendUpsertEnable,
+            String auditKeys) {
         this.appendMode = appendMode;
         this.catalogLoader = catalogLoader;
         this.inlongMetric = inlongMetric;
@@ -134,6 +136,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
         this.tableSchemaRowType = tableSchemaRowType;
         this.metaFieldIndex = metaFieldIndex;
         this.switchAppendUpsertEnable = switchAppendUpsertEnable;
+        this.auditKeys = auditKeys;
     }
 
     @Override
@@ -152,6 +155,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
                 .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
                 .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
                 .withRegisterMetric(MetricOption.RegisteredMetric.ALL)
+                .withAuditKeys(auditKeys)
                 .build();
         if (metricOption != null) {
             sinkMetricData = new SinkTableMetricData(metricOption, runtimeContext.getMetricGroup());
@@ -246,7 +250,7 @@ public class IcebergMultipleStreamWriter extends IcebergProcessFunction<RecordWi
                 IcebergSingleStreamWriter<RowData> writer = new IcebergSingleStreamWriter<>(
                         tableId.toString(), taskWriterFactory, subWriterInlongMetric,
                         auditHostAndPorts, flinkRowType, dirtyOptions, dirtySink, true,
-                        tableSchemaRowType, metaFieldIndex, switchAppendUpsertEnable);
+                        tableSchemaRowType, metaFieldIndex, switchAppendUpsertEnable, auditKeys);
                 writer.setup(getRuntimeContext(),
                         new CallbackCollector<>(
                                 writeResult -> collector.collect(new MultipleWriteResult(tableId, writeResult))),

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/sink/multiple/IcebergSingleStreamWriter.java
@@ -70,6 +70,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
     private final String fullTableName;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private RowDataTaskWriterFactory taskWriterFactory;
 
     private transient TaskWriter<RowData> writer;
@@ -100,7 +101,8 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
             boolean multipleSink,
             RowType tableSchemaRowType,
             int incrementalFieldIndex,
-            boolean switchAppendUpsertEnable) {
+            boolean switchAppendUpsertEnable,
+            String auditKeys) {
         this.fullTableName = fullTableName;
         this.taskWriterFactory = taskWriterFactory;
         this.inlongMetric = inlongMetric;
@@ -113,6 +115,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
         this.incrementalFieldIndex = incrementalFieldIndex;
         this.cachedWriteResults = new ArrayList<>();
         this.switchAppendUpsertEnable = switchAppendUpsertEnable;
+        this.auditKeys = auditKeys;
     }
 
     public RowType getFlinkRowType() {
@@ -141,6 +144,7 @@ public class IcebergSingleStreamWriter<T> extends IcebergProcessFunction<T, Writ
                     .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
                     .withInitDirtyBytes(metricState != null ? metricState.getMetricValue(DIRTY_BYTES_OUT) : 0L)
                     .withRegisterMetric(RegisteredMetric.ALL)
+                    .withAuditKeys(auditKeys)
                     .build();
             if (metricOption != null) {
                 metricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcBatchingOutputFormat.java
@@ -97,6 +97,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
     private final RecordExtractor<In, JdbcIn> jdbcRecordExtractor;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private transient JdbcExec jdbcStatementExecutor;
     private transient int batchCount = 0;
     private transient volatile boolean closed = false;
@@ -122,7 +123,8 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
             String inlongMetric,
             String auditHostAndPorts,
             DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            @Nullable DirtySink<Object> dirtySink,
+            String auditKeys) {
         super(connectionProvider);
         this.executionOptions = checkNotNull(executionOptions);
         this.statementExecutorFactory = checkNotNull(statementExecutorFactory);
@@ -131,6 +133,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
         this.auditHostAndPorts = auditHostAndPorts;
         this.dirtyOptions = dirtyOptions;
         this.dirtySink = dirtySink;
+        this.auditKeys = auditKeys;
     }
 
     public static Builder builder() {
@@ -165,6 +168,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
         MetricOption metricOption = MetricOption.builder()
                 .withInlongLabels(inlongMetric)
                 .withAuditAddress(auditHostAndPorts)
+                .withAuditKeys(auditKeys)
                 .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_OUT) : 0L)
                 .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_OUT) : 0L)
                 .withInitDirtyRecords(metricState != null ? metricState.getMetricValue(DIRTY_RECORDS_OUT) : 0L)
@@ -509,6 +513,7 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
         private int[] fieldTypes;
         private String inlongMetric;
         private String auditHostAndPorts;
+        private String auditKeys;
         private JdbcExecutionOptions.Builder executionOptionsBuilder =
                 JdbcExecutionOptions.builder();
         private DirtyOptions dirtyOptions;
@@ -563,6 +568,14 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
         }
 
         /**
+         * auditKeys
+         */
+        public Builder setAuditKeys(String auditKeys) {
+            this.auditKeys = auditKeys;
+            return this;
+        }
+
+        /**
          * optional, flush max size (includes all append, upsert and delete records), over this
          * number of records, will flush data.
          */
@@ -611,7 +624,8 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
                         inlongMetric,
                         auditHostAndPorts,
                         dirtyOptions,
-                        dirtySink);
+                        dirtySink,
+                        auditKeys);
             } else {
                 // warn: don't close over builder fields
                 String sql =
@@ -634,7 +648,8 @@ public class JdbcBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatchStat
                         inlongMetric,
                         auditHostAndPorts,
                         dirtyOptions,
-                        dirtySink);
+                        dirtySink,
+                        auditKeys);
             }
         }
     }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -113,6 +113,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     private final JdbcExecutionOptions executionOptions;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private transient int batchCount = 0;
     private transient volatile boolean closed = false;
     private transient ScheduledExecutorService scheduler;
@@ -163,7 +164,8 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
             String inlongMetric,
             String auditHostAndPorts,
             SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy,
-            DirtySinkHelper<Object> dirtySinkHelper) {
+            DirtySinkHelper<Object> dirtySinkHelper,
+            String auditKeys) {
         super(connectionProvider);
         this.executionOptions = checkNotNull(executionOptions);
         this.dmlOptions = dmlOptions;
@@ -177,6 +179,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
         this.auditHostAndPorts = auditHostAndPorts;
         this.schemaUpdateExceptionPolicy = schemaUpdateExceptionPolicy;
         this.dirtySinkHelper = dirtySinkHelper;
+        this.auditKeys = auditKeys;
     }
 
     /**

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/TableJdbcUpsertOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/TableJdbcUpsertOutputFormat.java
@@ -66,7 +66,8 @@ class TableJdbcUpsertOutputFormat
             String inlongMetric,
             String auditHostAndPorts,
             DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            @Nullable DirtySink<Object> dirtySink,
+            String auditKeys) {
         this(
                 connectionProvider,
                 batchOptions,
@@ -75,7 +76,8 @@ class TableJdbcUpsertOutputFormat
                 inlongMetric,
                 auditHostAndPorts,
                 dirtyOptions,
-                dirtySink);
+                dirtySink,
+                auditKeys);
     }
 
     @VisibleForTesting
@@ -87,9 +89,10 @@ class TableJdbcUpsertOutputFormat
             String inlongMetric,
             String auditHostAndPorts,
             DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            @Nullable DirtySink<Object> dirtySink,
+            String auditKeys) {
         super(connectionProvider, batchOptions, statementExecutorFactory, tuple2 -> tuple2.f1,
-                inlongMetric, auditHostAndPorts, dirtyOptions, dirtySink);
+                inlongMetric, auditHostAndPorts, dirtyOptions, dirtySink, auditKeys);
         this.deleteStatementExecutorFactory = deleteStatementExecutorFactory;
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicOutputFormatBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicOutputFormatBuilder.java
@@ -71,6 +71,7 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
     private DataType[] fieldDataTypes;
     private String inlongMetric;
     private String auditHostAndPorts;
+    private String auditKeys;
     private String sinkMultipleFormat;
     private String databasePattern;
     private String tablePattern;
@@ -252,6 +253,11 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
         return this;
     }
 
+    public JdbcDynamicOutputFormatBuilder setAuditKeys(String auditKeys) {
+        this.auditKeys = auditKeys;
+        return this;
+    }
+
     public JdbcDynamicOutputFormatBuilder setSinkMultipleFormat(String sinkMultipleFormat) {
         this.sinkMultipleFormat = sinkMultipleFormat;
         return this;
@@ -308,7 +314,8 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
                     inlongMetric,
                     auditHostAndPorts,
                     dirtyOptions,
-                    dirtySink);
+                    dirtySink,
+                    auditKeys);
         } else {
             // append only query
             final String sql =
@@ -330,7 +337,8 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
                     inlongMetric,
                     auditHostAndPorts,
                     dirtyOptions,
-                    dirtySink);
+                    dirtySink,
+                    auditKeys);
         }
     }
 
@@ -352,6 +360,7 @@ public class JdbcDynamicOutputFormatBuilder implements Serializable {
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdateExceptionPolicy,
-                dirtySinkHelper);
+                dirtySinkHelper,
+                auditKeys);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableFactory.java
@@ -218,6 +218,7 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         boolean appendMode = config.get(SINK_APPEND_MODE);
         String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
         String auditHostAndPorts = config.getOptional(INLONG_AUDIT).orElse(null);
+        String auditKeys = config.getOptional(AUDIT_KEYS).orElse(null);
         SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy =
                 helper.getOptions().getOptional(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY).orElse(null);
         // Build the dirty data side-output
@@ -238,7 +239,8 @@ public class JdbcDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                 auditHostAndPorts,
                 schemaUpdateExceptionPolicy,
                 dirtyOptions,
-                dirtySink);
+                dirtySink,
+                auditKeys);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableSink.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/table/JdbcDynamicTableSink.java
@@ -57,6 +57,7 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
     private final boolean multipleSink;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private final boolean appendMode;
     private final String sinkMultipleFormat;
     private final String databasePattern;
@@ -82,7 +83,8 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
             String auditHostAndPorts,
             SchemaUpdateExceptionPolicy schemaUpdateExceptionPolicy,
             DirtyOptions dirtyOptions,
-            @Nullable DirtySink<Object> dirtySink) {
+            @Nullable DirtySink<Object> dirtySink,
+            String auditKeys) {
         this.jdbcOptions = jdbcOptions;
         this.executionOptions = executionOptions;
         this.dmlOptions = dmlOptions;
@@ -99,6 +101,7 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
         this.schemaUpdateExceptionPolicy = schemaUpdateExceptionPolicy;
         this.dirtyOptions = dirtyOptions;
         this.dirtySink = dirtySink;
+        this.auditKeys = auditKeys;
     }
 
     @Override
@@ -129,6 +132,7 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
         builder.setAuditHostAndPorts(auditHostAndPorts);
         builder.setDirtyOptions(dirtyOptions);
         builder.setDirtySink(dirtySink);
+        builder.setAuditKeys(auditKeys);
         if (multipleSink) {
             builder.setSinkMultipleFormat(sinkMultipleFormat);
             builder.setDatabasePattern(databasePattern);
@@ -151,7 +155,7 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
                 tableSchema, appendMode, multipleSink, sinkMultipleFormat,
                 databasePattern, tablePattern, schemaPattern,
                 inlongMetric, auditHostAndPorts,
-                schemaUpdateExceptionPolicy, dirtyOptions, dirtySink);
+                schemaUpdateExceptionPolicy, dirtyOptions, dirtySink, auditKeys);
     }
 
     @Override
@@ -176,12 +180,13 @@ public class JdbcDynamicTableSink implements DynamicTableSink {
                 && Objects.equals(inlongMetric, that.inlongMetric)
                 && Objects.equals(auditHostAndPorts, that.auditHostAndPorts)
                 && Objects.equals(dirtyOptions, that.dirtyOptions)
-                && Objects.equals(dirtySink, that.dirtySink);
+                && Objects.equals(dirtySink, that.dirtySink)
+                && Objects.equals(auditKeys, that.auditKeys);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(jdbcOptions, executionOptions, dmlOptions, tableSchema, dialectName,
-                inlongMetric, auditHostAndPorts);
+                inlongMetric, auditHostAndPorts, auditKeys);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/debezium/DebeziumSourceFunction.java
@@ -240,6 +240,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     private String inlongAudit;
 
+    private String auditKeys;
+
     private boolean migrateAll;
 
     private SourceTableMetricData sourceMetricData;
@@ -257,7 +259,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             Validator validator,
             String inlongMetric,
             String inlongAudit,
-            boolean migrateAll) {
+            boolean migrateAll,
+            String auditKeys) {
         this.deserializer = deserializer;
         this.properties = properties;
         this.specificOffset = specificOffset;
@@ -265,6 +268,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
         this.migrateAll = migrateAll;
+        this.auditKeys = auditKeys;
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
@@ -73,6 +73,7 @@ public class MySqlSource {
         private String inlongMetric;
         private String inlongAudit;
         private boolean migrateAll;
+        private String auditKeys;
 
         public Builder<T> hostname(String hostname) {
             this.hostname = hostname;
@@ -180,6 +181,11 @@ public class MySqlSource {
             return this;
         }
 
+        public Builder<T> auditKeys(String auditKeys) {
+            this.auditKeys = auditKeys;
+            return this;
+        }
+
         public Builder<T> migrateAll(boolean migrateAll) {
             this.migrateAll = migrateAll;
             return this;
@@ -281,7 +287,7 @@ public class MySqlSource {
 
             return new DebeziumSourceFunction<>(
                     deserializer, props, specificOffset, new MySqlValidator(props), inlongMetric, inlongAudit,
-                    migrateAll);
+                    migrateAll, auditKeys);
         }
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSource.java
@@ -155,6 +155,7 @@ public class MySqlSource<T>
         MetricOption metricOption = MetricOption.builder()
                 .withInlongLabels(sourceConfig.getInlongMetric())
                 .withAuditAddress(sourceConfig.getInlongAudit())
+                .withAuditKeys(sourceConfig.getAuditKyes())
                 .withRegisterMetric(RegisteredMetric.ALL)
                 .build();
         sourceReaderMetrics.registerMetrics(metricOption);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/MySqlSourceBuilder.java
@@ -263,6 +263,11 @@ public class MySqlSourceBuilder<T> {
         return this;
     }
 
+    public MySqlSourceBuilder<T> auditKeys(String auditKeys) {
+        this.configFactory.auditKeys(auditKeys);
+        return this;
+    }
+
     public MySqlSourceBuilder<T> migrateAll(boolean migrateAll) {
         this.configFactory.migrateAll(migrateAll);
         return this;

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfig.java
@@ -71,6 +71,7 @@ public class MySqlSourceConfig implements Serializable {
 
     private final String inlongMetric;
     private final String inlongAudit;
+    private final String auditKyes;
     private final boolean includeIncremental;
     private final boolean ghostDdlChange;
     private final String ghostTableRegex;
@@ -103,7 +104,8 @@ public class MySqlSourceConfig implements Serializable {
             boolean includeIncremental,
             boolean ghostDdlChange,
             String ghostTableRegex,
-            boolean migrateAll) {
+            boolean migrateAll,
+            String auditKyes) {
         this.hostname = checkNotNull(hostname);
         this.port = port;
         this.username = checkNotNull(username);
@@ -133,6 +135,7 @@ public class MySqlSourceConfig implements Serializable {
         this.ghostDdlChange = ghostDdlChange;
         this.ghostTableRegex = ghostTableRegex;
         this.migrateAll = migrateAll;
+        this.auditKyes = auditKyes;
     }
 
     public String getHostname() {
@@ -238,6 +241,10 @@ public class MySqlSourceConfig implements Serializable {
 
     public String getInlongAudit() {
         return inlongAudit;
+    }
+
+    public String getAuditKyes() {
+        return auditKyes;
     }
 
     public boolean isIncludeIncremental() {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/source/config/MySqlSourceConfigFactory.java
@@ -76,6 +76,7 @@ public class MySqlSourceConfigFactory implements Serializable {
 
     private String inlongMetric;
     private String inlongAudit;
+    private String auditKeys;
     private boolean includeIncremental;
     private boolean ghostDdlChange;
     private String ghostTableRegex;
@@ -88,6 +89,11 @@ public class MySqlSourceConfigFactory implements Serializable {
 
     public MySqlSourceConfigFactory inlongAudit(String inlongAudit) {
         this.inlongAudit = inlongAudit;
+        return this;
+    }
+
+    public MySqlSourceConfigFactory auditKeys(String auditKeys) {
+        this.auditKeys = auditKeys;
         return this;
     }
 
@@ -390,6 +396,7 @@ public class MySqlSourceConfigFactory implements Serializable {
                 includeIncremental,
                 ghostDdlChange,
                 ghostTableRegex,
-                migrateAll);
+                migrateAll,
+                auditKeys);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableInlongSourceFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableInlongSourceFactory.java
@@ -131,6 +131,7 @@ public class MySqlTableInlongSourceFactory implements DynamicTableSourceFactory 
         final ReadableConfig config = helper.getOptions();
         final String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
         final String inlongAudit = config.get(INLONG_AUDIT);
+        final String auditKeys = config.get(AUDIT_KEYS);
         final String hostname = config.get(HOSTNAME);
         final String username = config.get(USERNAME);
         final String password = config.get(PASSWORD);
@@ -206,7 +207,8 @@ public class MySqlTableInlongSourceFactory implements DynamicTableSourceFactory 
                 includeSchemaChange,
                 includeIncremental,
                 ghostDdlChange,
-                ghostTableRegex);
+                ghostTableRegex,
+                auditKeys);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/table/MySqlTableSource.java
@@ -86,6 +86,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
     private final boolean migrateAll;
     private final String inlongMetric;
     private final String inlongAudit;
+    private final String auditKeys;
     private final boolean includeIncremental;
     private final boolean includeSchemaChange;
     private final boolean ghostDdlChange;
@@ -139,7 +140,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
             boolean includeSchemaChange,
             boolean includeIncremental,
             boolean ghostDdlChange,
-            String ghostTableRegex) {
+            String ghostTableRegex,
+            String auditKeys) {
         this.physicalSchema = physicalSchema;
         this.port = port;
         this.hostname = checkNotNull(hostname);
@@ -170,6 +172,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
         this.migrateAll = migrateAll;
         this.inlongMetric = inlongMetric;
         this.inlongAudit = inlongAudit;
+        this.auditKeys = auditKeys;
         this.rowKindsFiltered = rowKindsFiltered;
         this.includeIncremental = includeIncremental;
         this.includeSchemaChange = includeSchemaChange;
@@ -238,6 +241,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .heartbeatInterval(heartbeatInterval)
                             .inlongMetric(inlongMetric)
                             .inlongAudit(inlongAudit)
+                            .auditKeys(auditKeys)
                             .includeIncremental(includeIncremental)
                             .ghostDdlChange(ghostDdlChange)
                             .ghostTableRegex(ghostTableRegex)
@@ -258,6 +262,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                             .startupOptions(startupOptions)
                             .inlongMetric(inlongMetric)
                             .inlongAudit(inlongAudit)
+                            .auditKeys(auditKeys)
                             .migrateAll(migrateAll)
                             .deserializer(deserializer);
             Optional.ofNullable(serverId)
@@ -335,7 +340,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                         includeSchemaChange,
                         includeIncremental,
                         ghostDdlChange,
-                        ghostTableRegex);
+                        ghostTableRegex,
+                        auditKeys);
         source.metadataKeys = metadataKeys;
         source.producedDataType = producedDataType;
         return source;
@@ -380,7 +386,7 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 && Objects.equals(includeSchemaChange, that.includeSchemaChange)
                 && Objects.equals(includeIncremental, that.includeIncremental)
                 && Objects.equals(ghostDdlChange, that.ghostDdlChange)
-                && Objects.equals(ghostDdlChange, that.ghostDdlChange);
+                && Objects.equals(auditKeys, that.auditKeys);
     }
 
     @Override
@@ -416,7 +422,8 @@ public class MySqlTableSource implements ScanTableSource, SupportsReadingMetadat
                 includeSchemaChange,
                 includeIncremental,
                 ghostDdlChange,
-                ghostTableRegex);
+                ghostTableRegex,
+                auditKeys);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicSinkFunction.java
@@ -107,6 +107,7 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
     private transient ListState<MetricState> metricStateListState;
     private transient MetricState metricState;
     private final String auditHostAndPorts;
+    private final String auditKeys;
 
     private transient JsonDynamicSchemaFormat jsonDynamicSchemaFormat;
 
@@ -122,7 +123,8 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
             String inlongMetric,
             String auditHostAndPorts,
             SchemaUpdateExceptionPolicy schemaUpdatePolicy,
-            DirtySinkHelper<Object> dirtySinkHelper) {
+            DirtySinkHelper<Object> dirtySinkHelper,
+            String auditKeys) {
         StarRocksJdbcConnectionOptions jdbcOptions = new StarRocksJdbcConnectionOptions(sinkOptions.getJdbcUrl(),
                 sinkOptions.getUsername(), sinkOptions.getPassword());
         StarRocksJdbcConnectionProvider jdbcConnProvider = new StarRocksJdbcConnectionProvider(jdbcOptions);
@@ -143,6 +145,7 @@ public class StarRocksDynamicSinkFunction<T> extends RichSinkFunction<T> impleme
         this.tablePattern = tablePattern;
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
+        this.auditKeys = auditKeys;
 
         this.dirtySinkHelper = dirtySinkHelper;
     }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSink.java
@@ -39,6 +39,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
     private final String tablePattern;
     private final String inlongMetric;
     private final String auditHostAndPorts;
+    private final String auditKeys;
     private final SchemaUpdateExceptionPolicy schemaUpdatePolicy;
     private final DirtySinkHelper<Object> dirtySinkHelper;
 
@@ -51,7 +52,8 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
             String inlongMetric,
             String auditHostAndPorts,
             SchemaUpdateExceptionPolicy schemaUpdatePolicy,
-            DirtySinkHelper<Object> dirtySinkHelper) {
+            DirtySinkHelper<Object> dirtySinkHelper,
+            String auditKeys) {
         this.flinkSchema = schema;
         this.sinkOptions = sinkOptions;
         this.multipleSink = multipleSink;
@@ -62,6 +64,7 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
         this.auditHostAndPorts = auditHostAndPorts;
         this.schemaUpdatePolicy = schemaUpdatePolicy;
         this.dirtySinkHelper = dirtySinkHelper;
+        this.auditKeys = auditKeys;
     }
 
     @Override
@@ -83,7 +86,8 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtySinkHelper);
+                dirtySinkHelper,
+                auditKeys);
         return SinkFunctionProvider.of(starrocksSinkFunction, sinkOptions.getSinkParallelism());
     }
 
@@ -98,7 +102,8 @@ public class StarRocksDynamicTableSink implements DynamicTableSink {
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtySinkHelper);
+                dirtySinkHelper,
+                auditKeys);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/StarRocksDynamicTableSinkFactory.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.utils.TableSchemaUtils;
 import java.util.HashSet;
 import java.util.Set;
 
+import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.DIRTY_PREFIX;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
@@ -67,6 +68,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         SchemaUpdateExceptionPolicy schemaUpdatePolicy = helper.getOptions().get(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY);
         String inlongMetric = helper.getOptions().getOptional(INLONG_METRIC).orElse(INLONG_METRIC.defaultValue());
         String auditHostAndPorts = helper.getOptions().getOptional(INLONG_AUDIT).orElse(INLONG_AUDIT.defaultValue());
+        String auditKeys = helper.getOptions().getOptional(AUDIT_KEYS).orElse(AUDIT_KEYS.defaultValue());
 
         // Build the dirty data side-output
         final DirtyOptions dirtyOptions = DirtyOptions.fromConfig(helper.getOptions());
@@ -88,7 +90,8 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
                 inlongMetric,
                 auditHostAndPorts,
                 schemaUpdatePolicy,
-                dirtySinkHelper);
+                dirtySinkHelper,
+                auditKeys);
     }
 
     @Override
@@ -127,6 +130,7 @@ public class StarRocksDynamicTableSinkFactory implements DynamicTableSinkFactory
         optionalOptions.add(SINK_MULTIPLE_SCHEMA_UPDATE_POLICY);
         optionalOptions.add(INLONG_METRIC);
         optionalOptions.add(INLONG_AUDIT);
+        optionalOptions.add(AUDIT_KEYS);
 
         return optionalOptions;
     }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8797 

### Motivation

1. Sort does not support audit ids sent by the Manager for data sync.

### Modifications

1. The manager adds audit IDs to send.
2. `JDBC`, `MySQL-CDC`, `Iceberg`, and `Starrocks` connectors support audit id.

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/bcce8ced-642b-45c2-94b3-401a54bcaa2c)

