### PR TITLE
[INLONG-7784][Tool] Support parallel compilation and packaging

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -27,7 +27,6 @@ on:
       - 'inlong-common/**'
       - 'inlong-dashboard/**'
       - 'inlong-dataproxy/**'
-      - 'inlong-distribution/**'
       - 'inlong-manager/**'
       - 'inlong-sdk/**'
       - 'inlong-sort/**'
@@ -44,7 +43,6 @@ on:
       - 'inlong-common/**'
       - 'inlong-dashboard/**'
       - 'inlong-dataproxy/**'
-      - 'inlong-distribution/**'
       - 'inlong-manager/**'
       - 'inlong-sdk/**'
       - 'inlong-sort/**'
@@ -107,25 +105,3 @@ jobs:
         run: |
           version=`mvn -Dexec.executable='echo' -Dexec.args='${project.version}' --non-recursive exec:exec -q`
           echo "VERSION=${version}" >> $GITHUB_ENV
-
-      - name: Upload binary package
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: apache-inlong-${{ env.VERSION }}-bin.tar.gz
-          path: ./inlong-distribution/target/apache-inlong-${{ env.VERSION }}-bin.tar.gz
-
-      - name: Upload sort connectors package for flink v1.13
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: apache-inlong-${{ env.VERSION }}-sort-connectors-flink-v1.13.tar.gz
-          path: ./inlong-distribution/target/apache-inlong-${{ env.VERSION }}-sort-connectors-flink-v1.13.tar.gz
-
-      - name: Upload sort connectors package for flink v1.15
-        if: ${{ success() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: apache-inlong-${{ env.VERSION }}-sort-connectors-flink-v1.15.tar.gz
-          path: ./inlong-distribution/target/apache-inlong-${{ env.VERSION }}-sort-connectors-flink-v1.15.tar.gz
-

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <module>inlong-sort-standalone</module>
         <module>inlong-manager</module>
         <module>inlong-dashboard</module>
-        <module>inlong-distribution</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #7784

### Motivation

When using mvn -B or mvnd to compile the project, various problems will occur and the compilation will fail. The CR pipeline runs too slowly.

Reasons why parallel packaging cannot be done?
1. The inlong-distribution module uses assembly to compress and package the output of each module together. However, the module dependencies are not clearly specified in the pom file, causing maven to infer dependencies.
2. CR pipeline does not need to generate distribution

### Modifications
1. Remove package Distribution from CR pipeline
2. Clear distribution modules and all dependencies in the project
