### PR TITLE
[INLONG-9263][Agent] Print the statistics of task and instance not de…

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -69,6 +69,39 @@ public class InstanceManager extends AbstractDaemon {
     private volatile boolean runAtLeastOneTime = false;
     private volatile boolean running = false;
 
+    private class InstancePrintStat {
+
+        public int defaultCount = 0;
+        public int finishedCount = 0;
+        public int deleteCount = 0;
+        public int otherCount = 0;
+
+        private void stat(InstanceStateEnum state) {
+            switch (state) {
+                case DEFAULT: {
+                    defaultCount++;
+                    break;
+                }
+                case FINISHED: {
+                    finishedCount++;
+                    break;
+                }
+                case DELETE: {
+                    deleteCount++;
+                }
+                default: {
+                    otherCount++;
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("default %d finished %d delete %d other %d", defaultCount, finishedCount,
+                    deleteCount, otherCount);
+        }
+    }
+
     /**
      * Init task manager.
      */
@@ -130,13 +163,13 @@ public class InstanceManager extends AbstractDaemon {
             LOGGER.info("instanceManager coreThread running! taskId {} action count {}", taskId,
                     actionQueue.size());
             List<InstanceProfile> instances = instanceDb.getInstances(taskId);
+            InstancePrintStat stat = new InstancePrintStat();
             for (int i = 0; i < instances.size(); i++) {
                 InstanceProfile instance = instances.get(i);
-                LOGGER.info(
-                        "instanceManager coreThread instance taskId {} index {} total {} instanceId {} state {}",
-                        taskId, i,
-                        instances.size(), instance.getInstanceId(), instance.getState());
+                stat.stat(instance.getState());
             }
+            LOGGER.info("instanceManager coreThread running! taskId {} memory total {} db total {} db detail {} ",
+                    taskId, instanceMap.size(), instances.size(), stat);
             lastPrintTime = AgentUtils.getCurrentTime();
         }
     }


### PR DESCRIPTION
[INLONG-9263][Agent] Print the statistics of task and instance not detail

- Fixes #9263 

### Motivation

Print the statistics of task and instance not detail

### Modifications

Print the statistics of task and instance not detail

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
