### PR TITLE
[INLONG-9267][Agent] Fix bug: data loss when there are many files to read once

### DIFF
--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
@@ -101,7 +101,7 @@ public class TestLogFileSource {
             srcLen += check[i].getBytes(StandardCharsets.UTF_8).length;
         }
         LogFileSource source = getSource();
-        await().atMost(2, TimeUnit.SECONDS).until(() -> source.sourceFinish());
+        await().atMost(2, TimeUnit.SECONDS).until(() -> source.finishReadLog());
         int cnt = 0;
         int leftBeforeRead = MemoryManager.getInstance().getLeft(AGENT_GLOBAL_READER_QUEUE_PERMIT);
         Assert.assertTrue(leftBeforeRead + srcLen == DEFAULT_AGENT_GLOBAL_READER_QUEUE_PERMIT);
@@ -114,6 +114,7 @@ public class TestLogFileSource {
             msg = source.read();
             cnt++;
         }
+        await().atMost(2, TimeUnit.SECONDS).until(() -> source.sourceFinish());
         source.destroy();
         Assert.assertTrue(cnt == 3);
         Assert.assertTrue(srcLen == readLen);
@@ -123,10 +124,11 @@ public class TestLogFileSource {
 
     private void testCleanQueue() {
         LogFileSource source = getSource();
-        await().atMost(2, TimeUnit.SECONDS).until(() -> source.sourceFinish());
+        await().atMost(2, TimeUnit.SECONDS).until(() -> source.finishReadLog());
         for (int i = 0; i < 2; i++) {
             source.read();
         }
+        Assert.assertTrue(!source.sourceFinish());
         source.destroy();
         int leftAfterRead = MemoryManager.getInstance().getLeft(AGENT_GLOBAL_READER_QUEUE_PERMIT);
         Assert.assertTrue(leftAfterRead == DEFAULT_AGENT_GLOBAL_READER_QUEUE_PERMIT);


### PR DESCRIPTION
[INLONG-9267][Agent] Fix bug: data loss when there are many files to read once
- Fixes #9267 

### Motivation
Fix bug: data loss when there are many files to read once
### Modifications

Fix bug: data loss when there are many files to read once

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
