### PR TITLE
[INLONG-9033][TubeMQ] Fix the tubectl script missing for packaging

### DIFF
--- a/inlong-tubemq/tubemq-server/src/main/assembly/assembly.xml
+++ b/inlong-tubemq/tubemq-server/src/main/assembly/assembly.xml
@@ -50,7 +50,7 @@
         <fileSet>
             <directory>../bin</directory>
             <includes>
-                <include>*.*</include>
+                <include>**/*</include>
             </includes>
             <outputDirectory>bin</outputDirectory>
             <fileMode>0755</fileMode>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9033

### Motivation

Fix the tubectl script missing for packaging

### Modifications

Add all resources in the binary directory.
