### PR TITLE
[INLONG-8997][Sort] Keep the logic the same of mysql and sqlserver test container with flink v1.13 in end to end test

### DIFF
--- a/inlong-agent/agent-docker/Dockerfile
+++ b/inlong-agent/agent-docker/Dockerfile
@@ -26,7 +26,7 @@ ARG AGENT_TARBALL
 ADD ${AGENT_TARBALL} /opt/inlong-agent
 RUN cp /usr/share/java/snappy-java.jar lib/snappy-java-*.jar
 # add mysql connector
-RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar
+RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
 EXPOSE 8008
 ENV MANAGER_OPENAPI_IP=127.0.0.1
 ENV MANAGER_OPENAPI_PORT=8082

--- a/inlong-audit/audit-docker/Dockerfile
+++ b/inlong-audit/audit-docker/Dockerfile
@@ -56,7 +56,7 @@ ENV STORE_ES_PASSWD=inlong
 ENV AUDIT_JVM_HEAP_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 -XX:-UseAdaptiveSizePolicy"
 WORKDIR /opt/inlong-audit
 # add mysql connector
-RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar
+RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
 ADD audit-docker.sh bin/
 RUN chmod +x bin/audit-docker.sh
 CMD ["bin/audit-docker.sh"]

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -41,7 +41,7 @@ ENV MANAGER_JVM_HEAP_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.
 WORKDIR /opt/inlong-manager
 # add manager tarball
 ARG VERSION
-ARG default_jdbc_connector_url=https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar
+ARG default_jdbc_connector_url=https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
 ADD target/manager-web-${VERSION}-bin.tar.gz /opt/inlong-manager
 # add mysql connector
 RUN wget -P lib/ ${default_jdbc_connector_url}

--- a/inlong-sort/quick_start.md
+++ b/inlong-sort/quick_start.md
@@ -9,7 +9,7 @@ InLong Sort relies on Apache Flink 1.13.5. Chose `flink-1.13.5-bin-scala_2.11.tg
 
 caution:
 Please put required Connectors jars into under `FLINK_HOME/lib/` after download.  
-Put [mysql-connector-java:8.0.21.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.21/mysql-connector-java-8.0.21.jar) to `FLINK_HOME/lib/` when you use `mysql-cdc-inlong` connector.
+Put [mysql-connector-java:8.0.28.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar) to `FLINK_HOME/lib/` when you use `mysql-cdc-inlong` connector.
 
 ## Start an InLong Sort Job
 ```shell

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MSSQLServerContainer.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MSSQLServerContainer.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.tests.utils;
+
+import com.google.common.collect.Sets;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.LicenseAcceptance;
+
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class MSSQLServerContainer extends JdbcDatabaseContainer {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");
+    /** @deprecated */
+    @Deprecated
+    public static final String DEFAULT_TAG = "2017-CU12";
+    public static final String NAME = "sqlserver";
+    public static final String IMAGE;
+    public static final Integer MS_SQL_SERVER_PORT;
+    static final String DEFAULT_USER = "SA";
+    static final String DEFAULT_PASSWORD = "A_Str0ng_Required_Password";
+    private String password;
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 240;
+    private static final Pattern[] PASSWORD_CATEGORY_VALIDATION_PATTERNS;
+
+    /** @deprecated */
+    @Deprecated
+    public MSSQLServerContainer() {
+        this(DEFAULT_IMAGE_NAME.withTag("2017-CU12"));
+    }
+
+    public MSSQLServerContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public MSSQLServerContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        this.password = "A_Str0ng_Required_Password";
+        dockerImageName.assertCompatibleWith(new DockerImageName[]{DEFAULT_IMAGE_NAME});
+        this.withStartupTimeoutSeconds(240);
+        this.withConnectTimeoutSeconds(240);
+        this.addExposedPort(MS_SQL_SERVER_PORT);
+    }
+
+    public Set<Integer> getLivenessCheckPortNumbers() {
+        return Sets.newHashSet(new Integer[]{MS_SQL_SERVER_PORT});
+    }
+
+    protected void configure() {
+        if (!this.getEnvMap().containsKey("ACCEPT_EULA")) {
+            LicenseAcceptance.assertLicenseAccepted(this.getDockerImageName());
+            this.acceptLicense();
+        }
+
+        this.addEnv("SA_PASSWORD", this.password);
+        this.addEnv("MSSQL_AGENT_ENABLED", "true");
+        this.addFixedExposedPort(14433, MS_SQL_SERVER_PORT);
+    }
+
+    public MSSQLServerContainer acceptLicense() {
+        this.addEnv("ACCEPT_EULA", "Y");
+        return this;
+    }
+
+    public String getDriverClassName() {
+        return "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+    }
+
+    protected String constructUrlForConnection(String queryString) {
+
+        if (urlParameters.keySet().stream().map(sp -> ((String) sp).toLowerCase()).noneMatch("encrypt"::equals)) {
+            urlParameters.put("encrypt", "false");
+        }
+        return super.constructUrlForConnection(queryString);
+    }
+
+    public String getJdbcUrl() {
+        String additionalUrlParams = this.constructUrlParameters(";", ";");
+        return "jdbc:sqlserver://" + this.getHost() + ":" + this.getMappedPort(MS_SQL_SERVER_PORT)
+                + additionalUrlParams;
+    }
+
+    public String getUsername() {
+        return "SA";
+    }
+
+    public String getPassword() {
+        return this.password;
+    }
+
+    public String getTestQueryString() {
+        return "SELECT 1";
+    }
+
+    public MSSQLServerContainer withPassword(String password) {
+        this.checkPasswordStrength(password);
+        this.password = password;
+        return this;
+    }
+
+    private void checkPasswordStrength(String password) {
+        if (password == null) {
+            throw new IllegalArgumentException("Null password is not allowed");
+        } else if (password.length() < 8) {
+            throw new IllegalArgumentException("Password should be at least 8 characters long");
+        } else if (password.length() > 128) {
+            throw new IllegalArgumentException("Password can be up to 128 characters long");
+        } else {
+            long satisfiedCategories = Stream.of(PASSWORD_CATEGORY_VALIDATION_PATTERNS).filter((p) -> {
+                return p.matcher(password).find();
+            }).count();
+            if (satisfiedCategories < 3L) {
+                throw new IllegalArgumentException(
+                        "Password must contain characters from three of the following four categories:\n - Latin uppercase letters (A through Z)\n - Latin lowercase letters (a through z)\n - Base 10 digits (0 through 9)\n - Non-alphanumeric characters such as: exclamation point (!), dollar sign ($), number sign (#), or percent (%).");
+            }
+        }
+    }
+
+    static {
+        IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();
+        MS_SQL_SERVER_PORT = 1433;
+        PASSWORD_CATEGORY_VALIDATION_PATTERNS = new Pattern[]{Pattern.compile("[A-Z]+"), Pattern.compile("[a-z]+"),
+                Pattern.compile("[0-9]+"), Pattern.compile("[^a-zA-Z0-9]+", 2)};
+    }
+}

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
@@ -49,7 +49,7 @@ public class MySqlContainer extends JdbcDatabaseContainer {
 
     public MySqlContainer(MySqlVersion version) {
         super(DockerImageName.parse(IMAGE + ":" + version.getVersion()));
-        addExposedPort(MYSQL_PORT);
+        addFixedExposedPort(33306, 3306);
     }
 
     @Override
@@ -60,8 +60,6 @@ public class MySqlContainer extends JdbcDatabaseContainer {
     @Override
     protected void configure() {
         // HERE is the difference, copy to /etc/mysql/, if copy to /etc/mysql/conf.d will be wrong
-        optionallyMapResourceParameterAsVolume(
-                MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/", "mysql-default-conf");
 
         if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
             optionallyMapResourceParameterAsVolume(
@@ -79,6 +77,7 @@ public class MySqlContainer extends JdbcDatabaseContainer {
             throw new ContainerLaunchException(
                     "Empty password can be used only with the root user");
         }
+        withCommand("--default-authentication-plugin=mysql_native_password");
         setStartupAttempts(3);
     }
 
@@ -100,7 +99,8 @@ public class MySqlContainer extends JdbcDatabaseContainer {
                 + getDatabasePort()
                 + "/"
                 + databaseName
-                + additionalUrlParams;
+                + additionalUrlParams
+                + "?useSSL=false&allowPublicKeyRetrieval=true";
     }
 
     @Override

--- a/inlong-tubemq/tubemq-docker/tubemq-manager/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-manager/Dockerfile
@@ -35,7 +35,7 @@ ENV TUBE_MASTER_TOKEN=abc
 ENV TUBE_MANAGER_JVM_HEAP_OPTS="-XX:+UseContainerSupport -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=80.0 -XX:-UseAdaptiveSizePolicy"
 WORKDIR /opt/tubemq-manager
 # add mysql connector
-RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.27/mysql-connector-java-8.0.27.jar
+RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
 ADD manager-docker.sh bin/
 RUN chmod +x bin/manager-docker.sh
 CMD ["bin/manager-docker.sh"]

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <hadoop.version>2.10.2</hadoop.version>
         <postgresql.version>42.4.1</postgresql.version>
         <oracle.jdbc.version>19.3.0.0</oracle.jdbc.version>
-        <mysql.jdbc.version>8.0.21</mysql.jdbc.version>
+        <mysql.jdbc.version>8.0.28</mysql.jdbc.version>
         <sqlserver.jdbc.version>7.2.2.jre8</sqlserver.jdbc.version>
         <mybatis.starter.version>2.1.3</mybatis.starter.version>
         <mybatis.version>3.5.9</mybatis.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8997 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
