### PR TITLE
[INLONG-9066][Manager] Renaming group related states

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/impl/InlongGroupImpl.java
@@ -242,7 +242,7 @@ public class InlongGroupImpl implements InlongGroup {
         }
         boolean isDeleted = groupClient.deleteInlongGroup(groupInfo.getInlongGroupId(), async);
         if (isDeleted) {
-            groupInfo.setStatus(GroupStatus.DELETED.getCode());
+            groupInfo.setStatus(GroupStatus.CONFIG_DELETED.getCode());
         }
         return generateSnapshot();
     }
@@ -277,7 +277,7 @@ public class InlongGroupImpl implements InlongGroup {
         // if current group is not exists, set its status to deleted
         if (groupInfo == null) {
             groupInfo = groupContext.getGroupInfo();
-            groupInfo.setStatus(GroupStatus.DELETED.getCode());
+            groupInfo.setStatus(GroupStatus.CONFIG_DELETED.getCode());
             return new InlongGroupContext(groupContext);
         }
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/SimpleGroupStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/SimpleGroupStatus.java
@@ -39,9 +39,9 @@ public enum SimpleGroupStatus {
             case TO_BE_SUBMIT:
             case TO_BE_APPROVAL:
                 return CREATE;
-            case DELETING:
-            case SUSPENDING:
-            case RESTARTING:
+            case CONFIG_DELETING:
+            case CONFIG_OFFLINE_ING:
+            case CONFIG_ONLINE_ING:
                 return OPERATING;
             case APPROVE_REJECTED:
                 return REJECTED;
@@ -51,13 +51,12 @@ public enum SimpleGroupStatus {
             case CONFIG_FAILED:
                 return FAILED;
             case CONFIG_SUCCESSFUL:
-            case RESTARTED:
                 return STARTED;
-            case SUSPENDED:
+            case CONFIGURATION_OFFLINE:
                 return STOPPED;
             case FINISH:
                 return FINISHED;
-            case DELETED:
+            case CONFIG_DELETED:
                 return DELETED;
             default:
                 throw new IllegalArgumentException(String.format("Unsupported status %s for group", code));
@@ -83,9 +82,9 @@ public enum SimpleGroupStatus {
                 statusList.add(GroupStatus.TO_BE_SUBMIT.getCode());
                 return statusList;
             case OPERATING:
-                statusList.add(GroupStatus.DELETING.getCode());
-                statusList.add(GroupStatus.SUSPENDING.getCode());
-                statusList.add(GroupStatus.RESTARTING.getCode());
+                statusList.add(GroupStatus.CONFIG_DELETING.getCode());
+                statusList.add(GroupStatus.CONFIG_OFFLINE_ING.getCode());
+                statusList.add(GroupStatus.CONFIG_ONLINE_ING.getCode());
                 return statusList;
             case REJECTED:
                 statusList.add(GroupStatus.APPROVE_REJECTED.getCode());
@@ -99,17 +98,16 @@ public enum SimpleGroupStatus {
                 statusList.add(GroupStatus.CONFIG_FAILED.getCode());
                 return statusList;
             case STARTED:
-                statusList.add(GroupStatus.RESTARTED.getCode());
                 statusList.add(GroupStatus.CONFIG_SUCCESSFUL.getCode());
                 return statusList;
             case STOPPED:
-                statusList.add(GroupStatus.SUSPENDED.getCode());
+                statusList.add(GroupStatus.CONFIGURATION_OFFLINE.getCode());
                 return statusList;
             case FINISHED:
                 statusList.add(GroupStatus.FINISH.getCode());
                 return statusList;
             case DELETED:
-                statusList.add(GroupStatus.DELETED.getCode());
+                statusList.add(GroupStatus.CONFIG_DELETED.getCode());
                 return statusList;
             default:
                 throw new IllegalArgumentException(String.format("Unsupported status %s for inlong group", status));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -1226,7 +1226,7 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         clusterEntityList.forEach(e -> tagSet.addAll(Arrays.asList(e.getClusterTags().split(InlongConstants.COMMA))));
         List<String> clusterTagList = new ArrayList<>(tagSet);
         InlongGroupPageRequest groupRequest = InlongGroupPageRequest.builder()
-                .statusList(Arrays.asList(GroupStatus.CONFIG_SUCCESSFUL.getCode(), GroupStatus.RESTARTED.getCode()))
+                .statusList(Collections.singletonList(GroupStatus.CONFIG_SUCCESSFUL.getCode()))
                 .clusterTagList(clusterTagList)
                 .build();
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -449,7 +449,8 @@ public class AgentServiceImpl implements AgentService {
         List<StreamSourceEntity> sourceEntities = sourceMapper.selectTemplateSourceByCluster(needCopiedStatusList,
                 Lists.newArrayList(SourceType.FILE), agentClusterName);
         Set<GroupStatus> noNeedAddTask = Sets.newHashSet(
-                GroupStatus.SUSPENDED, GroupStatus.SUSPENDING, GroupStatus.DELETING, GroupStatus.DELETED);
+                GroupStatus.CONFIGURATION_OFFLINE, GroupStatus.CONFIG_OFFLINE_ING, GroupStatus.CONFIG_DELETING,
+                GroupStatus.CONFIG_DELETED);
         sourceEntities.stream()
                 .forEach(sourceEntity -> {
                     InlongGroupEntity groupEntity = groupMapper.selectByGroupId(sourceEntity.getInlongGroupId());
@@ -523,8 +524,7 @@ public class AgentServiceImpl implements AgentService {
                     SourceStatus.SOURCE_NORMAL,
                     SourceStatus.TO_BE_ISSUED_ADD,
                     SourceStatus.TO_BE_ISSUED_ACTIVE);
-            Set<GroupStatus> matchedGroupStatus = Sets.newHashSet(
-                    GroupStatus.CONFIG_SUCCESSFUL, GroupStatus.RESTARTED);
+            Set<GroupStatus> matchedGroupStatus = Sets.newHashSet(GroupStatus.CONFIG_SUCCESSFUL);
             if (matchGroup(sourceEntity, clusterNodeEntity)
                     && groupEntity != null
                     && !exceptedMatchedSourceStatus.contains(SourceStatus.forCode(sourceEntity.getStatus()))

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupProcessService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupProcessService.java
@@ -128,7 +128,7 @@ public class InlongGroupProcessService {
     public String suspendProcessAsync(String groupId, String operator) {
         LOGGER.info("begin to suspend process asynchronously for groupId={} by operator={}", groupId, operator);
 
-        groupService.updateStatus(groupId, GroupStatus.SUSPENDING.getCode(), operator);
+        groupService.updateStatus(groupId, GroupStatus.CONFIG_OFFLINE_ING.getCode(), operator);
         InlongGroupInfo groupInfo = groupService.get(groupId);
         GroupResourceProcessForm form = genGroupResourceProcessForm(groupInfo, GroupOperateType.SUSPEND);
         UserInfo userInfo = LoginUserUtils.getLoginUser();
@@ -151,7 +151,7 @@ public class InlongGroupProcessService {
     public WorkflowResult suspendProcess(String groupId, String operator) {
         LOGGER.info("begin to suspend process for groupId={} by operator={}", groupId, operator);
 
-        groupService.updateStatus(groupId, GroupStatus.SUSPENDING.getCode(), operator);
+        groupService.updateStatus(groupId, GroupStatus.CONFIG_OFFLINE_ING.getCode(), operator);
         InlongGroupInfo groupInfo = groupService.get(groupId);
         GroupResourceProcessForm form = genGroupResourceProcessForm(groupInfo, GroupOperateType.SUSPEND);
         WorkflowResult result = workflowService.start(ProcessName.SUSPEND_GROUP_PROCESS, operator, form);
@@ -175,7 +175,7 @@ public class InlongGroupProcessService {
     public String restartProcessAsync(String groupId, String operator) {
         LOGGER.info("begin to restart process asynchronously for groupId={} by operator={}", groupId, operator);
 
-        groupService.updateStatus(groupId, GroupStatus.RESTARTING.getCode(), operator);
+        groupService.updateStatus(groupId, GroupStatus.CONFIG_ONLINE_ING.getCode(), operator);
         InlongGroupInfo groupInfo = groupService.get(groupId);
         GroupResourceProcessForm form = genGroupResourceProcessForm(groupInfo, GroupOperateType.RESTART);
         UserInfo userInfo = LoginUserUtils.getLoginUser();
@@ -196,7 +196,7 @@ public class InlongGroupProcessService {
     public WorkflowResult restartProcess(String groupId, String operator) {
         LOGGER.info("begin to restart process for groupId={} by operator={}", groupId, operator);
 
-        groupService.updateStatus(groupId, GroupStatus.RESTARTING.getCode(), operator);
+        groupService.updateStatus(groupId, GroupStatus.CONFIG_ONLINE_ING.getCode(), operator);
         InlongGroupInfo groupInfo = groupService.get(groupId);
         GroupResourceProcessForm form = genGroupResourceProcessForm(groupInfo, GroupOperateType.RESTART);
         WorkflowResult result = workflowService.start(ProcessName.RESTART_GROUP_PROCESS, operator, form);
@@ -292,9 +292,9 @@ public class InlongGroupProcessService {
         boolean result;
         switch (status) {
             case CONFIG_ING:
-            case SUSPENDING:
-            case RESTARTING:
-            case DELETING:
+            case CONFIG_OFFLINE_ING:
+            case CONFIG_ONLINE_ING:
+            case CONFIG_DELETING:
                 final int rerunProcess = request.getRerunProcess();
                 final int resetFinalStatus = request.getResetFinalStatus();
                 result = pendingGroupOpt(groupInfo, operator, status, rerunProcess, resetFinalStatus);
@@ -333,13 +333,12 @@ public class InlongGroupProcessService {
     private GroupStatus getFinalStatus(GroupStatus pendingStatus) {
         switch (pendingStatus) {
             case CONFIG_ING:
+            case CONFIG_ONLINE_ING:
                 return GroupStatus.CONFIG_SUCCESSFUL;
-            case SUSPENDING:
-                return GroupStatus.SUSPENDED;
-            case RESTARTING:
-                return GroupStatus.RESTARTED;
+            case CONFIG_OFFLINE_ING:
+                return GroupStatus.CONFIGURATION_OFFLINE;
             default:
-                return GroupStatus.DELETED;
+                return GroupStatus.CONFIG_DELETED;
         }
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -549,7 +549,7 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         }
         // determine whether the current status can be deleted
         GroupStatus curState = GroupStatus.forCode(groupInfo.getStatus());
-        if (GroupStatus.notAllowedTransition(curState, GroupStatus.DELETING)) {
+        if (GroupStatus.notAllowedTransition(curState, GroupStatus.CONFIG_DELETING)) {
             throw new BusinessException(ErrorCodeEnum.GROUP_DELETE_NOT_ALLOWED,
                     String.format("current group status=%s was not allowed to delete", curState));
         }
@@ -580,7 +580,7 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         }
 
         entity.setIsDeleted(entity.getId());
-        entity.setStatus(GroupStatus.DELETED.getCode());
+        entity.setStatus(GroupStatus.CONFIG_DELETED.getCode());
         entity.setModifier(operator);
         int rowCount = groupMapper.updateByIdentifierSelective(entity);
         if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupCompleteListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupCompleteListener.java
@@ -65,11 +65,11 @@ public class UpdateGroupCompleteListener implements ProcessEventListener {
         String operator = context.getOperator();
         switch (operateType) {
             case SUSPEND:
-                groupService.updateStatus(groupId, GroupStatus.SUSPENDED.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIGURATION_OFFLINE.getCode(), operator);
                 groupService.update(groupRequest, operator);
                 break;
             case RESTART:
-                groupService.updateStatus(groupId, GroupStatus.RESTARTED.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_SUCCESSFUL.getCode(), operator);
                 groupService.update(groupRequest, operator);
                 break;
             case DELETE:

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupListener.java
@@ -62,13 +62,13 @@ public class UpdateGroupListener implements ProcessEventListener {
         String operator = context.getOperator();
         switch (operateType) {
             case SUSPEND:
-                groupService.updateStatus(groupId, GroupStatus.SUSPENDING.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_OFFLINE_ING.getCode(), operator);
                 break;
             case RESTART:
-                groupService.updateStatus(groupId, GroupStatus.RESTARTING.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_ONLINE_ING.getCode(), operator);
                 break;
             case DELETE:
-                groupService.updateStatus(groupId, GroupStatus.DELETING.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_DELETING.getCode(), operator);
                 break;
             default:
                 break;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/QueueResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/queue/QueueResourceListener.java
@@ -138,7 +138,7 @@ public class QueueResourceListener implements QueueOperateListener {
                 this.createQueueForStreams(groupInfo, groupProcessForm.getStreamInfos(), operator);
                 break;
             case DELETE:
-                groupService.updateStatus(groupId, GroupStatus.DELETING.getCode(), operator);
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_DELETING.getCode(), operator);
                 queueOperator.deleteQueueForGroup(groupInfo, operator);
                 break;
             default:

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -94,7 +94,7 @@ public class SortConfigListener implements SortOperateListener {
                 groupService.updateStatus(groupId, GroupStatus.CONFIG_ING.getCode(), context.getOperator());
                 break;
             case RESTART:
-                groupService.updateStatus(groupId, GroupStatus.RESTARTING.getCode(), context.getOperator());
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_ONLINE_ING.getCode(), context.getOperator());
                 break;
         }
         InlongGroupInfo groupInfo = groupService.get(groupId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamProcessService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/stream/InlongStreamProcessService.java
@@ -82,7 +82,7 @@ public class InlongStreamProcessService {
         InlongGroupInfo groupInfo = groupService.get(groupId);
         Preconditions.expectNotNull(groupInfo, ErrorCodeEnum.GROUP_NOT_FOUND.getMessage());
         GroupStatus groupStatus = GroupStatus.forCode(groupInfo.getStatus());
-        if (groupStatus != GroupStatus.CONFIG_SUCCESSFUL && groupStatus != GroupStatus.RESTARTED) {
+        if (groupStatus != GroupStatus.CONFIG_SUCCESSFUL) {
             throw new BusinessException(String.format("group status=%s not support start stream"
                     + " for groupId=%s", groupStatus, groupId));
         }
@@ -168,7 +168,7 @@ public class InlongStreamProcessService {
         InlongGroupInfo groupInfo = groupService.get(groupId);
         Preconditions.expectNotNull(groupInfo, ErrorCodeEnum.GROUP_NOT_FOUND.getMessage());
         GroupStatus groupStatus = GroupStatus.forCode(groupInfo.getStatus());
-        if (groupStatus != GroupStatus.CONFIG_SUCCESSFUL && groupStatus != GroupStatus.RESTARTED) {
+        if (groupStatus != GroupStatus.CONFIG_SUCCESSFUL) {
             throw new BusinessException(
                     String.format("group status=%s not support restart stream for groupId=%s", groupStatus, groupId));
         }
@@ -214,7 +214,7 @@ public class InlongStreamProcessService {
         }
 
         GroupStatus groupStatus = GroupStatus.forCode(groupInfo.getStatus());
-        if (GroupStatus.notAllowedTransition(groupStatus, GroupStatus.DELETING)) {
+        if (GroupStatus.notAllowedTransition(groupStatus, GroupStatus.CONFIG_DELETING)) {
             throw new BusinessException(ErrorCodeEnum.GROUP_DELETE_NOT_ALLOWED,
                     String.format("group status=%s not support delete stream for groupId=%s", groupStatus, groupId));
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
@@ -188,7 +188,7 @@ public class InlongTenantServiceImpl implements InlongTenantService {
         List<InlongGroupEntity> groups = groupMapper.selectAllGroupsByTenant(name);
         List<InlongGroupEntity> notStopGroups =
                 groups.stream().filter(
-                        group -> !GroupStatus.DELETED.getCode().equals(group.getStatus()))
+                        group -> !GroupStatus.CONFIG_DELETED.getCode().equals(group.getStatus()))
                         .collect(Collectors.toList());
         if (CollectionUtils.isNotEmpty(notStopGroups)) {
             List<String> notStopGroupNames =

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/core/impl/AgentServiceTest.java
@@ -142,7 +142,7 @@ class AgentServiceTest extends ServiceBaseTest {
         sources.stream()
                 .filter(source -> source.getTemplateId() != null)
                 .forEach(source -> sourceService.stop(source.getId(), GLOBAL_OPERATOR));
-        groupMapper.updateStatus(groupId, GroupStatus.SUSPENDED.getCode(), GLOBAL_OPERATOR);
+        groupMapper.updateStatus(groupId, GroupStatus.CONFIGURATION_OFFLINE.getCode(), GLOBAL_OPERATOR);
         streamMapper.updateStatusByIdentifier(groupId, streamId, StreamStatus.SUSPENDED.getCode(), GLOBAL_OPERATOR);
     }
 
@@ -154,7 +154,7 @@ class AgentServiceTest extends ServiceBaseTest {
         sources.stream()
                 .filter(source -> source.getTemplateId() != null)
                 .forEach(source -> sourceService.restart(source.getId(), GLOBAL_OPERATOR));
-        groupMapper.updateStatus(groupId, GroupStatus.RESTARTED.getCode(), GLOBAL_OPERATOR);
+        groupMapper.updateStatus(groupId, GroupStatus.CONFIG_SUCCESSFUL.getCode(), GLOBAL_OPERATOR);
         streamMapper.updateStatusByIdentifier(groupId, streamId, StreamStatus.RESTARTED.getCode(), GLOBAL_OPERATOR);
     }
 

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/group/InlongGroupProcessServiceTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/group/InlongGroupProcessServiceTest.java
@@ -96,7 +96,7 @@ public class InlongGroupProcessServiceTest extends ServiceBaseTest {
         ProcessResponse response = result.getProcessInfo();
         Assertions.assertSame(response.getStatus(), ProcessStatus.COMPLETED);
         InlongGroupInfo groupInfo = groupService.get(GROUP_ID);
-        Assertions.assertEquals(groupInfo.getStatus(), GroupStatus.SUSPENDED.getCode());
+        Assertions.assertEquals(groupInfo.getStatus(), GroupStatus.CONFIGURATION_OFFLINE.getCode());
     }
 
     private void testRestartProcess() {
@@ -104,7 +104,7 @@ public class InlongGroupProcessServiceTest extends ServiceBaseTest {
         ProcessResponse response = result.getProcessInfo();
         Assertions.assertSame(response.getStatus(), ProcessStatus.COMPLETED);
         InlongGroupInfo groupInfo = groupService.get(GROUP_ID);
-        Assertions.assertEquals(groupInfo.getStatus(), GroupStatus.RESTARTED.getCode());
+        Assertions.assertEquals(groupInfo.getStatus(), GroupStatus.CONFIG_SUCCESSFUL.getCode());
     }
 
 }

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/listener/StreamSourceListenerTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/source/listener/StreamSourceListenerTest.java
@@ -101,9 +101,9 @@ public class StreamSourceListenerTest extends ServiceBaseTest {
     }
 
     private void testRestartSource(Integer sourceId) {
-        groupService.updateStatus(GROUP_ID, GroupStatus.SUSPENDING.getCode(), GLOBAL_OPERATOR);
+        groupService.updateStatus(GROUP_ID, GroupStatus.CONFIG_OFFLINE_ING.getCode(), GLOBAL_OPERATOR);
         groupService.update(groupInfo.genRequest(), GLOBAL_OPERATOR);
-        groupService.updateStatus(GROUP_ID, GroupStatus.SUSPENDED.getCode(), GLOBAL_OPERATOR);
+        groupService.updateStatus(GROUP_ID, GroupStatus.CONFIGURATION_OFFLINE.getCode(), GLOBAL_OPERATOR);
         groupService.update(groupInfo.genRequest(), GLOBAL_OPERATOR);
 
         sourceService.updateStatus(GROUP_ID, null, SourceStatus.SOURCE_NORMAL.getCode(), GLOBAL_OPERATOR);

--- a/inlong-manager/manager-web/sql/changes-1.10.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.10.0.sql
@@ -26,6 +26,7 @@ USE `apache_inlong_manager`;
 ALTER TABLE `inlong_stream`
     ADD COLUMN `wrap_type` varchar(256) DEFAULT 'INLONG_MSG_V0' COMMENT 'The message body wrap type, including: RAW, INLONG_MSG_V0, INLONG_MSG_V1, etc';
 
+UPDATE inlong_group SET status = 130 where status = 150;
 
 
 


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9066 

### Motivation

Renaming group related states.
`SUSPENDING` rename to `CONFIG_OFFLINE_ING`.
`SUSPENDED` rename to `CONFIGURATION_OFFLINE`.
`RESTARTING` rename to `CONFIG_ONLINE_ING`.
`DELETING` rename to `CONFIG_DELETING`.
`DELETED` rename to `CONFIG_DELETED`.
Delete `RESTARTED`.

### Modifications

Renaming group related states.
