### PR TITLE
[INLONG-8897][Sort] update dbz option name 'xx. whitelist' to 'xx.include.list'(xx = database, schema or table)

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/MySqlSource.java
@@ -219,10 +219,10 @@ public class MySqlSource {
                 props.setProperty("database.server.id", String.valueOf(serverId));
             }
             if (databaseList != null) {
-                props.setProperty("database.whitelist", String.join(",", databaseList));
+                props.setProperty("database.include.list", String.join(",", databaseList));
             }
             if (tableList != null) {
-                props.setProperty("table.whitelist", String.join(",", tableList));
+                props.setProperty("table.include.list", String.join(",", tableList));
             }
             if (serverTimeZone != null) {
                 props.setProperty("database.serverTimezone", serverTimeZone);

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/DebeziumUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/cdc/mysql/debezium/DebeziumUtils.java
@@ -230,7 +230,7 @@ public class DebeziumUtils {
 
     /**
      * Creates {@link RelationalTableFilters} from configuration. The {@link RelationalTableFilters}
-     * can be used to filter tables according to "table.whitelist" and "database.whitelist" options.
+     * can be used to filter tables according to "table.include.list" and "database.include.list" options.
      */
     public static RelationalTableFilters createTableFilters(MySqlSourceConfig configuration) {
         Configuration debeziumConfig = configuration.getDbzConfiguration();

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/OracleSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/OracleSource.java
@@ -165,7 +165,7 @@ public class OracleSource {
             props.setProperty("database.history.skip.unparseable.ddl", String.valueOf(true));
             props.setProperty("database.dbname", checkNotNull(database));
             if (schemaList != null) {
-                props.setProperty("schema.whitelist", String.join(",", schemaList));
+                props.setProperty("schema.include.list", String.join(",", schemaList));
             }
             if (tableList != null) {
                 props.setProperty("table.include.list", String.join(",", tableList));

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/config/OracleSourceConfigFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/src/main/java/org/apache/inlong/sort/cdc/oracle/source/config/OracleSourceConfigFactory.java
@@ -109,7 +109,7 @@ public class OracleSourceConfigFactory extends JdbcSourceConfigFactory {
         }
 
         if (schemaList != null) {
-            props.setProperty("schema.whitelist", String.join(",", schemaList));
+            props.setProperty("schema.include.list", String.join(",", schemaList));
         }
 
         if (tableList != null) {

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/PostgreSQLSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/cdc/postgres/PostgreSQLSource.java
@@ -185,10 +185,10 @@ public class PostgreSQLSource {
             props.setProperty("heartbeat.interval.ms", String.valueOf(DEFAULT_HEARTBEAT_MS));
 
             if (schemaList != null) {
-                props.setProperty("schema.whitelist", String.join(",", schemaList));
+                props.setProperty("schema.include.list", String.join(",", schemaList));
             }
             if (tableList != null) {
-                props.setProperty("table.whitelist", String.join(",", tableList));
+                props.setProperty("table.include.list", String.join(",", tableList));
             }
 
             if (dbzProperties != null) {


### PR DESCRIPTION
### Prepare a Pull Request

[INLONG-8897] update dbz option name 'xx. whitelist' to 'xx.include.list'(xx = database, schema or table)

- Fixes #8897 

### Motivation

The options `database.whitelist, schema.whitelist, table.whitelist` have been deprecated in Debezium. Starting from Debezium version 1.3, they have been replaced with `database.include.list, schema.include.list, table.include.list`. For more details, please refer to this link: https://debezium.io/blog/2020/09/03/debezium-1-3-beta1-released/

<img width="894" alt="image" src="https://github.com/apache/inlong/assets/111486498/7b6ca985-19b4-40c1-bae1-5ef103fd7e80">


### Modifications

update dbz option name 'xx. whitelist' to 'xx.include.list'(xx = database, schema or table)
