### PR TITLE
[INLONG-8899][DataProxy] Optimize metadata update logic

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -436,7 +436,7 @@ public class CommonConfigHolder {
         tmpValue = this.props.get(KEY_UNCONFIGURED_TOPIC_DEFAULT_TOPICS);
         if (StringUtils.isNotBlank(tmpValue)) {
             List<String> tmpList = new ArrayList<>();
-            String[] topicItems = tmpValue.split("\\s+");
+            String[] topicItems = tmpValue.split(",|\\s+");
             for (String item : topicItems) {
                 if (StringUtils.isBlank(item)) {
                     continue;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/holder/MetaConfigHolder.java
@@ -110,10 +110,6 @@ public class MetaConfigHolder extends ConfigHolder {
                 idTopicConfig = id2TopicSrcMap.get(groupId);
             }
         }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get Topic Config by groupId = {}, streamId = {}, IdTopicConfig = {}",
-                    groupId, streamId, idTopicConfig);
-        }
         return idTopicConfig;
     }
 
@@ -130,10 +126,6 @@ public class MetaConfigHolder extends ConfigHolder {
             if (idTopicConfig != null) {
                 topic = idTopicConfig.getTopicName();
             }
-        }
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Get topic by groupId = {}, streamId = {}, topic = {}",
-                    groupId, streamId, topic);
         }
         return topic;
     }
@@ -154,12 +146,10 @@ public class MetaConfigHolder extends ConfigHolder {
     }
 
     public String getConfigMd5() {
-        synchronized (this.lastUpdVersion) {
-            if (this.lastSyncVersion.get() > this.lastUpdVersion.get()) {
-                return tmpDataMd5;
-            } else {
-                return dataMd5;
-            }
+        if (this.lastSyncVersion.get() > this.lastUpdVersion.get()) {
+            return tmpDataMd5;
+        } else {
+            return dataMd5;
         }
     }
 
@@ -169,18 +159,16 @@ public class MetaConfigHolder extends ConfigHolder {
             return false;
         }
         synchronized (this.lastSyncVersion) {
-            synchronized (this.lastUpdVersion) {
-                if (this.lastSyncVersion.get() > this.lastUpdVersion.get()) {
-                    if (inDataJsonStr.equals(tmpDataMd5)) {
-                        return false;
-                    }
-                    LOG.info("Load changed metadata {} , but reloading content, over {} ms",
-                            getFileName(), System.currentTimeMillis() - this.lastSyncVersion.get());
+            if (this.lastSyncVersion.get() > this.lastUpdVersion.get()) {
+                if (inDataJsonStr.equals(tmpDataMd5)) {
                     return false;
-                } else {
-                    if (inDataMd5.equals(dataMd5)) {
-                        return false;
-                    }
+                }
+                LOG.info("Load changed metadata {} , but reloading content, over {} ms",
+                        getFileName(), System.currentTimeMillis() - this.lastSyncVersion.get());
+                return false;
+            } else {
+                if (inDataMd5.equals(dataMd5)) {
+                    return false;
                 }
             }
             return storeConfigToFile(inDataMd5, inDataJsonStr);
@@ -231,7 +219,7 @@ public class MetaConfigHolder extends ConfigHolder {
             return false;
         }
         String jsonString = "";
-        readWriteLock.readLock().lock();
+        readWriteLock.writeLock().lock();
         try {
             jsonString = loadConfigFromFile();
             if (StringUtils.isBlank(jsonString)) {
@@ -240,36 +228,20 @@ public class MetaConfigHolder extends ConfigHolder {
             }
             DataProxyConfigResponse metaConfig =
                     GSON.fromJson(jsonString, DataProxyConfigResponse.class);
+            // check result tag
             if (!metaConfig.isResult() || metaConfig.getErrCode() != DataProxyConfigResponse.SUCC) {
                 LOG.warn("Load failed json config from {}, error code is {}",
                         getFileName(), metaConfig.getErrCode());
                 return true;
             }
+            // check cluster data
             DataProxyCluster clusterObj = metaConfig.getData();
             if (clusterObj == null) {
                 LOG.warn("Load failed json config from {}, malformed content, data is null", getFileName());
                 return true;
             }
             // update cache data
-            boolean updated;
-            synchronized (this.lastUpdVersion) {
-                if (metaConfig.getMd5().equals(this.dataMd5)) {
-                    LOG.warn("Load json config from {}, configure md5 not changed!", getFileName());
-                    return true;
-                }
-                updated = updateCacheData(clusterObj);
-                if (updated) {
-                    if (this.lastSyncVersion.get() == 0) {
-                        this.lastUpdVersion.set(System.currentTimeMillis());
-                        this.lastSyncVersion.compareAndSet(0, this.lastUpdVersion.get());
-                    } else {
-                        this.lastUpdVersion.set(this.lastSyncVersion.get());
-                    }
-                    this.dataMd5 = metaConfig.getMd5();
-                    this.dataStr = jsonString;
-                }
-            }
-            if (updated) {
+            if (updateCacheData(jsonString, metaConfig)) {
                 LOG.info("Load changed {} file success!", getFileName());
             }
             return true;
@@ -277,19 +249,19 @@ public class MetaConfigHolder extends ConfigHolder {
             LOG.warn("Process json {} changed data {} failure", getFileName(), jsonString, e);
             return false;
         } finally {
-            readWriteLock.readLock().unlock();
+            readWriteLock.writeLock().unlock();
         }
     }
 
-    private boolean updateCacheData(DataProxyCluster metaConfigObj) {
+    private boolean updateCacheData(String jsonString, DataProxyConfigResponse metaConfig) {
         // get and valid inlongIds configure
-        ProxyClusterObject proxyClusterObject = metaConfigObj.getProxyCluster();
+        ProxyClusterObject proxyClusterObject = metaConfig.getData().getProxyCluster();
         if (proxyClusterObject == null) {
             LOG.warn("Load failed json config from {}, malformed content, proxyCluster field is null",
                     getFileName());
             return false;
         }
-        CacheClusterSetObject clusterSetObject = metaConfigObj.getCacheClusterSet();
+        CacheClusterSetObject clusterSetObject = metaConfig.getData().getCacheClusterSet();
         if (clusterSetObject == null) {
             LOG.warn("Load failed json config from {}, malformed content, cacheClusterSet field is null",
                     getFileName());
@@ -328,6 +300,15 @@ public class MetaConfigHolder extends ConfigHolder {
         // get topic config info
         Map<String, IdTopicConfig> tmpTopicConfigMap = buildCacheTopicConfig(mqType, inLongIds);
         replaceCacheConfig(mqType, tmpClusterConfigMap, tmpTopicConfigMap);
+        // update cached data
+        this.dataMd5 = metaConfig.getMd5();
+        this.dataStr = jsonString;
+        if (this.lastSyncVersion.get() == 0) {
+            this.lastUpdVersion.set(System.currentTimeMillis());
+            this.lastSyncVersion.compareAndSet(0, this.lastUpdVersion.get());
+        } else {
+            this.lastUpdVersion.set(this.lastSyncVersion.get());
+        }
         return true;
     }
 


### PR DESCRIPTION

- Fixes #8899

1. Optimize the metadata update logic and remove the locking process of lastUpdVersion.
2. Allow the default Topic configuration to be separated by commas