### PR TITLE
[INLONG-9397][Agent] Do not directly delete the instance records of the local db when stopping the instances

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -417,7 +417,7 @@ public class InstanceManager extends AbstractDaemon {
 
     private void stopAllInstances() {
         instanceMap.values().forEach((instance) -> {
-            deleteInstance(instance.getInstanceId());
+            deleteFromMemory(instance.getInstanceId());
         });
         instanceMap.clear();
     }


### PR DESCRIPTION
[INLONG-9397][Agent] Do not directly delete the instance records of the local db when stopping the instances
- Fixes #9397 

### Motivation

Do not directly delete the instance records of the local db when stopping the instance to prevent data duplication

### Modifications

Do not directly delete the instance records of the local db when stopping the instance to prevent data duplication

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
