### PR TITLE
[INLONG-9338][Agent] Real time file collection uses the current time as the data time

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/AbstractConfiguration.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/AbstractConfiguration.java
@@ -175,6 +175,7 @@ public abstract class AbstractConfiguration {
     public int getInt(String key) {
         JsonElement value = configStorage.get(key);
         if (value == null) {
+            LOGGER.error("null value for key " + key);
             throw new NullPointerException("null value for key " + key);
         }
         return value.getAsInt();
@@ -231,6 +232,7 @@ public abstract class AbstractConfiguration {
     public String get(String key) {
         JsonElement value = configStorage.get(key);
         if (value == null) {
+            LOGGER.error("null value for key " + key);
             throw new NullPointerException("null value for key " + key);
         }
         return value.getAsString();

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
@@ -466,7 +466,7 @@ public class TaskManager extends AbstractDaemon {
                     task.getTaskId(), taskMap.size(), runningPool.getTaskCount(),
                     runningPool.getActiveCount());
         } catch (Throwable t) {
-            LOGGER.error("add task error {}", t.getMessage());
+            LOGGER.error("add task error: ", t);
         }
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
@@ -345,7 +345,7 @@ public class SenderManager {
                 message.getOffsetAckList().forEach(ack -> ack.setHasAck(true));
                 getMetricItem(groupId, streamId).pluginSendSuccessCount.addAndGet(msgCnt);
                 AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_SUCCESS, groupId, streamId,
-                        profile.getSinkDataTime(), message.getMsgCnt(), message.getTotalSize());
+                        dataTime, message.getMsgCnt(), message.getTotalSize());
             } else {
                 LOGGER.warn("send groupId {}, streamId {}, taskId {}, instanceId {}, dataTime {} fail with times {}, "
                         + "error {}", groupId, streamId, taskId, instanceId, dataTime, retry, result);


### PR DESCRIPTION
[INLONG-9338][Agent] Real time file collection uses the current time as the data time
- Fixes #9338 

### Motivation

Real time file collection uses the current time as the data time

### Modifications

Real time file collection uses the current time as the data time

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
