### PR TITLE
[INLONG-9347][Agent] Check task profile before save into db

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Task.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Task.java
@@ -49,4 +49,9 @@ public abstract class Task extends AbstractStateWrapper {
      * get task id
      */
     public abstract String getTaskId();
+
+    /**
+     * is profile valid
+     */
+    public abstract boolean isProfileValid(TaskProfile profile);
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
@@ -369,6 +369,10 @@ public class TaskManager extends AbstractDaemon {
             LOGGER.error("taskMap size {} over limit {}", taskMap.size(), taskMaxLimit);
             return;
         }
+        if (!isProfileValid(taskProfile)) {
+            LOGGER.error("task profile invalid {}", taskProfile.toJsonStr());
+            return;
+        }
         addToDb(taskProfile);
         TaskStateEnum state = TaskStateEnum.getTaskState(taskProfile.getInt(TASK_STATE));
         if (state == TaskStateEnum.RUNNING) {
@@ -415,6 +419,17 @@ public class TaskManager extends AbstractDaemon {
             task.destroy();
         });
         taskMap.clear();
+    }
+
+    private boolean isProfileValid(TaskProfile profile) {
+        try {
+            Class<?> taskClass = Class.forName(profile.getTaskClass());
+            Task task = (Task) taskClass.newInstance();
+            return task.isProfileValid(profile);
+        } catch (Throwable t) {
+            LOGGER.error("isProfileValid error: ", t);
+        }
+        return false;
     }
 
     /**

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/MockTask.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/MockTask.java
@@ -58,6 +58,11 @@ public class MockTask extends Task {
     }
 
     @Override
+    public boolean isProfileValid(TaskProfile profile) {
+        return true;
+    }
+
+    @Override
     public void addCallbacks() {
 
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/CronTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/CronTask.java
@@ -52,6 +52,11 @@ public class CronTask extends Task {
     }
 
     @Override
+    public boolean isProfileValid(TaskProfile profile) {
+        return true;
+    }
+
+    @Override
     public void addCallbacks() {
 
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/LogFileCollectTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/LogFileCollectTask.java
@@ -97,10 +97,6 @@ public class LogFileCollectTask extends Task {
 
     @Override
     public void init(Object srcManager, TaskProfile taskProfile, Db basicDb) throws IOException {
-        if (!isProfileValid(taskProfile)) {
-            LOGGER.error("task profile invalid {}", taskProfile.toJsonStr());
-            return;
-        }
         taskManager = (TaskManager) srcManager;
         commonInit(taskProfile, basicDb);
         if (retry) {
@@ -129,7 +125,8 @@ public class LogFileCollectTask extends Task {
         }
     }
 
-    private boolean isProfileValid(TaskProfile profile) {
+    @Override
+    public boolean isProfileValid(TaskProfile profile) {
         if (!profile.allRequiredKeyExist()) {
             LOGGER.error("task profile needs all required key");
             return false;


### PR DESCRIPTION
[INLONG-9347][Agent] Check task profile before save into db
- Fixes #9347

### Motivation

Check task profile before save into db

### Modifications

Check task profile before save into db

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
