### PR TITLE
[INLONG-9147][Manager] The group details are displayed with the tag of the cluster to which the group belongs

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongStreamApi.java
@@ -51,7 +51,7 @@ public interface InlongStreamApi {
     Call<Response<InlongStreamInfo>> getStream(@Query("groupId") String groupId,
             @Query("streamId") String streamId);
 
-    @GET("/stream/getBrief")
+    @GET("stream/getBrief")
     Call<Response<InlongStreamBriefInfo>> getStreamBriefInfo(@Query("groupId") String groupId,
             @Query("streamId") String streamId);
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/AbstractGroupOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/AbstractGroupOperator.java
@@ -132,6 +132,7 @@ public abstract class AbstractGroupOperator implements InlongGroupOperator {
     @Override
     public Map<String, Object> getClusterInfoByTag(String clusterTag) {
         Map<String, Object> clusterMap = new HashMap<>();
+        clusterMap.put("inlongClusterTag", clusterTag);
         Set<String> mqClusters = Sets.newHashSet(ClusterType.PULSAR, ClusterType.TUBEMQ, ClusterType.KAFKA);
         List<InlongClusterEntity> clusterEntities = clusterEntityMapper.selectByClusterTag(clusterTag);
         for (InlongClusterEntity clusterEntity : clusterEntities) {


### PR DESCRIPTION


### Prepare a Pull Request

- Fixes #9147

### Motivation

The group details are displayed with the tag of the cluster to which the group belongs.

### Modifications

The group details are displayed with the tag of the cluster to which the group belongs.

