### PR TITLE
[INLONG-9176][SDK] Fail fast when work is unavailable in Golang SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -62,7 +62,7 @@ var (
 	errBadLog           = &errNo{code: 10010, strCode: "10010", message: "input log is invalid"}
 	errServerError      = &errNo{code: 10011, strCode: "10011", message: "server error"}
 	errServerPanic      = &errNo{code: 10012, strCode: "10012", message: "server panic"}
-	errAllWorkerBusy    = &errNo{code: 10013, strCode: "10013", message: "all workers are busy"}
+	workerBusy          = &errNo{code: 10013, strCode: "10013", message: "worker is busy"}
 	errNoMatchReq4Rsp   = &errNo{code: 10014, strCode: "10014", message: "no match unacknowledged request for response"}
 	errConnClosedByPeer = &errNo{code: 10015, strCode: "10015", message: "conn closed by peer"}
 	errUnknown          = &errNo{code: 20001, strCode: "20001", message: "unknown"}


### PR DESCRIPTION
### [INLONG-9176][SDK] Fail fast when work is unavailable in Golang SDK

- Fixes #9176

### Motivation

Currently, when we send a message, if the worker is unavailable, we will try another one and wait 1ms, which will make the SDK step into a 'Blocking' like state, it is better to fail fast.

### Modifications

Fail fast when work is unavailable

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
