### PR TITLE
[INLONG-9214][Agent] Limit max file count to collect once

### DIFF
--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/instance/TestInstanceManager.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/instance/TestInstanceManager.java
@@ -50,7 +50,7 @@ public class TestInstanceManager {
         String pattern = helper.getTestRootDir() + "/YYYYMMDD_[0-9]+.txt";
         Db basicDb = TaskManager.initDb("/localdb");
         taskProfile = helper.getTaskProfile(1, pattern, false, 0L, 0L, TaskStateEnum.RUNNING);
-        manager = new InstanceManager("1", basicDb);
+        manager = new InstanceManager("1", 2, basicDb);
         manager.start();
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/FileScanner.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/FileScanner.java
@@ -18,7 +18,6 @@
 package org.apache.inlong.agent.plugin.task.filecollect;
 
 import org.apache.inlong.agent.conf.TaskProfile;
-import org.apache.inlong.agent.constant.TaskConstants;
 import org.apache.inlong.agent.plugin.utils.file.FilePathUtil;
 import org.apache.inlong.agent.plugin.utils.file.FileTimeComparator;
 import org.apache.inlong.agent.plugin.utils.file.Files;
@@ -34,6 +33,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static org.apache.inlong.agent.constant.CommonConstants.DEFAULT_FILE_MAX_NUM;
 
 /*
  * This class is mainly used for scanning log file that we want to read. We use this class at
@@ -69,14 +70,12 @@ public class FileScanner {
         logger.info("task {} this scan time is between {} and {}.",
                 new Object[]{conf.getTaskId(), startTime, endTime});
 
-        return scanTaskBetweenTimes(conf, originPattern, startTime, endTime);
+        return scanTaskBetweenTimes(conf.getCycleUnit(), originPattern, startTime, endTime);
     }
 
     /* Scan log files and create tasks between two times. */
-    public static List<BasicFileInfo> scanTaskBetweenTimes(TaskProfile conf, String originPattern, String startTime,
+    public static List<BasicFileInfo> scanTaskBetweenTimes(String cycleUnit, String originPattern, String startTime,
             String endTime) {
-        String cycleUnit = conf.getCycleUnit();
-        int maxFileNum = conf.getInt(TaskConstants.FILE_MAX_NUM);
         List<Long> dateRegion = NewDateUtils.getDateRegion(startTime, endTime, cycleUnit);
         List<BasicFileInfo> infos = new ArrayList<BasicFileInfo>();
         for (Long time : dateRegion) {
@@ -87,7 +86,7 @@ public class FileScanner {
             String firstDir = allPaths.get(0);
             String secondDir = allPaths.get(0) + File.separator + allPaths.get(1);
             ArrayList<String> fileList = getUpdatedOrNewFiles(firstDir, secondDir, filename, 3,
-                    maxFileNum);
+                    DEFAULT_FILE_MAX_NUM);
             for (String file : fileList) {
                 // TODO the time is not YYYYMMDDHH
                 String dataTime = NewDateUtils.millSecConvertToTimeStr(time, cycleUnit);
@@ -100,8 +99,7 @@ public class FileScanner {
         return infos;
     }
 
-    public static ArrayList<String> scanFile(TaskProfile conf, String originPattern, long dataTime) {
-        int maxFileNum = conf.getInt(TaskConstants.FILE_MAX_NUM);
+    public static ArrayList<String> scanFile(int maxFileNum, String originPattern, long dataTime) {
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(dataTime);
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/LogFileCollectTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/LogFileCollectTask.java
@@ -113,7 +113,8 @@ public class LogFileCollectTask extends Task {
         retry = taskProfile.getBoolean(TaskConstants.TASK_RETRY, false);
         originPatterns = Stream.of(taskProfile.get(TaskConstants.FILE_DIR_FILTER_PATTERNS).split(","))
                 .collect(Collectors.toSet());
-        instanceManager = new InstanceManager(taskProfile.getTaskId(), basicDb);
+        instanceManager = new InstanceManager(taskProfile.getTaskId(), taskProfile.getInt(TaskConstants.FILE_MAX_NUM),
+                basicDb);
         try {
             instanceManager.start();
         } catch (Exception e) {
@@ -409,7 +410,7 @@ public class LogFileCollectTask extends Task {
                 continue;
             }
             if (Files.isDirectory(child)) {
-                LOGGER.warn("The find creation event is triggered by a directory: " + child
+                LOGGER.info("The find creation event is triggered by a directory: " + child
                         .getFileName());
                 entity.registerRecursively(child);
                 continue;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/PluginUtils.java
@@ -55,7 +55,6 @@ import static org.apache.inlong.agent.constant.KubernetesConstants.HTTPS;
 import static org.apache.inlong.agent.constant.KubernetesConstants.KUBERNETES_SERVICE_HOST;
 import static org.apache.inlong.agent.constant.KubernetesConstants.KUBERNETES_SERVICE_PORT;
 import static org.apache.inlong.agent.constant.TaskConstants.FILE_DIR_FILTER_PATTERNS;
-import static org.apache.inlong.agent.constant.TaskConstants.FILE_MAX_NUM;
 import static org.apache.inlong.agent.constant.TaskConstants.JOB_RETRY_TIME;
 import static org.apache.inlong.agent.constant.TaskConstants.TASK_FILE_TIME_OFFSET;
 
@@ -97,7 +96,7 @@ public class PluginUtils {
         Set<PathPattern> pathPatterns =
                 PathPattern.buildPathPattern(dirPatterns, jobConf.get(TASK_FILE_TIME_OFFSET, null));
         updateRetryTime(jobConf, pathPatterns);
-        int maxFileNum = jobConf.getInt(FILE_MAX_NUM, DEFAULT_FILE_MAX_NUM);
+        int maxFileNum = DEFAULT_FILE_MAX_NUM;
         LOGGER.info("dir pattern {}, max file num {}", dirPatterns, maxFileNum);
         Collection<File> allFiles = new ArrayList<>();
         pathPatterns.forEach(pathPattern -> allFiles.addAll(pathPattern.walkSuitableFiles(maxFileNum)));


### PR DESCRIPTION
### Prepare a Pull Request
[INLONG-9214][Agent] Limit max file count to collect once
- Fixes #9214 

### Motivation

Limit max file count to collect once
### Modifications
Limit max file count to collect once

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
