### PR TITLE
[INLONG-9459][Sort] Fix redis table test cannot run on some operation systems

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -29,6 +29,7 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+        <embedded-redis.version>0.7.3</embedded-redis.version>
     </properties>
 
     <dependencies>
@@ -73,11 +74,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.codemonstur</groupId>
+            <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
-            <version>${embedded.redis.version}</version>
+            <version>${embedded-redis.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-planner_${flink.scala.binary.version}</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/test/java/org/apache/inlong/sort/redis/RedisTableTest.java
@@ -28,8 +28,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.embedded.RedisServer;
-
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
@@ -46,14 +44,14 @@ public class RedisTableTest {
     private static RedisServer redisServer;
 
     @BeforeClass
-    public static void setup() throws IOException {
+    public static void setup() {
         redisPort = NetUtils.getAvailablePort();
-        redisServer = RedisServer.newRedisServer().setting("maxmemory 128m").port(redisPort).build();
+        redisServer = new RedisServer(redisPort);
         redisServer.start();
     }
 
     @AfterClass
-    public static void cleanup() throws IOException {
+    public static void cleanup() {
         if (redisServer != null) {
             redisServer.stop();
         }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9459 

### Motivation


com.github.codemonstur
embedded-redis

which is out dated with its upstream ozimov:master as https://github.com/ozimov/embedded-redis

this bug is fixed in latest version of ozimov

### Modifications

use redis in latest version of ozimov redis embedded

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
