### PR TITLE
[INLONG-9508][Manager] Add Iceberg field type mapping strategy to improve usability

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/IcebergFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/IcebergFieldTypeStrategy.java
@@ -17,11 +17,12 @@
 
 package org.apache.inlong.manager.common.fieldtype.strategy;
 
-import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.DataNodeType;
 import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
 
 /**
  * The iceberg field type mapping strategy

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/IcebergFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/IcebergFieldTypeStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.common.fieldtype.strategy;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+/**
+ * The iceberg field type mapping strategy
+ */
+public class IcebergFieldTypeStrategy implements FieldTypeMappingStrategy {
+
+    private final FieldTypeMappingReader reader;
+
+    public IcebergFieldTypeStrategy() {
+        this.reader = new FieldTypeMappingReader(DataNodeType.ICEBERG);
+    }
+
+    @Override
+    public String getFieldTypeMapping(String sourceType) {
+        String dataType = StringUtils.substringBefore(sourceType, LEFT_BRACKET).toUpperCase();
+        return reader.getFIELD_TYPE_MAPPING_MAP().getOrDefault(dataType, sourceType.toUpperCase());
+    }
+}

--- a/inlong-manager/manager-common/src/main/resources/iceberg-field-type-mapping.yaml
+++ b/inlong-manager/manager-common/src/main/resources/iceberg-field-type-mapping.yaml
@@ -17,9 +17,6 @@
 
 source.type.to.target.type.converter:
 
-  - source.type: INT
-    target.type: INT
-
   - source.type: INTEGER
     target.type: INT
 
@@ -47,14 +44,14 @@ source.type.to.target.type.converter:
   - source.type: TIMESTAMP
     target.type: LOCAL_ZONE_TIMESTAMP
 
-  - source.type: TIMESTAMPTZ
+  - source.type: TIMESTAMP WITH TIMEZONE
     target.type: LOCAL_ZONE_TIMESTAMP
 
-  - source.type: TIMESTAMPLOCALTZ
-    target.type: LOCAL_ZONE_TIMESTAMP
+  - source.type: TIMESTAMP WITHOUT TIMEZONE
+    target.type: TIMESTAMP
 
-  - source.type: TIMESTAMP WITH LOCAL TIME ZONE
-    target.type: LOCAL_ZONE_TIMESTAMP
+  - source.type: UUID
+    target.type: STRING
 
   - source.type: STRING
     target.type: STRING

--- a/inlong-manager/manager-common/src/main/resources/iceberg-field-type-mapping.yaml
+++ b/inlong-manager/manager-common/src/main/resources/iceberg-field-type-mapping.yaml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source.type.to.target.type.converter:
+
+  - source.type: INT
+    target.type: INT
+
+  - source.type: INTEGER
+    target.type: INT
+
+  - source.type: FLOAT
+    target.type: FLOAT
+
+  - source.type: DOUBLE
+    target.type: DOUBLE
+
+  - source.type: LONG
+    target.type: LONG
+
+  - source.type: DECIMAL
+    target.type: DECIMAL
+
+  - source.type: BOOLEAN
+    target.type: BOOLEAN
+
+  - source.type: DATE
+    target.type: DATE
+
+  - source.type: TIME
+    target.type: TIME
+
+  - source.type: TIMESTAMP
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: TIMESTAMPTZ
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: TIMESTAMPLOCALTZ
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: TIMESTAMP WITH LOCAL TIME ZONE
+    target.type: LOCAL_ZONE_TIMESTAMP
+
+  - source.type: STRING
+    target.type: STRING
+
+  - source.type: FIXED
+    target.type: VARBINARY
+
+  - source.type: BINARY
+    target.type: BINARY

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/IcebergProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/IcebergProvider.java
@@ -19,6 +19,8 @@ package org.apache.inlong.manager.pojo.sort.node.provider;
 
 import org.apache.inlong.common.enums.MetaField;
 import org.apache.inlong.manager.common.consts.StreamType;
+import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.IcebergFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.sink.SinkField;
 import org.apache.inlong.manager.pojo.sink.iceberg.IcebergSink;
 import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
@@ -51,6 +53,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public class IcebergProvider implements ExtractNodeProvider, LoadNodeProvider {
 
+    private static final FieldTypeMappingStrategy FIELD_TYPE_MAPPING_STRATEGY = new IcebergFieldTypeStrategy();
+
     @Override
     public Boolean accept(String sinkType) {
         return StreamType.ICEBERG.equals(sinkType);
@@ -59,7 +63,8 @@ public class IcebergProvider implements ExtractNodeProvider, LoadNodeProvider {
     @Override
     public ExtractNode createExtractNode(StreamNode streamNodeInfo) {
         IcebergSource icebergSource = (IcebergSource) streamNodeInfo;
-        List<FieldInfo> fieldInfos = parseStreamFieldInfos(icebergSource.getFieldList(), icebergSource.getSourceName());
+        List<FieldInfo> fieldInfos = parseStreamFieldInfos(icebergSource.getFieldList(), icebergSource.getSourceName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         Map<String, String> properties = parseProperties(icebergSource.getProperties());
 
         return new IcebergExtractNode(icebergSource.getSourceName(),
@@ -81,7 +86,8 @@ public class IcebergProvider implements ExtractNodeProvider, LoadNodeProvider {
     public LoadNode createLoadNode(StreamNode nodeInfo, Map<String, StreamField> constantFieldMap) {
         IcebergSink icebergSink = (IcebergSink) nodeInfo;
         Map<String, String> properties = parseProperties(icebergSink.getProperties());
-        List<FieldInfo> fieldInfos = parseSinkFieldInfos(icebergSink.getSinkFieldList(), icebergSink.getSinkName());
+        List<FieldInfo> fieldInfos = parseSinkFieldInfos(icebergSink.getSinkFieldList(), icebergSink.getSinkName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
         List<FieldRelation> fieldRelations = parseSinkFields(icebergSink.getSinkFieldList(), constantFieldMap);
         IcebergConstant.CatalogType catalogType = CatalogType.forName(icebergSink.getCatalogType());
         Format format = parsingSinkMultipleFormat(icebergSink.getSinkMultipleEnable(),

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.pojo.sort.util;
 
 import org.apache.inlong.manager.common.enums.FieldType;
 import org.apache.inlong.manager.common.fieldtype.strategy.ClickHouseFieldTypeStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.IcebergFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MongoDBFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.OracleFieldTypeStrategy;
@@ -27,6 +28,7 @@ import org.apache.inlong.manager.common.fieldtype.strategy.SQLServerFieldTypeStr
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.sort.formats.common.ByteTypeInfo;
 import org.apache.inlong.sort.formats.common.IntTypeInfo;
+import org.apache.inlong.sort.formats.common.LocalZonedTimestampFormatInfo;
 import org.apache.inlong.sort.formats.common.LocalZonedTimestampTypeInfo;
 import org.apache.inlong.sort.formats.common.ShortTypeInfo;
 import org.apache.inlong.sort.formats.common.StringTypeInfo;
@@ -123,5 +125,18 @@ public class FieldInfoUtilsTest {
                 "nodeId", new ClickHouseFieldTypeStrategy());
         TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
         Assertions.assertTrue(typeInfo instanceof ByteTypeInfo);
+    }
+
+    @Test
+    public void testIcebergFieldTypeInfo() {
+        StreamField streamField = new StreamField();
+        streamField.setIsMetaField(0);
+        streamField.setFieldName("time");
+        streamField.setFieldType("TIMESTAMPLOCALTZ");
+        streamField.setFieldValue("2022-03-01T09:00:00 America/New_York");
+        FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
+                "nodeId", new IcebergFieldTypeStrategy());
+        TypeInfo typeInfo = fieldInfo.getFormatInfo().getTypeInfo();
+        Assertions.assertTrue(typeInfo instanceof LocalZonedTimestampTypeInfo);
     }
 }

--- a/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
+++ b/inlong-manager/manager-pojo/src/test/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtilsTest.java
@@ -28,7 +28,6 @@ import org.apache.inlong.manager.common.fieldtype.strategy.SQLServerFieldTypeStr
 import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.sort.formats.common.ByteTypeInfo;
 import org.apache.inlong.sort.formats.common.IntTypeInfo;
-import org.apache.inlong.sort.formats.common.LocalZonedTimestampFormatInfo;
 import org.apache.inlong.sort.formats.common.LocalZonedTimestampTypeInfo;
 import org.apache.inlong.sort.formats.common.ShortTypeInfo;
 import org.apache.inlong.sort.formats.common.StringTypeInfo;
@@ -132,7 +131,7 @@ public class FieldInfoUtilsTest {
         StreamField streamField = new StreamField();
         streamField.setIsMetaField(0);
         streamField.setFieldName("time");
-        streamField.setFieldType("TIMESTAMPLOCALTZ");
+        streamField.setFieldType("TIMESTAMP WITH TIMEZONE");
         streamField.setFieldValue("2022-03-01T09:00:00 America/New_York");
         FieldInfo fieldInfo = FieldInfoUtils.parseStreamFieldInfo(streamField,
                 "nodeId", new IcebergFieldTypeStrategy());


### PR DESCRIPTION
[INLONG-9508][Manager] Add Iceberg field type mapping strategy to improve usability

- Fixes #9508

### Motivation

Inlong Iceberg ExtractNode or LoadNode currently does not support some special field types, add Iceberg field type mapping strategy to mapping to the corresponding type to run correctly