### PR TITLE
[INLONG-8871][TubeMQ] Use an error code in checkMessageAndStatus() to return the check result instead of throwing an exception

### DIFF
--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentResult.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/MessageSentResult.java
@@ -32,6 +32,13 @@ public class MessageSentResult {
     private long appendTime = TBaseConstants.META_VALUE_UNDEFINED;
     private long appendOffset = TBaseConstants.META_VALUE_UNDEFINED;
 
+    public MessageSentResult(Message message, boolean success, int errCode, String errMsg) {
+        this.message = message;
+        this.success = success;
+        this.errCode = errCode;
+        this.errMsg = errMsg;
+    }
+
     public MessageSentResult(boolean success, int errCode, String errMsg,
             Message message, long messageId, Partition partition) {
         this.success = success;

--- a/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/SimpleMessageProducer.java
+++ b/inlong-tubemq/tubemq-client/src/main/java/org/apache/inlong/tubemq/client/producer/SimpleMessageProducer.java
@@ -249,6 +249,7 @@ public class SimpleMessageProducer implements MessageProducer {
         MessageSentResult result = checkMessageAndStatus(message);
         if (!result.isSuccess()) {
             cb.onMessageSent(result);
+            return;
         }
         final Partition partition =
                 this.selectPartition(message, BrokerWriteService.AsyncService.class);

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TErrCodeConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TErrCodeConstants.java
@@ -52,6 +52,12 @@ public class TErrCodeConstants {
     public static final int CLIENT_INCONSISTENT_SOURCECOUNT = 429;
     public static final int CLIENT_DUPLICATE_INDEXID = 430;
     public static final int TOPIC_NOT_DEPLOYED = 431;
+    public static final int PARAMETER_MSG_NULL = 440;
+    public static final int PARAMETER_MSG_TOPIC_BLANK = 441;
+    public static final int PARAMETER_MSG_BODY_EMPTY = 442;
+    public static final int PARAMETER_MSG_TOPIC_UNPUBLISHED = 443;
+    public static final int PARAMETER_MSG_TOPIC_NO_PARTITION = 444;
+    public static final int PARAMETER_MSG_OVER_MAX_LENGTH = 445;
 
     public static final int CONSUME_GROUP_FORBIDDEN = 450;
     public static final int SERVER_CONSUME_SPEED_LIMIT = 452;


### PR DESCRIPTION

- Fixes #8871 

1. Add new error code in TErrCodeConstants.java;
2. Use an error code in SimpleMessageProducer.checkMessageAndStatus() to return the check result instead of throwing an exception
3. In the SimpleMessageProducer.sendMessage() function, returns the result of the checkMessageAndStatus() check failure
