### PR TITLE
[INLONG-9233][Agent] Fix bug: source, proxy, sender get stuck

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
@@ -71,7 +71,7 @@ public class ProxySink extends AbstractSink {
             return;
         }
         boolean suc = false;
-        while (!suc) {
+        while (running && !suc) {
             suc = putInCache(message);
             if (!suc) {
                 AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
@@ -246,11 +246,13 @@ public class SenderManager {
     }
 
     public void sendBatch(SenderMessage message) {
-        while (!resendQueue.isEmpty()) {
+        while (!shutdown && !resendQueue.isEmpty()) {
             AgentUtils.silenceSleepInMs(retrySleepTime);
         }
         addAckInfo(message.getAckInfo());
-        sendBatchWithRetryCount(message, 0);
+        if (!shutdown) {
+            sendBatchWithRetryCount(message, 0);
+        }
     }
 
     private void addAckInfo(PackageAckInfo info) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -378,7 +378,7 @@ public class LogFileSource extends AbstractSource {
             suc = MemoryManager.getInstance().tryAcquire(permitName, permitLen);
             if (!suc) {
                 MemoryManager.getInstance().printDetail(permitName, "log file source");
-                if (!isRunnable()) {
+                if (!isInodeChanged() || !isRunnable()) {
                     return false;
                 }
                 AgentUtils.silenceSleepInSeconds(1);


### PR DESCRIPTION
[INLONG-9233][Agent] Fix bug: source, proxy, sender get stuck
- Fixes #9233 

### Motivation
source, proxy, sender get stuck
### Modifications
make sure they can jump out of endless loop
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
