### PR TITLE
[INLONG-8946][Manager] Optimize the audit ID method issued by the manager

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
@@ -255,7 +255,9 @@ public class AuditServiceImpl implements AuditService {
 
         InlongGroupEntity groupEntity = inlongGroupMapper.selectByGroupId(groupId);
         List<StreamSourceEntity> sourceEntityList = sourceEntityMapper.selectByRelatedId(groupId, streamId, null);
-        sourceNodeType = sourceEntityList.get(0).getSourceType();
+        if(CollectionUtils.isNotEmpty(sourceEntityList)) {
+            sourceNodeType = sourceEntityList.get(0).getSourceType();
+        }
 
         Map<String, String> auditIdMap = new HashMap<>();
         auditIdMap.put(getAuditId(sourceNodeType, false), sourceNodeType);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
@@ -48,7 +48,6 @@ import org.apache.inlong.manager.service.core.AuditService;
 import org.apache.inlong.manager.service.resource.sink.ck.ClickHouseConfig;
 import org.apache.inlong.manager.service.resource.sink.es.ElasticsearchApi;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ibatis.jdbc.SQL;
@@ -239,6 +238,7 @@ public class AuditServiceImpl implements AuditService {
         // for now, we use the first sink type only.
         // this is temporary behavior before multiple sinks in one stream is fully supported.
         String sinkNodeType = null;
+        String sourceNodeType = null;
         Integer sinkId = request.getSinkId();
         StreamSinkEntity sinkEntity = null;
         List<StreamSinkEntity> sinkEntityList = sinkEntityMapper.selectByRelatedId(groupId, streamId);
@@ -253,10 +253,20 @@ public class AuditServiceImpl implements AuditService {
             sinkNodeType = sinkEntity.getSinkType();
         }
 
-        Set<String> sinkAuditIds = Sets.newHashSet(getAuditId(sinkNodeType, true), getAuditId(sinkNodeType, false));
+        InlongGroupEntity groupEntity = inlongGroupMapper.selectByGroupId(groupId);
+        List<StreamSourceEntity> sourceEntityList = sourceEntityMapper.selectByRelatedId(groupId, streamId, null);
+        sourceNodeType = sourceEntityList.get(0).getSourceType();
+
+        Map<String, String> auditIdMap = new HashMap<>();
+        auditIdMap.put(getAuditId(sourceNodeType, false), sourceNodeType);
+        auditIdMap.put(getAuditId(sinkNodeType, true), sinkNodeType);
 
         // properly overwrite audit ids by role and stream config
-        request.setAuditIds(getAuditIds(groupId, streamId, sinkNodeType));
+        request.setAuditIds(getAuditIds(groupId, streamId, null, sinkNodeType));
+
+        if (InlongConstants.DATASYNC_MODE.equals(groupEntity.getInlongGroupMode())) {
+            request.setAuditIds(getAuditIds(groupId, streamId, sourceNodeType, sinkNodeType));
+        }
 
         List<AuditVO> result = new ArrayList<>();
         AuditQuerySource querySource = AuditQuerySource.valueOf(auditQuerySource);
@@ -275,7 +285,7 @@ public class AuditServiceImpl implements AuditService {
                     vo.setDelay(((BigDecimal) s.get("totalDelay")).longValue());
                     return vo;
                 }).collect(Collectors.toList());
-                result.add(new AuditVO(auditId, auditSet, sinkAuditIds.contains(auditId) ? sinkNodeType : null));
+                result.add(new AuditVO(auditId, auditSet, auditIdMap.getOrDefault(auditId, null)));
             } else if (AuditQuerySource.ELASTICSEARCH == querySource) {
                 String index = String.format("%s_%s", request.getStartDate().replaceAll("-", ""), auditId);
                 if (!elasticsearchApi.indexExists(index)) {
@@ -294,8 +304,7 @@ public class AuditServiceImpl implements AuditService {
                             vo.setDelay((long) ((ParsedSum) bucket.getAggregations().asList().get(1)).getValue());
                             return vo;
                         }).collect(Collectors.toList());
-                        result.add(new AuditVO(auditId, auditSet,
-                                auditId.equals(getAuditId(sinkNodeType, true)) ? sinkNodeType : null));
+                        result.add(new AuditVO(auditId, auditSet, auditIdMap.getOrDefault(auditId, null)));
                     }
                 }
             } else if (AuditQuerySource.CLICKHOUSE == querySource) {
@@ -312,8 +321,7 @@ public class AuditServiceImpl implements AuditService {
                         vo.setDelay(resultSet.getLong("total_delay"));
                         auditSet.add(vo);
                     }
-                    result.add(new AuditVO(auditId, auditSet,
-                            auditId.equals(getAuditId(sinkNodeType, true)) ? sinkNodeType : null));
+                    result.add(new AuditVO(auditId, auditSet, auditIdMap.getOrDefault(auditId, null)));
                 }
             }
         }
@@ -321,7 +329,7 @@ public class AuditServiceImpl implements AuditService {
         return aggregateByTimeDim(result, request.getTimeStaticsDim());
     }
 
-    private List<String> getAuditIds(String groupId, String streamId, String sinkNodeType) {
+    private List<String> getAuditIds(String groupId, String streamId, String sourceNodeType, String sinkNodeType) {
         Set<String> auditSet = LoginUserUtils.getLoginUser().getRoles().contains(UserRoleCode.TENANT_ADMIN)
                 ? new HashSet<>(auditIdListForAdmin)
                 : new HashSet<>(auditIdListForUser);
@@ -330,10 +338,10 @@ public class AuditServiceImpl implements AuditService {
         if (sinkNodeType == null) {
             auditSet.add(getAuditId(ClusterType.DATAPROXY, true));
         } else {
-            auditSet.add(getAuditId(sinkNodeType, false));
+            auditSet.add(getAuditId(sinkNodeType, true));
             InlongGroupEntity inlongGroup = inlongGroupMapper.selectByGroupId(groupId);
             if (InlongConstants.DATASYNC_MODE.equals(inlongGroup.getInlongGroupMode())) {
-                auditSet.add(getAuditId(sinkNodeType, true));
+                auditSet.add(getAuditId(sourceNodeType, false));
             }
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
@@ -255,7 +255,7 @@ public class AuditServiceImpl implements AuditService {
 
         InlongGroupEntity groupEntity = inlongGroupMapper.selectByGroupId(groupId);
         List<StreamSourceEntity> sourceEntityList = sourceEntityMapper.selectByRelatedId(groupId, streamId, null);
-        if(CollectionUtils.isNotEmpty(sourceEntityList)) {
+        if (CollectionUtils.isNotEmpty(sourceEntityList)) {
             sourceNodeType = sourceEntityList.get(0).getSourceType();
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -124,16 +124,15 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             // build a stream info from the nodes and relations
             List<StreamSource> sources = sourceMap.get(streamId);
             List<StreamSink> sinks = sinkMap.get(streamId);
-            // get audit list by sink type
-            List<String> auditIds = new ArrayList<>();
+
             for (StreamSink sink : sinks) {
-                auditIds.add(auditService.getAuditId(sink.getSinkType(), false));
-                auditIds.add(auditService.getAuditId(sink.getSinkType(), true));
+                Map<String, Object> properties = sink.getProperties();
+                properties.putIfAbsent("metrics.audit.key", auditService.getAuditId(sink.getSinkType(), true));
             }
             for (StreamSource source : sources) {
                 source.setFieldList(inlongStream.getFieldList());
                 Map<String, Object> properties = source.getProperties();
-                properties.putIfAbsent("metrics.audit.key", String.join("&", auditIds));
+                properties.putIfAbsent("metrics.audit.key", auditService.getAuditId(source.getSourceType(), false));
             }
             List<NodeRelation> relations;
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8946 

### Motivation

1. The manager only issues audit IDs through the sink type, all are placed in source Flink SQL.
image
2. When using the dashboard to query audit information, the manager should add the source type.

### Modifications

1. When creating Flink SQL, add the read audit ID to the source; add the send audit ID to the sink.
2. Add source type when getting audit information.

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/2251c392-1595-46a8-bb13-0dc0da42fb6d)
![企业微信截图_16952030682438](https://github.com/apache/inlong/assets/58519431/8571f94f-4f5d-4a2f-922b-03abc3254686)

