### PR TITLE
[INLONG-8975][Manager] Manager issues an audit IDs based on the group mode

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkOperation.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkOperation.java
@@ -256,7 +256,8 @@ public class FlinkOperation {
 
         List<String> nodeTypes = new ArrayList<>();
         if (StringUtils.isNotEmpty(dataflow)) {
-            checkNodeIds(dataflow);
+            // TODO Temporarily remove this method. The method of checking node needs to be modified.
+            // checkNodeIds(dataflow);
             JsonNode nodes = JsonUtils.parseTree(dataflow).get(InlongConstants.STREAMS)
                     .get(0).get(InlongConstants.NODES);
             List<String> types = JsonUtils.OBJECT_MAPPER.convertValue(nodes,

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditServiceImpl.java
@@ -260,14 +260,15 @@ public class AuditServiceImpl implements AuditService {
         }
 
         Map<String, String> auditIdMap = new HashMap<>();
-        auditIdMap.put(getAuditId(sourceNodeType, false), sourceNodeType);
         auditIdMap.put(getAuditId(sinkNodeType, true), sinkNodeType);
 
         // properly overwrite audit ids by role and stream config
-        request.setAuditIds(getAuditIds(groupId, streamId, null, sinkNodeType));
-
         if (InlongConstants.DATASYNC_MODE.equals(groupEntity.getInlongGroupMode())) {
+            auditIdMap.put(getAuditId(sourceNodeType, false), sourceNodeType);
             request.setAuditIds(getAuditIds(groupId, streamId, sourceNodeType, sinkNodeType));
+        } else {
+            auditIdMap.put(getAuditId(sinkNodeType, false), sinkNodeType);
+            request.setAuditIds(getAuditIds(groupId, streamId, null, sinkNodeType));
         }
 
         List<AuditVO> result = new ArrayList<>();
@@ -344,6 +345,8 @@ public class AuditServiceImpl implements AuditService {
             InlongGroupEntity inlongGroup = inlongGroupMapper.selectByGroupId(groupId);
             if (InlongConstants.DATASYNC_MODE.equals(inlongGroup.getInlongGroupMode())) {
                 auditSet.add(getAuditId(sourceNodeType, false));
+            } else {
+                auditSet.add(getAuditId(sinkNodeType, false));
             }
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -131,12 +131,10 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
             List<StreamSink> sinks = sinkMap.get(streamId);
 
             for (StreamSink sink : sinks) {
-                Map<String, Object> properties = sink.getProperties();
                 addAuditId(sink.getProperties(), sink.getSinkType(), true);
             }
             for (StreamSource source : sources) {
                 source.setFieldList(inlongStream.getFieldList());
-                addAuditId(source.getProperties(), source.getSourceType(), false);
             }
             List<NodeRelation> relations;
 
@@ -152,6 +150,10 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                 } else {
                     relations = NodeRelationUtils.createNodeRelations(sources, sinks);
                 }
+
+                for (StreamSink sink : sinks) {
+                    addAuditId(sink.getProperties(), sink.getSinkType(), false);
+                }
             } else {
                 if (CollectionUtils.isNotEmpty(transformResponses)) {
                     List<String> sourcesNames = sources.stream().map(StreamSource::getSourceName)
@@ -163,6 +165,10 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                             NodeRelationUtils.createNodeRelation(transFormNames, sinkNames));
                 } else {
                     relations = NodeRelationUtils.createNodeRelations(sources, sinks);
+                }
+
+                for (StreamSource source : sources) {
+                    addAuditId(source.getProperties(), source.getSourceType(), false);
                 }
             }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -151,8 +151,10 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                     relations = NodeRelationUtils.createNodeRelations(sources, sinks);
                 }
 
-                for (StreamSink sink : sinks) {
-                    addAuditId(sink.getProperties(), sink.getSinkType(), false);
+                if(sources.size() == sinks.size()) {
+                    for (int i = 0; i < sinks.size(); i++) {
+                        addAuditId(sources.get(i).getProperties(), sinks.get(i).getSinkType(), false);
+                    }
                 }
             } else {
                 if (CollectionUtils.isNotEmpty(transformResponses)) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sort/DefaultSortConfigOperator.java
@@ -151,7 +151,7 @@ public class DefaultSortConfigOperator implements SortConfigOperator {
                     relations = NodeRelationUtils.createNodeRelations(sources, sinks);
                 }
 
-                if(sources.size() == sinks.size()) {
+                if (sources.size() == sinks.size()) {
                     for (int i = 0; i < sinks.size(); i++) {
                         addAuditId(sources.get(i).getProperties(), sinks.get(i).getSinkType(), false);
                     }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #8975 

### Motivation

When the manager issues an audit ID, it distinguishes between `data ingestion` and `data synchronization`.

### Modifications

When the group mode is `data synchronization`, the manager issues the audit ID of the `source`.
When the group mode is `data ingestion`, the manager issues the audit ID of the `sink`.