### PR TITLE
[INLONG-9518][Manager] Support resetting the consumption location of the consumption group used by sort

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/SortConsumerInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/consume/SortConsumerInfo.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.consume;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Sort consumer info")
+public class SortConsumerInfo {
+
+    private Integer sinkId;
+    private String inlongGroupId;
+    private String inlongStreamId;
+    private String consumerGroup;
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/maintenanceTools/MaintenanceToolsService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/maintenanceTools/MaintenanceToolsService.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.maintenanceTools;
+
+import org.apache.inlong.manager.pojo.consume.SortConsumerInfo;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public interface MaintenanceToolsService {
+
+    List<SortConsumerInfo> getSortConsumer(MultipartFile file);
+
+    Boolean resetCursor(MultipartFile file, String resetTime);
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/maintenanceTools/MaintenanceToolsServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/maintenanceTools/MaintenanceToolsServiceImpl.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.maintenanceTools;
+
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
+import org.apache.inlong.manager.dao.mapper.InlongStreamEntityMapper;
+import org.apache.inlong.manager.dao.mapper.StreamSinkEntityMapper;
+import org.apache.inlong.manager.pojo.consume.SortConsumerInfo;
+import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
+import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
+import org.apache.inlong.manager.pojo.user.LoginUserUtils;
+import org.apache.inlong.manager.pojo.user.UserRoleCode;
+import org.apache.inlong.manager.service.group.InlongGroupService;
+import org.apache.inlong.manager.service.resource.queue.QueueResourceOperator;
+import org.apache.inlong.manager.service.resource.queue.QueueResourceOperatorFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class MaintenanceToolsServiceImpl implements MaintenanceToolsService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MaintenanceToolsServiceImpl.class);
+
+    @Autowired
+    private InlongGroupService groupService;
+    @Autowired
+    private StreamSinkEntityMapper sinkEntityMapper;
+    @Autowired
+    private InlongStreamEntityMapper streamEntityMapper;
+    @Autowired
+    private QueueResourceOperatorFactory queueOperatorFactory;
+
+    @Override
+    public List<SortConsumerInfo> getSortConsumer(MultipartFile file) {
+        LoginUserUtils.getLoginUser().getRoles().add(UserRoleCode.INLONG_SERVICE);
+        List<SortConsumerInfo> sortConsumerInfoList = new ArrayList<>();
+        try (InputStreamReader read = new InputStreamReader((file.getInputStream()), StandardCharsets.UTF_8)) {
+            BufferedReader bufferedReader = new BufferedReader(read);
+            String readerStr = null;
+            while ((readerStr = bufferedReader.readLine()) != null) {
+                String[] sinkIdList = readerStr.split(InlongConstants.COMMA);
+                for (String sinkIdStr : sinkIdList) {
+                    Integer sinkId = Integer.valueOf(sinkIdStr);
+                    StreamSinkEntity sinkEntity = sinkEntityMapper.selectByPrimaryKey(sinkId);
+
+                    InlongGroupInfo groupInfo = groupService.get(sinkEntity.getInlongGroupId());
+                    InlongStreamEntity streamEntity = streamEntityMapper
+                            .selectByIdentifier(sinkEntity.getInlongGroupId(), sinkEntity.getInlongStreamId());
+                    QueueResourceOperator queueOperator = queueOperatorFactory.getInstance(groupInfo.getMqType());
+
+                    String consumerGroup = queueOperator.getSortConsumeGroup(groupInfo, streamEntity, sinkEntity);
+
+                    SortConsumerInfo sortConsumerInfo = SortConsumerInfo.builder()
+                            .sinkId(sinkId)
+                            .consumerGroup(consumerGroup)
+                            .inlongGroupId(sinkEntity.getInlongGroupId())
+                            .inlongStreamId(sinkEntity.getInlongStreamId())
+                            .build();
+                    sortConsumerInfoList.add(sortConsumerInfo);
+                }
+            }
+            read.close();
+            LOGGER.info("success get sort consumer");
+            return sortConsumerInfoList;
+        } catch (IOException e) {
+            LOGGER.error("get sort consumer failed:", e);
+            throw new BusinessException(ErrorCodeEnum.INVALID_PARAMETER, "Can not properly read update file");
+        } finally {
+            LoginUserUtils.getLoginUser().getRoles().remove(UserRoleCode.INLONG_SERVICE);
+        }
+    }
+
+    @Override
+    public Boolean resetCursor(MultipartFile file, String resetTime) {
+        LoginUserUtils.getLoginUser().getRoles().add(UserRoleCode.INLONG_SERVICE);
+        try (InputStreamReader read = new InputStreamReader((file.getInputStream()), StandardCharsets.UTF_8)) {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            Date date = sdf.parse(resetTime);
+            long timeStamp = date.getTime();
+            BufferedReader bufferedReader = new BufferedReader(read);
+            String readerStr = null;
+            while ((readerStr = bufferedReader.readLine()) != null) {
+                String[] sinkIdList = readerStr.split(InlongConstants.COMMA);
+                for (String sinkIdStr : sinkIdList) {
+                    Integer sinkId = Integer.valueOf(sinkIdStr);
+                    StreamSinkEntity sinkEntity = sinkEntityMapper.selectByPrimaryKey(sinkId);
+                    InlongGroupInfo groupInfo = groupService.get(sinkEntity.getInlongGroupId());
+                    InlongPulsarInfo pulsarInfo = (InlongPulsarInfo) groupInfo;
+                    InlongStreamEntity streamEntity = streamEntityMapper
+                            .selectByIdentifier(sinkEntity.getInlongGroupId(), sinkEntity.getInlongStreamId());
+                    QueueResourceOperator queueOperator = queueOperatorFactory.getInstance(groupInfo.getMqType());
+                    queueOperator.resetCursor(groupInfo, streamEntity, sinkEntity, timeStamp);
+                }
+            }
+            read.close();
+            LOGGER.info("success reset cursor consumer");
+        } catch (Exception e) {
+            LOGGER.error("reset cursor consumer failed:", e);
+            throw new BusinessException(ErrorCodeEnum.INVALID_PARAMETER, "Can not properly read update file");
+        }
+        return true;
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/QueueResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/QueueResourceOperator.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.manager.service.resource.queue;
 
+import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
@@ -87,5 +89,19 @@ public interface QueueResourceOperator {
             Integer messageCount) throws Exception {
         return null;
     }
+
+    /**
+     * Reset cursor for consumer group
+     *
+     * @param groupInfo inlong group info
+     * @param streamEntity inlong stream entity
+     * @param sinkEntity sink entity
+     * @param resetTime timestamp for reset
+     */
+    default void resetCursor(InlongGroupInfo groupInfo, InlongStreamEntity streamEntity, StreamSinkEntity sinkEntity,
+            Long resetTime) throws Exception {
+    }
+
+    String getSortConsumeGroup(InlongGroupInfo groupInfo, InlongStreamEntity streamEntity, StreamSinkEntity sinkEntity);
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaQueueResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/kafka/KafkaQueueResourceOperator.java
@@ -23,6 +23,8 @@ import org.apache.inlong.manager.common.enums.ClusterType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.pojo.cluster.ClusterInfo;
 import org.apache.inlong.manager.pojo.cluster.kafka.KafkaClusterInfo;
 import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
@@ -204,5 +206,13 @@ public class KafkaQueueResourceOperator implements QueueResourceOperator {
                 String.format(KAFKA_CONSUMER_GROUP_REALTIME_REVIEW, groupInfo.getInlongClusterTag(), topicName);
         return kafkaOperator.queryLatestMessage((KafkaClusterInfo) clusterInfo, topicName, consumeGroup, messageCount,
                 streamInfo);
+    }
+
+    @Override
+    public String getSortConsumeGroup(InlongGroupInfo groupInfo, InlongStreamEntity streamEntity,
+            StreamSinkEntity sinkEntity) {
+        InlongKafkaInfo kafkaInfo = (InlongKafkaInfo) groupInfo;
+        String topicName = streamEntity.getMqResource();
+        return String.format(KAFKA_CONSUMER_GROUP, kafkaInfo.getInlongClusterTag(), topicName);
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarOperator.java
@@ -468,6 +468,20 @@ public class PulsarOperator {
     }
 
     /**
+     * Reset cursor for consumer group.
+     */
+    public void resetCursor(PulsarClusterInfo pulsarClusterInfo, String topicFullName, String subName,
+            Long resetTime) {
+        try {
+            PulsarUtils.resetCursor(restTemplate, pulsarClusterInfo, topicFullName, subName,
+                    resetTime);
+        } catch (Exception e) {
+            LOGGER.error("failed reset cursor consumer:", e);
+            throw new BusinessException("failed reset cursor consumer:" + e.getMessage());
+        }
+    }
+
+    /**
      * Build topicName Of Partition
      */
     private String buildTopicNameOfPartition(String topicName, int partition, boolean serial) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarUtils.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarUtils.java
@@ -787,6 +787,15 @@ public class PulsarUtils {
         return ret;
     }
 
+    public static void resetCursor(RestTemplate restTemplate, PulsarClusterInfo clusterInfo,
+            String topicPath, String subscription, Long resetTime) throws Exception {
+        HttpUtils.request(restTemplate,
+                clusterInfo.getAdminUrls(QUERY_PERSISTENT_PATH + "/" + topicPath + "/subscription/"
+                        + subscription + "/resetcursor/" + resetTime),
+                HttpMethod.POST, null,
+                getHttpHeaders(clusterInfo.getToken()));
+    }
+
     /**
      * Copy from deSerializeSingleMessageInBatch method of org.apache.pulsar.common.protocol.Commands class.
      *

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/tubemq/TubeMQQueueResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/tubemq/TubeMQQueueResourceOperator.java
@@ -23,6 +23,8 @@ import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.GroupStatus;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.InlongStreamEntity;
+import org.apache.inlong.manager.dao.entity.StreamSinkEntity;
 import org.apache.inlong.manager.pojo.cluster.tubemq.TubeClusterInfo;
 import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
@@ -138,6 +140,13 @@ public class TubeMQQueueResourceOperator implements QueueResourceOperator {
         String topicName = groupInfo.getMqResource();
 
         return tubeMQOperator.queryLastMessage(tubeCluster, topicName, messageCount, streamInfo);
+    }
+
+    @Override
+    public String getSortConsumeGroup(InlongGroupInfo groupInfo, InlongStreamEntity streamEntity,
+            StreamSinkEntity sinkEntity) {
+        String topicName = streamEntity.getMqResource();
+        return groupInfo.getInlongClusterTag() + "_" + topicName + "_consumer_group";
     }
 
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/MaintenanceToolsController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/MaintenanceToolsController.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.controller;
+
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.consume.SortConsumerInfo;
+import org.apache.inlong.manager.pojo.user.UserRoleCode;
+import org.apache.inlong.manager.service.maintenanceTools.MaintenanceToolsService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.RequiresRoles;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * Maintenance tools controller.
+ */
+@RestController
+@RequestMapping("/api")
+@Api(tags = "Maintenanct tools-API")
+public class MaintenanceToolsController {
+
+    @Autowired
+    private MaintenanceToolsService maintenanceToolsService;
+
+    @PostMapping("/maintenanceTools/getSortConsumer")
+    @ApiOperation(value = "get sort consumer info")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "file", value = "file object", required = true, dataType = "__FILE", dataTypeClass = MultipartFile.class, paramType = "query")
+    })
+    @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
+    public Response<List<SortConsumerInfo>> getSortConsumer(@RequestParam(value = "file") MultipartFile file) {
+        return Response.success(maintenanceToolsService.getSortConsumer(file));
+    }
+
+    @PostMapping("/maintenanceTools/resetCursor")
+    @ApiOperation(value = "reset cursor consumer")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "file", value = "file object", required = true, dataType = "__FILE", dataTypeClass = MultipartFile.class, paramType = "query"),
+            @ApiImplicitParam(name = "resetTime", dataTypeClass = String.class, required = true)
+    })
+    @RequiresRoles(value = UserRoleCode.INLONG_ADMIN)
+    public Response<Boolean> resetCursor(@RequestParam(value = "file") MultipartFile file,
+            @RequestParam(value = "resetTime") String resetTime) {
+        return Response.success(maintenanceToolsService.resetCursor(file, resetTime));
+    }
+
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9518 

### Motivation

Support resetting the consumption location of the consumption group used by sort.
Convenient for management personnel to batch reset the consumption group locations used by sort.
Management personnel can batch modify the corresponding consumption group location information by uploading files.
### Modifications

Support resetting the consumption location of the consumption group used by sort.
1.Added interface to retrieve all consumption groups used by sort through Sinkid.
2.Added interface for resetting consumption group sites through Sinkid.
