### PR TITLE
[INLONG-9333][Sort] Related problem with attribute exceptions when creating 'hudiSink'

### DIFF
--- a/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/File2HudiExample.java
+++ b/inlong-manager/manager-client-examples/src/test/java/org/apache/inlong/manager/client/File2HudiExample.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -157,6 +158,13 @@ public class File2HudiExample extends BaseExample {
         fields.add(field3);
         fields.add(field4);
         sink.setSinkFieldList(fields);
+
+        List<HashMap<String, String>> extList = new ArrayList<>();
+        HashMap<String, String> map = new HashMap<>();
+        map.put("hoodie.datasource.hive_sync.partition_fields", "name");
+        extList.add(map);
+        sink.setExtList(extList);
+        sink.setPrimaryKey("name");
         return sink;
     }
 }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/HudiExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/HudiExtractNode.java
@@ -25,6 +25,7 @@ import org.apache.inlong.sort.protocol.transformation.WatermarkField;
 import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -142,15 +143,17 @@ public class HudiExtractNode extends ExtractNode implements Serializable {
 
         // If the extend attributes starts with .ddl,
         // it will be passed to the ddl statement of the table
-        extList.forEach(ext -> {
-            String keyName = ext.get(EXTEND_ATTR_KEY_NAME);
-            if (StringUtils.isNoneBlank(keyName) &&
-                    keyName.startsWith(DDL_ATTR_PREFIX)) {
-                String ddlKeyName = keyName.substring(DDL_ATTR_PREFIX.length());
-                String ddlValue = ext.get(EXTEND_ATTR_VALUE_NAME);
-                options.put(ddlKeyName, ddlValue);
-            }
-        });
+        if (CollectionUtils.isNotEmpty(extList)) {
+            extList.forEach(ext -> {
+                String keyName = ext.get(EXTEND_ATTR_KEY_NAME);
+                if (StringUtils.isNoneBlank(keyName) &&
+                        keyName.startsWith(DDL_ATTR_PREFIX)) {
+                    String ddlKeyName = keyName.substring(DDL_ATTR_PREFIX.length());
+                    String ddlValue = ext.get(EXTEND_ATTR_VALUE_NAME);
+                    options.put(ddlKeyName, ddlValue);
+                }
+            });
+        }
 
         String path = String.format("%s/%s.db/%s", warehouse, dbName, tableName);
         options.put(HUDI_OPTION_DEFAULT_PATH, path);


### PR DESCRIPTION
Related problem with attribute exceptions when creating 'hudiSink'

### Prepare a Pull Request
*(Change the title refer to the following example)*

- [INLONG-9333][Sort] Related problem with attribute exceptions when creating 'hudiSink'

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9333 

### Motivation

When I tried to create a 'hudiSink', some properties did not prompt me to enter, but an error occurred

### Modifications

If some parameters are necessary, the task creation will prompt that these parameters must be assigned values

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ √] This change is already covered by existing tests, such as:
  1. Execute this method：org.apache.inlong.manager.client.File2HudiExample#testCreateGroupForHudi, an exception will occur in manager all log. Please refer to #9333  for detailed error logs;
  2. After adding the code I added, the task can be successfully created

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
