### PR TITLE
[INLONG-8827][Manager] Fix Inlong manager sql directory in docker README

### DIFF
--- a/docker/docker-compose/README.md
+++ b/docker/docker-compose/README.md
@@ -12,7 +12,7 @@ Requirements:
 Manually copy SQL files from `inlong-manager/sql` and `inlong-audit/sql` to the `docker/docker-compose/sql` directory.
 
 ```shell
-cp inlong-manager/sql/apache_inlong_manager.sql docker/docker-compose/sql
+cp inlong-manager/manager-web/sql/apache_inlong_manager.sql docker/docker-compose/sql
 cp inlong-audit/sql/apache_inlong_audit.sql docker/docker-compose/sql
 ```
 


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8827

### Motivation

Inlong manager sql directory is incorrect in docker README
![image](https://github.com/apache/inlong/assets/26538404/85da4b81-1c07-4382-9ae7-137f83cc5556)

### Modifications

make directory right 

### Documentation

  - Does this pull request introduce a new feature? (no)