### PR TITLE
[INLONG-8971][Manager] Add MQ audit IDs

### DIFF
--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -888,7 +888,13 @@ VALUES ('audit_sdk_collect', 'SDK', 0, '1'),
        ('audit_sort_kudu_input', 'KUDU', 0, '25'),
        ('audit_sort_kudu_output', 'KUDU', 1, '26'),
        ('audit_sort_postgres_input', 'POSTGRESQL', 0, '27'),
-       ('audit_sort_postgres_output', 'POSTGRESQL', 1, '28');
+       ('audit_sort_postgres_output', 'POSTGRESQL', 1, '28'),
+       ('audit_sort_pulsar_input', 'PULSAR', 0, '29'),
+       ('audit_sort_pulsar_output', 'PULSAR', 1, '30'),
+       ('audit_sort_tube_input', 'TUBEMQ', 0, '31'),
+       ('audit_sort_tube_output', 'TUBEMQ', 1, '32'),
+       ('audit_sort_kafka_input', 'KAFKA', 0, '33'),
+       ('audit_sort_kafka_output', 'KAFKA', 1, '34');
 
 -- ----------------------------
 -- Table structure for audit_source

--- a/inlong-manager/manager-web/sql/changes-1.9.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.9.0.sql
@@ -45,5 +45,14 @@ CREATE TABLE IF NOT EXISTS `tenant_cluster_tag`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4 COMMENT ='Tenant cluster tag table';
 
+INSERT INTO `audit_base`(`name`, `type`, `is_sent`, `audit_id`)
+VALUES ('audit_sort_pulsar_input', 'PULSAR', 0, '29'),
+       ('audit_sort_pulsar_output', 'PULSAR', 1, '30');
 
+INSERT INTO `audit_base`(`name`, `type`, `is_sent`, `audit_id`)
+VALUES ('audit_sort_tube_input', 'TUBEMQ', 0, '31'),
+       ('audit_sort_tube_output', 'TUBEMQ', 1, '32');
 
+INSERT INTO `audit_base`(`name`, `type`, `is_sent`, `audit_id`)
+VALUES ('audit_sort_kafka_input', 'KAFKA', 0, '33'),
+       ('audit_sort_kafka_output', 'KAFKA', 1, '34');


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8971 

### Motivation

When using `data ingestion`, the actual source is MQ, so the `source audit id` issued by the manager is the corresponding MQ audit id.

### Modifications

Add MQ audit IDs.

