### PR TITLE
[INLONG-9034][Sort] Fix sort redis test with incorrect use of sleep

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -120,6 +120,10 @@
             <artifactId>flink-clients_2.11</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.inlong.sort.redis;
 
-import static org.awaitility.Awaitility.await;
-
-import java.util.concurrent.TimeUnit;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
@@ -33,7 +30,9 @@ import redis.clients.jedis.Jedis;
 import redis.embedded.RedisServer;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION

- Fixes #9034

### Motivation

Fix sort redis test with incorrect use of sleep

### Modifications

Use Await to replace sleep 

### Verifying this change
See RedisTest

### Documentation

  - Does this pull request introduce a new feature? (no)