### PR TITLE
[INLONG-9528][Manager] Support configuring the switch to enable dataProxy nodes

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeDTO.java
@@ -44,12 +44,16 @@ public class DataProxyClusterNodeDTO {
     @ApiModelProperty("Report source type")
     private String reportSourceType = ReportResourceType.INLONG;
 
+    @ApiModelProperty("Enabled")
+    private Boolean enabledOnline = true;
+
     /**
      * Get the dto instance from the request
      */
     public static DataProxyClusterNodeDTO getFromRequest(DataProxyClusterNodeRequest request) {
         return DataProxyClusterNodeDTO.builder()
                 .reportSourceType(request.getReportSourceType())
+                .enabledOnline(request.getEnabledOnline())
                 .build();
     }
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeRequest.java
@@ -40,4 +40,7 @@ public class DataProxyClusterNodeRequest extends ClusterNodeRequest {
     @ApiModelProperty("Report source type")
     private String reportSourceType;
 
+    @ApiModelProperty("Enabled")
+    private Boolean enabledOnline;
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeResponse.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/dataproxy/DataProxyClusterNodeResponse.java
@@ -40,4 +40,7 @@ public class DataProxyClusterNodeResponse extends ClusterNodeResponse {
     @ApiModelProperty("Report source type")
     private String reportSourceType;
 
+    @ApiModelProperty("Enabled")
+    private Boolean enabledOnline;
+
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -1158,10 +1158,12 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         // TODO consider the data proxy load and re-balance
         List<DataProxyNodeInfo> nodeList = new ArrayList<>();
         for (InlongClusterNodeEntity nodeEntity : nodeEntities) {
-            if (Objects.equals(nodeEntity.getStatus(), NodeStatus.HEARTBEAT_TIMEOUT.getStatus())) {
-                LOGGER.debug("dataproxy node was timeout, parentId={} ip={} port={}", nodeEntity.getParentId(),
-                        nodeEntity.getIp(), nodeEntity.getPort());
-                continue;
+            if (StringUtils.isNotBlank(nodeEntity.getExtParams())) {
+                DataProxyClusterNodeDTO dataProxyClusterNodeDTO = DataProxyClusterNodeDTO.getFromJson(
+                        nodeEntity.getExtParams());
+                if (Objects.equals(dataProxyClusterNodeDTO.getEnabledOnline(), false)) {
+                    continue;
+                }
             }
             DataProxyNodeInfo nodeInfo = new DataProxyNodeInfo();
             nodeInfo.setId(nodeEntity.getId());
@@ -1214,6 +1216,9 @@ public class InlongClusterServiceImpl implements InlongClusterService {
                 }
                 if (StringUtils.isNotBlank(reportSourceType) && !Objects.equals(
                         dataProxyClusterNodeDTO.getReportSourceType(), reportSourceType)) {
+                    continue;
+                }
+                if (Objects.equals(dataProxyClusterNodeDTO.getEnabledOnline(), false)) {
                     continue;
                 }
             }


### PR DESCRIPTION

### Prepare a Pull Request

- Fixes #9528 

### Motivation

 Support configuring the switch to enable dataProxy nodes.

### Modifications

 Support configuring the switch to enable dataProxy nodes.
When the dataproxy node is enabled, it will be issued to the agent or SDK, otherwise it will not.