### PR TITLE
[INLONG-9046][CVE] Bump ZooKeeper to 3.7.2 to fix Authorization Bypass

### DIFF
--- a/inlong-tubemq/tubemq-server/pom.xml
+++ b/inlong-tubemq/tubemq-server/pom.xml
@@ -110,6 +110,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.ini4j</groupId>
             <artifactId>ini4j</artifactId>
         </dependency>

--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -441,8 +441,8 @@ The text of each license is the standard Apache 2.0 license.
   org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (https://github.com/eclipse-ee4j/beanvalidation-api/tree/1.1.0.Final), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine/tree/2.3/velocity-engine-core), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
   org.apache.shiro:shiro-core:1.10.1 - Apache Shiro Cache (https://shiro.apache.org/), (Apache License, Version 2.0)
 
 ========================================================================

--- a/licenses/inlong-audit/LICENSE
+++ b/licenses/inlong-audit/LICENSE
@@ -436,8 +436,8 @@ The text of each license is the standard Apache 2.0 license.
   com.tdunning:t-digest:3.2 - T-Digest (https://github.com/tdunning/t-digest/tree/t-digest-3.2), (The Apache Software License, Version 2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (https://github.com/eclipse-ee4j/beanvalidation-api/tree/1.1.0.Final), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine/tree/2.3/velocity-engine-core), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
 
 
 ========================================================================

--- a/licenses/inlong-dataproxy/LICENSE
+++ b/licenses/inlong-dataproxy/LICENSE
@@ -412,8 +412,8 @@ The text of each license is the standard Apache 2.0 license.
   org.xerial.snappy:snappy-java:1.1.10.1 - snappy-java (https://github.com/xerial/snappy-java), (Apache-2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (http://beanvalidation.org), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine/tree/2.3/velocity-engine-core), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
 
 
 ========================================================================

--- a/licenses/inlong-manager/LICENSE
+++ b/licenses/inlong-manager/LICENSE
@@ -590,8 +590,8 @@ The text of each license is the standard Apache 2.0 license.
   com.fasterxml.woodstox:woodstox-core:5.4.0 - Woodstox (https://github.com/FasterXML/woodstox/tree/woodstox-core-5.4.0), (The Apache License, Version 2.0)
   xerces:xercesImpl:2.12.0 - Xerces2 Java Parser (http://xerces.apache.org/xerces2-j), (The Apache License, Version 2.0)
   xml-apis:xml-apis:1.4.01 - XML Commons External Components XML APIs (http://xml.apache.org/commons/components/external/), (The Apache Software License, Version 2.0), (Apache 2.0, The SAX License, The W3C License)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
 
 ========================================================================
 Apache 2.0 License

--- a/licenses/inlong-sort-standalone/LICENSE
+++ b/licenses/inlong-sort-standalone/LICENSE
@@ -491,8 +491,8 @@ The text of each license is the standard Apache 2.0 license.
   com.fasterxml.woodstox:woodstox-core:5.4.0 - Woodstox (https://github.com/FasterXML/woodstox/tree/woodstox-core-5.4.0), (The Apache License, Version 2.0)
   xerces:xercesImpl:2.12.0 - Xerces2 Java Parser (http://xerces.apache.org/xerces2-j), (The Apache License, Version 2.0)
   xml-apis:xml-apis:1.4.01 - XML Commons External Components XML APIs (http://xml.apache.org/commons/components/external/), (The Apache Software License, Version 2.0), (Apache 2.0, The SAX License, The W3C License)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
   ru.yandex.clickhouse:clickhouse-jdbc:0.3.1 - clickhouse-jdbc (https://github.com/ClickHouse/clickhouse-jdbc/tree/master/clickhouse-jdbc), (The Apache Software License, Version 2.0)
 
 

--- a/licenses/inlong-tubemq-server/LICENSE
+++ b/licenses/inlong-tubemq-server/LICENSE
@@ -405,8 +405,8 @@ The text of each license is the standard Apache 2.0 license.
   io.prometheus:simpleclient_tracer_otel_agent:0.14.1 - Prometheus Java Span Context Supplier - OpenTelemetry Agent (https://github.com/prometheus/client_java/tree/parent-0.14.1), (The Apache Software License, Version 2.0)
   org.apache.velocity:velocity-engine-core:2.3 - Apache Velocity - Engine (https://github.com/apache/velocity-engine), (Apache License, Version 2.0)
   org.apache.velocity.tools:velocity-tools-generic:3.1 - Apache Velocity Tools - Generic tools (https://github.com/apache/velocity-tools), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper:3.6.3 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-server), (Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper-jute:3.6.3 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.6.3/zookeeper-jute), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper-jute:3.7.2 - Apache ZooKeeper - Jute (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-jute), (Apache License, Version 2.0)
 
 
 ========================================================================

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <dom4j.version>2.1.3</dom4j.version>
 
         <aws.sdk.version>1.12.346</aws.sdk.version>
-        <zookeeper.version>3.6.3</zookeeper.version>
+        <zookeeper.version>3.7.2</zookeeper.version>
         <pulsar.version>2.8.4</pulsar.version>
         <kafka.version>2.4.1</kafka.version>
         <iceberg.version>1.3.1</iceberg.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9046

### Motivation

Bump ZooKeeper to 3.7.2 to fix Authorization Bypass
