### PR TITLE
[INLONG-9465][CVE] Bump zookeeper to 3.7.2

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
@@ -30,13 +30,11 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
-        <zookeeper.version>3.4.14</zookeeper.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- HBase only works with ZooKeeper 3.4 -->
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hbase/pom.xml
@@ -31,13 +31,11 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
-        <zookeeper.version>3.4.14</zookeeper.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <!-- HBase only works with ZooKeeper 3.4 -->
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>

--- a/licenses/inlong-manager/notices/NOTICE-flink-shaded-zookeeper-3.txt
+++ b/licenses/inlong-manager/notices/NOTICE-flink-shaded-zookeeper-3.txt
@@ -18,7 +18,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.curator:curator-client:4.2.0
 - org.apache.curator:curator-framework:4.2.0
 - org.apache.curator:curator-recipes:4.2.0
-- org.apache.zookeeper:zookeeper:3.4.14
+- org.apache.zookeeper:zookeeper:3.7.2
 
 
 Curator Recipes

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -1043,7 +1043,7 @@ The text of each license is the standard Apache 2.0 license.
   com.tdunning:t-digest:3.2 - T-Digest (https://github.com/tdunning/t-digest/tree/t-digest-3.2), (The Apache Software License, Version 2.0)
   javax.validation:validation-api:1.1.0.Final - Bean Validation API (http://beanvalidation.org), (The Apache Software License, Version 2.0)
   com.fasterxml.woodstox:woodstox-core:5.4.0 - Woodstox (https://github.com/FasterXML/woodstox/tree/woodstox-core-5.4.0), (The Apache License, Version 2.0)
-  org.apache.zookeeper:zookeeper:3.4.14 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.4.14/zookeeper-server), (Apache License, Version 2.0)
+  org.apache.zookeeper:zookeeper:3.7.2 - Apache ZooKeeper - Server (https://github.com/apache/zookeeper/tree/release-3.7.2/zookeeper-server), (Apache License, Version 2.0)
   org.ini4j:ini4j:0.5.1 - ini4j (https://sourceforge.net/projects/ini4j), (The Apache Software License, Version 2.0)
   org.apache.doris:flink-doris-connector-1.13_2.11:1.0.3 - Flink Connector for Apache Doris (https://github.com/apache/doris-flink-connector/tree/1.13_2.11-1.0.3), (The Apache Software License, Version 2.0)
   com.amazonaws:aws-java-sdk-s3:jar:1.12.346 - AWS Java SDK for Amazon S3 (https://aws.amazon.com/sdkforjava), (The Apache Software License, Version 2.0)


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9465

### Motivation

Bump zookeeper to 3.7.2 to fix the CVE, and 3.7.2 is compatible with HBase.
