### PR TITLE
[INLONG-8918][DataProxy] Change tube to tubemq

### DIFF
--- a/bin/inlong-daemon
+++ b/bin/inlong-daemon
@@ -78,7 +78,7 @@ start_inlong_audit() {
     bash +x ./bin/proxy-start.sh pulsar
   fi
   if [ "${mq_type}" = "tubemq" ]; then
-    bash +x ./bin/proxy-start.sh tube
+    bash +x ./bin/proxy-start.sh tubemq
   fi
   if [ "${mq_type}" = "kafka" ]; then
     bash +x ./bin/proxy-start.sh kafka


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #8918 

### Motivation

*Fix a script parameter error in `bin/inlong-daemon`*

### Modifications

*Change `tube` to `tubemq` (Line 81)*
*https://github.com/apache/inlong/blob/95580578336373f484622d3442d4ee01e9a41541/bin/inlong-daemon#L81*

