### PR TITLE
[INLONG-9337][Manager] Support querying operation records

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/OperationLogClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/OperationLogClient.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.inner.client;
+
+import org.apache.inlong.manager.client.api.ClientConfiguration;
+import org.apache.inlong.manager.client.api.service.OperationLogApi;
+import org.apache.inlong.manager.client.api.util.ClientUtils;
+import org.apache.inlong.manager.pojo.common.PageResult;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogRequest;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogResponse;
+
+public class OperationLogClient {
+
+    private final OperationLogApi operationLogApi;
+
+    public OperationLogClient(ClientConfiguration configuration) {
+        operationLogApi = ClientUtils.createRetrofit(configuration).create(OperationLogApi.class);
+    }
+
+    /**
+     * create us task by sink id
+     *
+     * @return task id
+     */
+    public PageResult<OperationLogResponse> list(OperationLogRequest request) {
+        Response<PageResult<OperationLogResponse>> response =
+                ClientUtils.executeHttpCall(operationLogApi.list(request));
+        ClientUtils.assertRespSuccess(response);
+        if (response.isSuccess()) {
+            return response.getData();
+        }
+        throw new RuntimeException(response.getErrMsg());
+    }
+
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/OperationLogApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/OperationLogApi.java
@@ -15,32 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.dao.mapper;
+package org.apache.inlong.manager.client.api.service;
 
-import org.apache.inlong.manager.dao.entity.OperationLogEntity;
+import org.apache.inlong.manager.pojo.common.PageResult;
+import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.operationLog.OperationLogRequest;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogResponse;
 
-import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Repository;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.POST;
 
-import java.util.List;
+public interface OperationLogApi {
 
-@Repository
-public interface OperationLogEntityMapper {
+    @POST("operationLog/list")
+    Call<Response<PageResult<OperationLogResponse>>> list(@Body OperationLogRequest request);
 
-    int deleteByPrimaryKey(Integer id);
-
-    int insert(OperationLogEntity record);
-
-    int insertBatch(List<OperationLogEntity> list);
-
-    int insertSelective(OperationLogEntity record);
-
-    OperationLogEntity selectByPrimaryKey(Integer id);
-
-    List<OperationLogEntity> selectByCondition(@Param("request") OperationLogRequest operationLogRequest);
-
-    int updateByPrimaryKeySelective(OperationLogEntity record);
-
-    int updateByPrimaryKey(OperationLogEntity record);
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/OperationTarget.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/OperationTarget.java
@@ -15,35 +15,35 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.service.operationlog;
-
-import org.apache.inlong.manager.common.enums.OperationTarget;
-import org.apache.inlong.manager.common.enums.OperationType;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.apache.inlong.manager.common.enums;
 
 /**
- * The interface of operation log
+ * Operation target
  */
-@Target({ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME)
-public @interface OperationLog {
+public enum OperationTarget {
 
-    /**
-     * Operation type
-     */
-    OperationType operation();
+    TENANT,
 
-    /**
-     * Operation target
-     */
-    OperationTarget operationTarget();
+    GROUP,
 
-    /**
-     * Whether to store in the database
-     */
-    boolean db() default true;
+    STREAM,
+
+    SOURCE,
+
+    SINK,
+
+    CONSUME,
+
+    WORKFLOW,
+
+    NODE,
+
+    CLUSTER,
+
+    TRANSFORM,
+
+    INLONG_ROLE,
+
+    TENANT_ROLE
+
 }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
@@ -80,6 +80,7 @@
                 and request_time &lt; #{request.endDate, jdbcType=VARCHAR}
             </if>
         </where>
+        order by request_time desc
     </select>
     <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
         delete

--- a/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
@@ -63,6 +63,12 @@
             <if test="request.inlongStreamId != null and request.inlongStreamId != ''">
                 and inlong_stream_id = #{request.inlongStreamId, jdbcType=VARCHAR}
             </if>
+            <if test="request.operationType != null and request.operationType != ''">
+                and operation_type = #{request.operationType, jdbcType=VARCHAR}
+            </if>
+            <if test="request.operationTarget != null and request.operationTarget != ''">
+                and operation_target = #{request.operationTarget, jdbcType=VARCHAR}
+            </if>
             <if test="request.startDate != null and request.startDate != '' and request.endDate != null and request.endDate != ''">
                 and request_time &gt;= #{request.startDate, jdbcType=VARCHAR}
                 and request_time &lt; #{request.endDate, jdbcType=VARCHAR}

--- a/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
@@ -22,8 +22,11 @@
 <mapper namespace="org.apache.inlong.manager.dao.mapper.OperationLogEntityMapper">
     <resultMap id="BaseResultMap" type="org.apache.inlong.manager.dao.entity.OperationLogEntity">
         <id column="id" jdbcType="INTEGER" property="id"/>
+        <result column="inlong_group_id" jdbcType="VARCHAR" property="inlongGroupId"/>
+        <result column="inlong_stream_id" jdbcType="VARCHAR" property="inlongStreamId"/>
         <result column="authentication_type" jdbcType="VARCHAR" property="authenticationType"/>
         <result column="operation_type" jdbcType="VARCHAR" property="operationType"/>
+        <result column="operation_target" jdbcType="VARCHAR" property="operationTarget"/>
         <result column="http_method" jdbcType="VARCHAR" property="httpMethod"/>
         <result column="invoke_method" jdbcType="VARCHAR" property="invokeMethod"/>
         <result column="operator" jdbcType="VARCHAR" property="operator"/>
@@ -38,7 +41,7 @@
         <result column="err_msg" jdbcType="LONGVARCHAR" property="errMsg"/>
     </resultMap>
     <sql id="Base_Column_List">
-        id, authentication_type, operation_type, http_method, invoke_method, operator,
+        id, inlong_group_id, inlong_stream_id, authentication_type, operation_type, operation_target, http_method, invoke_method, operator,
         proxy, request_url, remote_address, cost_time, status, request_time, body, param, err_msg
     </sql>
 
@@ -48,25 +51,46 @@
         from operation_log
         where id = #{id,jdbcType=INTEGER}
     </select>
+    <select id="selectByCondition" resultMap="BaseResultMap"
+            parameterType="org.apache.inlong.manager.pojo.operationLog.OperationLogRequest">
+        select
+        <include refid="Base_Column_List"/>
+        from operation_log
+        <where>
+            <if test="request.inlongGroupId != null and request.inlongGroupId != ''">
+                and inlong_group_id = #{request.inlongGroupId, jdbcType=VARCHAR}
+            </if>
+            <if test="request.inlongStreamId != null and request.inlongStreamId != ''">
+                and inlong_stream_id = #{request.inlongStreamId, jdbcType=VARCHAR}
+            </if>
+            <if test="request.startDate != null and request.startDate != '' and request.endDate != null and request.endDate != ''">
+                and request_time &gt;= #{request.startDate, jdbcType=VARCHAR}
+                and request_time &lt; #{request.endDate, jdbcType=VARCHAR}
+            </if>
+        </where>
+    </select>
     <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
         delete
         from operation_log
         where id = #{id,jdbcType=INTEGER}
     </delete>
     <insert id="insert" parameterType="org.apache.inlong.manager.dao.entity.OperationLogEntity">
-        insert into operation_log (id, authentication_type, operation_type,
+        insert into operation_log (id, inlong_group_id, inlong_stream_id,
+                                   authentication_type, operation_type, operation_target,
                                    http_method, invoke_method, operator,
                                    proxy, request_url, remote_address,
                                    cost_time, status, request_time,
                                    body, param, err_msg)
-        values (#{id,jdbcType=INTEGER}, #{authenticationType,jdbcType=VARCHAR}, #{operationType,jdbcType=VARCHAR},
+        values (#{id,jdbcType=INTEGER}, #{inlongGroupId,jdbcType=VARCHAR}, #{inlongStreamId,jdbcType=VARCHAR},
+                #{authenticationType,jdbcType=VARCHAR}, #{operationType,jdbcType=VARCHAR}, #{operationTarget,jdbcType=VARCHAR},
                 #{httpMethod,jdbcType=VARCHAR}, #{invokeMethod,jdbcType=VARCHAR}, #{operator,jdbcType=VARCHAR},
                 #{proxy,jdbcType=VARCHAR}, #{requestUrl,jdbcType=VARCHAR}, #{remoteAddress,jdbcType=VARCHAR},
                 #{costTime,jdbcType=BIGINT}, #{status,jdbcType=TINYINT}, #{requestTime,jdbcType=TIMESTAMP},
                 #{body,jdbcType=LONGVARCHAR}, #{param,jdbcType=LONGVARCHAR}, #{errMsg,jdbcType=LONGVARCHAR})
     </insert>
     <insert id="insertBatch">
-        insert into operation_log (id, authentication_type, operation_type,
+        insert into operation_log (id, inlong_group_id, inlong_stream_id,
+        authentication_type, operation_type, operation_target,
         http_method, invoke_method, operator,
         proxy, request_url, remote_address,
         cost_time, status, request_time,
@@ -75,8 +99,9 @@
         VALUES
         <foreach collection="list" item="log" separator=",">
             (
-            #{log.id,jdbcType=INTEGER}, #{log.authenticationType,jdbcType=VARCHAR},
-            #{log.operationType,jdbcType=VARCHAR},
+            #{log.id,jdbcType=INTEGER}, #{log.inlongGroupId,jdbcType=VARCHAR},
+            #{log.inlongStreamId,jdbcType=VARCHAR}, #{log.authenticationType,jdbcType=VARCHAR},
+            #{log.operationType,jdbcType=VARCHAR}, #{log.operationTarget,jdbcType=VARCHAR},
             #{log.httpMethod,jdbcType=VARCHAR}, #{log.invokeMethod,jdbcType=VARCHAR},
             #{log.operator,jdbcType=VARCHAR},
             #{log.proxy,jdbcType=VARCHAR}, #{log.requestUrl,jdbcType=VARCHAR},
@@ -95,11 +120,20 @@
             <if test="id != null">
                 id,
             </if>
+            <if test="inlongGroupId != null">
+                inlong_group_id,
+            </if>
+            <if test="inlongStreamId != null">
+                inlong_stream_id,
+            </if>
             <if test="authenticationType != null">
                 authentication_type,
             </if>
             <if test="operationType != null">
                 operation_type,
+            </if>
+            <if test="operationTarget != null">
+                operation_target,
             </if>
             <if test="httpMethod != null">
                 http_method,
@@ -142,11 +176,20 @@
             <if test="id != null">
                 #{id,jdbcType=INTEGER},
             </if>
+            <if test="inlongGroupId != null">
+                #{inlongGroupId,jdbcType=VARCHAR},
+            </if>
+            <if test="inlongStreamId != null">
+                #{inlongStreamId,jdbcType=VARCHAR},
+            </if>
             <if test="authenticationType != null">
                 #{authenticationType,jdbcType=VARCHAR},
             </if>
             <if test="operationType != null">
                 #{operationType,jdbcType=VARCHAR},
+            </if>
+            <if test="operationTarget != null">
+                #{operationTarget,jdbcType=VARCHAR},
             </if>
             <if test="httpMethod != null">
                 #{httpMethod,jdbcType=VARCHAR},
@@ -190,11 +233,20 @@
             parameterType="org.apache.inlong.manager.dao.entity.OperationLogEntity">
         update operation_log
         <set>
+            <if test="inlongGroupId != null">
+                inlong_group_id = #{inlongGroupId,jdbcType=VARCHAR},
+            </if>
+            <if test="inlongStreamId != null">
+                inlong_stream_id = #{inlongStreamId,jdbcType=VARCHAR},
+            </if>
             <if test="authenticationType != null">
                 authentication_type = #{authenticationType,jdbcType=VARCHAR},
             </if>
             <if test="operationType != null">
                 operation_type = #{operationType,jdbcType=VARCHAR},
+            </if>
+            <if test="operationTarget != null">
+                operation_target = #{operationTarget,jdbcType=VARCHAR},
             </if>
             <if test="httpMethod != null">
                 http_method = #{httpMethod,jdbcType=VARCHAR},
@@ -238,8 +290,11 @@
     <update id="updateByPrimaryKey"
             parameterType="org.apache.inlong.manager.dao.entity.OperationLogEntity">
         update operation_log
-        set authentication_type = #{authenticationType,jdbcType=VARCHAR},
+        set inlong_group_id = #{inlongGroupId,jdbcType=VARCHAR},
+            inlong_stream_id = #{inlongStreamId,jdbcType=VARCHAR},
+            authentication_type = #{authenticationType,jdbcType=VARCHAR},
             operation_type      = #{operationType,jdbcType=VARCHAR},
+            operation_target    = #{operationTarget,jdbcType=VARCHAR},
             http_method         = #{httpMethod,jdbcType=VARCHAR},
             invoke_method       = #{invokeMethod,jdbcType=VARCHAR},
             operator            = #{operator,jdbcType=VARCHAR},

--- a/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/OperationLogEntityMapper.xml
@@ -69,6 +69,12 @@
             <if test="request.operationTarget != null and request.operationTarget != ''">
                 and operation_target = #{request.operationTarget, jdbcType=VARCHAR}
             </if>
+            <if test="request.keyword != null and request.keyword != ''">
+                and (
+                inlong_group_id like CONCAT('%', #{request.keyword}, '%')
+                or inlong_stream_id like CONCAT('%', #{request.keyword}, '%')
+                )
+            </if>
             <if test="request.startDate != null and request.startDate != '' and request.endDate != null and request.endDate != ''">
                 and request_time &gt;= #{request.startDate, jdbcType=VARCHAR}
                 and request_time &lt; #{request.endDate, jdbcType=VARCHAR}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
@@ -38,6 +38,12 @@ public class OperationLogRequest extends PageRequest {
     @ApiModelProperty("Inlong stream id")
     private String inlongStreamId;
 
+    @ApiModelProperty("Operation type")
+    private String operationType;
+
+    @ApiModelProperty("Operation target")
+    private String operationTarget;
+
     @ApiModelProperty(value = "query start date, format by 'yyyy-MM-dd'", required = false, example = "2022-01-01")
     private String startDate;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
@@ -44,6 +44,9 @@ public class OperationLogRequest extends PageRequest {
     @ApiModelProperty("Operation target")
     private String operationTarget;
 
+    @ApiModelProperty(value = "keyword")
+    private String keyword;
+
     @ApiModelProperty(value = "query start date, format by 'yyyy-MM-dd'", required = false, example = "2022-01-01")
     private String startDate;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogRequest.java
@@ -15,37 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.dao.entity;
+package org.apache.inlong.manager.pojo.operationLog;
 
+import org.apache.inlong.manager.pojo.common.PageRequest;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Data;
-
-import java.io.Serializable;
-import java.util.Date;
+import lombok.NoArgsConstructor;
 
 /**
- * Operation log entity, including operation type, request url, etc.
+ * Request of get operation records
  */
 @Data
-public class OperationLogEntity implements Serializable {
+@NoArgsConstructor
+@AllArgsConstructor
+public class OperationLogRequest extends PageRequest {
 
-    private static final long serialVersionUID = 1L;
-    private Integer id;
+    @ApiModelProperty("Inlong group id")
     private String inlongGroupId;
+
+    @ApiModelProperty("Inlong stream id")
     private String inlongStreamId;
-    private String authenticationType;
-    private String operationType;
-    private String operationTarget;
-    private String httpMethod;
-    private String invokeMethod;
-    private String operator;
-    private String proxy;
-    private String requestUrl;
-    private String remoteAddress;
-    private Long costTime;
-    private Boolean status;
-    private Date requestTime;
-    private String body;
-    private String param;
-    private String errMsg;
+
+    @ApiModelProperty(value = "query start date, format by 'yyyy-MM-dd'", required = false, example = "2022-01-01")
+    private String startDate;
+
+    @ApiModelProperty(value = "query end date, format by 'yyyy-MM-dd'", required = false, example = "2022-01-01")
+    private String endDate;
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogResponse.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/operationLog/OperationLogResponse.java
@@ -15,37 +15,50 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.dao.entity;
+package org.apache.inlong.manager.pojo.operationLog;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-import java.io.Serializable;
 import java.util.Date;
 
-/**
- * Operation log entity, including operation type, request url, etc.
- */
 @Data
-public class OperationLogEntity implements Serializable {
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Operation records")
+public class OperationLogResponse {
 
-    private static final long serialVersionUID = 1L;
-    private Integer id;
+    @ApiModelProperty("Inlong group id")
     private String inlongGroupId;
+
+    @ApiModelProperty("Inlong stream id")
     private String inlongStreamId;
-    private String authenticationType;
-    private String operationType;
-    private String operationTarget;
+
+    @ApiModelProperty("Http method")
     private String httpMethod;
-    private String invokeMethod;
-    private String operator;
-    private String proxy;
-    private String requestUrl;
-    private String remoteAddress;
-    private Long costTime;
-    private Boolean status;
-    private Date requestTime;
+
+    @ApiModelProperty("Operation type")
+    private String operationType;
+
+    @ApiModelProperty("Operation target")
+    private String operationTarget;
+
+    @ApiModelProperty("request body")
     private String body;
-    private String param;
-    private String errMsg;
+
+    @ApiModelProperty("is success")
+    private Boolean status;
+
+    @ApiModelProperty(value = "Name of operator")
+    private String operator;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private Date requestTime;
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogRecorder.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogRecorder.java
@@ -17,12 +17,15 @@
 
 package org.apache.inlong.manager.service.operationlog;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.NetworkUtils;
 import org.apache.inlong.manager.dao.entity.OperationLogEntity;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
 import org.apache.inlong.manager.pojo.user.UserInfo;
 
+import com.alibaba.fastjson.JSON;
+import com.alibaba.fastjson.JSONObject;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.extern.slf4j.Slf4j;
@@ -35,6 +38,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import javax.servlet.http.HttpServletRequest;
 
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -44,6 +48,9 @@ import java.util.Optional;
 public class OperationLogRecorder {
 
     private static final String ANONYMOUS_USER = "AnonymousUser";
+    private static final String INLONG_GROUP_ID = "inlongGroupId";
+    private static final String INLONG_STREAM_ID = "inlongStreamId";
+
     private static final Gson GSON = new GsonBuilder().create(); // thread safe
 
     /**
@@ -63,6 +70,22 @@ public class OperationLogRecorder {
         String requestUrl = request.getRequestURI();
         String httpMethod = request.getMethod();
         String remoteAddress = NetworkUtils.getClientIpAddress(request);
+        Object[] args = joinPoint.getArgs();
+        String groupId = "";
+        String streamId = "";
+        for (Object arg : args) {
+            try {
+                JSONObject obj = (JSONObject) JSON.toJSON(arg);
+                for (String key : obj.keySet()) {
+                    if (Objects.equals(key, INLONG_GROUP_ID) || Objects.equals(key, INLONG_STREAM_ID)) {
+                        groupId = obj.getString(key);
+                    }
+                }
+            } catch (Exception ignored) {
+                log.debug("do nothing when exception");
+            }
+
+        }
         String param = GSON.toJson(request.getParameterMap());
         String body = GSON.toJson(joinPoint.getArgs());
 
@@ -78,7 +101,11 @@ public class OperationLogRecorder {
         } finally {
             long costTime = System.currentTimeMillis() - start;
             OperationType operationType = operationLog.operation();
+            OperationTarget operationTarget = operationLog.operationTarget();
             OperationLogEntity operationLogEntity = new OperationLogEntity();
+            operationLogEntity.setInlongGroupId(groupId);
+            operationLogEntity.setInlongStreamId(streamId);
+            operationLogEntity.setOperationTarget(operationTarget.name());
             operationLogEntity.setOperationType(operationType.name());
             operationLogEntity.setHttpMethod(httpMethod);
             operationLogEntity.setOperator(operator);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogService.java
@@ -15,32 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.dao.mapper;
+package org.apache.inlong.manager.service.operationlog;
 
-import org.apache.inlong.manager.dao.entity.OperationLogEntity;
+import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.operationLog.OperationLogRequest;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogResponse;
 
-import org.apache.ibatis.annotations.Param;
-import org.springframework.stereotype.Repository;
+/**
+ * Operation log service
+ */
+public interface OperationLogService {
 
-import java.util.List;
-
-@Repository
-public interface OperationLogEntityMapper {
-
-    int deleteByPrimaryKey(Integer id);
-
-    int insert(OperationLogEntity record);
-
-    int insertBatch(List<OperationLogEntity> list);
-
-    int insertSelective(OperationLogEntity record);
-
-    OperationLogEntity selectByPrimaryKey(Integer id);
-
-    List<OperationLogEntity> selectByCondition(@Param("request") OperationLogRequest operationLogRequest);
-
-    int updateByPrimaryKeySelective(OperationLogEntity record);
-
-    int updateByPrimaryKey(OperationLogEntity record);
+    PageResult<OperationLogResponse> listByCondition(OperationLogRequest request);
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/operationlog/OperationLogServiceImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.operationlog;
+
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.OperationLogEntity;
+import org.apache.inlong.manager.dao.mapper.OperationLogEntityMapper;
+import org.apache.inlong.manager.pojo.common.OrderFieldEnum;
+import org.apache.inlong.manager.pojo.common.OrderTypeEnum;
+import org.apache.inlong.manager.pojo.common.PageResult;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogRequest;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogResponse;
+
+import com.github.pagehelper.Page;
+import com.github.pagehelper.PageHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static org.apache.inlong.manager.pojo.common.PageRequest.MAX_PAGE_SIZE;
+
+/**
+ * Operation log operation
+ */
+@Service
+public class OperationLogServiceImpl implements OperationLogService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OperationLogServiceImpl.class);
+
+    @Autowired
+    private OperationLogEntityMapper operationLogMapper;
+
+    @Override
+    public PageResult<OperationLogResponse> listByCondition(OperationLogRequest request) {
+        if (request.getPageSize() > MAX_PAGE_SIZE) {
+            LOGGER.warn("list operation logs, change page size from {} to {}", request.getPageSize(), MAX_PAGE_SIZE);
+            request.setPageSize(MAX_PAGE_SIZE);
+        }
+        PageHelper.startPage(request.getPageNum(), request.getPageSize());
+        OrderFieldEnum.checkOrderField(request);
+        OrderTypeEnum.checkOrderType(request);
+        Page<OperationLogEntity> entityPage = (Page<OperationLogEntity>) operationLogMapper.selectByCondition(request);
+        PageResult<OperationLogResponse> pageResult = PageResult.fromPage(entityPage)
+                .map(entity -> CommonBeanUtils.copyProperties(entity, OperationLogResponse::new));
+        return pageResult;
+    }
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/tubemq/TubeMQOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/tubemq/TubeMQOperator.java
@@ -288,7 +288,7 @@ public class TubeMQOperator {
             String url = "http://" + brokerUrl + QUERY_MESSAGE_PATH + TOPIC_NAME + topicName + MSG_COUNT + msgCount;
             TubeMessageResponse response = HttpUtils.request(restTemplate, url, HttpMethod.GET,
                     null, new HttpHeaders(), TubeMessageResponse.class);
-            if (response.getErrCode() != SUCCESS_CODE) {
+            if (response.getErrCode() != SUCCESS_CODE && response.getErrCode() != 200) {
                 String msg = String.format("failed to query message for topic %s, error: %s",
                         topicName, response.getErrMsg());
                 LOGGER.error(msg + " in {} for broker {}", masterUrl, brokerUrl);

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -333,8 +333,9 @@ CREATE TABLE IF NOT EXISTS `operation_log`
     `request_time`        timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Request time',
     `err_msg`             mediumtext COMMENT 'Error message',
     PRIMARY KEY (`id`),
-    INDEX `operation_log_group_stream_index` (`inlong_group_id`, `inlong_stream_id`)
-) ENGINE = InnoDB
+    INDEX `operation_log_group_stream_index` (`inlong_group_id`, `inlong_stream_id`),
+    INDEX `operation_log_request_time_index` (`request_time`)
+    ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -332,7 +332,8 @@ CREATE TABLE IF NOT EXISTS `operation_log`
     `status`              int(4)             DEFAULT NULL COMMENT 'Operate status',
     `request_time`        timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Request time',
     `err_msg`             mediumtext COMMENT 'Error message',
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    INDEX `operation_log_group_stream_index` (`inlong_group_id`, `inlong_stream_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4;
 

--- a/inlong-manager/manager-web/sql/changes-1.10.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.10.0.sql
@@ -47,4 +47,6 @@ ALTER TABLE `operation_log`
 
 CREATE INDEX operation_log_group_stream_index ON operation_log (`inlong_group_id`, `inlong_stream_id`);
 
+CREATE INDEX `operation_log_request_time_index` ON operation_log (`request_time`);
+
 

--- a/inlong-manager/manager-web/sql/changes-1.10.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.10.0.sql
@@ -36,4 +36,14 @@ VALUES ('audit_sort_mysql_binlog_input', 'MYSQL_BINLOG', 0, '29'),
        ('audit_sort_tube_input', 'TUBEMQ', 0, '33'),
        ('audit_sort_tube_output', 'TUBEMQ', 1, '34');
 
+ALTER TABLE `operation_log`
+    ADD COLUMN  `inlong_group_id`  varchar(256) DEFAULT NULL COMMENT 'Inlong group id';
+
+ALTER TABLE `operation_log`
+    ADD COLUMN  `inlong_stream_id` varchar(256) DEFAULT NULL COMMENT 'Inlong stream id',
+
+ALTER TABLE `operation_log`
+    ADD COLUMN `operation_target` varchar(256) DEFAULT NULL COMMENT 'Operation target',
+
+
 

--- a/inlong-manager/manager-web/sql/changes-1.10.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.10.0.sql
@@ -45,5 +45,6 @@ ALTER TABLE `operation_log`
 ALTER TABLE `operation_log`
     ADD COLUMN `operation_target` varchar(256) DEFAULT NULL COMMENT 'Operation target',
 
+CREATE INDEX operation_log_group_stream_index ON operation_log (`inlong_group_id`, `inlong_stream_id`);
 
 

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/DataNodeController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.common.validation.SaveValidation;
@@ -60,7 +61,7 @@ public class DataNodeController {
 
     @PostMapping(value = "/node/save")
     @ApiOperation(value = "Save node")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.NODE)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody DataNodeRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(dataNodeService.save(request, currentUser));
@@ -84,7 +85,7 @@ public class DataNodeController {
     }
 
     @PostMapping(value = "/node/update")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.NODE)
     @ApiOperation(value = "Update data node")
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody DataNodeRequest request) {
         String username = LoginUserUtils.getLoginUser().getName();
@@ -92,7 +93,7 @@ public class DataNodeController {
     }
 
     @PostMapping(value = "/node/updateByKey")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.NODE)
     @ApiOperation(value = "Update data node by key")
     public Response<UpdateResult> updateByKey(
             @Validated(UpdateByKeyValidation.class) @RequestBody DataNodeRequest request) {
@@ -102,7 +103,7 @@ public class DataNodeController {
 
     @DeleteMapping(value = "/node/delete/{id}")
     @ApiOperation(value = "Delete data node by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.NODE)
     @ApiImplicitParam(name = "id", value = "Data node ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> delete(@PathVariable Integer id) {
         return Response.success(dataNodeService.delete(id, LoginUserUtils.getLoginUser().getName()));
@@ -110,7 +111,7 @@ public class DataNodeController {
 
     @DeleteMapping(value = "/node/deleteByKey")
     @ApiOperation(value = "Delete data node by key")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.NODE)
     @ApiImplicitParams({
             @ApiImplicitParam(name = "name", value = "Data node name", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "type", value = "Data node type", dataTypeClass = String.class, required = true)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.SaveValidation;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
@@ -74,7 +75,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/tag/save")
     @ApiOperation(value = "Save cluster tag")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Integer> saveTag(@Validated(SaveValidation.class) @RequestBody ClusterTagRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
@@ -98,7 +99,7 @@ public class InlongClusterController {
     }
 
     @PostMapping(value = "/cluster/tag/update")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster tag")
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> updateTag(@Validated(UpdateValidation.class) @RequestBody ClusterTagRequest request) {
@@ -108,7 +109,7 @@ public class InlongClusterController {
 
     @DeleteMapping(value = "/cluster/tag/delete/{id}")
     @ApiOperation(value = "Delete cluster tag by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster tag ID", dataTypeClass = Integer.class, required = true)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteTag(@PathVariable Integer id) {
@@ -117,7 +118,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/tenant/tag/save")
     @ApiOperation(value = "Save tenant cluster tag")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Integer> saveTenantTag(
             @Validated(SaveValidation.class) @RequestBody TenantClusterTagRequest request) {
@@ -147,7 +148,7 @@ public class InlongClusterController {
 
     @DeleteMapping(value = "/cluster/tenant/tag/delete/{id}")
     @ApiOperation(value = "Delete tenant cluster tag by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster tag ID", dataTypeClass = Integer.class, required = true)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteTenantTag(@PathVariable Integer id) {
@@ -156,7 +157,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/save")
     @ApiOperation(value = "Save cluster")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody ClusterRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
@@ -181,7 +182,7 @@ public class InlongClusterController {
     }
 
     @PostMapping(value = "/cluster/update")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster")
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody ClusterRequest request) {
@@ -190,7 +191,7 @@ public class InlongClusterController {
     }
 
     @PostMapping(value = "/cluster/updateByKey")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster by key")
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<UpdateResult> updateByKey(
@@ -200,7 +201,7 @@ public class InlongClusterController {
     }
 
     @PostMapping(value = "/cluster/bindTag")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Bind or unbind cluster tag")
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> bindTag(@Validated @RequestBody BindTagRequest request) {
@@ -210,7 +211,7 @@ public class InlongClusterController {
 
     @DeleteMapping(value = "/cluster/delete/{id}")
     @ApiOperation(value = "Delete cluster by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
     @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> delete(@PathVariable Integer id) {
@@ -219,7 +220,7 @@ public class InlongClusterController {
 
     @DeleteMapping(value = "/cluster/deleteByKey")
     @ApiOperation(value = "Delete cluster by cluster name and type")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParams({
             @ApiImplicitParam(name = "name", value = "Cluster name", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "type", value = "Cluster type", dataTypeClass = String.class, required = true),
@@ -232,7 +233,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/node/save")
     @ApiOperation(value = "Save cluster node")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Integer> saveNode(@Validated @RequestBody ClusterNodeRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.saveNode(request, currentUser));
@@ -260,14 +261,14 @@ public class InlongClusterController {
             @ApiImplicitParam(name = "clusterType", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "protocolType", dataTypeClass = String.class, required = false)
     })
-    @OperationLog(operation = OperationType.GET)
+    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.CLUSTER)
     public Response<List<ClusterNodeResponse>> listByGroupId(@RequestParam String inlongGroupId,
             @RequestParam String clusterType, @RequestParam(required = false) String protocolType) {
         return Response.success(clusterService.listNodeByGroupId(inlongGroupId, clusterType, protocolType));
     }
 
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster node")
     public Response<Boolean> updateNode(@Validated(UpdateValidation.class) @RequestBody ClusterNodeRequest request) {
         String username = LoginUserUtils.getLoginUser().getName();
@@ -276,7 +277,7 @@ public class InlongClusterController {
 
     @RequestMapping(value = "/cluster/node/delete/{id}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete cluster node")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> deleteNode(@PathVariable Integer id) {
         return Response.success(clusterService.deleteNode(id, LoginUserUtils.getLoginUser().getName()));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.common.validation.SaveValidation;
@@ -68,7 +69,7 @@ public class InlongGroupController {
     private InlongGroupProcessService groupProcessOperation;
 
     @RequestMapping(value = "/group/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.GROUP)
     @ApiOperation(value = "Save inlong group")
     public Response<String> save(@Validated(SaveValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         String operator = LoginUserUtils.getLoginUser().getName();
@@ -126,7 +127,7 @@ public class InlongGroupController {
     }
 
     @RequestMapping(value = "/group/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.GROUP)
     @ApiOperation(value = "Update inlong group")
     public Response<String> update(@Validated(UpdateValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         String operator = LoginUserUtils.getLoginUser().getName();
@@ -135,7 +136,7 @@ public class InlongGroupController {
 
     @RequestMapping(value = "/group/delete/{groupId}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete inlong group info")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.GROUP)
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
     public Response<Boolean> delete(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
@@ -144,7 +145,7 @@ public class InlongGroupController {
 
     @RequestMapping(value = "/group/deleteAsync/{groupId}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete inlong group info")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.GROUP)
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
     public Response<String> deleteAsync(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongRoleController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongRoleController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
@@ -58,7 +59,7 @@ public class InlongRoleController {
     }
 
     @RequestMapping(value = "/role/inlong/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.INLONG_ROLE)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     @ApiOperation(value = "Save inlong role")
     public Response<Integer> save(@Validated @RequestBody InlongRoleRequest request) {
@@ -67,7 +68,7 @@ public class InlongRoleController {
     }
 
     @RequestMapping(value = "/role/inlong/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.INLONG_ROLE)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     @ApiOperation(value = "Update inlong role")
     public Response<Boolean> update(@Validated @RequestBody InlongRoleRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongStreamController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongStreamController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.tool.excel.ExcelTool;
@@ -78,7 +79,7 @@ public class InlongStreamController {
     private InlongStreamProcessService streamProcessOperation;
 
     @RequestMapping(value = "/stream/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Save inlong stream")
     public Response<Integer> save(@RequestBody InlongStreamRequest request) {
         int result = streamService.save(request, LoginUserUtils.getLoginUser().getName());
@@ -133,7 +134,7 @@ public class InlongStreamController {
     }
 
     @RequestMapping(value = "/stream/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Update inlong stream")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody InlongStreamRequest request) {
         String username = LoginUserUtils.getLoginUser().getName();
@@ -190,7 +191,7 @@ public class InlongStreamController {
 
     @Deprecated
     @RequestMapping(value = "/stream/delete", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Delete inlong stream")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -62,7 +63,7 @@ public class InlongTenantController {
     }
 
     @RequestMapping(value = "/tenant/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Save inlong tenant")
     @RequiresRoles(INLONG_ADMIN)
     public Response<Integer> save(@Validated @RequestBody InlongTenantRequest request) {
@@ -76,7 +77,7 @@ public class InlongTenantController {
     }
 
     @RequestMapping(value = "/tenant/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Update inlong tenant")
     @RequiresRoles(INLONG_ADMIN)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody InlongTenantRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantRoleController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongTenantRoleController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
@@ -59,7 +60,7 @@ public class InlongTenantRoleController {
     }
 
     @RequestMapping(value = "/role/tenant/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TENANT_ROLE)
     @ApiOperation(value = "Save tenant role")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@Validated @RequestBody TenantRoleRequest request) {
@@ -68,7 +69,7 @@ public class InlongTenantRoleController {
     }
 
     @RequestMapping(value = "/role/tenant/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.TENANT_ROLE)
     @ApiOperation(value = "Update tenant role")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> update(@Validated @RequestBody TenantRoleRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/OperationLogController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/OperationLogController.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.controller;
+
+import org.apache.inlong.manager.pojo.common.PageResult;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogRequest;
+import org.apache.inlong.manager.pojo.operationLog.OperationLogResponse;
+import org.apache.inlong.manager.service.operationlog.OperationLogService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Operation record controller.
+ */
+@RestController
+@RequestMapping("/api")
+@Api(tags = "Operation log-API")
+public class OperationLogController {
+
+    @Autowired
+    private OperationLogService operationLogService;
+
+    @RequestMapping(value = "/operationLog/list", method = RequestMethod.POST)
+    @ApiOperation(value = "List operation log by paginating")
+    public Response<PageResult<OperationLogResponse>> listByCondition(@RequestBody OperationLogRequest request) {
+        return Response.success(operationLogService.listByCondition(request));
+    }
+
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSinkController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
 import org.apache.inlong.manager.common.validation.UpdateByKeyValidation;
@@ -59,7 +60,7 @@ public class StreamSinkController {
     private StreamSinkService sinkService;
 
     @RequestMapping(value = "/sink/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Save stream sink")
     public Response<Integer> save(@Validated @RequestBody SinkRequest request) {
         return Response.success(sinkService.save(request, LoginUserUtils.getLoginUser().getName()));
@@ -67,6 +68,7 @@ public class StreamSinkController {
 
     @RequestMapping(value = "/sink/get/{id}", method = RequestMethod.GET)
     @ApiOperation(value = "Get stream sink")
+    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.SINK)
     @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
     public Response<StreamSink> get(@PathVariable Integer id) {
         return Response.success(sinkService.get(id, LoginUserUtils.getLoginUser()));
@@ -79,14 +81,14 @@ public class StreamSinkController {
     }
 
     @RequestMapping(value = "/sink/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Update stream sink")
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody SinkRequest request) {
         return Response.success(sinkService.update(request, LoginUserUtils.getLoginUser().getName()));
     }
 
     @RequestMapping(value = "/sink/updateByKey", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Update stream sink by key")
     public Response<UpdateResult> updateByKey(
             @Validated(UpdateByKeyValidation.class) @RequestBody SinkRequest request) {
@@ -94,7 +96,7 @@ public class StreamSinkController {
     }
 
     @RequestMapping(value = "/sink/delete/{id}", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Delete stream sink")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "startProcess", dataTypeClass = boolean.class),
@@ -106,7 +108,7 @@ public class StreamSinkController {
     }
 
     @RequestMapping(value = "/sink/deleteByKey", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Delete stream sink by key")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "startProcess", dataTypeClass = boolean.class),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamSourceController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.SaveValidation;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
@@ -54,7 +55,7 @@ public class StreamSourceController {
     StreamSourceService sourceService;
 
     @RequestMapping(value = "/source/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Save stream source")
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody SourceRequest request) {
         return Response.success(sourceService.save(request, LoginUserUtils.getLoginUser().getName()));
@@ -74,14 +75,14 @@ public class StreamSourceController {
     }
 
     @RequestMapping(value = "/source/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Update stream source")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody SourceRequest request) {
         return Response.success(sourceService.update(request, LoginUserUtils.getLoginUser().getName()));
     }
 
     @RequestMapping(value = "/source/delete/{id}", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Delete stream source")
     @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> delete(@PathVariable Integer id) {
@@ -106,7 +107,7 @@ public class StreamSourceController {
     }
 
     @RequestMapping(value = "/source/forceDelete", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Force delete stream source by groupId and streamId")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "inlongGroupId", dataTypeClass = String.class, required = true),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamTransformController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/StreamTransformController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -52,7 +53,7 @@ public class StreamTransformController {
     protected StreamTransformService streamTransformService;
 
     @RequestMapping(value = "/transform/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TRANSFORM)
     @ApiOperation(value = "Save stream transform")
     public Response<Integer> save(@Validated @RequestBody TransformRequest request) {
         return Response.success(
@@ -73,7 +74,7 @@ public class StreamTransformController {
     }
 
     @RequestMapping(value = "/transform/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.TRANSFORM)
     @ApiOperation(value = "Update stream transform")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody TransformRequest request) {
         String operator = LoginUserUtils.getLoginUser().getName();
@@ -81,7 +82,7 @@ public class StreamTransformController {
     }
 
     @RequestMapping(value = "/transform/delete", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.TRANSFORM)
     @ApiOperation(value = "Delete stream transform")
     public Response<Boolean> delete(@Validated DeleteTransformRequest request) {
         String operator = LoginUserUtils.getLoginUser().getName();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowApproverController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -55,7 +56,7 @@ public class WorkflowApproverController {
     private WorkflowApproverService workflowApproverService;
 
     @PostMapping("/workflow/approver/save")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Save approver info")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@RequestBody ApproverRequest config) {
@@ -79,7 +80,7 @@ public class WorkflowApproverController {
     }
 
     @PostMapping("/workflow/approver/update")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Update approver info")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> update(@RequestBody ApproverRequest request) {
@@ -87,7 +88,7 @@ public class WorkflowApproverController {
     }
 
     @DeleteMapping("/workflow/approver/delete/{id}")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Delete approver by ID")
     @ApiImplicitParam(name = "id", value = "Workflow approver ID", dataTypeClass = Integer.class, required = true)
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
@@ -65,7 +66,7 @@ public class WorkflowController {
     private WorkflowService workflowService;
 
     @PostMapping("/workflow/start")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Initiation process")
     public Response<WorkflowResult> start(@RequestBody WorkflowOperationRequest request) {
         String applicant = LoginUserUtils.getLoginUser().getName();
@@ -73,7 +74,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/cancel/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Cancellation process")
     @ApiImplicitParam(name = "id", value = "Process ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> cancel(@PathVariable Integer id, @RequestBody WorkflowOperationRequest request) {
@@ -82,7 +83,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/continue/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Continue process")
     @ApiImplicitParam(name = "id", value = "Process ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> continueProcess(@PathVariable Integer id,
@@ -92,7 +93,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/approve/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Approval and consent")
     @ApiImplicitParam(name = "id", value = "Task ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> approve(@PathVariable Integer id, @RequestBody WorkflowApprovalRequest request) {
@@ -101,7 +102,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/reject/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Approval rejected")
     @ApiImplicitParam(name = "id", value = "Task ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> reject(@PathVariable Integer id, @RequestBody WorkflowApprovalRequest request) {
@@ -110,7 +111,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/transfer/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Turn to another approver", notes = "Change approver")
     @ApiImplicitParam(name = "id", value = "Task ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> transfer(@PathVariable Integer id, @RequestBody WorkflowApprovalRequest request) {
@@ -120,7 +121,7 @@ public class WorkflowController {
     }
 
     @PostMapping("/workflow/complete/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Complete task by ID")
     @ApiImplicitParam(name = "id", value = "Task ID", dataTypeClass = Integer.class, required = true)
     public Response<WorkflowResult> complete(@PathVariable Integer id, @RequestBody WorkflowApprovalRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowEventController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/WorkflowEventController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.enums.ProcessEvent;
 import org.apache.inlong.manager.common.enums.TaskEvent;
@@ -66,7 +67,7 @@ public class WorkflowEventController {
 
     @Deprecated
     @PostMapping("/workflow/event/executeEventListener/{id}")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Execute the listener based on the event log ID")
     @ApiImplicitParam(name = "id", value = "Event log ID", dataTypeClass = Integer.class, required = true)
     public Response<Object> executeEventListener(@PathVariable Integer id) {
@@ -76,7 +77,7 @@ public class WorkflowEventController {
 
     @Deprecated
     @PostMapping("/workflow/event/executeProcessEventListener")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Re-execute the specified listener based on the process ID")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "processId", value = "Process ID", dataTypeClass = Integer.class),
@@ -90,7 +91,7 @@ public class WorkflowEventController {
 
     @Deprecated
     @PostMapping("/workflow/event/executeTaskEventListener")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Re-execute the specified listener based on the task ID")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "taskId", value = "Task ID", dataTypeClass = Integer.class),
@@ -103,7 +104,7 @@ public class WorkflowEventController {
 
     @Deprecated
     @PostMapping("/workflow/event/triggerProcessEvent")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Re-trigger the process event based on the process ID")
     public Response<Object> triggerProcessEvent(
             @ApiParam(value = "process id", required = true) Integer processId,
@@ -114,7 +115,7 @@ public class WorkflowEventController {
 
     @Deprecated
     @PostMapping("/workflow/event/triggerTaskEvent")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.WORKFLOW)
     @ApiOperation(value = "Re-trigger the task event based on the task ID")
     public Response<Object> triggerTaskEvent(
             @ApiParam(value = "task id", required = true) Integer taskId,

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenDataNodeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenDataNodeController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.SaveValidation;
@@ -75,7 +76,7 @@ public class OpenDataNodeController {
 
     @PostMapping(value = "/node/save")
     @ApiOperation(value = "Save node")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.NODE)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody DataNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -84,7 +85,7 @@ public class OpenDataNodeController {
 
     @PostMapping(value = "/node/update")
     @ApiOperation(value = "Update data node")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.NODE)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody DataNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.REQUEST_IS_EMPTY);
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -93,7 +94,7 @@ public class OpenDataNodeController {
 
     @DeleteMapping(value = "/node/delete/{id}")
     @ApiOperation(value = "Delete data node by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.NODE)
     @ApiImplicitParam(name = "id", value = "Data node ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> delete(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "data node id cannot be null");

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.common.util.Preconditions;
@@ -94,7 +95,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/tag/save")
     @ApiOperation(value = "Save cluster tag")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Integer> saveTag(@Validated(SaveValidation.class) @RequestBody ClusterTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -102,7 +103,7 @@ public class OpenInLongClusterController {
     }
 
     @PostMapping(value = "/cluster/tag/update")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster tag")
     public Response<Boolean> updateTag(@Validated(UpdateValidation.class) @RequestBody ClusterTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -112,7 +113,7 @@ public class OpenInLongClusterController {
 
     @DeleteMapping(value = "/cluster/tag/delete/{id}")
     @ApiOperation(value = "Delete cluster tag by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster tag ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> deleteTag(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "tag id cannot be null");
@@ -141,7 +142,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/save")
     @ApiOperation(value = "Save cluster")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -150,7 +151,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/update")
     @ApiOperation(value = "Update cluster")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -159,7 +160,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/bindTag")
     @ApiOperation(value = "Bind or unbind cluster tag")
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Boolean> bindTag(@Validated @RequestBody BindTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -168,7 +169,7 @@ public class OpenInLongClusterController {
 
     @DeleteMapping(value = "/cluster/delete/{id}")
     @ApiOperation(value = "Delete cluster by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> delete(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "cluster id cannot be null");
@@ -200,7 +201,7 @@ public class OpenInLongClusterController {
             @ApiImplicitParam(name = "clusterType", dataTypeClass = String.class, required = true),
             @ApiImplicitParam(name = "protocolType", dataTypeClass = String.class, required = false)
     })
-    @OperationLog(operation = OperationType.GET)
+    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.CLUSTER)
     public Response<List<ClusterNodeResponse>> listByGroupId(@RequestParam String inlongGroupId,
             @RequestParam String clusterType, @RequestParam(required = false) String protocolType) {
         Preconditions.expectNotBlank(inlongGroupId, ErrorCodeEnum.INVALID_PARAMETER, "inlongGroupId cannot be blank");
@@ -212,7 +213,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/node/save")
     @ApiOperation(value = "Save cluster node")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     public Response<Integer> saveNode(@Validated @RequestBody ClusterNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -220,7 +221,7 @@ public class OpenInLongClusterController {
     }
 
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster node")
     public Response<Boolean> updateNode(@Validated(UpdateValidation.class) @RequestBody ClusterNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -230,7 +231,7 @@ public class OpenInLongClusterController {
 
     @RequestMapping(value = "/cluster/node/delete/{id}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete cluster node")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> deleteNode(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "cluster id cannot be null");
@@ -240,7 +241,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/tenant/tag/save")
     @ApiOperation(value = "Save tenant cluster tag")
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Integer> saveTenantTag(
             @Validated(SaveValidation.class) @RequestBody TenantClusterTagRequest request) {
@@ -270,7 +271,7 @@ public class OpenInLongClusterController {
 
     @DeleteMapping(value = "/cluster/tenant/tag/delete/{id}")
     @ApiOperation(value = "Delete tenant cluster tag by id")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster tag ID", dataTypeClass = Integer.class, required = true)
     @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteTenantTag(@PathVariable Integer id) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongGroupController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.SaveValidation;
@@ -79,7 +80,7 @@ public class OpenInLongGroupController {
     }
 
     @RequestMapping(value = "/group/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.GROUP)
     @ApiOperation(value = "Save inlong group")
     public Response<String> save(@Validated(SaveValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         Preconditions.expectNotNull(groupRequest, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -88,7 +89,7 @@ public class OpenInLongGroupController {
     }
 
     @RequestMapping(value = "/group/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.GROUP)
     @ApiOperation(value = "Update inlong group")
     public Response<String> update(@Validated(UpdateValidation.class) @RequestBody InlongGroupRequest groupRequest) {
         Preconditions.expectNotNull(groupRequest, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -98,7 +99,7 @@ public class OpenInLongGroupController {
 
     @RequestMapping(value = "/group/delete/{groupId}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete inlong group info")
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.GROUP)
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
     public Response<Boolean> delete(@PathVariable String groupId) {
         Preconditions.expectNotBlank(groupId, ErrorCodeEnum.INVALID_PARAMETER, "groupId cannot be blank");

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongStreamController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongStreamController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
@@ -96,7 +97,7 @@ public class OpenInLongStreamController {
     }
 
     @RequestMapping(value = "/stream/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Save inlong stream")
     public Response<Integer> save(@RequestBody InlongStreamRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -105,7 +106,7 @@ public class OpenInLongStreamController {
     }
 
     @RequestMapping(value = "/stream/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Update inlong stream")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody InlongStreamRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -114,7 +115,7 @@ public class OpenInLongStreamController {
     }
 
     @RequestMapping(value = "/stream/delete", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Delete inlong stream")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongConsumeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongConsumeController.java
@@ -115,11 +115,4 @@ public class OpenInlongConsumeController {
         return Response.success(consumeProcessService.startProcess(id, username));
     }
 
-    @RequestMapping(value = "/consume/autoAdd", method = RequestMethod.POST)
-    @ApiOperation(value = "Auto add inlong consume")
-    public Response<Integer> autoAdd(@RequestBody InlongConsumeRequest request) {
-        String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(consumeService.autoAdd(request, operator));
-    }
-
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongConsumeController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongConsumeController.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.web.controller;
+package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
@@ -52,9 +52,9 @@ import org.springframework.web.bind.annotation.RestController;
  * Inlong consume control layer
  */
 @RestController
-@RequestMapping("/api")
-@Api(tags = "Inlong-Consume-API")
-public class InlongConsumeController {
+@RequestMapping("/openapi")
+@Api(tags = "Open-Consume-API")
+public class OpenInlongConsumeController {
 
     @Autowired
     private InlongConsumeService consumeService;
@@ -113,6 +113,13 @@ public class InlongConsumeController {
     public Response<WorkflowResult> startProcess(@PathVariable(name = "id") Integer id) {
         String username = LoginUserUtils.getLoginUser().getName();
         return Response.success(consumeProcessService.startProcess(id, username));
+    }
+
+    @RequestMapping(value = "/consume/autoAdd", method = RequestMethod.POST)
+    @ApiOperation(value = "Auto add inlong consume")
+    public Response<Integer> autoAdd(@RequestBody InlongConsumeRequest request) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(consumeService.autoAdd(request, operator));
     }
 
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongTenantController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongTenantController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller.openapi;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
 import org.apache.inlong.manager.pojo.common.PageResult;
@@ -55,7 +56,7 @@ public class OpenInlongTenantController {
     }
 
     @RequestMapping(value = "/tenant/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Save inlong tenant")
     public Response<Integer> save(@Validated @RequestBody InlongTenantRequest request) {
         return Response.success(tenantService.save(request));
@@ -68,7 +69,7 @@ public class OpenInlongTenantController {
     }
 
     @RequestMapping(value = "/tenant/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Update inlong tenant")
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody InlongTenantRequest request) {
         return Response.success(tenantService.update(request));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongTenantRoleController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInlongTenantRoleController.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.web.controller.openapi;
 
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.pojo.common.Response;
@@ -59,7 +60,7 @@ public class OpenInlongTenantRoleController {
     }
 
     @RequestMapping(value = "/role/tenant/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Save tenant role")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Integer> save(@Validated @RequestBody TenantRoleRequest request) {
@@ -68,7 +69,7 @@ public class OpenInlongTenantRoleController {
     }
 
     @RequestMapping(value = "/role/tenant/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.TENANT)
     @ApiOperation(value = "Update tenant role")
     @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.TENANT_ADMIN, UserRoleCode.INLONG_ADMIN})
     public Response<Boolean> update(@Validated @RequestBody TenantRoleRequest request) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamSinkController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamSinkController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.UpdateByIdValidation;
@@ -57,6 +58,7 @@ public class OpenStreamSinkController {
 
     @RequestMapping(value = "/sink/get/{id}", method = RequestMethod.GET)
     @ApiOperation(value = "Get stream sink")
+    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.SINK)
     @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
     public Response<StreamSink> get(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "sinkId cannot be null");
@@ -73,7 +75,7 @@ public class OpenStreamSinkController {
     }
 
     @RequestMapping(value = "/sink/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Save stream sink")
     public Response<Integer> save(@Validated @RequestBody SinkRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -82,7 +84,7 @@ public class OpenStreamSinkController {
     }
 
     @RequestMapping(value = "/sink/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Update stream sink")
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody SinkRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -91,7 +93,7 @@ public class OpenStreamSinkController {
     }
 
     @RequestMapping(value = "/sink/delete/{id}", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SINK)
     @ApiOperation(value = "Delete stream sink")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "startProcess", dataTypeClass = boolean.class),

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamSourceController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamSourceController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.SaveValidation;
@@ -71,7 +72,7 @@ public class OpenStreamSourceController {
     }
 
     @RequestMapping(value = "/source/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Save stream source")
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody SourceRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -80,7 +81,7 @@ public class OpenStreamSourceController {
     }
 
     @RequestMapping(value = "/source/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Update stream source")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody SourceRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -89,7 +90,7 @@ public class OpenStreamSourceController {
     }
 
     @RequestMapping(value = "/source/delete/{id}", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.DELETE)
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SOURCE)
     @ApiOperation(value = "Delete stream source")
     @ApiImplicitParam(name = "id", dataTypeClass = Integer.class, required = true)
     public Response<Boolean> delete(@PathVariable Integer id) {

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamTransformController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenStreamTransformController.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.web.controller.openapi;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.OperationTarget;
 import org.apache.inlong.manager.common.enums.OperationType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
@@ -63,7 +64,7 @@ public class OpenStreamTransformController {
     }
 
     @RequestMapping(value = "/transform/save", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.CREATE)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Save stream transform")
     public Response<Integer> save(@Validated @RequestBody TransformRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -73,7 +74,7 @@ public class OpenStreamTransformController {
     }
 
     @RequestMapping(value = "/transform/update", method = RequestMethod.POST)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Update stream transform")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody TransformRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
@@ -82,7 +83,7 @@ public class OpenStreamTransformController {
     }
 
     @RequestMapping(value = "/transform/delete", method = RequestMethod.DELETE)
-    @OperationLog(operation = OperationType.UPDATE)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.STREAM)
     @ApiOperation(value = "Delete stream transform")
     public Response<Boolean> delete(@Validated DeleteTransformRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #9337 

### Motivation

Support querying operation records.
1.For `operation_log` table has added `operation_target`, `inlong_stream_id`, `inlong_group_id` field.
2.supports querying operation log records based on `inlongGroupId`, `inlongStreamId`, and operation request time.
3.The return values are operation time, operation object, and whether the operation was successful.

Through this query operation record, it is possible to query which operations were performed in a certain `inlongGroup` during a certain time period, whether these operations were successful, and effectively record the parameters of information changes.

### Modifications

Support querying operation records.
