### PR TITLE
[INLONG-9390][Agent] Collect supplementary data in chronological order

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -78,6 +78,7 @@ public class InstanceManager extends AbstractDaemon {
     private final String taskId;
     private volatile boolean runAtLeastOneTime = false;
     private volatile boolean running = false;
+    private final double reserveCoefficient = 0.8;
 
     private class InstancePrintStat {
 
@@ -438,6 +439,10 @@ public class InstanceManager extends AbstractDaemon {
             }
             return false;
         }
+    }
+
+    public boolean isFull() {
+        return (instanceMap.size() + actionQueue.size()) >= instanceLimit * reserveCoefficient;
     }
 
     public boolean allInstanceFinished() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/FileInstance.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/FileInstance.java
@@ -94,11 +94,6 @@ public class FileInstance extends Instance {
         running = true;
         while (!isFinished()) {
             if (!source.sourceExist()) {
-                if (profile.isRetry()) {
-                    handleReadEnd();
-                } else {
-                    handleSourceDeleted();
-                }
                 handleSourceDeleted();
                 break;
             }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/FileScanner.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/FileScanner.java
@@ -57,9 +57,23 @@ public class FileScanner {
 
     private static final Logger logger = LoggerFactory.getLogger(FileScanner.class);
 
+    public static List<String> getDataTimeList(long startTime, long endTime, String cycleUnit, String timeOffset,
+            boolean isRetry) {
+        if (!isRetry) {
+            startTime += DateTransUtils.calcOffset(timeOffset);
+            endTime += DateTransUtils.calcOffset(timeOffset);
+        }
+        List<String> dataTimeList = new ArrayList<>();
+        List<Long> dateRegion = NewDateUtils.getDateRegion(startTime, endTime, cycleUnit);
+        for (Long time : dateRegion) {
+            String dataTime = DateTransUtils.millSecConvertToTimeStr(time, cycleUnit);
+            dataTimeList.add(dataTime);
+        }
+        return dataTimeList;
+    }
+
     public static List<BasicFileInfo> scanTaskBetweenTimes(String originPattern, String cycleUnit, String timeOffset,
-            long startTime,
-            long endTime, boolean isRetry) {
+            long startTime, long endTime, boolean isRetry) {
         if (!isRetry) {
             startTime += DateTransUtils.calcOffset(timeOffset);
             endTime += DateTransUtils.calcOffset(timeOffset);
@@ -69,12 +83,12 @@ public class FileScanner {
         logger.info("{} scan time is between {} and {}",
                 new Object[]{originPattern, strStartTime, strEndTime});
 
-        return scanTaskBetweenTimes(cycleUnit, originPattern, strStartTime, strEndTime);
+        return scanTaskBetweenTimes(cycleUnit, originPattern, startTime, endTime);
     }
 
     /* Scan log files and create tasks between two times. */
-    public static List<BasicFileInfo> scanTaskBetweenTimes(String cycleUnit, String originPattern, String startTime,
-            String endTime) {
+    public static List<BasicFileInfo> scanTaskBetweenTimes(String cycleUnit, String originPattern, long startTime,
+            long endTime) {
         List<Long> dateRegion = NewDateUtils.getDateRegion(startTime, endTime, cycleUnit);
         List<BasicFileInfo> infos = new ArrayList<BasicFileInfo>();
         for (Long time : dateRegion) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/WatchEntity.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/filecollect/WatchEntity.java
@@ -59,12 +59,10 @@ public class WatchEntity {
     private final Map<String, WatchKey> pathToKeys = new ConcurrentHashMap<String, WatchKey>();
     private final String dirSeparator = System.getProperty("file.separator");
     private String cycleUnit;
-    private String timeOffset;
 
     public WatchEntity(WatchService watchService,
             String originPattern,
-            String cycleUnit,
-            String timeOffset) {
+            String cycleUnit) {
         this.watchService = watchService;
         this.originPattern = originPattern;
         ArrayList<String> directoryLayers = FilePathUtil.getDirectoryLayers(originPattern);
@@ -83,7 +81,6 @@ public class WatchEntity {
         this.dateExpression = DateUtils.extractLongestTimeRegexWithPrefixOrSuffix(originPattern);
         this.containRegexPattern = isPathContainRegexPattern();
         this.cycleUnit = cycleUnit;
-        this.timeOffset = timeOffset;
         logger.info("add a new watchEntity {}", this);
     }
 
@@ -343,10 +340,6 @@ public class WatchEntity {
 
     public String getCycleUnit() {
         return cycleUnit;
-    }
-
-    public String getTimeOffset() {
-        return timeOffset;
     }
 
     public String getOriginPattern() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/file/NewDateUtils.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/utils/file/NewDateUtils.java
@@ -544,23 +544,8 @@ public class NewDateUtils {
         return cycleUnit;
     }
 
-    // start: 20120810
-    // end: 20120817
-    // timeval: YYYYMMDDhh
-    public static List<Long> getDateRegion(String start, String end,
-            String cycleUnit) {
-        // TODO : timeval verify
-
+    public static List<Long> getDateRegion(long startTime, long endTime, String cycleUnit) {
         List<Long> ret = new ArrayList<Long>();
-        long startTime;
-        long endTime;
-        try {
-            startTime = DateTransUtils.timeStrConvertToMillSec(start, cycleUnit);
-            endTime = DateTransUtils.timeStrConvertToMillSec(end, cycleUnit);
-        } catch (ParseException e) {
-            logger.error("date format is error: ", e);
-            return ret;
-        }
         DateTime dtStart = DateTime.forInstant(startTime, TimeZone.getDefault());
         DateTime dtEnd = DateTime.forInstant(endTime, TimeZone.getDefault());
 
@@ -593,7 +578,7 @@ public class NewDateUtils {
         } else if (cycleUnit.equalsIgnoreCase("s")) {
             second = 1;
         } else {
-            logger.error("cycelUnit {} is error: ", cycleUnit);
+            logger.error("cycleUnit {} is error: ", cycleUnit);
             return ret;
         }
         while (dtStart.lteq(dtEnd)) {
@@ -601,7 +586,6 @@ public class NewDateUtils {
             dtStart = dtStart.plus(year, month, day, hour, minute, second, 0,
                     DateTime.DayOverflow.LastDay);
         }
-
         return ret;
     }
 }


### PR DESCRIPTION
[INLONG-9390][Agent] Collect supplementary data in chronological order
- Fixes #9390 

### Motivation
Collect supplementary data in chronological order, and prioritize data from the current cycle
### Modifications
Collect supplementary data in chronological order, and prioritize data from the current cycle

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
