### PR TITLE
add memCacheMsgSizeInMB attribute to AddTopicReq.class

### DIFF
--- a/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddTopicReq.java
+++ b/inlong-tubemq/tubemq-manager/src/main/java/org/apache/inlong/tubemq/manager/controller/node/request/AddTopicReq.java
@@ -36,6 +36,7 @@ public class AddTopicReq extends BaseReq {
     private Integer unflushDataHold;
     private Integer memCacheMsgCntInK;
     private Integer memCacheFlushIntvl;
+    private Integer memCacheMsgSizeInMB;
     private Integer maxMsgSizeInMB;
     private String deletePolicy;
     private Boolean acceptPublish;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes https://github.com/apache/inlong/issues/8812

### Motivation

The parameter of the AddTopicReq class is missing memCacheMsgSizeInMB compared to the HTTP API parameter.

### Modifications

add memCacheMsgSizeInMB attribute to AddTopicReq.class

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
