### PR TITLE
[INLONG-9091][Agent] Add offset profile

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/OffsetProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/OffsetProfile.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.conf;
+
+import org.apache.inlong.agent.constant.TaskConstants;
+
+import com.google.gson.Gson;
+
+/**
+ * job profile which contains details describing properties of one job.
+ */
+public class OffsetProfile extends AbstractConfiguration {
+
+    private static final Gson GSON = new Gson();
+
+    /**
+     * parse json string to configuration instance.
+     *
+     * @return job configuration
+     */
+    public static OffsetProfile parseJsonStr(String jsonStr) {
+        OffsetProfile offsetProfile = new OffsetProfile();
+        offsetProfile.loadJsonStrResource(jsonStr);
+        return offsetProfile;
+    }
+
+    public OffsetProfile() {
+    }
+
+    public OffsetProfile(String taskId, String instanceId, long offset, String inodeInfo) {
+        setTaskId(taskId);
+        setInstanceId(instanceId);
+        setOffset(offset);
+        setInodeInfo(inodeInfo);
+    }
+
+    public String toJsonStr() {
+        return GSON.toJson(getConfigStorage());
+    }
+
+    public String getTaskId() {
+        return get(TaskConstants.TASK_ID);
+    }
+
+    public void setTaskId(String taskId) {
+        set(TaskConstants.TASK_ID, taskId);
+    }
+
+    public String getInstanceId() {
+        return get(TaskConstants.INSTANCE_ID);
+    }
+
+    public void setInstanceId(String instanceId) {
+        set(TaskConstants.INSTANCE_ID, instanceId);
+    }
+
+    public long getLastUpdateTime() {
+        return getLong(TaskConstants.LAST_UPDATE_TIME, 0);
+    }
+
+    public void setLastUpdateTime(long lastUpdateTime) {
+        setLong(TaskConstants.LAST_UPDATE_TIME, lastUpdateTime);
+    }
+
+    public Long getOffset() {
+        return getLong(TaskConstants.OFFSET, TaskConstants.DEFAULT_OFFSET);
+    }
+
+    public void setOffset(Long offset) {
+        setLong(TaskConstants.OFFSET, offset);
+    }
+
+    public String getInodeInfo() {
+        return get(TaskConstants.INODE_INFO);
+    }
+
+    public void setInodeInfo(String inodeInfo) {
+        set(TaskConstants.INODE_INFO, inodeInfo);
+    }
+
+    @Override
+    public boolean allRequiredKeyExist() {
+        return hasKey(TaskConstants.TASK_ID) && hasKey(TaskConstants.INSTANCE_ID)
+                && hasKey(TaskConstants.INODE_INFO) && hasKey(TaskConstants.OFFSET)
+                && hasKey(TaskConstants.LAST_UPDATE_TIME);
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request
- [INLONG-9091][Agent] Add offset profile

- Fixes #9091 

### Motivation
       Agent uses one job profile to store all the file collect infos that belong to the job. The infos contains basic file infos and the offsets. However hundreds and thousands of files in one collect task is not uncommon. It will be a nightmare to all the infos in one record.

### Modifications

*Offset will be sotred independently*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
