### PR TITLE
[INLONG-9117][Agent] Rewrite class RocksDbImp to enable it to be constructed with a child path

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/KeyValueEntity.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/db/KeyValueEntity.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.agent.db;
 
 import org.apache.inlong.agent.conf.JobProfile;
+import org.apache.inlong.agent.conf.OffsetProfile;
 import org.apache.inlong.agent.conf.TriggerProfile;
 
 /**
@@ -88,6 +89,13 @@ public class KeyValueEntity {
      */
     public TriggerProfile getAsTriggerProfile() {
         return TriggerProfile.parseJsonStr(getJsonValue());
+    }
+
+    /**
+     * convert keyValue to offset profile
+     */
+    public OffsetProfile getAsOffsetProfile() {
+        return OffsetProfile.parseJsonStr(getJsonValue());
     }
 
     /**

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/db/TestRocksDbImp.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/db/TestRocksDbImp.java
@@ -18,9 +18,6 @@
 package org.apache.inlong.agent.db;
 
 import org.apache.inlong.agent.AgentBaseTestsHelper;
-import org.apache.inlong.agent.conf.JobProfile;
-import org.apache.inlong.agent.utils.AgentUtils;
-import org.apache.inlong.common.db.CommandEntity;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -30,10 +27,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.inlong.agent.constant.JobConstants.JOB_ID;
-import static org.apache.inlong.agent.constant.JobConstants.JOB_ID_PREFIX;
-import static org.apache.inlong.agent.constant.JobConstants.JOB_INSTANCE_ID;
-
 public class TestRocksDbImp {
 
     private static RocksDbImp db;
@@ -42,7 +35,7 @@ public class TestRocksDbImp {
     @BeforeClass
     public static void setup() throws Exception {
         helper = new AgentBaseTestsHelper(TestRocksDbImp.class.getName()).setupAgentHome();
-        db = new RocksDbImp();
+        db = new RocksDbImp("/localdb");
     }
 
     @AfterClass
@@ -81,22 +74,6 @@ public class TestRocksDbImp {
         db.put(entity);
         KeyValueEntity newEntity = db.get("test1");
         Assert.assertEquals("testC", newEntity.getJsonValue());
-
-    }
-
-    @Test
-    public void testCommandDb() {
-        CommandEntity commandEntity = new CommandEntity();
-        commandEntity.setId("1");
-        commandEntity.setCommandResult(0);
-        commandEntity.setAcked(false);
-        commandEntity.setTaskId(1);
-        commandEntity.setVersion(1);
-        db.putCommand(commandEntity);
-        CommandEntity command = db.getCommand("1");
-        Assert.assertEquals("1", command.getId());
-        List<CommandEntity> commandEntities = db.searchCommands(false);
-        Assert.assertEquals("1", commandEntities.get(0).getId());
     }
 
     @Test
@@ -115,16 +92,4 @@ public class TestRocksDbImp {
         KeyValueEntity entityResult = db.searchOne(StateSearchKey.ACCEPTED);
         Assert.assertEquals("searchKey1", entityResult.getKey());
     }
-
-    @Test
-    public void testBinlogJobStore() {
-        JobProfile jobProfile = JobProfile.parseJsonFile("binlogJob.json");
-        JobProfileDb jobDb = new JobProfileDb(db);
-        String jobId = jobProfile.get(JOB_ID);
-        jobProfile.set(JOB_INSTANCE_ID, AgentUtils.getSingleJobId(JOB_ID_PREFIX, jobId));
-        jobDb.storeJobFirstTime(jobProfile);
-        List<JobProfile> restarts = jobDb.getRestartJobs();
-        Assert.assertEquals(1, restarts.size());
-    }
-
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
@@ -29,6 +29,7 @@ import org.apache.inlong.agent.core.trigger.TriggerManager;
 import org.apache.inlong.agent.db.CommandDb;
 import org.apache.inlong.agent.db.Db;
 import org.apache.inlong.agent.db.JobProfileDb;
+import org.apache.inlong.agent.db.RocksDbImp;
 import org.apache.inlong.agent.db.TriggerProfileDb;
 
 import org.slf4j.Logger;
@@ -102,11 +103,8 @@ public class AgentManager extends AbstractDaemon {
      */
     private Db initDb() {
         try {
-            // db is a required component, so if not init correctly,
-            // throw exception and stop running.
-            return (Db) Class.forName(conf.get(
-                    AgentConstants.AGENT_DB_CLASSNAME, AgentConstants.DEFAULT_AGENT_DB_CLASSNAME))
-                    .newInstance();
+            String childPath = conf.get(AgentConstants.AGENT_ROCKS_DB_PATH, AgentConstants.DEFAULT_AGENT_ROCKS_DB_PATH);
+            return new RocksDbImp(childPath);
         } catch (Exception ex) {
             throw new UnsupportedClassVersionError(ex.getMessage());
         }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/RocksDBUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/RocksDBUtils.java
@@ -17,7 +17,9 @@
 
 package org.apache.inlong.agent.plugin.utils;
 
+import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.TriggerProfile;
+import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.agent.constant.JobConstants;
 import org.apache.inlong.agent.db.Db;
 import org.apache.inlong.agent.db.RocksDbImp;
@@ -31,7 +33,9 @@ import static org.apache.inlong.agent.constant.JobConstants.JOB_ID_PREFIX;
 public class RocksDBUtils {
 
     public static void main(String[] args) {
-        Db db = new RocksDbImp();
+        AgentConfiguration agentConf = AgentConfiguration.getAgentConf();
+        Db db = new RocksDbImp(
+                agentConf.get(AgentConstants.AGENT_ROCKS_DB_PATH, AgentConstants.DEFAULT_AGENT_ROCKS_DB_PATH));
         upgrade(db);
     }
 


### PR DESCRIPTION
### Prepare a Pull Request
[INLONG-9117][Agent] Rewrite class RocksDbImp to enable it to be constructed with a child path
- Fixes #9117 

### Motivation

*Agent will have more than one local db instance including task, instance and offset. So we need to init the db instance with different child path.

### Modifications

 Rewrite class RocksDbImp to enable it to be constructed with a child path
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
