### PR TITLE
[INLONG-8403][Manager] Support resource migrate to another tenant

### DIFF
--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
@@ -52,8 +52,8 @@ public interface DataNodeEntityMapper {
     int deleteById(Integer id);
 
     @MultiTenantQuery(with = false)
-    int copy(@Param("name") String name, @Param("type") String type, @Param("from") String from, @Param("to") String to,
-            @Param("newName") String newName);
+    int copy(@Param("name") String name, @Param("type") String type, @Param("sourceTenant") String sourceTenant,
+             @Param("targetTenant") String targetTenant, @Param("newName") String newName);
 
     @MultiTenantQuery(with = false)
     DataNodeEntity selectByIdSelective(DataNodeEntity record);

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
@@ -53,7 +53,7 @@ public interface DataNodeEntityMapper {
 
     @MultiTenantQuery(with = false)
     int copy(@Param("name") String name, @Param("type") String type, @Param("from") String from, @Param("to") String to,
-             @Param("newName") String newName);
+            @Param("newName") String newName);
 
     @MultiTenantQuery(with = false)
     DataNodeEntity selectByIdSelective(DataNodeEntity record);

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
@@ -53,7 +53,7 @@ public interface DataNodeEntityMapper {
 
     @MultiTenantQuery(with = false)
     int copy(@Param("name") String name, @Param("type") String type, @Param("sourceTenant") String sourceTenant,
-             @Param("targetTenant") String targetTenant, @Param("newName") String newName);
+            @Param("targetTenant") String targetTenant, @Param("newName") String newName);
 
     @MultiTenantQuery(with = false)
     DataNodeEntity selectByIdSelective(DataNodeEntity record);

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
@@ -52,6 +52,10 @@ public interface DataNodeEntityMapper {
     int deleteById(Integer id);
 
     @MultiTenantQuery(with = false)
-    int copy(String name, String type, String from, String to, String newName);
+    int copy(@Param("name") String name, @Param("type") String type, @Param("from") String from, @Param("to") String to,
+             @Param("newName") String newName);
+
+    @MultiTenantQuery(with = false)
+    DataNodeEntity selectByIdSelective(DataNodeEntity record);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/DataNodeEntityMapper.java
@@ -51,4 +51,7 @@ public interface DataNodeEntityMapper {
 
     int deleteById(Integer id);
 
+    @MultiTenantQuery(with = false)
+    int copy(String name, String type, String from, String to, String newName);
+
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
@@ -55,7 +55,7 @@ public interface InlongConsumeEntityMapper {
 
     @MultiTenantQuery(with = false)
     int migrate(@Param("groupId") String groupId, @Param("sourceTenant") String sourceTenant,
-                @Param("targetTenant") String targetTenant);
+            @Param("targetTenant") String targetTenant);
 
     List<InlongConsumeEntity> selectByGroupId(String groupId);
 

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
@@ -53,4 +53,9 @@ public interface InlongConsumeEntityMapper {
 
     int deleteById(Integer id);
 
+    @MultiTenantQuery(with = false)
+    int migrate(String groupId, String from, String to);
+
+    List<InlongConsumeEntity> selectByGroupId(String groupId);
+
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
@@ -54,7 +54,7 @@ public interface InlongConsumeEntityMapper {
     int deleteById(Integer id);
 
     @MultiTenantQuery(with = false)
-    int migrate(String groupId, String from, String to);
+    int migrate(@Param("groupId") String groupId, @Param("from") String from, @Param("to") String to);
 
     List<InlongConsumeEntity> selectByGroupId(String groupId);
 

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongConsumeEntityMapper.java
@@ -54,7 +54,8 @@ public interface InlongConsumeEntityMapper {
     int deleteById(Integer id);
 
     @MultiTenantQuery(with = false)
-    int migrate(@Param("groupId") String groupId, @Param("from") String from, @Param("to") String to);
+    int migrate(@Param("groupId") String groupId, @Param("sourceTenant") String sourceTenant,
+                @Param("targetTenant") String targetTenant);
 
     List<InlongConsumeEntity> selectByGroupId(String groupId);
 

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -117,6 +117,6 @@ public interface InlongGroupEntityMapper {
 
     @MultiTenantQuery(with = false)
     int migrate(@Param(value = "groupId") String groupId, @Param(value = "from") String from,
-                @Param(value = "to") String to);
+            @Param(value = "to") String to);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -115,4 +115,7 @@ public interface InlongGroupEntityMapper {
     @MultiTenantQuery(with = false)
     List<InlongGroupEntity> selectAllGroupsByTenant(@Param(value = "tenant") String tenant);
 
+    @MultiTenantQuery(with = false)
+    int migrate(String groupId, String from, String to);
+
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -116,7 +116,7 @@ public interface InlongGroupEntityMapper {
     List<InlongGroupEntity> selectAllGroupsByTenant(@Param(value = "tenant") String tenant);
 
     @MultiTenantQuery(with = false)
-    int migrate(@Param(value = "groupId") String groupId, @Param(value = "from") String from,
-            @Param(value = "to") String to);
+    int migrate(@Param(value = "groupId") String groupId, @Param(value = "sourceTenant") String sourceTenant,
+            @Param(value = "targetTenant") String targetTenant);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/InlongGroupEntityMapper.java
@@ -116,6 +116,7 @@ public interface InlongGroupEntityMapper {
     List<InlongGroupEntity> selectAllGroupsByTenant(@Param(value = "tenant") String tenant);
 
     @MultiTenantQuery(with = false)
-    int migrate(String groupId, String from, String to);
+    int migrate(@Param(value = "groupId") String groupId, @Param(value = "from") String from,
+                @Param(value = "to") String to);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
@@ -39,6 +39,6 @@ public interface TenantClusterTagEntityMapper {
     List<TenantClusterTagEntity> selectByCondition(TenantClusterTagPageRequest request);
 
     int copy(@Param("clusterTag") String clusterTag, @Param("sourceTenant") String sourceTenant,
-             @Param("targetTenant") String targetTenant);
+            @Param("targetTenant") String targetTenant);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.manager.dao.mapper;
 
-import org.apache.inlong.manager.common.tenant.MultiTenantQuery;
+import org.apache.ibatis.annotations.Param;
 import org.apache.inlong.manager.dao.entity.TenantClusterTagEntity;
 import org.apache.inlong.manager.pojo.cluster.TenantClusterTagPageRequest;
 
@@ -38,6 +38,6 @@ public interface TenantClusterTagEntityMapper {
 
     List<TenantClusterTagEntity> selectByCondition(TenantClusterTagPageRequest request);
 
-    int copy(String clusterTag, String from, String to);
+    int copy(@Param("clusterTag") String clusterTag, @Param("from") String from, @Param("to") String to);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
@@ -38,6 +38,7 @@ public interface TenantClusterTagEntityMapper {
 
     List<TenantClusterTagEntity> selectByCondition(TenantClusterTagPageRequest request);
 
-    int copy(@Param("clusterTag") String clusterTag, @Param("from") String from, @Param("to") String to);
+    int copy(@Param("clusterTag") String clusterTag, @Param("sourceTenant") String sourceTenant,
+             @Param("targetTenant") String targetTenant);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.dao.mapper;
 
+import org.apache.inlong.manager.common.tenant.MultiTenantQuery;
 import org.apache.inlong.manager.dao.entity.TenantClusterTagEntity;
 import org.apache.inlong.manager.pojo.cluster.TenantClusterTagPageRequest;
 
@@ -36,5 +37,7 @@ public interface TenantClusterTagEntityMapper {
     List<TenantClusterTagEntity> selectByTag(String clusterTag);
 
     List<TenantClusterTagEntity> selectByCondition(TenantClusterTagPageRequest request);
+
+    int copy(String clusterTag, String from, String to);
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/TenantClusterTagEntityMapper.java
@@ -17,10 +17,10 @@
 
 package org.apache.inlong.manager.dao.mapper;
 
-import org.apache.ibatis.annotations.Param;
 import org.apache.inlong.manager.dao.entity.TenantClusterTagEntity;
 import org.apache.inlong.manager.pojo.cluster.TenantClusterTagPageRequest;
 
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -126,6 +126,32 @@
             and is_deleted = 0
         </where>
     </select>
+    <select id="selectByIdSelective"
+            parameterType="org.apache.inlong.manager.dao.entity.DataNodeEntity"
+            resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from data_node
+        <where>
+            <if test="type != null">
+                and type = #{type, jdbcType=VARCHAR}
+            </if>
+            <if test="url != null">
+                and url = #{url, jdbcType=VARCHAR}
+            </if>
+            <if test="username != null">
+                and username = #{username, jdbcType=VARCHAR}
+            </if>
+            <if test="token != null">
+                and token = #{token, jdbcType=VARCHAR}
+            </if>
+            <if test="extParams != null">
+                and ext_params = #{extParams, jdbcType=LONGVARCHAR}
+            </if>
+            and tenant = #{tenant, jdbcType=LONGVARCHAR}
+            and is_deleted = 0
+        </where>
+    </select>
     <update id="updateById" parameterType="org.apache.inlong.manager.dao.entity.DataNodeEntity">
         <bind name="_isInlongService" value="LoginUser.InlongService"/>
         update data_node
@@ -224,7 +250,7 @@
                token,
                ext_params,
                description,
-               #{to, jdbcType=VARCHAR},
+               #{targetTenant, jdbcType=VARCHAR},
                in_charges,
                status,
                creator,
@@ -234,33 +260,7 @@
             name = #{name, jdbcType=VARCHAR}
             and type = #{type, jdbcType=VARCHAR}
             and is_deleted = 0
-            and tenant = #{from, jdbcType=VARCHAR}
+            and tenant = #{sourceTenant, jdbcType=VARCHAR}
         </where>
     </insert>
-    <select id="selectByIdSelective"
-            parameterType="org.apache.inlong.manager.dao.entity.DataNodeEntity"
-            resultMap="BaseResultMap">
-        select
-        <include refid="Base_Column_List"/>
-        from data_node
-        <where>
-            <if test="type != null">
-                and type = #{type, jdbcType=VARCHAR}
-            </if>
-            <if test="url != null">
-                and url = #{url, jdbcType=VARCHAR}
-            </if>
-            <if test="username != null">
-                and username = #{username, jdbcType=VARCHAR}
-            </if>
-            <if test="token != null">
-                and token = #{token, jdbcType=VARCHAR}
-            </if>
-            <if test="extParams != null">
-                and ext_params = #{extParams, jdbcType=LONGVARCHAR}
-            </if>
-            and tenant = #{tenant, jdbcType=LONGVARCHAR}
-            and is_deleted = 0
-        </where>
-    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -212,7 +212,7 @@
             </if>
         </where>
     </delete>
-    <select id="copy">
+    <insert id="copy">
         insert into data_node (name, display_name, type, url, username,
                                token, ext_params, description, tenant,
                                in_charges, status, creator, modifier)
@@ -224,17 +224,43 @@
                token,
                ext_params,
                description,
-               #{to, jdbcType=VARCHAR}
+               #{to, jdbcType=VARCHAR},
                in_charges,
                status,
                creator,
                modifier
         from data_node
         <where>
-            name = #{name, jdbcType=VARCHAR},
-            and type = #{type, jdbcType=VARCHAR},
-            and is_deleted = 0,
+            name = #{name, jdbcType=VARCHAR}
+            and type = #{type, jdbcType=VARCHAR}
+            and is_deleted = 0
             and tenant = #{from, jdbcType=VARCHAR}
+        </where>
+    </insert>
+    <select id="selectByIdSelective"
+            parameterType="org.apache.inlong.manager.dao.entity.DataNodeEntity"
+            resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from data_node
+        <where>
+            <if test="type != null">
+                and type = #{type, jdbcType=VARCHAR}
+            </if>
+            <if test="url != null">
+                and url = #{url, jdbcType=VARCHAR}
+            </if>
+            <if test="username != null">
+                and username = #{username, jdbcType=VARCHAR}
+            </if>
+            <if test="token != null">
+                and token = #{token, jdbcType=VARCHAR}
+            </if>
+            <if test="extParams != null">
+                and ext_params = #{extParams, jdbcType=LONGVARCHAR}
+            </if>
+            and tenant = #{tenant, jdbcType=LONGVARCHAR}
+            and is_deleted = 0
         </where>
     </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/DataNodeEntityMapper.xml
@@ -212,5 +212,29 @@
             </if>
         </where>
     </delete>
-
+    <select id="copy">
+        insert into data_node (name, display_name, type, url, username,
+                               token, ext_params, description, tenant,
+                               in_charges, status, creator, modifier)
+        select #{newName, jdbcType=VARCHAR},
+               display_name,
+               type,
+               url,
+               username,
+               token,
+               ext_params,
+               description,
+               #{to, jdbcType=VARCHAR}
+               in_charges,
+               status,
+               creator,
+               modifier
+        from data_node
+        <where>
+            name = #{name, jdbcType=VARCHAR},
+            and type = #{type, jdbcType=VARCHAR},
+            and is_deleted = 0,
+            and tenant = #{from, jdbcType=VARCHAR}
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
@@ -305,7 +305,7 @@
             </if>
         </where>
     </delete>
-    <select id="migrate">
+    <insert id="migrate">
         update inlong_consume
         set tenant = #{to, jdbcType=VARCHAR}
         <where>
@@ -313,8 +313,8 @@
             and is_deleted = 0
             and tenant = #{from, jdbcType=VARCHAR}
         </where>
-    </select>
-    <select id="selectByGroupId">
+    </insert>
+    <select id="selectByGroupId" resultMap="BaseResultMap">
         <bind name="_isInlongService" value="LoginUser.InlongService"/>
         select
         <include refid="Base_Column_List"/>
@@ -323,7 +323,7 @@
             <if test="_isInlongService == false">
                 tenant = #{tenant,jdbcType=VARCHAR}
             </if>
-            and is_deleted = 0,
+            and is_deleted = 0
             and inlong_group_id = #{groupId, jdbcType=VARCHAR}
         </where>
     </select>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
@@ -307,11 +307,11 @@
     </delete>
     <insert id="migrate">
         update inlong_consume
-        set tenant = #{to, jdbcType=VARCHAR}
+        set tenant = #{targetTenant, jdbcType=VARCHAR}
         <where>
             inlong_group_id = #{groupId, jdbcType=VARCHAR}
             and is_deleted = 0
-            and tenant = #{from, jdbcType=VARCHAR}
+            and tenant = #{sourceTenant, jdbcType=VARCHAR}
         </where>
     </insert>
     <select id="selectByGroupId" resultMap="BaseResultMap">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongConsumeEntityMapper.xml
@@ -305,4 +305,26 @@
             </if>
         </where>
     </delete>
+    <select id="migrate">
+        update inlong_consume
+        set tenant = #{to, jdbcType=VARCHAR}
+        <where>
+            inlong_group_id = #{groupId, jdbcType=VARCHAR}
+            and is_deleted = 0
+            and tenant = #{from, jdbcType=VARCHAR}
+        </where>
+    </select>
+    <select id="selectByGroupId">
+        <bind name="_isInlongService" value="LoginUser.InlongService"/>
+        select
+        <include refid="Base_Column_List"/>
+        from inlong_consume
+        <where>
+            <if test="_isInlongService == false">
+                tenant = #{tenant,jdbcType=VARCHAR}
+            </if>
+            and is_deleted = 0,
+            and inlong_group_id = #{groupId, jdbcType=VARCHAR}
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -527,7 +527,15 @@
             and is_deleted = 0
         </where>
     </update>
-
+    <update id="migrate">
+        update inlong_group
+        set tenant = #{targetTenant, jdbcType=VARCHAR}
+        <where>
+            inlong_group_id = #{groupId, jdbcType=VARCHAR}
+            and is_deleted = 0
+            and tenant = #{sourceTenant, jdbcType=VARCHAR}
+        </where>
+    </update>
     <delete id="deleteByPrimaryKey">
         <bind name="_isInlongService" value="LoginUser.InlongService"/>
         delete
@@ -562,13 +570,4 @@
             and is_deleted = 0
         </where>
     </select>
-    <update id="migrate">
-        update inlong_group
-        set tenant = #{to, jdbcType=VARCHAR}
-        <where>
-            inlong_group_id = #{groupId, jdbcType=VARCHAR}
-            and is_deleted = 0
-            and tenant = #{from, jdbcType=VARCHAR}
-        </where>
-    </update>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -562,5 +562,13 @@
             and is_deleted = 0
         </where>
     </select>
-
+    <select id="migrate">
+        update inlong_group
+        set tenant = #{to, jdbcType=VARCHAR}
+        <where>
+            inlong_group_id = #{groupId, jdbcType=VARCHAR}
+            and is_deleted = 0
+            and tenant = #{from, jdbcType=VARCHAR}
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/InlongGroupEntityMapper.xml
@@ -562,7 +562,7 @@
             and is_deleted = 0
         </where>
     </select>
-    <select id="migrate">
+    <update id="migrate">
         update inlong_group
         set tenant = #{to, jdbcType=VARCHAR}
         <where>
@@ -570,5 +570,5 @@
             and is_deleted = 0
             and tenant = #{from, jdbcType=VARCHAR}
         </where>
-    </select>
+    </update>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
@@ -101,7 +101,7 @@
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
     </update>
-    <select id="copy">
+    <insert id="copy">
         insert into tenant_cluster_tag (tenant, cluster_tag, creator, modifier)
         select #{to, jdbcType=VARCHAR},
         cluster_tag,
@@ -111,7 +111,7 @@
         <where>
             tenant = #{from, jdbcType=VARCHAR}
             and cluster_tag = #{clusterTag, jdbcType=VARCHAR}
-            and is_deleted = 0,
+            and is_deleted = 0
         </where>
-    </select>
+    </insert>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
@@ -101,4 +101,17 @@
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
     </update>
+    <select id="copy">
+        insert into tenant_cluster_tag (tenant, cluster_tag, creator, modifier)
+        select #{to, jdbcType=VARCHAR},
+        cluster_tag,
+        creator,
+        modifier
+        from tenant_cluster_tag
+        <where>
+            tenant = #{from, jdbcType=VARCHAR}
+            and cluster_tag = #{clusterTag, jdbcType=VARCHAR}
+            and is_deleted = 0,
+        </where>
+    </select>
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/TenantClusterTagEntityMapper.xml
@@ -81,6 +81,19 @@
         values (#{id,jdbcType=INTEGER}, #{tenant,jdbcType=VARCHAR}, #{clusterTag,jdbcType=VARCHAR},
                 #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
     </insert>
+    <insert id="copy">
+        insert into tenant_cluster_tag (tenant, cluster_tag, creator, modifier)
+        select #{targetTenant, jdbcType=VARCHAR},
+        cluster_tag,
+        creator,
+        modifier
+        from tenant_cluster_tag
+        <where>
+            tenant = #{sourceTenant, jdbcType=VARCHAR}
+            and cluster_tag = #{clusterTag, jdbcType=VARCHAR}
+            and is_deleted = 0
+        </where>
+    </insert>
     <update id="updateByIdSelective" parameterType="org.apache.inlong.manager.dao.entity.TenantClusterTagEntity">
         update tenant_cluster_tag
         <set>
@@ -101,17 +114,4 @@
         where id = #{id,jdbcType=INTEGER}
         and version = #{version,jdbcType=INTEGER}
     </update>
-    <insert id="copy">
-        insert into tenant_cluster_tag (tenant, cluster_tag, creator, modifier)
-        select #{to, jdbcType=VARCHAR},
-        cluster_tag,
-        creator,
-        modifier
-        from tenant_cluster_tag
-        <where>
-            tenant = #{from, jdbcType=VARCHAR}
-            and cluster_tag = #{clusterTag, jdbcType=VARCHAR}
-            and is_deleted = 0
-        </where>
-    </insert>
 </mapper>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/GroupCheckService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/GroupCheckService.java
@@ -19,19 +19,13 @@ package org.apache.inlong.manager.service.group;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.GroupStatus;
-import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
-import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
-import org.apache.inlong.manager.dao.entity.UserEntity;
 import org.apache.inlong.manager.dao.mapper.InlongGroupEntityMapper;
 import org.apache.inlong.manager.dao.mapper.UserEntityMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Service of inlong group check.

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/GroupCheckService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/GroupCheckService.java
@@ -56,13 +56,6 @@ public class GroupCheckService {
             throw new BusinessException(String.format("InlongGroup does not exist with InlongGroupId=%s", groupId));
         }
 
-        UserEntity userEntity = userMapper.selectByName(operator);
-        List<String> managers = Arrays.asList(inlongGroupEntity.getInCharges().split(","));
-        Preconditions.expectTrue(
-                managers.contains(operator)
-                        || TenantUserTypeEnum.TENANT_ADMIN.getCode().equals(userEntity.getAccountType()),
-                String.format(ErrorCodeEnum.USER_IS_NOT_MANAGER.getMessage(), operator, managers));
-
         GroupStatus status = GroupStatus.forCode(inlongGroupEntity.getStatus());
         if (GroupStatus.notAllowedUpdate(status)) {
             throw new BusinessException(String.format(ErrorCodeEnum.OPT_NOT_ALLOWED_BY_STATUS.getMessage(), status));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantService.java
@@ -68,4 +68,6 @@ public interface InlongTenantService {
      * @return true= delete success/ false = delete fail
      */
     Boolean delete(String name);
+
+    Boolean migrate(String groupId, String to);
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.service.tenant;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.GroupStatus;
@@ -25,20 +26,33 @@ import org.apache.inlong.manager.common.enums.SourceStatus;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
 import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.DataNodeEntity;
+import org.apache.inlong.manager.dao.entity.InlongConsumeEntity;
 import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
+import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
 import org.apache.inlong.manager.dao.entity.InlongTenantEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.dao.entity.StreamSourceEntity;
+import org.apache.inlong.manager.dao.entity.TenantClusterTagEntity;
+import org.apache.inlong.manager.dao.mapper.DataNodeEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongConsumeEntityMapper;
 import org.apache.inlong.manager.dao.mapper.InlongGroupEntityMapper;
+import org.apache.inlong.manager.dao.mapper.InlongStreamEntityMapper;
 import org.apache.inlong.manager.dao.mapper.InlongTenantEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StreamSinkEntityMapper;
 import org.apache.inlong.manager.dao.mapper.StreamSourceEntityMapper;
+import org.apache.inlong.manager.dao.mapper.TenantClusterTagEntityMapper;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.tenant.InlongTenantInfo;
 import org.apache.inlong.manager.pojo.tenant.InlongTenantPageRequest;
 import org.apache.inlong.manager.pojo.tenant.InlongTenantRequest;
+import org.apache.inlong.manager.pojo.user.InlongRoleInfo;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
+import org.apache.inlong.manager.pojo.user.TenantRoleInfo;
 import org.apache.inlong.manager.pojo.user.UserInfo;
 import org.apache.inlong.manager.pojo.workflow.ApproverRequest;
 import org.apache.inlong.manager.service.core.WorkflowApproverService;
+import org.apache.inlong.manager.service.user.InlongRoleService;
 import org.apache.inlong.manager.service.user.TenantRoleService;
 
 import com.github.pagehelper.Page;
@@ -47,8 +61,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.stream.Collectors;
@@ -66,7 +83,17 @@ public class InlongTenantServiceImpl implements InlongTenantService {
     @Autowired
     private InlongGroupEntityMapper groupMapper;
     @Autowired
+    private InlongStreamEntityMapper streamMapper;
+    @Autowired
+    private StreamSinkEntityMapper sinkMapper;
+    @Autowired
     private StreamSourceEntityMapper sourceMapper;
+    @Autowired
+    private DataNodeEntityMapper dataNodeEntityMapper;
+    @Autowired
+    private InlongConsumeEntityMapper consumeEntityMapper;
+    @Autowired
+    private TenantClusterTagEntityMapper tenantClusterTagMapper;
     @Autowired
     private TenantRoleService tenantRoleService;
     @Autowired
@@ -199,10 +226,115 @@ public class InlongTenantServiceImpl implements InlongTenantService {
             throw new BusinessException(errMsg);
         }
         int success = inlongTenantEntityMapper.deleteById(inlongTenantEntity.getId());
-        Preconditions.expectTrue(success == 1, "delete failed");
+        Preconditions.expectTrue(success == InlongConstants.AFFECTED_ONE_ROW, "delete failed");
         log.info("success delete inlong tenant name={} by user={}", name, operator);
         return true;
     }
+
+    @Override
+    public Boolean migrate(String groupId, String to) {
+        UserInfo userInfo = LoginUserUtils.getLoginUser();
+        Preconditions.expectTrue(hasPermission(userInfo, to),
+                String.format("user=[%s] has no permission to tenant=[%s]", userInfo.getName(), to));
+        return doMigrate(groupId, userInfo.getTenant(), to);
+    }
+
+    public Boolean doMigrate(String groupId, String from, String to) {
+        // get related streams, consumes and tag;
+        List<InlongStreamEntity> streamList = streamMapper.selectByGroupId(groupId);
+        List<InlongConsumeEntity> consumeList = consumeEntityMapper.selectByGroupId(groupId);
+        InlongGroupEntity group = groupMapper.selectByGroupId(groupId);
+        boolean streamMigrateResult = streamList.stream().allMatch(stream -> migrateStream(stream, from, to));
+        boolean consumeMigrateResult = this.migrateConsume(groupId, from, to, consumeList.size());
+        boolean tagCopyResult = this.copyTenantTag(group.getInlongClusterTag(), from, to);
+
+        return streamMigrateResult
+                && consumeMigrateResult
+                && tagCopyResult
+                && this.migrateGroup(groupId, from, to);
+    }
+
+    public Boolean migrateStream(InlongStreamEntity stream, String from, String to) {
+        List<StreamSinkEntity> sinks =
+                sinkMapper.selectByRelatedId(stream.getInlongGroupId(), stream.getInlongStreamId());
+        List<StreamSourceEntity> sources =
+                sourceMapper.selectByRelatedId(stream.getInlongGroupId(), stream.getInlongStreamId(), null);
+        boolean sinkMigrateResult = sinks.stream().allMatch(sink -> migrateStreamSink(sink, from, to));
+        boolean sourceMigrateResult = sources.stream().allMatch(source -> migrateStreamSource(source, from, to));
+        return sinkMigrateResult && sourceMigrateResult;
+    }
+
+    public Boolean migrateStreamSink(StreamSinkEntity sink, String from, String to) {
+        String dataNodeName = sink.getDataNodeName();
+        String type = sink.getSinkType();
+        if (StringUtils.isAnyBlank(dataNodeName, type)) {
+            return true;
+        }
+        DataNodeEntity dataNode = dataNodeEntityMapper.selectByUniqueKey(dataNodeName, type);
+        if (dataNode == null) {
+            return true;
+        }
+
+        // use display name as new name
+        String newName = dataNode.getDisplayName();
+        sink.setDataNodeName(newName);
+        return copyDataNode(dataNodeName, type, from, to, newName)
+                && sinkMapper.updateByIdSelective(sink) == InlongConstants.AFFECTED_ONE_ROW;
+
+    }
+
+    public Boolean migrateStreamSource(StreamSourceEntity source, String from, String to) {
+        String dataNodeName = source.getDataNodeName();
+        String type = source.getSourceType();
+        if (StringUtils.isAnyBlank(dataNodeName, type)) {
+            return true;
+        }
+        DataNodeEntity dataNode = dataNodeEntityMapper.selectByUniqueKey(dataNodeName, type);
+        if (dataNode == null) {
+            return true;
+        }
+
+        // use display name as new name
+        String newName = dataNode.getDisplayName();
+        source.setDataNodeName(newName);
+        return copyDataNode(dataNodeName, type, from, to, newName)
+                && sourceMapper.updateByPrimaryKeySelective(source) == InlongConstants.AFFECTED_ONE_ROW;
+    }
+
+    public Boolean copyDataNode(String name, String type, String from, String to, String newName) {
+
+        try {
+            // use displayName as the new name
+            return dataNodeEntityMapper.copy(name, type, from, to, newName) == InlongConstants.AFFECTED_ONE_ROW;
+        } catch (Exception e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof SQLIntegrityConstraintViolationException) {
+                log.debug("data node name={}, type={} in tenant={} already exist", name, type, to);
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    public Boolean migrateConsume(String groupId, String from, String to, int size) {
+        return consumeEntityMapper.migrate(groupId, from, to) == size;
+    }
+
+    public Boolean migrateGroup(String groupId, String from, String to) {
+        return groupMapper.migrate(groupId, from, to) == InlongConstants.AFFECTED_ONE_ROW;
+    }
+
+    public Boolean copyTenantTag(String clusterTag, String from, String to) {
+        return tenantClusterTagMapper.copy(clusterTag, from, to) == InlongConstants.AFFECTED_ONE_ROW;
+    }
+
+
+    private boolean hasPermission(UserInfo userInfo, String tenant) {
+        return tenantRoleService.getByUsernameAndTenant(userInfo.getName(), tenant) != null
+                || isInlongRoles(userInfo);
+    }
+
 
     public void setTargetTenantList(InlongTenantPageRequest request, UserInfo userInfo) {
         if (isInlongRoles(userInfo)) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.web.controller;
 
-import io.swagger.annotations.ApiImplicitParams;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -31,6 +30,7 @@ import org.apache.inlong.manager.service.tenant.InlongTenantService;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import io.swagger.annotations.ApiImplicitParams;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -90,4 +91,13 @@ public class InlongTenantController {
         return Response.success(tenantService.delete(name));
     }
 
+    @RequestMapping(value = "/tenant/migrate/{group}/{tenant}", method = RequestMethod.GET)
+    @ApiOperation(value = "Migrate group to another tenant")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "group", dataTypeClass = String.class, required = true),
+            @ApiImplicitParam(name = "tenant", dataTypeClass = String.class, required = true),
+    })
+    public Response<Boolean> migrate(@PathVariable String group, @PathVariable String tenant) {
+        return Response.success(tenantService.migrate(group, tenant));
+    }
 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8403

### Motivation

We need a set of interfaces to support resource migrate from/to different tenant.

There are three major resources will be migrated from one tenant to another, Inlong Group, Inlong Consume and DataNode.

All migration should be start with a specific Inlong Group , then migrate the group-related Inlong Consume and DataNode.

The migration is followed by these steps:

1. Check if the target tenant exists
2. List all Inlong Stream of this group
3. List all InlongConsume of this group
4. List all DataNode of related StreamSink
5. List all DataNode of related StreamSource
6. Copy DataNode if the the target tenant doesn't have it
7. Change the datanode name of each sink to the new one
8. Copy TenantClusterTag if the the target tenant doesn't have it


### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
