### PR TITLE
[INLONG-9284][Agent] Report audit by data time not real time

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/DateTransUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/DateTransUtils.java
@@ -44,7 +44,6 @@ public class DateTransUtils {
     public static long timeStrConvertTomillSec(String time, String cycleUnit, TimeZone timeZone)
             throws ParseException {
         long retTime = 0;
-        // SimpleDateFormat df=new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         SimpleDateFormat df = null;
         if (cycleUnit.equals("Y") && time.length() == 4) {
             df = new SimpleDateFormat("yyyy");

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -160,16 +160,15 @@ public class InstanceManager extends AbstractDaemon {
 
     private void printInstanceDetail() {
         if (AgentUtils.getCurrentTime() - lastPrintTime > CORE_THREAD_PRINT_TIME) {
-            LOGGER.info("instanceManager coreThread running! taskId {} action count {}", taskId,
-                    actionQueue.size());
             List<InstanceProfile> instances = instanceDb.getInstances(taskId);
             InstancePrintStat stat = new InstancePrintStat();
             for (int i = 0; i < instances.size(); i++) {
                 InstanceProfile instance = instances.get(i);
                 stat.stat(instance.getState());
             }
-            LOGGER.info("instanceManager coreThread running! taskId {} memory total {} db total {} db detail {} ",
-                    taskId, instanceMap.size(), instances.size(), stat);
+            LOGGER.info(
+                    "instanceManager running! taskId {} mem {} db total {} {} action count {}",
+                    taskId, instanceMap.size(), instances.size(), stat, actionQueue.size());
             lastPrintTime = AgentUtils.getCurrentTime();
         }
     }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
@@ -203,8 +203,7 @@ public class TaskManager extends AbstractDaemon {
                 TaskProfile task = tasksInDb.get(i);
                 stat.stat(task.getState());
             }
-            LOGGER.info("taskManager coreThread running! memory total {} db total {} db detail {} ", taskMap.size(),
-                    tasksInDb.size(), stat);
+            LOGGER.info("taskManager running! mem {} db total {} {} ", taskMap.size(), tasksInDb.size(), stat);
             lastPrintTime = AgentUtils.getCurrentTime();
         }
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
@@ -331,11 +331,11 @@ public class SenderManager {
     }
 
     private void asyncSendByMessageSender(SendMessageCallback cb,
-            List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
+            List<byte[]> bodyList, String groupId, String streamId, long dataTime, String msgUUID,
             long timeout, TimeUnit timeUnit,
             Map<String, String> extraAttrMap, boolean isProxySend) throws ProxysdkException {
         sender.asyncSendMessage(cb, bodyList, groupId,
-                streamId, dt, msgUUID,
+                streamId, dataTime, msgUUID,
                 timeout, timeUnit, extraAttrMap, isProxySend);
     }
 
@@ -428,7 +428,7 @@ public class SenderManager {
                 message.getAckInfo().setHasAck(true);
                 getMetricItem(groupId, streamId).pluginSendSuccessCount.addAndGet(msgCnt);
                 AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_SUCCESS, groupId, streamId,
-                        System.currentTimeMillis(), message.getMsgCnt(), message.getTotalSize());
+                        dataTime, message.getMsgCnt(), message.getTotalSize());
             } else {
                 LOGGER.warn("send groupId {}, streamId {}, taskId {}, instanceId {}, dataTime {} fail with times {}, "
                         + "error {}", groupId, streamId, taskId, instanceId, dataTime, retry, result);


### PR DESCRIPTION
[INLONG-9284][Agent] Report audit by data time not real time
- Fixes #9284 

### Motivation

Report audit by data time not real time
### Modifications

Report audit by data time not real time

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
