### PR TITLE
[INLONG-8799][Manager][Agent][Dataproxy] Fix the configuration related to "Opentelemetry".

### DIFF
--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -20,9 +20,11 @@
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_agent
 export OTEL_VERSION=1.28.0
-export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
-
+# Whether to enable observability.
+export ENABLE_OBSERVABILITY=false
 #project directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -23,7 +23,7 @@ export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
-# Whether to enable observability.
+# Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
 #project directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)

--- a/inlong-agent/bin/agent-env.sh
+++ b/inlong-agent/bin/agent-env.sh
@@ -21,10 +21,11 @@
 export OTEL_SERVICE_NAME=inlong_agent
 export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
-export OTEL_RESOURCE_ATTRIBUTES=
 # Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
+# OTEL_EXPORTER_OTLP_ENDPOINT must be configured as a URL when ENABLE_OBSERVABILITY=true.
+export OTEL_EXPORTER_OTLP_ENDPOINT=
+
 #project directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 

--- a/inlong-agent/bin/agent.sh
+++ b/inlong-agent/bin/agent.sh
@@ -46,7 +46,11 @@ function start_agent() {
     echo "agent is running."
     exit 1
   fi
-  nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+    nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  else
+    nohup ${JAVA} ${AGENT_ARGS} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
+  fi
 }
 
 # stop agent

--- a/inlong-agent/bin/agent.sh
+++ b/inlong-agent/bin/agent.sh
@@ -46,7 +46,7 @@ function start_agent() {
     echo "agent is running."
     exit 1
   fi
-  if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+  if [ "$ENABLE_OBSERVABILITY" = "true" ]; then
     nohup ${JAVA} ${AGENT_ARGS} -javaagent:${OTEL_AGENT} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &
   else
     nohup ${JAVA} ${AGENT_ARGS} org.apache.inlong.agent.core.AgentMain > /dev/null 2>&1 &

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -33,7 +33,7 @@ export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
-# Whether to enable observability.
+# Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
 
 CLEAN_FLAG=1

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -31,10 +31,10 @@ FLUME_VERSION_CLASS="org.apache.flume.tools.VersionInfo"
 export OTEL_SERVICE_NAME=inlong_dataproxy
 export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
-export OTEL_RESOURCE_ATTRIBUTES=
 # Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
+# OTEL_EXPORTER_OTLP_ENDPOINT must be configured as a URL when ENABLE_OBSERVABILITY=true.
+export OTEL_EXPORTER_OTLP_ENDPOINT=
 
 CLEAN_FLAG=1
 ################################

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -225,7 +225,7 @@ run_flume() {
     set -x
   fi
 
-  if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+  if [ "$ENABLE_OBSERVABILITY" = "true" ]; then
     $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_AGENT} -cp "$DATAPROXY_CLASSPATH" \
           -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
   else

--- a/inlong-dataproxy/bin/dataproxy-ng
+++ b/inlong-dataproxy/bin/dataproxy-ng
@@ -30,11 +30,11 @@ FLUME_VERSION_CLASS="org.apache.flume.tools.VersionInfo"
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_dataproxy
 export OTEL_VERSION=1.28.0
-export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
-
-# Opentelemetry java agent path
-OTEL_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
+# Whether to enable observability.
+export ENABLE_OBSERVABILITY=false
 
 CLEAN_FLAG=1
 ################################
@@ -224,8 +224,14 @@ run_flume() {
   if [ ${CLEAN_FLAG} -ne 0 ]; then
     set -x
   fi
-  $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_AGENT} -cp "$DATAPROXY_CLASSPATH" \
-      -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
+
+  if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+    $EXEC $JAVA_HOME/bin/java $JAVA_OPTS -javaagent:${OTEL_AGENT} -cp "$DATAPROXY_CLASSPATH" \
+          -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
+  else
+    $EXEC $JAVA_HOME/bin/java -cp "$DATAPROXY_CLASSPATH" \
+          -Djava.library.path=$FLUME_JAVA_LIBRARY_PATH "$FLUME_APPLICATION_CLASS" $*
+  fi
 }
 
 ################################
@@ -357,6 +363,9 @@ fi
 if [ -z "${DATAPROXY_HOME}" ]; then
   DATAPROXY_HOME=$(cd $(dirname $0)/..; pwd)
 fi
+
+# Opentelemetry java agent path
+OTEL_AGENT="${DATAPROXY_HOME}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # prepend $DATAPROXY_HOME/lib jars to the specified classpath (if any)
 if [ -n "${DATAPROXY_CLASSPATH}" ] ; then

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -98,7 +98,7 @@ export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
-# Whether to enable observability.
+# Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
 
 # Opentelemetry java agent path

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -96,10 +96,10 @@ JAVA_OPT="${JAVA_OPT} -XX:+IgnoreUnrecognizedVMOptions -XX:+UseConcMarkSweepGC -
 export OTEL_SERVICE_NAME=inlong_manager
 export OTEL_VERSION=1.28.0
 export OTEL_LOGS_EXPORTER=otlp
-export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
-export OTEL_RESOURCE_ATTRIBUTES=
 # Whether to enable observability. true:enable; others:disable.
 export ENABLE_OBSERVABILITY=false
+# OTEL_EXPORTER_OTLP_ENDPOINT must be configured as a URL when ENABLE_OBSERVABILITY=true.
+export OTEL_EXPORTER_OTLP_ENDPOINT=
 
 # Opentelemetry java agent path
 OTEL_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -95,17 +95,23 @@ JAVA_OPT="${JAVA_OPT} -XX:+IgnoreUnrecognizedVMOptions -XX:+UseConcMarkSweepGC -
 # Opentelemetry startup parameter configuration
 export OTEL_SERVICE_NAME=inlong_manager
 export OTEL_VERSION=1.28.0
-export OTEL_EXPORTER_OTLP_ENDPOINT=
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://127.0.0.1:4317"
 export OTEL_RESOURCE_ATTRIBUTES=
+# Whether to enable observability.
+export ENABLE_OBSERVABILITY=false
 
 # Opentelemetry java agent path
 OTEL_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
-nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
-
-# Print the startup log
-STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"
+if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+  nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
+  STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"
+else
+  nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
+  STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"
+fi
 
 # Process ID
 PID="$!"

--- a/inlong-manager/manager-web/bin/startup.sh
+++ b/inlong-manager/manager-web/bin/startup.sh
@@ -105,7 +105,7 @@ export ENABLE_OBSERVABILITY=false
 OTEL_AGENT="${BASE_PATH}/lib/opentelemetry-javaagent-${OTEL_VERSION}.jar"
 
 # Start service: start the project in the background, and output the log to the logs folder under the project root directory
-if [ "$OPEN_OBSERVABILITY" = "true" ]; then
+if [ "$ENABLE_OBSERVABILITY" = "true" ]; then
   nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &
   STARTUP_LOG="startup command: nohup java ${JAVA_OPT} -javaagent:${OTEL_AGENT} -cp ${CLASSPATH} ${MAIN_CLASS} 1>/dev/null 2>${LOG_DIR}/error.log &\n"
 else


### PR DESCRIPTION
### Prepare a Pull Request
- Title Example: [INLONG-8799][Manager][Agent][Dataproxy] Fix the configuration related to "Opentelemetry".

- Fixes #8799 

### Modifications

- Correct the path of javaagent in dataproxy.
- Make it be configurable whether the observable service is turned on or not.
- Add Default otlp export address is missing.
- Add export protocol of logs.
