### PR TITLE
[INLONG-8836][Audit] Add audit_tag information to distinguish data sources and data targets 

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/protocol/AuditData.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/protocol/AuditData.java
@@ -28,6 +28,7 @@ public class AuditData {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
+    private String subAuditId;
     private long count;
     private long size;
     private long delay;
@@ -104,6 +105,13 @@ public class AuditData {
         this.auditId = auditId;
     }
 
+    public String getSubAuditId() {
+        return subAuditId;
+    }
+
+    public void setSubAuditId(String subAuditId) {
+        this.subAuditId = subAuditId;
+    }
     public long getCount() {
         return count;
     }

--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/protocol/AuditData.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/protocol/AuditData.java
@@ -28,7 +28,7 @@ public class AuditData {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
-    private String subAuditId;
+    private String auditTag;
     private long count;
     private long size;
     private long delay;
@@ -105,12 +105,12 @@ public class AuditData {
         this.auditId = auditId;
     }
 
-    public String getSubAuditId() {
-        return subAuditId;
+    public String getAuditTag() {
+        return auditTag;
     }
 
-    public void setSubAuditId(String subAuditId) {
-        this.subAuditId = subAuditId;
+    public void setAuditTag(String auditTag) {
+        this.auditTag = auditTag;
     }
     public long getCount() {
         return count;

--- a/inlong-audit/audit-common/src/main/proto/AuditApi.proto
+++ b/inlong-audit/audit-common/src/main/proto/AuditApi.proto
@@ -58,9 +58,10 @@ message AuditMessageBody {
   string inlong_group_id = 2;
   string inlong_stream_id = 3;
   string audit_id = 4;
-  uint64 count = 5;
-  uint64 size = 6;
-  int64  delay = 7;
+  string sub_audit_id = 5;
+  uint64 count = 6;
+  uint64 size = 7;
+  int64  delay = 8;
 }
 
 message AuditReply {

--- a/inlong-audit/audit-common/src/main/proto/AuditApi.proto
+++ b/inlong-audit/audit-common/src/main/proto/AuditApi.proto
@@ -58,10 +58,10 @@ message AuditMessageBody {
   string inlong_group_id = 2;
   string inlong_stream_id = 3;
   string audit_id = 4;
-  string sub_audit_id = 5;
-  uint64 count = 6;
-  uint64 size = 7;
-  int64  delay = 8;
+  uint64 count = 5;
+  uint64 size = 6;
+  int64  delay = 7;
+  string audit_tag = 8;
 }
 
 message AuditReply {

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
@@ -166,7 +166,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
 
             auditData.setLogTs(auditMessageBody.getLogTs());
             auditData.setAuditId(auditMessageBody.getAuditId());
-            auditData.setSubAuditId(auditMessageBody.getSubAuditId());
+            auditData.setAuditTag(auditMessageBody.getAuditTag());
             auditData.setCount(auditMessageBody.getCount());
             auditData.setDelay(auditMessageBody.getDelay());
             auditData.setInlongGroupId(auditMessageBody.getInlongGroupId());

--- a/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
+++ b/inlong-audit/audit-proxy/src/main/java/org/apache/inlong/audit/source/ServerMessageHandler.java
@@ -166,6 +166,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
 
             auditData.setLogTs(auditMessageBody.getLogTs());
             auditData.setAuditId(auditMessageBody.getAuditId());
+            auditData.setSubAuditId(auditMessageBody.getSubAuditId());
             auditData.setCount(auditMessageBody.getCount());
             auditData.setDelay(auditMessageBody.getDelay());
             auditData.setInlongGroupId(auditMessageBody.getInlongGroupId());

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
@@ -46,7 +46,7 @@ public class AuditOperator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditOperator.class);
     private static final String FIELD_SEPARATORS = ":";
-    private static final String DEFAULT_SUB_AUDIT_ID = "-1";
+    private static final String DEFAULT_AUDIT_TAG = "-1";
     private static final int BATCH_NUM = 100;
     private static final AuditOperator AUDIT_OPERATOR = new AuditOperator();
     private static final ReentrantLock GLOBAL_LOCK = new ReentrantLock();
@@ -134,14 +134,14 @@ public class AuditOperator {
      * Add audit data
      */
     public void add(int auditID, String inlongGroupID, String inlongStreamID, Long logTime, long count, long size) {
-        add(auditID, DEFAULT_SUB_AUDIT_ID, inlongGroupID, inlongStreamID, logTime, count, size);
+        add(auditID, DEFAULT_AUDIT_TAG, inlongGroupID, inlongStreamID, logTime, count, size);
     }
 
-    public void add(int auditID, String subAuditID, String inlongGroupID, String inlongStreamID, Long logTime,
+    public void add(int auditID, String auditTag, String inlongGroupID, String inlongStreamID, Long logTime,
             long count, long size) {
         long delayTime = System.currentTimeMillis() - logTime;
         String key = (logTime / PERIOD) + FIELD_SEPARATORS + inlongGroupID + FIELD_SEPARATORS
-                + inlongStreamID + FIELD_SEPARATORS + auditID + FIELD_SEPARATORS + subAuditID;
+                + inlongStreamID + FIELD_SEPARATORS + auditID + FIELD_SEPARATORS + auditTag;
         addByKey(key, count, size, delayTime);
     }
 
@@ -202,14 +202,14 @@ public class AuditOperator {
             String inlongGroupID = keyArray[1];
             String inlongStreamID = keyArray[2];
             String auditID = keyArray[3];
-            String subAuditID = keyArray[4];
+            String auditTag = keyArray[4];
             StatInfo value = entry.getValue();
             AuditApi.AuditMessageBody msgBody = AuditApi.AuditMessageBody.newBuilder()
                     .setLogTs(logTime)
                     .setInlongGroupId(inlongGroupID)
                     .setInlongStreamId(inlongStreamID)
                     .setAuditId(auditID)
-                    .setAuditId(subAuditID)
+                    .setAuditTag(auditTag)
                     .setCount(value.count.get())
                     .setSize(value.size.get())
                     .setDelay(value.delay.get())

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
@@ -46,6 +46,7 @@ public class AuditOperator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditOperator.class);
     private static final String FIELD_SEPARATORS = ":";
+    private static final String DEFAULT_SUB_AUDIT_ID = "-1";
     private static final int BATCH_NUM = 100;
     private static final AuditOperator AUDIT_OPERATOR = new AuditOperator();
     private static final ReentrantLock GLOBAL_LOCK = new ReentrantLock();
@@ -133,9 +134,18 @@ public class AuditOperator {
      * Add audit data
      */
     public void add(int auditID, String inlongGroupID, String inlongStreamID, Long logTime, long count, long size) {
+        // long delayTime = System.currentTimeMillis() - logTime;
+        // String key = (logTime / PERIOD) + FIELD_SEPARATORS + inlongGroupID + FIELD_SEPARATORS
+        // + inlongStreamID + FIELD_SEPARATORS + auditID;
+        // addByKey(key, count, size, delayTime);
+        add(auditID, DEFAULT_SUB_AUDIT_ID, inlongGroupID, inlongStreamID, logTime, count, size);
+    }
+
+    public void add(int auditID, String subAuditID, String inlongGroupID, String inlongStreamID, Long logTime,
+            long count, long size) {
         long delayTime = System.currentTimeMillis() - logTime;
         String key = (logTime / PERIOD) + FIELD_SEPARATORS + inlongGroupID + FIELD_SEPARATORS
-                + inlongStreamID + FIELD_SEPARATORS + auditID;
+                + inlongStreamID + FIELD_SEPARATORS + auditID + FIELD_SEPARATORS + subAuditID;
         addByKey(key, count, size, delayTime);
     }
 
@@ -196,12 +206,14 @@ public class AuditOperator {
             String inlongGroupID = keyArray[1];
             String inlongStreamID = keyArray[2];
             String auditID = keyArray[3];
+            String subAuditID = keyArray[4];
             StatInfo value = entry.getValue();
             AuditApi.AuditMessageBody msgBody = AuditApi.AuditMessageBody.newBuilder()
                     .setLogTs(logTime)
                     .setInlongGroupId(inlongGroupID)
                     .setInlongStreamId(inlongStreamID)
                     .setAuditId(auditID)
+                    .setAuditId(subAuditID)
                     .setCount(value.count.get())
                     .setSize(value.size.get())
                     .setDelay(value.delay.get())

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditOperator.java
@@ -134,10 +134,6 @@ public class AuditOperator {
      * Add audit data
      */
     public void add(int auditID, String inlongGroupID, String inlongStreamID, Long logTime, long count, long size) {
-        // long delayTime = System.currentTimeMillis() - logTime;
-        // String key = (logTime / PERIOD) + FIELD_SEPARATORS + inlongGroupID + FIELD_SEPARATORS
-        // + inlongStreamID + FIELD_SEPARATORS + auditID;
-        // addByKey(key, count, size, delayTime);
         add(auditID, DEFAULT_SUB_AUDIT_ID, inlongGroupID, inlongStreamID, logTime, count, size);
     }
 

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/AuditDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/AuditDataPo.java
@@ -36,6 +36,7 @@ public class AuditDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
+    private String subAuditId;
     private Long count;
     private Long size;
     private Long delay;

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/AuditDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/AuditDataPo.java
@@ -36,7 +36,7 @@ public class AuditDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
-    private String subAuditId;
+    private String auditTag;
     private Long count;
     private Long size;
     private Long delay;

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
@@ -35,7 +35,7 @@ public class ClickHouseDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
-    private String subAuditId;
+    private String auditTag;
     private Long count;
     private Long size;
     private Long delay;

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ClickHouseDataPo.java
@@ -35,6 +35,7 @@ public class ClickHouseDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
+    private String subAuditId;
     private Long count;
     private Long size;
     private Long delay;

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ESDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ESDataPo.java
@@ -34,6 +34,7 @@ public class ESDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
+    private String subAuditId;
     private long count;
     private long size;
     private long delay;
@@ -41,7 +42,7 @@ public class ESDataPo {
 
     public String getDocId() {
         String docId = ip + dockerId + threadId + sdkTs + packetId + logTs + inlongGroupId + inlongStreamId
-                + auditId + count;
+                + auditId + subAuditId + count;
         return docId;
     }
 }

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ESDataPo.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/db/entities/ESDataPo.java
@@ -34,7 +34,7 @@ public class ESDataPo {
     private String inlongGroupId;
     private String inlongStreamId;
     private String auditId;
-    private String subAuditId;
+    private String auditTag;
     private long count;
     private long size;
     private long delay;
@@ -42,7 +42,7 @@ public class ESDataPo {
 
     public String getDocId() {
         String docId = ip + dockerId + threadId + sdkTs + packetId + logTs + inlongGroupId + inlongStreamId
-                + auditId + subAuditId + count;
+                + auditId + auditTag + count;
         return docId;
     }
 }

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ClickHouseService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ClickHouseService.java
@@ -45,7 +45,7 @@ public class ClickHouseService implements InsertData, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseService.class);
     public static final String INSERT_SQL = "insert into audit_data (ip, docker_id, thread_id,\r\n"
             + "      sdk_ts, packet_id, log_ts,\r\n"
-            + "      inlong_group_id, inlong_stream_id, audit_id,sub_audit_id,\r\n"
+            + "      inlong_group_id, inlong_stream_id, audit_id,audit_tag,\r\n"
             + "      count, size, delay, \r\n"
             + "      update_time)\r\n"
             + "    values (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
@@ -110,7 +110,7 @@ public class ClickHouseService implements InsertData, AutoCloseable {
                 pstat.setString(7, data.getInlongGroupId());
                 pstat.setString(8, data.getInlongStreamId());
                 pstat.setString(9, data.getAuditId());
-                pstat.setString(10, data.getSubAuditId());
+                pstat.setString(10, data.getAuditTag());
                 pstat.setLong(11, data.getCount());
                 pstat.setLong(12, data.getSize());
                 pstat.setLong(13, data.getDelay());
@@ -174,7 +174,7 @@ public class ClickHouseService implements InsertData, AutoCloseable {
         data.setSdkTs(new Timestamp(msgBody.getSdkTs()));
         data.setLogTs(new Timestamp(msgBody.getLogTs()));
         data.setAuditId(msgBody.getAuditId());
-        data.setSubAuditId(msgBody.getSubAuditId());
+        data.setAuditTag(msgBody.getAuditTag());
         data.setCount(msgBody.getCount());
         data.setDelay(msgBody.getDelay());
         data.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ClickHouseService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ClickHouseService.java
@@ -45,10 +45,10 @@ public class ClickHouseService implements InsertData, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseService.class);
     public static final String INSERT_SQL = "insert into audit_data (ip, docker_id, thread_id,\r\n"
             + "      sdk_ts, packet_id, log_ts,\r\n"
-            + "      inlong_group_id, inlong_stream_id, audit_id,\r\n"
+            + "      inlong_group_id, inlong_stream_id, audit_id,sub_audit_id,\r\n"
             + "      count, size, delay, \r\n"
             + "      update_time)\r\n"
-            + "    values (?,?,?,?,?,?,?,?,?,?,?,?,?)";
+            + "    values (?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 
     private ClickHouseConfig chConfig;
 
@@ -110,10 +110,11 @@ public class ClickHouseService implements InsertData, AutoCloseable {
                 pstat.setString(7, data.getInlongGroupId());
                 pstat.setString(8, data.getInlongStreamId());
                 pstat.setString(9, data.getAuditId());
-                pstat.setLong(10, data.getCount());
-                pstat.setLong(11, data.getSize());
-                pstat.setLong(12, data.getDelay());
-                pstat.setTimestamp(13, data.getUpdateTime());
+                pstat.setString(10, data.getSubAuditId());
+                pstat.setLong(11, data.getCount());
+                pstat.setLong(12, data.getSize());
+                pstat.setLong(13, data.getDelay());
+                pstat.setTimestamp(14, data.getUpdateTime());
                 pstat.addBatch();
                 this.batchCounter.decrementAndGet();
                 if (++counter >= chConfig.getBatchThreshold()) {
@@ -173,6 +174,7 @@ public class ClickHouseService implements InsertData, AutoCloseable {
         data.setSdkTs(new Timestamp(msgBody.getSdkTs()));
         data.setLogTs(new Timestamp(msgBody.getLogTs()));
         data.setAuditId(msgBody.getAuditId());
+        data.setSubAuditId(msgBody.getSubAuditId());
         data.setCount(msgBody.getCount());
         data.setDelay(msgBody.getDelay());
         data.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ElasticsearchService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ElasticsearchService.java
@@ -235,7 +235,7 @@ public class ElasticsearchService implements InsertData, AutoCloseable {
                 builder.endObject();
             }
             {
-                builder.startObject("sub_audit_id");
+                builder.startObject("audit_tag");
                 {
                     builder.field("type", "keyword");
                 }
@@ -337,7 +337,7 @@ public class ElasticsearchService implements InsertData, AutoCloseable {
         esPo.setSdkTs(new Date(msgBody.getSdkTs()).getTime());
         esPo.setLogTs(new Date(msgBody.getLogTs()));
         esPo.setAuditId(msgBody.getAuditId());
-        esPo.setSubAuditId(msgBody.getSubAuditId());
+        esPo.setAuditTag(msgBody.getAuditTag());
         esPo.setCount(msgBody.getCount());
         esPo.setDelay(msgBody.getDelay());
         esPo.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ElasticsearchService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/ElasticsearchService.java
@@ -235,6 +235,13 @@ public class ElasticsearchService implements InsertData, AutoCloseable {
                 builder.endObject();
             }
             {
+                builder.startObject("sub_audit_id");
+                {
+                    builder.field("type", "keyword");
+                }
+                builder.endObject();
+            }
+            {
                 builder.startObject("inlong_group_id");
                 {
                     builder.field("type", "keyword");
@@ -330,6 +337,7 @@ public class ElasticsearchService implements InsertData, AutoCloseable {
         esPo.setSdkTs(new Date(msgBody.getSdkTs()).getTime());
         esPo.setLogTs(new Date(msgBody.getLogTs()));
         esPo.setAuditId(msgBody.getAuditId());
+        esPo.setSubAuditId(msgBody.getSubAuditId());
         esPo.setCount(msgBody.getCount());
         esPo.setDelay(msgBody.getDelay());
         esPo.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/MySqlService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/MySqlService.java
@@ -44,6 +44,7 @@ public class MySqlService implements InsertData {
         po.setSdkTs(new Date(msgBody.getSdkTs()));
         po.setLogTs(new Date(msgBody.getLogTs()));
         po.setAuditId(msgBody.getAuditId());
+        po.setSubAuditId(msgBody.getSubAuditId());
         po.setCount(msgBody.getCount());
         po.setDelay(msgBody.getDelay());
         po.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/MySqlService.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/MySqlService.java
@@ -44,7 +44,7 @@ public class MySqlService implements InsertData {
         po.setSdkTs(new Date(msgBody.getSdkTs()));
         po.setLogTs(new Date(msgBody.getLogTs()));
         po.setAuditId(msgBody.getAuditId());
-        po.setSubAuditId(msgBody.getSubAuditId());
+        po.setAuditTag(msgBody.getAuditTag());
         po.setCount(msgBody.getCount());
         po.setDelay(msgBody.getDelay());
         po.setInlongGroupId(msgBody.getInlongGroupId());

--- a/inlong-audit/sql/apache_inlong_audit.sql
+++ b/inlong-audit/sql/apache_inlong_audit.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS `audit_data`
     `inlong_group_id`  varchar(100) NOT NULL DEFAULT '' COMMENT 'The target inlong group id',
     `inlong_stream_id` varchar(100) NOT NULL DEFAULT '' COMMENT 'The target inlong stream id',
     `audit_id`         varchar(100) NOT NULL DEFAULT '' COMMENT 'Audit id',
+    `sub_audit_id`     varchar(100) DEFAULT '' COMMENT 'Sub Audit id',
     `count`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message count',
     `size`             BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message size',
     `delay`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message delay count',

--- a/inlong-audit/sql/apache_inlong_audit.sql
+++ b/inlong-audit/sql/apache_inlong_audit.sql
@@ -42,7 +42,7 @@ CREATE TABLE IF NOT EXISTS `audit_data`
     `inlong_group_id`  varchar(100) NOT NULL DEFAULT '' COMMENT 'The target inlong group id',
     `inlong_stream_id` varchar(100) NOT NULL DEFAULT '' COMMENT 'The target inlong stream id',
     `audit_id`         varchar(100) NOT NULL DEFAULT '' COMMENT 'Audit id',
-    `sub_audit_id`     varchar(100) DEFAULT '' COMMENT 'Sub Audit id',
+    `audit_tag`        varchar(100) DEFAULT '' COMMENT 'Audit tag',
     `count`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message count',
     `size`             BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message size',
     `delay`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message delay count',

--- a/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
+++ b/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `audit_data`
     `inlong_group_id`  String COMMENT 'The target inlong group id',
     `inlong_stream_id` String COMMENT 'The target inlong stream id',
     `audit_id`         String COMMENT 'Audit id',
-    `sub_audit_id`     String COMMENT 'Sub Audit id',
+    `audit_tag`        String COMMENT 'Audit tag',
     `count`            Int64 COMMENT 'Message count',
     `size`             Int64 COMMENT 'Message size',
     `delay`            Int64 COMMENT 'Message delay',

--- a/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
+++ b/inlong-audit/sql/apache_inlong_audit_clickhouse.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS `audit_data`
     `inlong_group_id`  String COMMENT 'The target inlong group id',
     `inlong_stream_id` String COMMENT 'The target inlong stream id',
     `audit_id`         String COMMENT 'Audit id',
+    `sub_audit_id`     String COMMENT 'Sub Audit id',
     `count`            Int64 COMMENT 'Message count',
     `size`             Int64 COMMENT 'Message size',
     `delay`            Int64 COMMENT 'Message delay',

--- a/inlong-audit/sql/clickhouse-changes-1.9.0.sql
+++ b/inlong-audit/sql/clickhouse-changes-1.9.0.sql
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- This is the SQL change file from version 1.8.0 to the current version 1.9.0.
+-- When upgrading to version 1.9.0, please execute those SQLs in the DB (such as MySQL) used by the Manager module.
+
+USE `apache_inlong_audit`;
+
+ALTER TABLE audit_data ADD COLUMN audit_tag String DEFAULT '' COMMENT 'Audit tag' after `audit_id`;
+
+

--- a/inlong-audit/sql/mysql-changes-1.9.0.sql
+++ b/inlong-audit/sql/mysql-changes-1.9.0.sql
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+-- This is the SQL change file from version 1.8.0 to the current version 1.9.0.
+-- When upgrading to version 1.9.0, please execute those SQLs in the DB (such as MySQL) used by the Manager module.
+
+USE `apache_inlong_audit`;
+
+ALTER TABLE audit_data ADD COLUMN audit_tag varchar(100) DEFAULT '' COMMENT 'Audit tag' after `audit_id`;
+
+


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8836

### Motivation

*The same audit id may have multiple different data sources or data targets, and an audit_tag information needs to be added to further distinguish.*

### Modifications

*Differentiate different audit objects under the same audit_id by adding audit_tag information.*
