### PR TITLE
[INLONG-9271][Manager] When creating 'StreamField', 'isMetaField' must be initialized

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/StreamField.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/stream/StreamField.java
@@ -101,6 +101,8 @@ public class StreamField implements Serializable {
         this.fieldName = fieldName;
         this.fieldComment = fieldComment;
         this.fieldValue = fieldValue;
+        // default
+        this.isMetaField = 0;
     }
 
     public StreamField(int index, String fieldType, String fieldName, String fieldComment, String fieldValue,

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
+import org.apache.inlong.manager.common.enums.FieldType;
 import org.apache.inlong.manager.common.fieldtype.strategy.ClickHouseFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MongoDBFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
@@ -39,6 +40,18 @@ import org.junit.jupiter.api.Test;
  * Different data source field type conversion mapping test class.
  */
 public class FieldInfoUtilsTest {
+
+    @Test
+    public void testCreateFieldTypeInfo() {
+
+        StreamField streamField = new StreamField(0, FieldType.STRING.toString(), "name", null, null);
+
+        FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
+                "nodeId", new MySQLFieldTypeStrategy());
+
+        TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
+        Assertions.assertTrue(typeInfo instanceof StringTypeInfo);
+    }
 
     @Test
     public void testPostgreSQLFieldTypeInfo() {


### PR DESCRIPTION
When creating 'StreamField', 'isMetaField' must be initialized

### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-9271] [Manager]When creating 'StreamField', 'isMetaField' must be initialized

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9271 

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve?*

### Modifications

When I create 'StreamField' using a constructor, 'isMetaField' has an initial value

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [√ ] This change added tests and can be verified as follows:

  *(example:)*
  - Added integration tests ：org.apache.inlong.manager.pojo.sort.util.FieldInfoUtilsTest#testCreateFieldTypeInfo

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
