### PR TITLE
[INLONG-9556][Agent] Prevent thread freeze caused by deleting data sources when the backend cannot send out

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Sink.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Sink.java
@@ -30,7 +30,7 @@ public interface Sink {
      *
      * @param message message
      */
-    void write(Message message);
+    boolean write(Message message);
 
     /**
      * set source file name where the message is generated

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/FileInstance.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/FileInstance.java
@@ -50,6 +50,7 @@ public class FileInstance extends Instance {
     public static final int CORE_THREAD_SLEEP_TIME = 1;
     private static final int DESTROY_LOOP_WAIT_TIME_MS = 10;
     private static final int CHECK_FINISH_AT_LEAST_COUNT = 5;
+    private final int WRITE_FAILED_WAIT_TIME_MS = 10;
     private InstanceManager instanceManager;
     private volatile boolean running = false;
     private volatile boolean inited = false;
@@ -126,7 +127,13 @@ public class FileInstance extends Instance {
                 AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_INSTANCE_HEARTBEAT, inlongGroupId, inlongStreamId,
                         AgentUtils.getCurrentTime(), 1, 1);
             } else {
-                sink.write(msg);
+                boolean suc = false;
+                while (!isFinished() && !suc) {
+                    suc = sink.write(msg);
+                    if (!suc) {
+                        AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);
+                    }
+                }
             }
         }
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/ProxySink.java
@@ -56,7 +56,6 @@ import static org.apache.inlong.agent.constant.TaskConstants.INODE_INFO;
 public class ProxySink extends AbstractSink {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProxySink.class);
-    private final int WRITE_FAILED_WAIT_TIME_MS = 10;
     private final int DESTROY_LOOP_WAIT_TIME_MS = 10;
     public final int SAVE_OFFSET_INTERVAL_MS = 1000;
     private static final ThreadPoolExecutor EXECUTOR_SERVICE = new ThreadPoolExecutor(
@@ -76,18 +75,9 @@ public class ProxySink extends AbstractSink {
     private volatile boolean offsetRunning = false;
     private OffsetManager offsetManager;
 
-    public ProxySink() {
-    }
-
     @Override
-    public void write(Message message) {
-        boolean suc = false;
-        while (!shutdown && !suc) {
-            suc = putInCache(message);
-            if (!suc) {
-                AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);
-            }
-        }
+    public boolean write(Message message) {
+        return putInCache(message);
     }
 
     private boolean putInCache(Message message) {


### PR DESCRIPTION
[INLONG-9556][Agent] Prevent thread freeze caused by deleting data sources when the backend cannot send out
- Fixes #9556 

### Motivation

Prevent thread freeze caused by deleting data sources when the backend cannot send out
### Modifications

Prevent thread freeze caused by deleting data sources when the backend cannot send out

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
