### PR TITLE
[INLONG-8796][Sort] Add SchemaChangeEventHandler to deal schema change event by each connector

### DIFF
--- a/inlong-sort/sort-flink/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/relational/handler/SchemaChangeEventHandler.java
+++ b/inlong-sort/sort-flink/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/relational/handler/SchemaChangeEventHandler.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.base.relational.handler;
+
+import io.debezium.schema.SchemaChangeEvent;
+
+import java.util.Map;
+
+/** SchemaChangeEvent Handler */
+public interface SchemaChangeEventHandler {
+
+    Map<String, Object> parseSource(SchemaChangeEvent event);
+}

--- a/inlong-sort/sort-flink/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/util/RecordUtils.java
+++ b/inlong-sort/sort-flink/cdc-base/src/main/java/org/apache/inlong/sort/cdc/base/util/RecordUtils.java
@@ -56,8 +56,7 @@ public class RecordUtils {
             .asList("CHAR", "NCHAR", "NVARCHAR2", "NVCHAER", "VARCHAR", "VARCHAR2", "CLOB", "NCLOB", "XMLType");
     private static final List<String> BINARY_TYPE = Arrays.asList("BLOB", "ROWID");
     private static final List<String> BIGINT_TYPE = Arrays.asList("INTERVAL DAY TO SECOND", "INTERVAL YEAR TO MONTH");
-    public static final String MYSQL_SCHEMA_CHANGE_EVENT_KEY_NAME = "io.debezium.connector.mysql.SchemaChangeKey";
-    public static final String ORACLE_SCHEMA_CHANGE_EVENT_KEY_NAME = "io.debezium.connector.oracle.SchemaChangeKey";
+    public static final String SCHEMA_CHANGE_EVENT_KEY_NAME = "io.debezium.connector.*.SchemaChangeKey";
     public static final String CONNECTOR = "connector";
     public static final String MYSQL_CONNECTOR = "mysql";
 
@@ -145,18 +144,7 @@ public class RecordUtils {
      */
     public static boolean isSchemaChangeEvent(SourceRecord sourceRecord) {
         Schema keySchema = sourceRecord.keySchema();
-        return keySchema != null && (MYSQL_SCHEMA_CHANGE_EVENT_KEY_NAME.equalsIgnoreCase(keySchema.name())
-                || ORACLE_SCHEMA_CHANGE_EVENT_KEY_NAME.equalsIgnoreCase(keySchema.name()));
-    }
-
-    /**
-     * Whether the source belong Mysql Connector
-     * @param source
-     * @return true if the source belong Mysql Connector
-     */
-    public static boolean isMysqlConnector(Struct source) {
-        String connector = source.getString(CONNECTOR);
-        return MYSQL_CONNECTOR.equalsIgnoreCase(connector);
+        return keySchema != null && (keySchema.name().matches(SCHEMA_CHANGE_EVENT_KEY_NAME));
     }
 
     public static boolean isDdlRecord(Struct value) {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/fetch/OracleSourceFetchTaskContext.java
@@ -25,6 +25,7 @@ import org.apache.inlong.sort.cdc.base.source.meta.split.SourceSplitBase;
 import org.apache.inlong.sort.cdc.base.source.reader.external.JdbcSourceFetchTaskContext;
 import org.apache.inlong.sort.cdc.oracle.source.config.OracleSourceConfig;
 import org.apache.inlong.sort.cdc.oracle.source.meta.offset.RedoLogOffset;
+import org.apache.inlong.sort.cdc.oracle.source.reader.handler.OracleSchemaChangeEventHandler;
 import org.apache.inlong.sort.cdc.oracle.source.relational.OracleSourceEventDispatcher;
 import org.apache.inlong.sort.cdc.oracle.source.utils.OracleUtils;
 
@@ -134,7 +135,8 @@ public class OracleSourceFetchTaskContext extends JdbcSourceFetchTaskContext {
                         connectorConfig.getTableFilters().dataCollectionFilter(),
                         DataChangeEvent::new,
                         metadataProvider,
-                        schemaNameAdjuster);
+                        schemaNameAdjuster,
+                        new OracleSchemaChangeEventHandler());
 
         final OracleChangeEventSourceMetricsFactory changeEventSourceMetricsFactory =
                 new OracleChangeEventSourceMetricsFactory(

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/handler/OracleSchemaChangeEventHandler.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/reader/handler/OracleSchemaChangeEventHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.oracle.source.reader.handler;
+
+import org.apache.inlong.sort.cdc.base.relational.handler.SchemaChangeEventHandler;
+
+import io.debezium.schema.SchemaChangeEvent;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.debezium.connector.oracle.SourceInfo.SCN_KEY;
+
+public class OracleSchemaChangeEventHandler implements SchemaChangeEventHandler {
+
+    @Override
+    public Map<String, Object> parseSource(SchemaChangeEvent event) {
+        Map<String, Object> source = new HashMap<>();
+        Struct sourceInfo = event.getSource();
+        String scn = sourceInfo.getString(SCN_KEY);
+        source.put(SCN_KEY, scn);
+        return source;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/relational/OracleSourceEventDispatcher.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/relational/OracleSourceEventDispatcher.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.cdc.oracle.source.relational;
 
 import org.apache.inlong.sort.cdc.base.relational.JdbcSourceEventDispatcher;
+import org.apache.inlong.sort.cdc.base.relational.handler.SchemaChangeEventHandler;
 
 import io.debezium.config.CommonConnectorConfig;
 import io.debezium.connector.base.ChangeEventQueue;
@@ -66,7 +67,8 @@ public class OracleSourceEventDispatcher extends JdbcSourceEventDispatcher {
             DataCollectionFilters.DataCollectionFilter<TableId> filter,
             ChangeEventCreator changeEventCreator,
             EventMetadataProvider metadataProvider,
-            SchemaNameAdjuster schemaNameAdjuster) {
+            SchemaNameAdjuster schemaNameAdjuster,
+            SchemaChangeEventHandler schemaChangeEventHandler) {
         super(
                 connectorConfig,
                 topicSelector,
@@ -75,7 +77,8 @@ public class OracleSourceEventDispatcher extends JdbcSourceEventDispatcher {
                 filter,
                 changeEventCreator,
                 metadataProvider,
-                schemaNameAdjuster);
+                schemaNameAdjuster,
+                schemaChangeEventHandler);
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8796] Add SchemaChangeEventHandler to deal schema change event by each connector

- Fixes #8796 

### Motivation

When a SchemaChangeEvent is triggered, the `schemaChangeRecordValue` will obtain binlog information from **sourceInfo**. However, only MySQL CDC has binlog information, and other CDC will report an error after triggering a SchemaChangeEvent event.  So I provided an interface for each connector to implement their own sourceinfo parsing. 

<img width="1413" alt="image" src="https://github.com/ververica/flink-cdc-connectors/assets/111486498/8ce12a7d-0734-46d2-bf4f-1b8cd3cb1bd5">

### Modifications

Add the `SchemaChangeEventHandler` interface, and each connector implements this interface to parse source.
