### PR TITLE
[INLONG-9178][SDK] Update the default values of the config options of Golang SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
@@ -44,10 +44,10 @@ type Options struct {
 	URL                     string                // the Manager URL for discovering the DataProxy cluster
 	UpdateInterval          time.Duration         // interval to refresh the endpoint list, default: 5m
 	ConnTimeout             time.Duration         // connection timeout: default: 3000ms
-	WriteBufferSize         int                   // write buffer size in bytes, default: 16M
-	ReadBufferSize          int                   // read buffer size in bytes, default: 16M
-	SocketSendBufferSize    int                   // socket send buffer size in bytes, default: 16M
-	SocketRecvBufferSize    int                   // socket receive buffer size in bytes, default: 16M
+	WriteBufferSize         int                   // write buffer size in bytes, default: 8M
+	ReadBufferSize          int                   // read buffer size in bytes, default: 1M
+	SocketSendBufferSize    int                   // socket send buffer size in bytes, default: 8M
+	SocketRecvBufferSize    int                   // socket receive buffer size in bytes, default: 1M
 	BufferPool              bufferpool.BufferPool // encoding/decoding buffer pool, if not given, SDK will init a new one
 	BytePool                bufferpool.BytePool   // encoding/decoding byte pool, if not given, SDK will init a new one
 	BufferPoolSize          int                   // buffer pool size, default: 409600
@@ -59,10 +59,10 @@ type Options struct {
 	WorkerNum               int                   // worker number, default: 8
 	SendTimeout             time.Duration         // send timeout, default: 30000ms
 	MaxRetries              int                   // max retry count, default: 2
-	BatchingMaxPublishDelay time.Duration         // the time period within which the messages sent will be batched, default: 10ms
-	BatchingMaxMessages     int                   // the maximum number of messages permitted in a batch, default: 10
-	BatchingMaxSize         int                   // the maximum number of bytes permitted in a batch, default: 4K
-	MaxPendingMessages      int                   // the max size of the queue holding the messages pending to receive an acknowledgment from the broker, default: 409600
+	BatchingMaxPublishDelay time.Duration         // the time period within which the messages sent will be batched, default: 20ms
+	BatchingMaxMessages     int                   // the maximum number of messages permitted in a batch, default: 50
+	BatchingMaxSize         int                   // the maximum number of bytes permitted in a batch, default: 40K
+	MaxPendingMessages      int                   // the max size of the queue holding the messages pending to receive an acknowledgment from the broker, default: 204800
 	BlockIfQueueIsFull      bool                  // whether Send and SendAsync block if producer's message queue is full, default: false
 	AddColumns              map[string]string     // addition columns to add to the message, for example: __addcol1__worldid=xxx&__addcol2__ip=yyy, all the message will be added 2 more columns with worldid=xxx and ip=yyy
 	addColumnStr            string                // the string format of the AddColumns, just a cache, used internal
@@ -89,19 +89,19 @@ func (options *Options) ValidateAndSetDefault() error {
 	}
 
 	if options.BatchingMaxPublishDelay <= 0 {
-		options.BatchingMaxPublishDelay = 10 * time.Millisecond
+		options.BatchingMaxPublishDelay = 20 * time.Millisecond
 	}
 
 	if options.BatchingMaxMessages <= 0 {
-		options.BatchingMaxMessages = 10
+		options.BatchingMaxMessages = 50
 	}
 
 	if options.BatchingMaxSize <= 0 {
-		options.BatchingMaxSize = 4 * 1024
+		options.BatchingMaxSize = 40 * 1024
 	}
 
 	if options.MaxPendingMessages <= 0 {
-		options.MaxPendingMessages = 409600
+		options.MaxPendingMessages = 204800
 	}
 
 	if options.BufferPoolSize <= 0 {
@@ -149,19 +149,19 @@ func (options *Options) ValidateAndSetDefault() error {
 	}
 
 	if options.WriteBufferSize <= 0 {
-		options.WriteBufferSize = 16 * 1024 * 1024
+		options.WriteBufferSize = 8 * 1024 * 1024
 	}
 
 	if options.ReadBufferSize <= 0 {
-		options.ReadBufferSize = 16 * 1024 * 1024
+		options.ReadBufferSize = 1 * 1024 * 1024
 	}
 
 	if options.SocketSendBufferSize <= 0 {
-		options.SocketSendBufferSize = 16 * 1024 * 1024
+		options.SocketSendBufferSize = 8 * 1024 * 1024
 	}
 
 	if options.SocketRecvBufferSize <= 0 {
-		options.SocketRecvBufferSize = 16 * 1024 * 1024
+		options.SocketRecvBufferSize = 1 * 1024 * 1024
 	}
 
 	sb := strings.Builder{}


### PR DESCRIPTION
### [INLONG-9178][SDK] Update the default values of the config options of Golang SDK

- Fixes #9178 

### Motivation

Currently, the default values of the config options of Golang SDK are too BIG, which will cost a lot of memory, we can make it smaller, and some are to small, we need to make it bigger.

### Modifications

options.go

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
