### PR TITLE
[INLONG-9532][Sort] Fix the wrong params for HudiExtractNode

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/HudiExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/HudiExtractNode.java
@@ -159,8 +159,8 @@ public class HudiExtractNode extends ExtractNode implements Serializable {
         options.put(HUDI_OPTION_DEFAULT_PATH, path);
 
         // read options
-        options.put(READ_START_COMMIT, String.valueOf(readStreamingSkipCompaction));
-        options.put(READ_STREAMING_SKIP_COMPACT, readStartCommit);
+        options.put(READ_START_COMMIT, readStartCommit);
+        options.put(READ_STREAMING_SKIP_COMPACT, String.valueOf(readStreamingSkipCompaction));
 
         options.put(HUDI_OPTION_DATABASE_NAME, dbName);
         options.put(HUDI_OPTION_TABLE_NAME, tableName);


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9532

### Motivation

Fix the wrong params for HudiExtractNode

### Modifications

Fix the wrong params for HudiExtractNode, Discussed in https://github.com/apache/inlong/discussions/9275
