### PR TITLE
[INLONG-9070][Manager] Add MessageWrapType.forType method for MessageWrapType

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/MessageWrapType.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/MessageWrapType.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.common.enums;
 
+import java.util.Objects;
+
 /**
  * Enumeration class of encoding format of data output from DataProxy to MQ
  */
@@ -52,6 +54,15 @@ public enum MessageWrapType {
     public static MessageWrapType valueOf(int value) {
         for (MessageWrapType msgEncType : MessageWrapType.values()) {
             if (msgEncType.getId() == value) {
+                return msgEncType;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public static MessageWrapType forType(String type) {
+        for (MessageWrapType msgEncType : MessageWrapType.values()) {
+            if (Objects.equals(msgEncType.getName(), type)) {
                 return msgEncType;
             }
         }


### PR DESCRIPTION

### Prepare a Pull Request
- Fixes #9070 

### Motivation

Add MessageWrapType.forType method for MessageWrapType.

Currently, the `MessageWrapType` type can only be obtained based on `id`, and an interface needs to be added to obtain the `MessageWrapType` type through `name`.

### Modifications

Add MessageWrapType.forType method for MessageWrapType.


