### PR TITLE
[INLONG-9477][CVE] Bump kafka-client to 2.7.2

### DIFF
--- a/licenses/inlong-agent/LICENSE
+++ b/licenses/inlong-agent/LICENSE
@@ -473,7 +473,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.eclipse.jetty:jetty-servlets:9.4.43.v20210629 - Jetty :: Utility Servlets and Filters (https://eclipse.org/jetty/jetty-servlets), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.eclipse.jetty:jetty-util:9.4.48.v20220622 - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.eclipse.jetty:jetty-util-ajax:9.4.48.v20220622 - Jetty :: Utilities :: Ajax(JSON) (https://eclipse.org/jetty/jetty-util-ajax), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
-  org.apache.kafka:kafka_2.11:2.4.1 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
+  org.apache.kafka:kafka_2.12:2.7.2 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
   org.apache.kafka:kafka-clients:3.0.0 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
   org.apache.thrift:libthrift:0.9.3 - Apache Thrift (http://thrift.apache.org),  (The Apache Software License, Version 2.0)
   log4j:log4j:1.2.17 - Apache Log4j (http://logging.apache.org/log4j/1.2/), (The Apache Software License, Version 2.0)

--- a/licenses/inlong-dataproxy/LICENSE
+++ b/licenses/inlong-dataproxy/LICENSE
@@ -431,7 +431,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
   org.eclipse.jetty:jetty-servlet:9.4.48.v20220622 - Jetty :: Servlet Handling (https://eclipse.org/jetty/jetty-servlet), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.eclipse.jetty:jetty-util:9.4.48.v20220622 - Jetty :: Utilities (https://eclipse.org/jetty/jetty-util), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
   org.eclipse.jetty:jetty-util-ajax:9.4.48.v20220622 - Jetty :: Utilities :: Ajax(JSON) (https://eclipse.org/jetty/jetty-util-ajax), (Apache Software License - Version 2.0;  Eclipse Public License - Version 1.0)
-  org.apache.kafka:kafka-clients:2.4.1 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
+  org.apache.kafka:kafka-clients:2.7.2 - Apache Kafka (https://kafka.apache.org), (The Apache Software License, Version 2.0)
   org.apache.thrift:libthrift:0.9.3 - Apache Thrift (http://thrift.apache.org), (The Apache Software License, Version 2.0)
   org.apache.logging.log4j:log4j-api:2.17.2 - Apache Log4j API (https://logging.apache.org/log4j/2.x/log4j-api/), (Apache License, Version 2.0)
   org.apache.logging.log4j:log4j-core:2.17.2 - Apache Log4j Core (https://logging.apache.org/log4j/2.x/log4j-core/), (Apache License, Version 2.0)

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 
         <netty.version>4.1.94.Final</netty.version>
         <jboss.netty.version>3.10.6.Final</jboss.netty.version>
-        <scala.binary.version>2.11</scala.binary.version>
+        <scala.binary.version>2.12</scala.binary.version>
         <spark.version>2.4.4</spark.version>
 
         <simpleclient.httpserver.version>0.14.1</simpleclient.httpserver.version>
@@ -155,7 +155,7 @@
         <aws.sdk.version>1.12.346</aws.sdk.version>
         <zookeeper.version>3.7.2</zookeeper.version>
         <pulsar.version>2.8.4</pulsar.version>
-        <kafka.version>2.4.1</kafka.version>
+        <kafka.version>2.7.2</kafka.version>
         <iceberg.version>1.3.1</iceberg.version>
         <flink.jackson.version>2.12.1-13.0</flink.jackson.version>
         <flink.protobuf.version>2.7.6</flink.protobuf.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9477

### Motivation

Bump kafka-client to 2.7.2 to solve the CVE.
