### PR TITLE
[INLONG-9174][SDK] Optimize response attr parsing in Golang SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
@@ -293,9 +293,13 @@ func (b *batchRsp) decode(input []byte) {
 
 	// fmt.Println(string(attr))
 
-	attrList := strings.Split(string(attr), "&")
+	attrList := strings.FieldsFunc(string(attr), func(r rune) bool {
+		return r == '&'
+	})
 	for _, item := range attrList {
-		kv := strings.Split(item, "=")
+		kv := strings.FieldsFunc(item, func(r rune) bool {
+			return r == '='
+		})
 		if len(kv) != 2 {
 			continue
 		}


### PR DESCRIPTION
### [INLONG-9174][SDK] Optimize response attr parsing in Golang SDK

- Fixes #9174

### Motivation

Currently, when we parse the attr in response, we use Strings.Spilt() to parse, which will alloc new strings in runtime, and this is a frequently called method, and will finally decrease the perf of the SDK. We need to improve it.

### Modifications

Use `Strings.FieldsFunc()` instead of `Strings.Spilt()`

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
