### PR TITLE
[INLONG-9007][SDK] ClientList out of bounds

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
@@ -467,7 +467,7 @@ public class ClientMgr {
             int randomId = random.nextInt();
             client = clientList.get(randomId % currSize);
             if (client != null && client.isActive()) {
-                clientId = randomId;
+                clientId = randomId % currSize;
                 break;
             }
             maxRetry--;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes https://github.com/apache/inlong/issues/9007

### Motivation

In the org. apache. inlong. sdk. dataproxy. network. ClientManager class, the getClientByWeightRoundRobin() method will cause ArrayList to exceed the bounds.Directly using random numbers as index to get Nettyclient.

### Modifications

Restrict the index of a list to the size range of the list using the remainder operation.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
