### PR TITLE
[INLONG-9308][Agent] The sink end of the file instance supports sending data with different streamIds

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/TaskProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/TaskProfile.java
@@ -110,7 +110,8 @@ public class TaskProfile extends AbstractConfiguration {
         return hasKey(TaskConstants.TASK_ID) && hasKey(TaskConstants.TASK_SOURCE)
                 && hasKey(TaskConstants.TASK_SINK) && hasKey(TaskConstants.TASK_CHANNEL)
                 && hasKey(TaskConstants.TASK_GROUP_ID) && hasKey(TaskConstants.TASK_STREAM_ID)
-                && hasKey(TaskConstants.TASK_CYCLE_UNIT);
+                && hasKey(TaskConstants.TASK_CYCLE_UNIT)
+                && hasKey(TaskConstants.TASK_FILE_TIME_ZONE);
     }
 
     public String toJsonStr() {
@@ -125,10 +126,13 @@ public class TaskProfile extends AbstractConfiguration {
         instanceProfile.setSourceDataTime(dataTime);
         Long sinkDataTime = 0L;
         try {
-            sinkDataTime = DateTransUtils.timeStrConvertTomillSec(dataTime, getCycleUnit(),
+            sinkDataTime = DateTransUtils.timeStrConvertToMillSec(dataTime, getCycleUnit(),
                     TimeZone.getTimeZone(getTimeZone()));
         } catch (ParseException e) {
-            logger.error("createInstanceProfile error: ", e);
+            logger.error("createInstanceProfile ParseException error: ", e);
+            return null;
+        } catch (Exception e) {
+            logger.error("createInstanceProfile Exception error: ", e);
             return null;
         }
         instanceProfile.setSinkDataTime(sinkDataTime);

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/OffsetAckInfo.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/OffsetAckInfo.java
@@ -19,15 +19,12 @@ package org.apache.inlong.agent.message.filecollect;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
-@NoArgsConstructor
-public class PackageAckInfo {
+public class OffsetAckInfo {
 
-    private Long index;
     private Long offset;
-    private Integer len;
+    private int len;
     private Boolean hasAck;
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/ProxyMessage.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.message.filecollect;
+
+import org.apache.inlong.agent.constant.TaskConstants;
+import org.apache.inlong.agent.plugin.Message;
+
+import java.util.Map;
+
+import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_DATA;
+import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_GROUP_ID;
+import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_STREAM_ID;
+
+/**
+ * Bus message with body, header, inlongGroupId and inlongStreamId.
+ */
+public class ProxyMessage implements Message {
+
+    private static final String DEFAULT_INLONG_STREAM_ID = "__";
+
+    private final byte[] body;
+    private final Map<String, String> header;
+    private final String inlongGroupId;
+    private final String inlongStreamId;
+    // determine the group key when making batch
+    private final String batchKey;
+    private final String dataKey;
+    OffsetAckInfo ackInfo;
+
+    public ProxyMessage(byte[] body, Map<String, String> header) {
+        this.body = body;
+        this.header = header;
+        this.inlongGroupId = header.get(PROXY_KEY_GROUP_ID);
+        this.inlongStreamId = header.getOrDefault(PROXY_KEY_STREAM_ID, DEFAULT_INLONG_STREAM_ID);
+        this.dataKey = header.getOrDefault(PROXY_KEY_DATA, "");
+        // use the batch key of user and inlongStreamId to determine one batch
+        this.batchKey = dataKey + inlongStreamId;
+        Long offset = Long.parseLong(header.get(TaskConstants.OFFSET));
+        ackInfo = new OffsetAckInfo(offset, body.length, false);
+    }
+
+    public ProxyMessage(Message message) {
+        this(message.getBody(), message.getHeader());
+    }
+
+    public String getDataKey() {
+        return dataKey;
+    }
+
+    /**
+     * Get first line of body list
+     *
+     * @return first line of body list
+     */
+    @Override
+    public byte[] getBody() {
+        return body;
+    }
+
+    public OffsetAckInfo getAckInfo() {
+        return ackInfo;
+    }
+
+    /**
+     * Get header of message
+     *
+     * @return header
+     */
+    @Override
+    public Map<String, String> getHeader() {
+        return header;
+    }
+
+    public String getInlongGroupId() {
+        return inlongGroupId;
+    }
+
+    public String getInlongStreamId() {
+        return inlongStreamId;
+    }
+
+    public String getBatchKey() {
+        return batchKey;
+    }
+}

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/SenderMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/filecollect/SenderMessage.java
@@ -43,7 +43,7 @@ public class SenderMessage {
     private List<byte[]> dataList;
     private long dataTime;
     private Map<String, String> extraMap;
-    private PackageAckInfo ackInfo;
+    private List<OffsetAckInfo> offsetAckList;
 
     public InLongMsg getInLongMsg() {
         InLongMsg message = InLongMsg.newInLongMsg(true);

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/DateTransUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/DateTransUtils.java
@@ -36,12 +36,12 @@ public class DateTransUtils {
     }
 
     // convert YYYMMDD to millSec by cycleUnit
-    public static long timeStrConvertTomillSec(String time, String cycleUnit)
+    public static long timeStrConvertToMillSec(String time, String cycleUnit)
             throws ParseException {
-        return timeStrConvertTomillSec(time, cycleUnit, TimeZone.getDefault());
+        return timeStrConvertToMillSec(time, cycleUnit, TimeZone.getDefault());
     }
 
-    public static long timeStrConvertTomillSec(String time, String cycleUnit, TimeZone timeZone)
+    public static long timeStrConvertToMillSec(String time, String cycleUnit, TimeZone timeZone)
             throws ParseException {
         long retTime = 0;
         SimpleDateFormat df = null;
@@ -62,9 +62,6 @@ public class DateTransUtils {
         try {
             df.setTimeZone(timeZone);
             retTime = df.parse(time).getTime();
-            if (cycleUnit.equals("10m")) {
-
-            }
         } catch (ParseException e) {
             logger.error("convert time string error. ", e);
         }
@@ -98,7 +95,6 @@ public class DateTransUtils {
         retTime = df.format(dateTime);
 
         if (cycleUnit.contains("m")) {
-
             int cycleNum = Integer.parseInt(cycleUnit.substring(0,
                     cycleUnit.length() - 1));
             int mmTime = Integer.parseInt(retTime.substring(

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
@@ -19,10 +19,13 @@ package org.apache.inlong.agent.plugin.sinks.filecollect;
 
 import org.apache.inlong.agent.common.AgentThreadFactory;
 import org.apache.inlong.agent.conf.InstanceProfile;
+import org.apache.inlong.agent.conf.OffsetProfile;
 import org.apache.inlong.agent.constant.CommonConstants;
+import org.apache.inlong.agent.core.task.OffsetManager;
 import org.apache.inlong.agent.core.task.file.MemoryManager;
 import org.apache.inlong.agent.message.EndMessage;
-import org.apache.inlong.agent.message.ProxyMessage;
+import org.apache.inlong.agent.message.filecollect.OffsetAckInfo;
+import org.apache.inlong.agent.message.filecollect.ProxyMessage;
 import org.apache.inlong.agent.message.filecollect.SenderMessage;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.MessageFilter;
@@ -33,12 +36,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static org.apache.inlong.agent.constant.CommonConstants.DEFAULT_FIELD_SPLITTER;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_WRITER_PERMIT;
+import static org.apache.inlong.agent.constant.TaskConstants.INODE_INFO;
 
 /**
  * sink message data to inlong-dataproxy
@@ -48,8 +58,7 @@ public class ProxySink extends AbstractSink {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxySink.class);
     private final int WRITE_FAILED_WAIT_TIME_MS = 10;
     private final int DESTROY_LOOP_WAIT_TIME_MS = 10;
-    private final Integer NO_WRITE_WAIT_AT_LEAST_MS = 5 * 1000;
-    private final Integer SINK_FINISH_AT_LEAST_COUNT = 5;
+    public final int SAVE_OFFSET_INTERVAL_MS = 1000;
     private static final ThreadPoolExecutor EXECUTOR_SERVICE = new ThreadPoolExecutor(
             0, Integer.MAX_VALUE,
             1L, TimeUnit.SECONDS,
@@ -61,8 +70,11 @@ public class ProxySink extends AbstractSink {
     private volatile boolean shutdown = false;
     private volatile boolean running = false;
     private volatile boolean inited = false;
-    private volatile long lastWriteTime = 0;
-    private volatile long checkSinkFinishCount = 0;
+    private long lastPrintTime = 0;
+    private List<OffsetAckInfo> ackInfoList = new ArrayList<>();
+    private final ReentrantReadWriteLock packageAckInfoLock = new ReentrantReadWriteLock(true);
+    private volatile boolean offsetRunning = false;
+    private OffsetManager offsetManager;
 
     public ProxySink() {
     }
@@ -71,7 +83,6 @@ public class ProxySink extends AbstractSink {
     public void write(Message message) {
         boolean suc = false;
         while (!shutdown && !suc) {
-            lastWriteTime = AgentUtils.getCurrentTime();
             suc = putInCache(message);
             if (!suc) {
                 AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);
@@ -84,8 +95,6 @@ public class ProxySink extends AbstractSink {
             if (message == null) {
                 return true;
             }
-            message.getHeader().put(CommonConstants.PROXY_KEY_GROUP_ID, inlongGroupId);
-            message.getHeader().put(CommonConstants.PROXY_KEY_STREAM_ID, inlongStreamId);
             extractStreamFromMessage(message, fieldSplitter);
             if (message instanceof EndMessage) {
                 // increment the count of failed sinks
@@ -101,8 +110,10 @@ public class ProxySink extends AbstractSink {
             }
             cache.generateExtraMap(proxyMessage.getDataKey());
             // add message to package proxy
-            boolean suc = cache.addProxyMessage(proxyMessage);
-            if (!suc) {
+            boolean suc = cache.add(proxyMessage);
+            if (suc) {
+                addAckInfo(proxyMessage.getAckInfo());
+            } else {
                 MemoryManager.getInstance().release(AGENT_GLOBAL_WRITER_PERMIT, message.getBody().length);
                 // increment the count of failed sinks
                 sinkMetric.sinkFailCount.incrementAndGet();
@@ -123,8 +134,6 @@ public class ProxySink extends AbstractSink {
         if (messageFilter != null) {
             message.getHeader().put(CommonConstants.PROXY_KEY_STREAM_ID,
                     messageFilter.filterStreamId(message, fieldSplitter));
-        } else {
-            message.getHeader().put(CommonConstants.PROXY_KEY_STREAM_ID, inlongStreamId);
         }
     }
 
@@ -139,38 +148,32 @@ public class ProxySink extends AbstractSink {
                     "flushCache-" + profile.getTaskId() + "-" + profile.getInstanceId());
             LOGGER.info("start flush cache {}:{}", inlongGroupId, sourceName);
             running = true;
-            long lastPrintTime = AgentUtils.getCurrentTime();
             while (!shutdown) {
-                try {
-                    SenderMessage senderMessage = cache.fetchSenderMessage();
-                    if (senderMessage != null) {
-                        checkSinkFinishCount = 0;
-                        senderManager.sendBatch(senderMessage);
-                        if (AgentUtils.getCurrentTime() - lastPrintTime > TimeUnit.SECONDS.toMillis(1)) {
-                            lastPrintTime = AgentUtils.getCurrentTime();
-                            LOGGER.info("send groupId {}, streamId {}, message size {}, taskId {}, "
-                                    + "instanceId {} sendTime is {}", inlongGroupId, inlongStreamId,
-                                    senderMessage.getDataList().size(), profile.getTaskId(),
-                                    profile.getInstanceId(),
-                                    senderMessage.getDataTime());
-                        }
-                    }
-                    if (noWriteLongEnough() && senderManager.sendFinished()) {
-                        checkSinkFinishCount++;
-                    } else {
-                        checkSinkFinishCount = 0;
-                    }
-                } catch (Exception ex) {
-                    LOGGER.error("error caught", ex);
-                } catch (Throwable t) {
-                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), t);
-                } finally {
-                    AgentUtils.silenceSleepInMs(batchFlushInterval);
-                }
+                sendMessageFromCache();
+                AgentUtils.silenceSleepInMs(batchFlushInterval);
             }
             LOGGER.info("stop flush cache {}:{}", inlongGroupId, sourceName);
             running = false;
         };
+    }
+
+    public void sendMessageFromCache() {
+        ConcurrentHashMap<String, LinkedBlockingQueue<ProxyMessage>> messageQueueMap = cache.getMessageQueueMap();
+        for (Map.Entry<String, LinkedBlockingQueue<ProxyMessage>> entry : messageQueueMap.entrySet()) {
+            SenderMessage senderMessage = cache.fetchSenderMessage(entry.getKey(), entry.getValue());
+            if (senderMessage == null) {
+                continue;
+            }
+            senderManager.sendBatch(senderMessage);
+            if (AgentUtils.getCurrentTime() - lastPrintTime > TimeUnit.SECONDS.toMillis(1)) {
+                lastPrintTime = AgentUtils.getCurrentTime();
+                LOGGER.info("send groupId {}, streamId {}, message size {}, taskId {}, "
+                        + "instanceId {} sendTime is {}", inlongGroupId, inlongStreamId,
+                        senderMessage.getDataList().size(), profile.getTaskId(),
+                        profile.getInstanceId(),
+                        senderMessage.getDataTime());
+            }
+        }
     }
 
     @Override
@@ -179,10 +182,12 @@ public class ProxySink extends AbstractSink {
         fieldSplitter = profile.get(CommonConstants.FIELD_SPLITTER, DEFAULT_FIELD_SPLITTER).getBytes(
                 StandardCharsets.UTF_8);
         sourceName = profile.getInstanceId();
+        offsetManager = OffsetManager.init();
         senderManager = new SenderManager(profile, inlongGroupId, sourceName);
         try {
             senderManager.Start();
             EXECUTOR_SERVICE.execute(coreThread());
+            EXECUTOR_SERVICE.execute(flushOffset());
             inited = true;
         } catch (Throwable ex) {
             shutdown = true;
@@ -199,11 +204,11 @@ public class ProxySink extends AbstractSink {
             return;
         }
         shutdown = true;
-        while (running) {
+        while (running || offsetRunning) {
             AgentUtils.silenceSleepInMs(DESTROY_LOOP_WAIT_TIME_MS);
         }
-        MemoryManager.getInstance().release(AGENT_GLOBAL_WRITER_PERMIT, (int) cache.getCacheSize());
         senderManager.Stop();
+        clearOffset();
         LOGGER.info("destroy sink {} end", sourceName);
     }
 
@@ -212,18 +217,70 @@ public class ProxySink extends AbstractSink {
      */
     @Override
     public boolean sinkFinish() {
-        if (noWriteLongEnough() && sinkFinishLongEnough()) {
-            return true;
-        } else {
-            return false;
+        boolean finished = false;
+        packageAckInfoLock.writeLock().lock();
+        if (ackInfoList.isEmpty()) {
+            finished = true;
         }
+        packageAckInfoLock.writeLock().unlock();
+        return finished;
     }
 
-    public boolean noWriteLongEnough() {
-        return AgentUtils.getCurrentTime() - lastWriteTime > NO_WRITE_WAIT_AT_LEAST_MS;
+    private void addAckInfo(OffsetAckInfo info) {
+        packageAckInfoLock.writeLock().lock();
+        ackInfoList.add(info);
+        packageAckInfoLock.writeLock().unlock();
     }
 
-    public boolean sinkFinishLongEnough() {
-        return checkSinkFinishCount > SINK_FINISH_AT_LEAST_COUNT;
+    /**
+     * flushOffset
+     *
+     * @return thread runner
+     */
+    private Runnable flushOffset() {
+        return () -> {
+            AgentThreadFactory.nameThread(
+                    "flushOffset-" + profile.getTaskId() + "-" + profile.getInstanceId());
+            LOGGER.info("start flush offset {}:{}", inlongGroupId, sourceName);
+            offsetRunning = true;
+            while (!shutdown) {
+                doFlushOffset();
+                AgentUtils.silenceSleepInMs(SAVE_OFFSET_INTERVAL_MS);
+            }
+            LOGGER.info("stop flush offset {}:{}", inlongGroupId, sourceName);
+            offsetRunning = false;
+        };
+    }
+
+    /**
+     * flushOffset
+     */
+    private void doFlushOffset() {
+        packageAckInfoLock.writeLock().lock();
+        OffsetAckInfo info = null;
+        for (int i = 0; i < ackInfoList.size();) {
+            if (ackInfoList.get(i).getHasAck()) {
+                info = ackInfoList.remove(i);
+                MemoryManager.getInstance().release(AGENT_GLOBAL_WRITER_PERMIT, info.getLen());
+            } else {
+                break;
+            }
+        }
+        if (info != null) {
+            LOGGER.info("save offset {} taskId {} instanceId {}", info.getOffset(), profile.getTaskId(),
+                    profile.getInstanceId());
+            OffsetProfile offsetProfile = new OffsetProfile(profile.getTaskId(), profile.getInstanceId(),
+                    info.getOffset(), profile.get(INODE_INFO));
+            offsetManager.setOffset(offsetProfile);
+        }
+        packageAckInfoLock.writeLock().unlock();
+    }
+
+    private void clearOffset() {
+        packageAckInfoLock.writeLock().lock();
+        for (int i = 0; i < ackInfoList.size();) {
+            MemoryManager.getInstance().release(AGENT_GLOBAL_WRITER_PERMIT, ackInfoList.remove(i).getLen());
+        }
+        packageAckInfoLock.writeLock().unlock();
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/WatchEntity.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/WatchEntity.java
@@ -274,7 +274,7 @@ public class WatchEntity {
         logger.info("removeUselessWatchDirectories {}", curDataTime);
 
         /* Calculate the data time which is 3 cycle units earlier than current task data time. */
-        long curDataTimeMillis = DateTransUtils.timeStrConvertTomillSec(curDataTime, cycleUnit);
+        long curDataTimeMillis = DateTransUtils.timeStrConvertToMillSec(curDataTime, cycleUnit);
         Calendar calendar = Calendar.getInstance();
         calendar.setTimeInMillis(curDataTimeMillis);
         if ("D".equalsIgnoreCase(cycleUnit)) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/file/NewDateUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/file/NewDateUtils.java
@@ -124,7 +124,7 @@ public class NewDateUtils {
         String retTime = DateTransUtils.millSecConvertToTimeStr(
                 System.currentTimeMillis(), cycleUnit);
         try {
-            long time = DateTransUtils.timeStrConvertTomillSec(dataTime, cycleUnit);
+            long time = DateTransUtils.timeStrConvertToMillSec(dataTime, cycleUnit);
 
             Calendar calendar = Calendar.getInstance();
             calendar.setTimeInMillis(time);
@@ -592,8 +592,8 @@ public class NewDateUtils {
         long startTime;
         long endTime;
         try {
-            startTime = DateTransUtils.timeStrConvertTomillSec(start, cycleUnit);
-            endTime = DateTransUtils.timeStrConvertTomillSec(end, cycleUnit);
+            startTime = DateTransUtils.timeStrConvertToMillSec(start, cycleUnit);
+            endTime = DateTransUtils.timeStrConvertToMillSec(end, cycleUnit);
         } catch (ParseException e) {
             logger.error("date format is error: ", e);
             return ret;

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
@@ -21,7 +21,7 @@ import org.apache.inlong.agent.common.AgentThreadFactory;
 import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.constant.TaskConstants;
-import org.apache.inlong.agent.message.filecollect.PackageAckInfo;
+import org.apache.inlong.agent.message.filecollect.OffsetAckInfo;
 import org.apache.inlong.agent.message.filecollect.SenderMessage;
 import org.apache.inlong.agent.plugin.AgentBaseTestsHelper;
 import org.apache.inlong.agent.plugin.utils.file.FileDataUtils;
@@ -49,8 +49,6 @@ import java.util.List;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
-import static org.awaitility.Awaitility.await;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(SenderManager.class)
@@ -98,37 +96,45 @@ public class TestSenderManager {
                     Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any(),
                     Mockito.anyLong(), Mockito.any(),
                     Mockito.any(), Mockito.anyBoolean());
-
             senderManager.Start();
-            Long packageIndex = 0L;
-            Long packageOffset = 100L;
-            List<byte[]> bodyList = new ArrayList<>();
-            bodyList.add("123456789".getBytes(StandardCharsets.UTF_8));
-            Integer resultBatchSize = 0;
-            for (int i = 0; i < bodyList.size(); i++) {
-                resultBatchSize += bodyList.get(i).length;
-            }
+            Long offset = 0L;
+            List<OffsetAckInfo> ackInfoListTotal = new ArrayList<>();
             for (int i = 0; i < 10; i++) {
-                PackageAckInfo ackInfo = new PackageAckInfo(packageIndex++, packageOffset, resultBatchSize, false);
+                List<byte[]> bodyList = new ArrayList<>();
+                List<OffsetAckInfo> ackInfoList = new ArrayList<>();
+                bodyList.add("123456789".getBytes(StandardCharsets.UTF_8));
+                for (int j = 0; j < bodyList.size(); j++) {
+                    OffsetAckInfo ackInfo = new OffsetAckInfo(offset++, bodyList.get(j).length, false);
+                    ackInfoList.add(ackInfo);
+                    ackInfoListTotal.add(ackInfo);
+                }
                 SenderMessage senderMessage = new SenderMessage("taskId", "instanceId", "groupId", "streamId", bodyList,
-                        AgentUtils.getCurrentTime(), null, ackInfo);
+                        AgentUtils.getCurrentTime(), null, ackInfoList);
                 senderManager.sendBatch(senderMessage);
-                packageOffset += 100;
             }
             Assert.assertTrue(cbList.size() == 10);
             for (int i = 0; i < 5; i++) {
                 cbList.get(4 - i).onMessageAck(SendResult.OK);
             }
-
-            await().atMost(2, TimeUnit.SECONDS).until(() -> !senderManager.sendFinished());
+            Assert.assertTrue(calHasAckCount(ackInfoListTotal) == 5);
             for (int i = 5; i < 10; i++) {
                 cbList.get(i).onMessageAck(SendResult.OK);
                 AgentUtils.silenceSleepInMs(10);
             }
-            await().atMost(2, TimeUnit.SECONDS).until(() -> senderManager.sendFinished());
+            Assert.assertTrue(String.valueOf(calHasAckCount(ackInfoListTotal)), calHasAckCount(ackInfoListTotal) == 10);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.assertTrue("testNormalAck failed", false);
         }
+    }
+
+    private int calHasAckCount(List<OffsetAckInfo> ackInfoListTotal) {
+        int count = 0;
+        for (int i = 0; i < ackInfoListTotal.size(); i++) {
+            if (ackInfoListTotal.get(i).getHasAck()) {
+                count++;
+            }
+        }
+        return count;
     }
 }


### PR DESCRIPTION
[INLONG-9308][Agent] The sink end of the file instance supports sending data with different streamIds
- Fixes #9308 

### Motivation

The sink end of the file instance supports sending data with different streamIds

### Modifications

The sink end of the file instance supports sending data with different streamIds

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
