### PR TITLE
[INLONG-9211][Manager] Fix failure to obtain data from redis sink

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/postgresql/PostgreSQLResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/sink/postgresql/PostgreSQLResourceOperator.java
@@ -100,7 +100,7 @@ public class PostgreSQLResourceOperator implements SinkResourceOperator {
         try (Connection conn = PostgreSQLJdbcUtils.getConnection(postgreSQLSink.getJdbcUrl(),
                 postgreSQLSink.getUsername(), postgreSQLSink.getPassword())) {
             // 1.If schema not exists,create it
-            PostgreSQLJdbcUtils.createSchema(conn, tableInfo.getTableName(), tableInfo.getUserName());
+            PostgreSQLJdbcUtils.createSchema(conn, tableInfo.getSchemaName(), tableInfo.getUserName());
             // 2.If table not exists, create it
             PostgreSQLJdbcUtils.createTable(conn, tableInfo);
             // 3.Table exists, add columns - skip the exists columns


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9211 

### Motivation

1. When there is a redis data node, data should be obtained from the DataNode first.

### Modifications

1. Get data from the data node first for redis.
2. Correct wrong variable name.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.
