### PR TITLE
[INLONG-9318][Manager] ManagerClient supports pulling clusters based on tenant roles

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongClusterClient.java
@@ -155,6 +155,19 @@ public class InlongClusterClient {
     }
 
     /**
+     * Paging query clusters according to tenant role.
+     *
+     * @param request query conditions
+     * @return cluster list
+     */
+    public PageResult<ClusterInfo> listByTenantRole(ClusterPageRequest request) {
+        Response<PageResult<ClusterInfo>> response =
+                ClientUtils.executeHttpCall(inlongClusterApi.listByTenantRole(request));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    /**
      * Update cluster information.
      *
      * @param request cluster to be modified

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -29,6 +29,7 @@ import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.common.UpdateResult;
+
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongClusterApi.java
@@ -29,7 +29,6 @@ import org.apache.inlong.manager.pojo.cluster.ClusterTagResponse;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.common.UpdateResult;
-
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
@@ -65,6 +64,9 @@ public interface InlongClusterApi {
 
     @POST("cluster/list")
     Call<Response<PageResult<ClusterInfo>>> list(@Body ClusterPageRequest request);
+
+    @POST("cluster/listByTenantRole")
+    Call<Response<PageResult<ClusterInfo>>> listByTenantRole(@Body ClusterPageRequest request);
 
     @POST("cluster/update")
     Call<Response<Boolean>> update(@Body ClusterRequest request);


### PR DESCRIPTION


### Prepare a Pull Request

- Fixes #9318 

### Motivation

ManagerClient supports pulling clusters based on tenant roles.

### Modifications

ManagerClient supports pulling clusters based on tenant roles..

