### PR TITLE
[INLONG-8997][Sort] Keep the logic the same of mysql with flink v1.13 in end to end test

### DIFF
--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
@@ -59,10 +59,6 @@ public class MySqlContainer extends JdbcDatabaseContainer {
 
     @Override
     protected void configure() {
-        // HERE is the difference, copy to /etc/mysql/, if copy to /etc/mysql/conf.d will be wrong
-        optionallyMapResourceParameterAsVolume(
-                MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/", "mysql-default-conf");
-
         if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
             optionallyMapResourceParameterAsVolume(
                     SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A");
@@ -79,6 +75,7 @@ public class MySqlContainer extends JdbcDatabaseContainer {
             throw new ContainerLaunchException(
                     "Empty password can be used only with the root user");
         }
+        withCommand("--default-authentication-plugin=mysql_native_password");
         setStartupAttempts(3);
     }
 
@@ -100,7 +97,8 @@ public class MySqlContainer extends JdbcDatabaseContainer {
                 + getDatabasePort()
                 + "/"
                 + databaseName
-                + additionalUrlParams;
+                + additionalUrlParams
+                + "?useSSL=false&allowPublicKeyRetrieval=true";
     }
 
     @Override

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/MySqlContainer.java
@@ -49,7 +49,7 @@ public class MySqlContainer extends JdbcDatabaseContainer {
 
     public MySqlContainer(MySqlVersion version) {
         super(DockerImageName.parse(IMAGE + ":" + version.getVersion()));
-        addFixedExposedPort(33306, 3306);
+        addExposedPort(MYSQL_PORT);
     }
 
     @Override
@@ -59,8 +59,6 @@ public class MySqlContainer extends JdbcDatabaseContainer {
 
     @Override
     protected void configure() {
-        // HERE is the difference, copy to /etc/mysql/, if copy to /etc/mysql/conf.d will be wrong
-
         if (parameters.containsKey(SETUP_SQL_PARAM_NAME)) {
             optionallyMapResourceParameterAsVolume(
                     SETUP_SQL_PARAM_NAME, "/docker-entrypoint-initdb.d/", "N/A");


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8997

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
