### PR TITLE
[INLONG-8433][Agent] Improve the TaskTypeEnum file

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
@@ -17,6 +17,12 @@
 
 package org.apache.inlong.common.enums;
 
+import com.google.common.collect.Maps;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
 /**
  * Enum of task type.
  */
@@ -42,6 +48,29 @@ public enum TaskTypeEnum {
 
     ;
 
+    private static final Map<Integer, String> taskTypeEnumHashMap = Maps.newHashMap();
+
+    /*
+     * Init tasktype
+     */
+    static {
+        taskTypeEnumHashMap.put(0, "DATABASE_MIGRATION");
+        taskTypeEnumHashMap.put(1, "SQL");
+        taskTypeEnumHashMap.put(2, "BINLOG");
+        taskTypeEnumHashMap.put(3, "FILE");
+        taskTypeEnumHashMap.put(4, "KAFKA");
+        taskTypeEnumHashMap.put(5, "PULSAR");
+        taskTypeEnumHashMap.put(6, "POSTGRES");
+        taskTypeEnumHashMap.put(7, "ORACLE");
+        taskTypeEnumHashMap.put(8, "SQLSERVER");
+        taskTypeEnumHashMap.put(9, "MONGODB");
+        taskTypeEnumHashMap.put(10, "TUBEMQ");
+        taskTypeEnumHashMap.put(11, "REDIS");
+        taskTypeEnumHashMap.put(12, "MQTT");
+        taskTypeEnumHashMap.put(13, "HUDI");
+        taskTypeEnumHashMap.put(201, "MOCK");
+    }
+
     private final int type;
 
     TaskTypeEnum(int type) {
@@ -49,40 +78,11 @@ public enum TaskTypeEnum {
     }
 
     public static TaskTypeEnum getTaskType(int taskType) {
-        switch (taskType) {
-            case 0:
-                return DATABASE_MIGRATION;
-            case 1:
-                return SQL;
-            case 2:
-                return BINLOG;
-            case 3:
-                return FILE;
-            case 4:
-                return KAFKA;
-            case 5:
-                return PULSAR;
-            case 6:
-                return POSTGRES;
-            case 7:
-                return ORACLE;
-            case 8:
-                return SQLSERVER;
-            case 9:
-                return MONGODB;
-            case 10:
-                return TUBEMQ;
-            case 11:
-                return REDIS;
-            case 12:
-                return MQTT;
-            case 13:
-                return HUDI;
-            case 201:
-                return MOCK;
-            default:
-                throw new RuntimeException("Unsupported task type " + taskType);
+        String taskTypeString = taskTypeEnumHashMap.get(taskType);
+        if (StringUtils.isBlank(taskTypeString)) {
+            throw new NoSuchElementException(String.format("Unsupported task type:[%s]", taskType));
         }
+        return TaskTypeEnum.valueOf(taskTypeString);
     }
 
     public int getType() {

--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
@@ -18,10 +18,12 @@
 package org.apache.inlong.common.enums;
 
 import com.google.common.collect.Maps;
-import org.apache.commons.lang3.StringUtils;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Enum of task type.
@@ -48,27 +50,15 @@ public enum TaskTypeEnum {
 
     ;
 
-    private static final Map<Integer, String> taskTypeEnumHashMap = Maps.newHashMap();
+    private static final Map<Integer, TaskTypeEnum> TASK_TYPE_ENUM_MAP = Maps.newHashMap();
 
     /*
      * Init tasktype
      */
     static {
-        taskTypeEnumHashMap.put(0, "DATABASE_MIGRATION");
-        taskTypeEnumHashMap.put(1, "SQL");
-        taskTypeEnumHashMap.put(2, "BINLOG");
-        taskTypeEnumHashMap.put(3, "FILE");
-        taskTypeEnumHashMap.put(4, "KAFKA");
-        taskTypeEnumHashMap.put(5, "PULSAR");
-        taskTypeEnumHashMap.put(6, "POSTGRES");
-        taskTypeEnumHashMap.put(7, "ORACLE");
-        taskTypeEnumHashMap.put(8, "SQLSERVER");
-        taskTypeEnumHashMap.put(9, "MONGODB");
-        taskTypeEnumHashMap.put(10, "TUBEMQ");
-        taskTypeEnumHashMap.put(11, "REDIS");
-        taskTypeEnumHashMap.put(12, "MQTT");
-        taskTypeEnumHashMap.put(13, "HUDI");
-        taskTypeEnumHashMap.put(201, "MOCK");
+        TASK_TYPE_ENUM_MAP.putAll(
+                Arrays.stream(TaskTypeEnum.values()).collect(Collectors.toMap(TaskTypeEnum::getType, type -> type)));
+
     }
 
     private final int type;
@@ -78,11 +68,11 @@ public enum TaskTypeEnum {
     }
 
     public static TaskTypeEnum getTaskType(int taskType) {
-        String taskTypeString = taskTypeEnumHashMap.get(taskType);
-        if (StringUtils.isBlank(taskTypeString)) {
+        TaskTypeEnum taskTypeEnum = TASK_TYPE_ENUM_MAP.get(taskType);
+        if (Objects.isNull(taskTypeEnum)) {
             throw new NoSuchElementException(String.format("Unsupported task type:[%s]", taskType));
         }
-        return TaskTypeEnum.valueOf(taskTypeString);
+        return taskTypeEnum;
     }
 
     public int getType() {

--- a/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
@@ -19,6 +19,8 @@ package org.apache.inlong.common.enums;
 
 import org.junit.Test;
 
+import java.util.NoSuchElementException;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -37,7 +39,7 @@ public class TaskTypeEnumTest {
         try {
             // not exixts type:666
             taskType = TaskTypeEnum.getTaskType(666);
-        } catch (Exception e) {
+        } catch (NoSuchElementException e) {
             System.out.println("=====error====");
         }
         // "java.util.NoSuchElementException: Unsupported task type:[14]"

--- a/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
@@ -23,6 +23,7 @@ import java.util.NoSuchElementException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class TaskTypeEnumTest {
 
@@ -35,15 +36,13 @@ public class TaskTypeEnumTest {
 
     @Test
     public void testGetTaskTypeWithOther() {
+        int typeNum = 666;
         TaskTypeEnum taskType = null;
         try {
-            // not exixts type:666
-            taskType = TaskTypeEnum.getTaskType(666);
-        } catch (NoSuchElementException e) {
-            System.out.println("=====error====");
+            taskType = TaskTypeEnum.getTaskType(typeNum);
+        } catch (Exception e) {
+            assertTrue(e instanceof NoSuchElementException);
         }
-        // "java.util.NoSuchElementException: Unsupported task type:[14]"
         assertNull(taskType);
-
     }
 }

--- a/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
@@ -33,7 +33,13 @@ public class TaskTypeEnumTest {
 
     @Test
     public void testGetTaskTypeWithOther() {
-        TaskTypeEnum taskType = TaskTypeEnum.getTaskType(14);
+        TaskTypeEnum taskType = null;
+        try {
+            // not exixts type:666
+            taskType = TaskTypeEnum.getTaskType(666);
+        } catch (Exception e) {
+            System.out.println("=====error====");
+        }
         // "java.util.NoSuchElementException: Unsupported task type:[14]"
         assertNull(taskType);
 

--- a/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.enums;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Description
+ *
+ * @author lijie0203 2023/11/24 14:00
+ */
+public class TaskTypeEnumTest {
+
+    @Test
+    public void testGetTaskType() {
+        TaskTypeEnum taskType = TaskTypeEnum.getTaskType(4);
+        assertEquals(TaskTypeEnum.KAFKA, taskType);
+
+    }
+}

--- a/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
+++ b/inlong-common/src/test/java/org/apache/inlong/common/enums/TaskTypeEnumTest.java
@@ -20,18 +20,22 @@ package org.apache.inlong.common.enums;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
-/**
- * Description
- *
- * @author lijie0203 2023/11/24 14:00
- */
 public class TaskTypeEnumTest {
 
     @Test
     public void testGetTaskType() {
         TaskTypeEnum taskType = TaskTypeEnum.getTaskType(4);
         assertEquals(TaskTypeEnum.KAFKA, taskType);
+
+    }
+
+    @Test
+    public void testGetTaskTypeWithOther() {
+        TaskTypeEnum taskType = TaskTypeEnum.getTaskType(14);
+        // "java.util.NoSuchElementException: Unsupported task type:[14]"
+        assertNull(taskType);
 
     }
 }


### PR DESCRIPTION
Improve the TaskTypeEnum.java file in Inlong-common-enums

### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-8433][Agent] Improve the TaskTypeEnum.java file in Inlong-common-enums

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #8433 

### Motivation

In the getTaskType() method we are using switch case to get the task , we can improve it using Hashmap to store the Task and then can get Task Type from HashMap, which is more efficient.

### Modifications

use Hashmap to store the Task and then can get Task Type from HashMap

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [√] This change added tests and can be verified as follows:

add test file: org.apache.inlong.common.enums.TaskTypeEnumTest#testGetTaskType

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
