### PR TITLE
[INLONG-8819][DataProxy] Optimize ConfigHolder related subclass loading processing

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/PropertiesHolder.java
@@ -84,15 +84,15 @@ public abstract class PropertiesHolder extends ConfigHolder {
         try {
             Map<String, String> loadMap = loadConfigFromFile();
             if (loadMap == null || loadMap.isEmpty()) {
-                LOG.debug("Load changed properties {}, but no records configured", getFileName());
-                return false;
+                LOG.warn("Load changed properties {}, but no records configured", getFileName());
+                return true;
             }
             // filter blank items
             Map<String, String> filteredMap = filterInValidRecords(loadMap);
             if (filteredMap.isEmpty()) {
-                LOG.info("Load changed properties {}, but the records are all illegal {}",
+                LOG.warn("Load changed properties {}, but the records are all illegal {}",
                         getFileName(), loadMap);
-                return false;
+                return true;
             }
             // remove records
             Set<String> rmvKeys = new HashSet<>();
@@ -116,13 +116,14 @@ public abstract class PropertiesHolder extends ConfigHolder {
                 }
             }
             if (rmvKeys.isEmpty() && repKeys.isEmpty()) {
-                return false;
+                LOG.warn("Load changed properties {}, but no add or delete records", getFileName());
+                return true;
             }
             // update cache data
             boolean result = updateCacheData();
             // output update result
-            LOG.info("Load changed properties {}, loaded config {}, updated holder {}, updated cache {}",
-                    getFileName(), loadMap, confHolder, result);
+            LOG.info("Load changed properties {}, deleted_record = {}, updated_record = {}, updated_cache = {}",
+                    getFileName(), rmvKeys.isEmpty(), repKeys.isEmpty(), result);
             return true;
         } finally {
             readWriteLock.readLock().unlock();

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/VisitConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/VisitConfigHolder.java
@@ -63,7 +63,7 @@ public class VisitConfigHolder extends ConfigHolder {
         try {
             Map<String, Long> tmpHolder = loadFile();
             if (tmpHolder == null) {
-                return false;
+                return true;
             }
             // clear removed records
             boolean added = false;
@@ -126,14 +126,23 @@ public class VisitConfigHolder extends ConfigHolder {
                     added = true;
                 }
             }
-            if (!tmpKeys.isEmpty()) {
-                if (this.isBlackList) {
+            // output load result
+            if (this.isBlackList) {
+                if (!tmpKeys.isEmpty()) {
                     LOG.warn("Load BlackList data error, found error data items: " + tmpKeys);
-                } else {
+                }
+                if (added) {
+                    LOG.info("Load BlackList data, new data items are added!");
+                }
+            } else {
+                if (!tmpKeys.isEmpty()) {
                     LOG.warn("Load WhiteList data error, found error data items: " + tmpKeys);
                 }
+                if (removed) {
+                    LOG.info("Load WhiteList data, cached data items are deleted!");
+                }
             }
-            return (isBlackList && added) || (!isBlackList && removed);
+            return true;
         } finally {
             readWriteLock.writeLock().unlock();
         }


### PR DESCRIPTION

- Fixes #8819

1. Adjust the initialization value of lastModifyTime, only when the configuration file is updated successfully will the last modification time of the file be saved;
2. Adjust the return value of the subclass loadFromFileToHolder() function so that it returns true as long as the loading operation is performed.
3. Adjust the MD5 value comparison function in MetaConfigHolder to use case-sensitive mode;
4. Adjust the log output content to accurately express the problems found in each inspection link