### PR TITLE
[INLONG-9369][Agent] Increase sending failure audit and real-time audit

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -41,7 +41,11 @@ public class AuditUtils {
     public static final String AUDIT_KEY_MAX_CACHE_ROWS = "audit.maxCacheRows";
     public static final int AUDIT_DEFAULT_MAX_CACHE_ROWS = 2000000;
     public static final int AUDIT_ID_AGENT_READ_SUCCESS = 3;
+    public static final int AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME = 200;
     public static final int AUDIT_ID_AGENT_SEND_SUCCESS = 4;
+    public static final int AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME = 300;
+    public static final int AUDIT_ID_AGENT_SEND_FAILED = 201;
+    public static final int AUDIT_ID_AGENT_SEND_FAILED_REAL_TIME = 202;
 
     private static boolean IS_AUDIT = true;
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -41,11 +41,11 @@ public class AuditUtils {
     public static final String AUDIT_KEY_MAX_CACHE_ROWS = "audit.maxCacheRows";
     public static final int AUDIT_DEFAULT_MAX_CACHE_ROWS = 2000000;
     public static final int AUDIT_ID_AGENT_READ_SUCCESS = 3;
-    public static final int AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME = 200;
     public static final int AUDIT_ID_AGENT_SEND_SUCCESS = 4;
-    public static final int AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME = 300;
-    public static final int AUDIT_ID_AGENT_SEND_FAILED = 201;
-    public static final int AUDIT_ID_AGENT_SEND_FAILED_REAL_TIME = 202;
+    public static final int AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME = 25;
+    public static final int AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME = 26;
+    public static final int AUDIT_ID_AGENT_SEND_FAILED = 10004;
+    public static final int AUDIT_ID_AGENT_SEND_FAILED_REAL_TIME = 10026;
 
     private static boolean IS_AUDIT = true;
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
@@ -346,11 +346,17 @@ public class SenderManager {
                 getMetricItem(groupId, streamId).pluginSendSuccessCount.addAndGet(msgCnt);
                 AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_SUCCESS, groupId, streamId,
                         dataTime, message.getMsgCnt(), message.getTotalSize());
+                AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME, groupId, streamId,
+                        AgentUtils.getCurrentTime(), message.getMsgCnt(), message.getTotalSize());
             } else {
                 LOGGER.warn("send groupId {}, streamId {}, taskId {}, instanceId {}, dataTime {} fail with times {}, "
                         + "error {}", groupId, streamId, taskId, instanceId, dataTime, retry, result);
                 getMetricItem(groupId, streamId).pluginSendFailCount.addAndGet(msgCnt);
                 putInResendQueue(new AgentSenderCallback(message, retry));
+                AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_FAILED, groupId, streamId,
+                        dataTime, message.getMsgCnt(), message.getTotalSize());
+                AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_SEND_FAILED_REAL_TIME, groupId, streamId,
+                        AgentUtils.getCurrentTime(), message.getMsgCnt(), message.getTotalSize());
             }
         }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -319,6 +319,8 @@ public class LogFileSource extends AbstractSource {
                         if (overLen) {
                             LOGGER.warn("readLines over len finally string len {}",
                                     new String(baos.toByteArray()).length());
+                            AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME, inlongGroupId,
+                                    inlongStreamId, AgentUtils.getCurrentTime(), 1, maxPackSize);
                         }
                         baos.reset();
                         overLen = false;
@@ -382,6 +384,8 @@ public class LogFileSource extends AbstractSource {
         }
         AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_READ_SUCCESS, inlongGroupId, header.get(PROXY_KEY_STREAM_ID),
                 auditTime, 1, msgWithMetaData.length());
+        AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME, inlongGroupId, header.get(PROXY_KEY_STREAM_ID),
+                AgentUtils.getCurrentTime(), 1, msgWithMetaData.length());
         Message finalMsg = new DefaultMessage(msgWithMetaData.getBytes(StandardCharsets.UTF_8), header);
         // if the message size is greater than max pack size,should drop it.
         if (finalMsg.getBody().length > maxPackSize) {


### PR DESCRIPTION
[INLONG-9369][Agent] Increase sending failure audit and real-time audit
- Fixes #9369 

### Motivation

Increase sending failure audit and real-time audit

### Modifications

Increase sending failure audit and real-time audit

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
