### PR TITLE
[INLONG-8914][DataProxy] Optimize DataProxy event statistics

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/ConfigManager.java
@@ -359,8 +359,8 @@ public class ConfigManager {
                 String returnStr = EntityUtils.toString(response.getEntity());
                 long dltTime = System.currentTimeMillis() - startTime;
                 if (dltTime >= CommonConfigHolder.getInstance().getMetaConfigWastAlarmMs()) {
-                    LOG.warn("End to request {} to get config info:{}, WAIST {} ms",
-                            url, returnStr, dltTime);
+                    LOG.warn("End to request {} to get config info, WAIST {} ms, over alarm value {} ms",
+                            url, dltTime, CommonConfigHolder.getInstance().getMetaConfigWastAlarmMs());
                 } else {
                     if (LOG.isDebugEnabled()) {
                         LOG.debug("End to request {} to get config info:{}, WAIST {} ms",

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/ConfigConstants.java
@@ -37,8 +37,6 @@ public class ConfigConstants {
 
     public static final String TOPIC = "topic";
 
-    public static final String ATTR = "attr";
-
     public static final String FILTER_EMPTY_MSG = "filter-empty-msg";
 
     public static final String TCP_NO_DELAY = "tcpNoDelay";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -41,7 +41,7 @@ public class StatConstants {
     public static final java.lang.String EVENT_HTTP_LINK_UNKNOWN_EXCEPTION = "http.link.unknown.exception";
     public static final java.lang.String EVENT_HTTP_LINK_UNWRITABLE = "http.link.unwritable";
     // configure
-    public static final java.lang.String EVENT_CONFIG_TOPIC_MISSING = "config.topic.missing";
+    public static final java.lang.String EVENT_SOURCE_TOPIC_MISSING = "source.topic.missing";
     public static final java.lang.String EVENT_CONFIG_IDNUM_EMPTY = "config.idnum.empty";
     public static final java.lang.String EVENT_CONFIG_GROUPIDNUM_MISSING = "config.groupidnum.missing";
     public static final java.lang.String EVENT_CONFIG_GROUP_IDNUM_INCONSTANT = "config.group.idnum.incons";
@@ -91,12 +91,14 @@ public class StatConstants {
     public static final java.lang.String EVENT_SINK_EVENT_V1_MALFORMED = "sink.event.v1.malformed";
     public static final java.lang.String EVENT_SINK_EVENT_TAKE_SUCCESS = "sink.event.take.success";
     public static final java.lang.String EVENT_SINK_EVENT_TAKE_FAILURE = "sink.event.take.failure";
-    public static final java.lang.String EVENT_SINK_EVENT_V1_FILE = "sink.event.v1.file";
-    public static final java.lang.String EVENT_SINK_EVENT_V0_FILE = "sink.event.v1.file";
+    public static final java.lang.String EVENT_SINK_FILE_V1_TAKE_SUCCESS = "sink.file.v1.take.success";
+    public static final java.lang.String EVENT_SINK_FILE_V0_TAKE_SUCCESS = "sink.file.v0.take.success";
     public static final java.lang.String EVENT_SINK_CONFIG_TOPIC_MISSING = "sink.topic.missing";
     public static final java.lang.String EVENT_SINK_DEFAULT_TOPIC_MISSING = "default.topic.empty";
     public static final java.lang.String EVENT_SINK_DEFAULT_TOPIC_USED = "default.topic.used";
     public static final java.lang.String EVENT_SINK_PRODUCER_NULL = "sink.producer.null";
+    public static final java.lang.String EVENT_SINK_PRODUCER_CREATE_SUCCESS = "sink.producer.create.success";
+    public static final java.lang.String EVENT_SINK_PRODUCER_CREATE_FAILURE = "sink.producer.create.failure";
     public static final java.lang.String EVENT_SINK_CLUSTER_EMPTY = "sink.cluster.empty";
     public static final java.lang.String EVENT_SINK_CLUSTER_UNMATCHED = "sink.cluster.unmatched";
     public static final java.lang.String EVENT_SINK_CPRODUCER_NULL = "sink.cluster.producer.null";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSink.java
@@ -234,7 +234,7 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable, 
                     ProxyEvent proxyEvent = new ProxyEvent(groupId, streamId, msgTimeStr,
                             sourceIp, sourceTimeStr, event.getHeaders(), event.getBody());
                     this.dispatchManager.addEvent(proxyEvent);
-                    context.fileMetricIncSumStats(StatConstants.EVENT_SINK_EVENT_V1_FILE);
+                    context.fileMetricIncSumStats(StatConstants.EVENT_SINK_FILE_V1_TAKE_SUCCESS);
                 } else {
                     context.fileMetricIncSumStats(StatConstants.EVENT_SINK_EVENT_V1_MALFORMED);
                 }
@@ -243,7 +243,7 @@ public class MessageQueueZoneSink extends AbstractSink implements Configurable, 
                 simpleEvent.setBody(event.getBody());
                 simpleEvent.setHeaders(event.getHeaders());
                 this.dispatchManager.addSimpleEvent(simpleEvent);
-                context.fileMetricIncSumStats(StatConstants.EVENT_SINK_EVENT_V0_FILE);
+                context.fileMetricIncSumStats(StatConstants.EVENT_SINK_FILE_V0_TAKE_SUCCESS);
             }
             tx.commit();
             return Status.READY;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/kafka/KafkaHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/kafka/KafkaHandler.java
@@ -124,7 +124,20 @@ public class KafkaHandler implements MessageQueueHandler {
             IdTopicConfig idConfig = ConfigManager.getInstance().getSinkIdTopicConfig(
                     profile.getInlongGroupId(), profile.getInlongStreamId());
             if (idConfig == null) {
-                if (!CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
+                // add default topics first
+                if (CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
+                    topic = CommonConfigHolder.getInstance().getRandDefTopics();
+                    if (StringUtils.isEmpty(topic)) {
+                        sinkContext.fileMetricIncWithDetailStats(
+                                StatConstants.EVENT_SINK_DEFAULT_TOPIC_MISSING, profile.getUid());
+                        sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
+                        sinkContext.getMqZoneSink().releaseAcquiredSizePermit(profile);
+                        profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
+                        return false;
+                    }
+                    sinkContext.fileMetricIncWithDetailStats(
+                            StatConstants.EVENT_SINK_DEFAULT_TOPIC_USED, profile.getUid());
+                } else {
                     sinkContext.fileMetricIncWithDetailStats(
                             StatConstants.EVENT_SINK_CONFIG_TOPIC_MISSING, profile.getUid());
                     sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
@@ -132,15 +145,6 @@ public class KafkaHandler implements MessageQueueHandler {
                     profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
                     return false;
                 }
-                topic = CommonConfigHolder.getInstance().getRandDefTopics();
-                if (StringUtils.isEmpty(topic)) {
-                    sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_DEFAULT_TOPIC_MISSING);
-                    sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
-                    sinkContext.getMqZoneSink().releaseAcquiredSizePermit(profile);
-                    profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
-                    return false;
-                }
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_DEFAULT_TOPIC_USED);
             } else {
                 topic = idConfig.getTopicName();
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/tube/TubeHandler.java
@@ -189,7 +189,20 @@ public class TubeHandler implements MessageQueueHandler {
             IdTopicConfig idConfig = ConfigManager.getInstance().getSinkIdTopicConfig(
                     profile.getInlongGroupId(), profile.getInlongStreamId());
             if (idConfig == null) {
-                if (!CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
+                // add default topics first
+                if (CommonConfigHolder.getInstance().isEnableUnConfigTopicAccept()) {
+                    topic = CommonConfigHolder.getInstance().getRandDefTopics();
+                    if (StringUtils.isEmpty(topic)) {
+                        sinkContext.fileMetricIncWithDetailStats(
+                                StatConstants.EVENT_SINK_DEFAULT_TOPIC_MISSING, profile.getUid());
+                        sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
+                        sinkContext.getMqZoneSink().releaseAcquiredSizePermit(profile);
+                        profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
+                        return false;
+                    }
+                    sinkContext.fileMetricIncWithDetailStats(
+                            StatConstants.EVENT_SINK_DEFAULT_TOPIC_USED, profile.getUid());
+                } else {
                     sinkContext.fileMetricIncWithDetailStats(
                             StatConstants.EVENT_SINK_CONFIG_TOPIC_MISSING, profile.getUid());
                     sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
@@ -197,15 +210,6 @@ public class TubeHandler implements MessageQueueHandler {
                     profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
                     return false;
                 }
-                topic = CommonConfigHolder.getInstance().getRandDefTopics();
-                if (StringUtils.isEmpty(topic)) {
-                    sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_DEFAULT_TOPIC_MISSING);
-                    sinkContext.addSendResultMetric(profile, clusterName, profile.getUid(), false, 0);
-                    sinkContext.getMqZoneSink().releaseAcquiredSizePermit(profile);
-                    profile.fail(DataProxyErrCode.GROUPID_OR_STREAMID_NOT_CONFIGURE, "");
-                    return false;
-                }
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_DEFAULT_TOPIC_USED);
             } else {
                 topic = idConfig.getTopicName();
             }
@@ -273,7 +277,8 @@ public class TubeHandler implements MessageQueueHandler {
                     sinkContext.getMqZoneSink().releaseAcquiredSizePermit(batchProfile);
                     batchProfile.ack();
                 } else {
-                    sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_FAILURE);
+                    sinkContext.fileMetricIncWithDetailStats(StatConstants.EVENT_SINK_FAILURE,
+                            topic + "." + result.getErrCode());
                     sinkContext.processSendFail(batchProfile, clusterName, topic, sendTime,
                             DataProxyErrCode.MQ_RETURN_ERROR, result.getErrMsg());
                     if (logCounter.shouldPrint()) {
@@ -284,7 +289,7 @@ public class TubeHandler implements MessageQueueHandler {
 
             @Override
             public void onException(Throwable ex) {
-                sinkContext.fileMetricIncSumStats(StatConstants.EVENT_SINK_RECEIVEEXCEPT);
+                sinkContext.fileMetricIncWithDetailStats(StatConstants.EVENT_SINK_RECEIVEEXCEPT, topic);
                 sinkContext.processSendFail(batchProfile, clusterName, topic, sendTime,
                         DataProxyErrCode.MQ_RETURN_ERROR, ex.getMessage());
                 if (logCounter.shouldPrint()) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
@@ -90,8 +90,6 @@ public abstract class BaseSource
     protected String msgFactoryName;
     // message handler name
     protected String messageHandlerName;
-    // source default append attribute
-    protected String defAttr = "";
     // allowed max message length
     protected int maxMsgLength;
     // whether compress message
@@ -161,11 +159,6 @@ public abstract class BaseSource
         Preconditions.checkArgument(StringUtils.isNotBlank(tmpVal),
                 SourceConstants.SRCCXT_MESSAGE_HANDLER_NAME + " config is blank");
         this.messageHandlerName = tmpVal;
-        // get default attributes
-        tmpVal = context.getString(SourceConstants.SRCCXT_DEF_ATTR);
-        if (StringUtils.isNotBlank(tmpVal)) {
-            this.defAttr = tmpVal.trim();
-        }
         // get allowed max message length
         this.maxMsgLength = ConfStringUtils.getIntValue(context,
                 SourceConstants.SRCCXT_MAX_MSG_LENGTH, SourceConstants.VAL_DEF_MAX_MSG_LENGTH);
@@ -371,10 +364,6 @@ public abstract class BaseSource
         return strPort;
     }
 
-    public String getDefAttr() {
-        return defAttr;
-    }
-
     public int getMaxMsgLength() {
         return maxMsgLength;
     }
@@ -417,9 +406,10 @@ public abstract class BaseSource
         }
     }
 
-    public void fileMetricIncDetailStats(String eventKey) {
+    public void fileMetricIncWithDetailStats(String eventKey, String detailInfoKey) {
         if (enableFileMetric) {
-            monitorStats.incDetailStats(eventKey);
+            monitorStats.incSumStats(eventKey);
+            monitorStats.incDetailStats(eventKey + "#" + detailInfoKey);
         }
     }
 

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -308,12 +308,13 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
             source.addMetric(false, event.getBody().length, event);
             if (msgCodec.isNeedResp()) {
                 msgCodec.setFailureInfo(DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,
-                        strBuff.append("Put event to channel failure: ").append(ex.getMessage()).toString());
+                        strBuff.append("Put msg event to channel failure: ").append(ex.getMessage()).toString());
                 strBuff.delete(0, strBuff.length());
                 responseV0Msg(channel, msgCodec, strBuff);
             }
             if (logCounter.shouldPrint()) {
-                logger.error("Error writing event to channel failure.", ex);
+                logger.error("Error writing msg event to channel failure, attrs={}",
+                        msgCodec.getAttr(), ex);
             }
         }
     }
@@ -428,8 +429,9 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
         for (ProxyEvent event : events) {
             // get configured topic name
             String topic = configManager.getTopicName(event.getInlongGroupId(), event.getInlongStreamId());
-            if (StringUtils.isBlank(topic)) {
-                source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+            if (StringUtils.isEmpty(topic)) {
+                source.fileMetricIncWithDetailStats(
+                        StatConstants.EVENT_SOURCE_TOPIC_MISSING, event.getInlongGroupId());
                 source.addMetric(false, event.getBody().length, event);
                 this.responsePackage(ctx, ProxySdk.ResultCode.ERR_ID_ERROR, packObject);
                 return;

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SourceConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/SourceConstants.java
@@ -33,8 +33,6 @@ public class SourceConstants {
     public static final String SRCCXT_MSG_FACTORY_NAME = "msg-factory-name";
     // message handler name
     public static final String SRCCXT_MESSAGE_HANDLER_NAME = "message-handler-name";
-    // default attributes
-    public static final String SRCCXT_DEF_ATTR = "attr";
     // max message length
     public static final String SRCCXT_MAX_MSG_LENGTH = "max-msg-length";
     // allowed max message length

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/httpMsg/HttpMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/httpMsg/HttpMessageHandler.java
@@ -275,7 +275,7 @@ public class HttpMessageHandler extends SimpleChannelInboundHandler<FullHttpRequ
         // get and check streamId
         String streamId = reqAttrs.get(HttpAttrConst.KEY_STREAM_ID);
         if (StringUtils.isBlank(streamId)) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_MSG_STREAMID_MISSING);
+            source.fileMetricIncWithDetailStats(StatConstants.EVENT_MSG_STREAMID_MISSING, groupId);
             sendResponse(ctx, DataProxyErrCode.MISS_REQUIRED_STREAMID_ARGUMENT.getErrCode(),
                     strBuff.append("Field ").append(HttpAttrConst.KEY_STREAM_ID)
                             .append(" must exist and not blank!").toString(),
@@ -284,8 +284,8 @@ public class HttpMessageHandler extends SimpleChannelInboundHandler<FullHttpRequ
         }
         // get and check topicName
         String topicName = ConfigManager.getInstance().getTopicName(groupId, streamId);
-        if (StringUtils.isBlank(topicName)) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+        if (StringUtils.isEmpty(topicName)) {
+            source.fileMetricIncWithDetailStats(StatConstants.EVENT_SOURCE_TOPIC_MISSING, groupId);
             sendResponse(ctx, DataProxyErrCode.TOPIC_IS_BLANK.getErrCode(),
                     strBuff.append("Topic not configured for ").append(HttpAttrConst.KEY_GROUP_ID)
                             .append("(").append(groupId).append("),")
@@ -308,13 +308,13 @@ public class HttpMessageHandler extends SimpleChannelInboundHandler<FullHttpRequ
         String body = reqAttrs.get(HttpAttrConst.KEY_BODY);
         if (StringUtils.isBlank(body)) {
             if (body == null) {
-                source.fileMetricIncSumStats(StatConstants.EVENT_MSG_BODY_MISSING);
+                source.fileMetricIncWithDetailStats(StatConstants.EVENT_MSG_BODY_MISSING, groupId);
                 sendResponse(ctx, DataProxyErrCode.MISS_REQUIRED_BODY_ARGUMENT.getErrCode(),
                         strBuff.append("Field ").append(HttpAttrConst.KEY_BODY)
                                 .append(" is not exist!").toString(),
                         isCloseCon, callback);
             } else {
-                source.fileMetricIncSumStats(StatConstants.EVENT_MSG_BODY_BLANK);
+                source.fileMetricIncWithDetailStats(StatConstants.EVENT_MSG_BODY_BLANK, groupId);
                 sendResponse(ctx, DataProxyErrCode.EMPTY_MSG.getErrCode(),
                         strBuff.append("Field ").append(HttpAttrConst.KEY_BODY)
                                 .append(" is Blank!").toString(),
@@ -323,7 +323,7 @@ public class HttpMessageHandler extends SimpleChannelInboundHandler<FullHttpRequ
             return;
         }
         if (body.length() > source.getMaxMsgLength()) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_MSG_BODY_OVERMAX);
+            source.fileMetricIncWithDetailStats(StatConstants.EVENT_MSG_BODY_OVERMAX, groupId);
             sendResponse(ctx, DataProxyErrCode.BODY_EXCEED_MAX_LEN.getErrCode(),
                     strBuff.append("Error msg, the ").append(HttpAttrConst.KEY_BODY)
                             .append(" length(").append(body.length())
@@ -377,7 +377,7 @@ public class HttpMessageHandler extends SimpleChannelInboundHandler<FullHttpRequ
                     "b2b", dataTime, pkgTime, 1);
             source.addMetric(false, event.getBody().length, event);
             sendErrorMsg(ctx, DataProxyErrCode.PUT_EVENT_TO_CHANNEL_FAILURE,
-                    strBuff.append("Put event to channel failure: ").append(ex.getMessage()).toString(), callback);
+                    strBuff.append("Put HTTP event to channel failure: ").append(ex.getMessage()).toString(), callback);
             if (logCounter.shouldPrint()) {
                 logger.error("Error writing HTTP event to channel failure.", ex);
             }

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecBinMsg.java
@@ -259,7 +259,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
             String confStreamId;
             String strGroupIdNum = String.valueOf(this.groupIdNum);
             confGroupId = configManager.getGroupIdNameByNum(strGroupIdNum);
-            if (StringUtils.isBlank(confGroupId)) {
+            if (StringUtils.isEmpty(confGroupId)) {
                 if (configManager.isGroupIdNumConfigEmpty()) {
                     source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_IDNUM_EMPTY);
                     this.errCode = DataProxyErrCode.CONF_SERVICE_UNREADY;
@@ -291,7 +291,7 @@ public class CodecBinMsg extends AbsV0MsgCodec {
             } else {
                 String strStreamIdNum = String.valueOf(this.streamIdNum);
                 confStreamId = configManager.getStreamIdNameByIdNum(strGroupIdNum, strStreamIdNum);
-                if (StringUtils.isBlank(confStreamId)) {
+                if (StringUtils.isEmpty(confStreamId)) {
                     if (configManager.isStreamIdNumConfigEmpty()) {
                         source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_IDNUM_EMPTY);
                         this.errCode = DataProxyErrCode.CONF_SERVICE_UNREADY;
@@ -327,8 +327,8 @@ public class CodecBinMsg extends AbsV0MsgCodec {
         }
         // get and check topic configure
         this.topicName = configManager.getTopicName(this.groupId, this.streamId);
-        if (StringUtils.isBlank(this.topicName)) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+        if (StringUtils.isEmpty(this.topicName)) {
+            source.fileMetricIncWithDetailStats(StatConstants.EVENT_SOURCE_TOPIC_MISSING, this.groupId);
             this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
             this.errMsg = String.format("Topic not configured for groupId=(%s), streamId=(%s)",
                     this.groupId, this.streamId);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
@@ -152,8 +152,8 @@ public class CodecTextMsg extends AbsV0MsgCodec {
         }
         // get and check topic configure
         String tmpTopicName = ConfigManager.getInstance().getTopicName(tmpGroupId, tmpStreamId);
-        if (StringUtils.isBlank(tmpTopicName)) {
-            source.fileMetricIncSumStats(StatConstants.EVENT_CONFIG_TOPIC_MISSING);
+        if (StringUtils.isEmpty(tmpTopicName)) {
+            source.fileMetricIncWithDetailStats(StatConstants.EVENT_SOURCE_TOPIC_MISSING, tmpGroupId);
             this.errCode = DataProxyErrCode.TOPIC_IS_BLANK;
             this.errMsg = String.format(
                     "Topic not configured for groupId=(%s), streamId=(%s)", tmpGroupId, tmpStreamId);

--- a/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/source/UdpSourceTest.java
+++ b/inlong-dataproxy/dataproxy-source/src/test/java/org/apache/inlong/dataproxy/source/UdpSourceTest.java
@@ -35,7 +35,6 @@ public class UdpSourceTest {
         map.put(ConfigConstants.CONFIG_PORT, "8080");
         map.put(ConfigConstants.CONFIG_HOST, "127.0.0.1");
         map.put(ConfigConstants.TOPIC, "topic");
-        map.put(ConfigConstants.ATTR, "{}");
         Context context = new Context(map);
         SimpleUdpSource udpSource = new SimpleUdpSource();
         udpSource.configure(context);


### PR DESCRIPTION
- Fixes #8914

1. Add detailed event indicator printing API at the Source side, and adjust the output of some events from simple event statistics to detailed event statistics;
2. Optimize the logic of obtaining the default Topic on the Sink side, and update the event indicator output type to detailed indicators;
3. Remove unused default attribute acquisition logic;
4. Optimize some log output