### PR TITLE
[INLONG-9375][Agent] Modify the agent's real-time audit id to prevent duplication

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -42,8 +42,8 @@ public class AuditUtils {
     public static final int AUDIT_DEFAULT_MAX_CACHE_ROWS = 2000000;
     public static final int AUDIT_ID_AGENT_READ_SUCCESS = 3;
     public static final int AUDIT_ID_AGENT_SEND_SUCCESS = 4;
-    public static final int AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME = 25;
-    public static final int AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME = 26;
+    public static final int AUDIT_ID_AGENT_READ_SUCCESS_REAL_TIME = 47;
+    public static final int AUDIT_ID_AGENT_SEND_SUCCESS_REAL_TIME = 48;
     public static final int AUDIT_ID_AGENT_SEND_FAILED = 10004;
     public static final int AUDIT_ID_AGENT_SEND_FAILED_REAL_TIME = 10026;
 


### PR DESCRIPTION
[INLONG-9375][Agent] Modify the agent's real-time audit id to prevent duplication
- Fixes #9375 

### Motivation
Modify the agent's real-time audit id to prevent duplication
### Modifications
Modify the agent's real-time audit id to prevent duplication
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
