### PR TITLE
[INLONG-9180][SDK] Cache up batchReq.dataReqs Golang SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
@@ -53,7 +53,9 @@ func init() {
 	}
 	batchPool = &sync.Pool{
 		New: func() interface{} {
-			return &batchReq{}
+			return &batchReq{
+				dataReqs: make([]*sendDataReq, 0, 50),
+			}
 		},
 	}
 }
@@ -109,12 +111,17 @@ func (b *batchReq) append(req *sendDataReq) {
 
 func (b *batchReq) done(err error) {
 	errorCode := getErrorCode(err)
-	for _, req := range b.dataReqs {
+	for i, req := range b.dataReqs {
 		req.done(err, errorCode)
+		b.dataReqs[i] = nil
+	}
+	if b.dataReqs != nil {
+		b.dataReqs = b.dataReqs[:0]
 	}
 
 	if b.callback != nil {
 		b.callback()
+		b.callback = nil
 	}
 
 	if b.buffer != nil && b.bufferPool != nil {
@@ -128,10 +135,12 @@ func (b *batchReq) done(err error) {
 		}
 		b.metrics.observeTime(errorCode, time.Since(b.batchTime).Milliseconds())
 		b.metrics.observeSize(errorCode, b.dataSize)
+		b.metrics = nil
 	}
 
 	if b.pool != nil {
 		b.pool.Put(b)
+		b.pool = nil
 	}
 }
 
@@ -334,25 +343,29 @@ type sendDataReq struct {
 func (s *sendDataReq) done(err error, errCode string) {
 	if s.semaphore != nil {
 		s.semaphore.Release()
+		if s.metrics != nil {
+			s.metrics.decPending(s.workerID)
+		}
+		s.semaphore = nil
 	}
 
 	if s.callback != nil {
 		s.callback(s.msg, err)
+		s.callback = nil
 	}
 
 	if s.metrics != nil {
-		if s.semaphore != nil {
-			s.metrics.decPending(s.workerID)
-		}
 		if errCode == "" {
 			errCode = getErrorCode(err)
 		}
 
 		s.metrics.incMessage(errCode)
+		s.metrics = nil
 	}
 
 	if s.pool != nil {
 		s.pool.Put(s)
+		s.pool = nil
 	}
 }
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -322,13 +322,17 @@ func (w *worker) handleSendData(req *sendDataReq) {
 	if !ok {
 		streamID := req.msg.StreamID
 		batch = batchPool.Get().(*batchReq)
+		dataReqs := batch.dataReqs
+		if dataReqs == nil {
+			dataReqs = make([]*sendDataReq, 0, w.options.BatchingMaxMessages)
+		}
 		*batch = batchReq{
 			pool:       batchPool,
 			workerID:   w.indexStr,
 			batchID:    util.SnowFlakeID(),
 			groupID:    w.options.GroupID,
 			streamID:   streamID,
-			dataReqs:   make([]*sendDataReq, 0, w.options.BatchingMaxMessages),
+			dataReqs:   dataReqs,
 			batchTime:  time.Now(),
 			retries:    0,
 			bufferPool: w.bufferPool,


### PR DESCRIPTION
### [INLONG-9180][SDK] Cache up batchReq.dataReqs Golang SDK

- Fixes #9180 

### Motivation

Cache up batchReq.dataReqs Golang SDK to improve perf

### Modifications

request.go
worker.go

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
