### PR TITLE
[INLONG-9388][Sort] Updated version of embedded-redis in sort-connector-redis

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -73,9 +73,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <version>0.6</version>
+            <version>1.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+        <embedded.redis.version>1.1.0</embedded.redis.version>
     </properties>
 
     <dependencies>
@@ -75,7 +76,7 @@
         <dependency>
             <groupId>com.github.codemonstur</groupId>
             <artifactId>embedded-redis</artifactId>
-            <version>1.1.0</version>
+            <version>${embedded.redis.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -29,7 +29,6 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
-        <embedded.redis.version>1.1.0</embedded.redis.version>
     </properties>
 
     <dependencies>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.embedded.RedisServer;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -45,14 +46,14 @@ public class RedisTableTest {
     private static RedisServer redisServer;
 
     @BeforeClass
-    public static void setup() {
+    public static void setup() throws IOException {
         redisPort = NetUtils.getAvailablePort();
-        redisServer = RedisServer.builder().setting("maxmemory 128m").port(redisPort).build();
+        redisServer = RedisServer.newRedisServer().setting("maxmemory 128m").port(redisPort).build();
         redisServer.start();
     }
 
     @AfterClass
-    public static void cleanup() {
+    public static void cleanup() throws IOException {
         if (redisServer != null) {
             redisServer.stop();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <dockerfile.maven.version>1.4.13</dockerfile.maven.version>
         <testcontainers.version>1.17.2</testcontainers.version>
         <docker.organization>inlong</docker.organization>
+        <embedded.redis.version>1.1.0</embedded.redis.version>
 
         <netty.version>4.1.94.Final</netty.version>
         <jboss.netty.version>3.10.6.Final</jboss.netty.version>


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9388 

### Motivation

The current version of embedded-redis does not support macOS Sonoma.
