### PR TITLE
[INLONG-8850][Agent] Remove unregister of MetricRegister when initialize taskmanager 

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -81,7 +81,6 @@ public class TaskManager extends AbstractDaemon {
         this.taskMetrics = new AgentMetricItemSet(this.getClass().getSimpleName());
         this.dimensions = new HashMap<>();
         this.dimensions.put(KEY_COMPONENT_NAME, this.getClass().getSimpleName());
-        MetricRegister.unregister(taskMetrics);
         MetricRegister.register(taskMetrics);
 
         tasks = new ConcurrentHashMap<>();


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8850 

### Motivation

*When  initialize taskmanager, there is no need to unregister of MetricRegister*

### Modifications

*Remove unregister of MetricRegister when initialize taskmanager*