### PR TITLE
[INLONG-9170][SDK] Use pointers instead of objects

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
@@ -361,7 +361,7 @@ func (c *client) onResponse(frame []byte) {
 		return
 	}
 
-	c.workers[index].onRsp(rsp)
+	c.workers[index].onRsp(&rsp)
 }
 
 func (c *client) OnEndpointUpdate(all, add, del discoverer.EndpointList) {


### PR DESCRIPTION
### [INLONG-9170][SDK] use pointers instead of objects

- Fixes #9170 

### Motivation

Currently, date types in worker.sendFailedBatches and woker.responseBatches are objects, not pointers, which will cost more memory in runtime, we can use pointer instead of ojbects.

### Modifications

worker.go
``` go
        sendFailedBatches  chan sendFailedBatchReq // send failed batches channel
	responseBatches    chan batchRsp           // batch response channel
```
to 
``` go
        sendFailedBatches  chan *sendFailedBatchReq // send failed batches channel
	responseBatches    chan *batchRsp           // batch response channel
```

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
