### PR TITLE
[INLONG-9559][Manager] Add Dameng Extract Node to Inlong Manager

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/enums/TaskTypeEnum.java
@@ -36,6 +36,7 @@ public enum TaskTypeEnum {
     REDIS(11),
     MQTT(12),
     HUDI(13),
+    DAMENG(14),
 
     // only used for unit test
     MOCK(201)

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/DataNodeType.java
@@ -42,4 +42,6 @@ public class DataNodeType {
      */
     public static final String CLS = "CLS";
     public static final String PULSAR = "PULSAR";
+
+    public static final String DAMENG = "DAMENG";
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SourceType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SourceType.java
@@ -57,7 +57,7 @@ public class SourceType extends StreamType {
             put(REDIS, TaskTypeEnum.REDIS);
             put(MQTT, TaskTypeEnum.MQTT);
             put(HUDI, TaskTypeEnum.HUDI);
-            put(DAMENG,TaskTypeEnum.DAMENG);
+            put(DAMENG, TaskTypeEnum.DAMENG);
 
         }
     };

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SourceType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/SourceType.java
@@ -37,6 +37,8 @@ public class SourceType extends StreamType {
     public static final String REDIS = "REDIS";
     public static final String MQTT = "MQTT";
 
+    public static final String DAMENG = "DAMENG";
+
     public static final Map<String, TaskTypeEnum> SOURCE_TASK_MAP = new HashMap<String, TaskTypeEnum>() {
 
         {
@@ -55,6 +57,7 @@ public class SourceType extends StreamType {
             put(REDIS, TaskTypeEnum.REDIS);
             put(MQTT, TaskTypeEnum.MQTT);
             put(HUDI, TaskTypeEnum.HUDI);
+            put(DAMENG,TaskTypeEnum.DAMENG);
 
         }
     };

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/DamengFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/DamengFieldTypeStrategy.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.inlong.manager.common.fieldtype.strategy;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.DataNodeType;
+import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
+
+public class DamengFieldTypeStrategy implements FieldTypeMappingStrategy {
+    private final FieldTypeMappingReader reader;
+
+    public DamengFieldTypeStrategy() {
+        this.reader = new FieldTypeMappingReader(DataNodeType.DAMENG);
+    }
+
+    @Override
+    public String getFieldTypeMapping(String sourceType) {
+        String dataType = StringUtils.substringBefore(sourceType, LEFT_BRACKET).toUpperCase();
+        return reader.getFIELD_TYPE_MAPPING_MAP().getOrDefault(dataType, sourceType.toUpperCase());
+    }
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/DamengFieldTypeStrategy.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/fieldtype/strategy/DamengFieldTypeStrategy.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-
 package org.apache.inlong.manager.common.fieldtype.strategy;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.DataNodeType;
 import org.apache.inlong.manager.common.fieldtype.FieldTypeMappingReader;
+
+import org.apache.commons.lang3.StringUtils;
 
 import static org.apache.inlong.manager.common.consts.InlongConstants.LEFT_BRACKET;
 
 public class DamengFieldTypeStrategy implements FieldTypeMappingStrategy {
+
     private final FieldTypeMappingReader reader;
 
     public DamengFieldTypeStrategy() {

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/ExtractNodeProviderFactory.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/ExtractNodeProviderFactory.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.pojo.sort.node;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
+import org.apache.inlong.manager.pojo.sort.node.provider.DMProvider;
 import org.apache.inlong.manager.pojo.sort.node.provider.HudiProvider;
 import org.apache.inlong.manager.pojo.sort.node.provider.IcebergProvider;
 import org.apache.inlong.manager.pojo.sort.node.provider.KafkaProvider;
@@ -58,7 +59,7 @@ public class ExtractNodeProviderFactory {
         EXTRACT_NODE_PROVIDER_LIST.add(new PostgreSQLProvider());
         EXTRACT_NODE_PROVIDER_LIST.add(new MySQLBinlogProvider());
         EXTRACT_NODE_PROVIDER_LIST.add(new IcebergProvider());
-
+        EXTRACT_NODE_PROVIDER_LIST.add(new DMProvider());
     }
 
     /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/DMProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/DMProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.sort.node.provider;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.consts.StreamType;
+import org.apache.inlong.manager.common.fieldtype.strategy.DamengFieldTypeStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
+import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
+import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
+import org.apache.inlong.manager.pojo.sort.util.FieldInfoUtils;
+import org.apache.inlong.manager.pojo.source.dameng.DamengSource;
+import org.apache.inlong.manager.pojo.source.mysql.MySQLBinlogSource;
+import org.apache.inlong.manager.pojo.source.oracle.OracleSource;
+import org.apache.inlong.manager.pojo.stream.StreamField;
+import org.apache.inlong.manager.pojo.stream.StreamNode;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.constant.DMConstant;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.DamengExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+
+import com.google.common.base.Splitter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The Provider for creating MySQLBinlog extract nodes.
+ */
+public class DMProvider implements ExtractNodeProvider {
+
+    private static final FieldTypeMappingStrategy FIELD_TYPE_MAPPING_STRATEGY = new DamengFieldTypeStrategy();
+
+    @Override
+    public Boolean accept(String sourceType) {
+        return SourceType.DAMENG.equals(sourceType);
+    }
+
+    @Override
+    public ExtractNode createExtractNode(StreamNode streamNodeInfo) {
+        DamengSource source = (DamengSource) streamNodeInfo;
+        List<FieldInfo> fieldInfos = parseStreamFieldInfos(source.getFieldList(), source.getSourceName(),
+                FIELD_TYPE_MAPPING_STRATEGY);
+        DMConstant.ScanStartUpMode scanStartupMode = StringUtils.isBlank(source.getScanStartupMode())
+                ? null
+                : DMConstant.ScanStartUpMode.forName(source.getScanStartupMode());
+        Map<String, String> properties = parseProperties(source.getProperties());
+
+        return new DamengExtractNode(
+                source.getSourceName(),
+                source.getSourceName(),
+                fieldInfos,
+                null,
+                properties,
+                source.getPrimaryKey(),
+                source.getHost(),
+                source.getUsername(),
+                source.getPassword(),
+                source.getDbName(),
+                source.getSchemaName(),
+                source.getTableName(),
+                source.getPort(),
+                scanStartupMode);
+    }
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/DMProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/DMProvider.java
@@ -17,30 +17,21 @@
 
 package org.apache.inlong.manager.pojo.sort.node.provider;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.SourceType;
-import org.apache.inlong.manager.common.consts.StreamType;
 import org.apache.inlong.manager.common.fieldtype.strategy.DamengFieldTypeStrategy;
 import org.apache.inlong.manager.common.fieldtype.strategy.FieldTypeMappingStrategy;
-import org.apache.inlong.manager.common.fieldtype.strategy.MySQLFieldTypeStrategy;
 import org.apache.inlong.manager.pojo.sort.node.base.ExtractNodeProvider;
-import org.apache.inlong.manager.pojo.sort.util.FieldInfoUtils;
 import org.apache.inlong.manager.pojo.source.dameng.DamengSource;
-import org.apache.inlong.manager.pojo.source.mysql.MySQLBinlogSource;
-import org.apache.inlong.manager.pojo.source.oracle.OracleSource;
-import org.apache.inlong.manager.pojo.stream.StreamField;
 import org.apache.inlong.manager.pojo.stream.StreamNode;
 import org.apache.inlong.sort.protocol.FieldInfo;
 import org.apache.inlong.sort.protocol.constant.DMConstant;
 import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.DamengExtractNode;
-import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
 
-import com.google.common.base.Splitter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * The Provider for creating MySQLBinlog extract nodes.

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.manager.pojo.source.dameng;
 
 import io.swagger.annotations.ApiModel;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
@@ -1,0 +1,67 @@
+package org.apache.inlong.manager.pojo.source.dameng;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.source.SourceRequest;
+import org.apache.inlong.manager.pojo.source.StreamSource;
+
+import java.util.Map;
+
+@Data
+@SuperBuilder
+@AllArgsConstructor
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Dameng source info")
+@JsonTypeDefine(value = SourceType.DAMENG)
+public class DamengSource extends StreamSource {
+    @ApiModelProperty("The database name")
+    private String dbName;
+
+    @ApiModelProperty("Schema name")
+    private String schemaName;
+
+    @ApiModelProperty("The table name")
+    private String tableName;
+
+    @ApiModelProperty("host")
+    private String host;
+
+    @ApiModelProperty("port")
+    private Integer port;
+
+    @ApiModelProperty("username")
+    private String username;
+
+    @ApiModelProperty("password")
+    private String password;
+
+    @ApiModelProperty("Scan startup mode")
+    private String scanStartupMode;
+
+    @ApiModelProperty("Primary key must be shared by all tables")
+    private String primaryKey;
+
+    @ApiModelProperty("Need transfer total database")
+    @Builder.Default
+    private boolean allMigration = false;
+
+    public DamengSource() {
+        this.setSourceType(SourceType.DAMENG);
+    }
+
+    @Override
+    public SourceRequest genSourceRequest() {
+        return CommonBeanUtils.copyProperties(this, DamengSourceRequest::new);
+    }
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSource.java
@@ -17,6 +17,12 @@
 
 package org.apache.inlong.manager.pojo.source.dameng;
 
+import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.source.SourceRequest;
+import org.apache.inlong.manager.pojo.source.StreamSource;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -25,13 +31,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.apache.inlong.manager.common.consts.SourceType;
-import org.apache.inlong.manager.common.util.CommonBeanUtils;
-import org.apache.inlong.manager.common.util.JsonTypeDefine;
-import org.apache.inlong.manager.pojo.source.SourceRequest;
-import org.apache.inlong.manager.pojo.source.StreamSource;
-
-import java.util.Map;
 
 @Data
 @SuperBuilder
@@ -41,6 +40,7 @@ import java.util.Map;
 @ApiModel(value = "Dameng source info")
 @JsonTypeDefine(value = SourceType.DAMENG)
 public class DamengSource extends StreamSource {
+
     @ApiModelProperty("The database name")
     private String dbName;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.manager.pojo.source.dameng;
 
 import io.swagger.annotations.ApiModelProperty;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
@@ -17,22 +17,18 @@
 
 package org.apache.inlong.manager.pojo.source.dameng;
 
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonUtils;
+
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
-import org.apache.inlong.manager.common.exceptions.BusinessException;
-import org.apache.inlong.manager.common.util.CommonBeanUtils;
-import org.apache.inlong.manager.common.util.JsonUtils;
-import org.apache.inlong.manager.pojo.source.hudi.HudiSourceDTO;
-import org.apache.inlong.manager.pojo.source.hudi.HudiSourceRequest;
 
 import javax.validation.constraints.NotNull;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 @Data
 @Builder

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceDTO.java
@@ -1,0 +1,77 @@
+package org.apache.inlong.manager.pojo.source.dameng;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.JsonUtils;
+import org.apache.inlong.manager.pojo.source.hudi.HudiSourceDTO;
+import org.apache.inlong.manager.pojo.source.hudi.HudiSourceRequest;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DamengSourceDTO {
+
+    @ApiModelProperty("The database name")
+    private String dbName;
+
+    @ApiModelProperty("Schema name")
+    private String schemaName;
+
+    @ApiModelProperty("The table name")
+    private String tableName;
+
+    @ApiModelProperty("host")
+    private String host;
+
+    @ApiModelProperty("port")
+    private String port;
+
+    @ApiModelProperty("username")
+    private String username;
+
+    @ApiModelProperty("password")
+    private String password;
+
+    @ApiModelProperty("Scan startup mode")
+    private String scanStartupMode;
+
+    @ApiModelProperty("Primary key must be shared by all tables")
+    private String primaryKey;
+
+    @ApiModelProperty("Need transfer total database")
+    @Builder.Default
+    private boolean allMigration = false;
+
+    /**
+     * Get the dto instance from the request
+     */
+    public static DamengSourceDTO getFromRequest(DamengSourceRequest request) {
+        DamengSourceDTO damengSourceDTO = new DamengSourceDTO();
+        CommonBeanUtils.copyProperties(request, damengSourceDTO);
+        return damengSourceDTO;
+    }
+
+    /**
+     * Get the dto instance from the JSON string
+     */
+    public static DamengSourceDTO getFromJson(@NotNull String extParams) {
+        try {
+            return JsonUtils.parseObject(extParams, DamengSourceDTO.class);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCodeEnum.SOURCE_INFO_INCORRECT,
+                    String.format("parse extParams of DamengSourceDTO failure: %s", e.getMessage()));
+        }
+    }
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.source.dameng;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.source.SourceRequest;
+
+/**
+ * Request info of the Dameng source
+ */
+@Data
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@ApiModel(value = "Request of the Dameng source")
+@JsonTypeDefine(value = SourceType.DAMENG)
+public class DamengSourceRequest extends SourceRequest {
+
+    @ApiModelProperty("The database name")
+    private String dbName;
+
+    @ApiModelProperty("Schema name")
+    private String schemaName;
+
+    @ApiModelProperty("The table name")
+    private String tableName;
+
+    @ApiModelProperty("host")
+    private String host;
+
+    @ApiModelProperty("port")
+    private String port;
+
+    @ApiModelProperty("username")
+    private String username;
+
+    @ApiModelProperty("password")
+    private String password;
+
+    @ApiModelProperty("Scan startup mode")
+    private String scanStartupMode;
+
+    @ApiModelProperty("Primary key must be shared by all tables")
+    private String primaryKey;
+
+    @ApiModelProperty("Need transfer total database")
+    @Builder.Default
+    private boolean allMigration = false;
+
+    public DamengSourceRequest() {
+        this.setSourceType(SourceType.DAMENG);
+    }
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/dameng/DamengSourceRequest.java
@@ -17,19 +17,16 @@
 
 package org.apache.inlong.manager.pojo.source.dameng;
 
+import org.apache.inlong.manager.common.consts.SourceType;
+import org.apache.inlong.manager.common.util.JsonTypeDefine;
+import org.apache.inlong.manager.pojo.source.SourceRequest;
+
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
-import org.apache.inlong.manager.common.consts.SourceType;
-import org.apache.inlong.manager.common.util.JsonTypeDefine;
-import org.apache.inlong.manager.pojo.source.SourceRequest;
 
 /**
  * Request info of the Dameng source

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/DMConstant.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/constant/DMConstant.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.constant;
+
+import lombok.Getter;
+
+/**
+ * Dameng options constant
+ */
+public class DMConstant {
+
+    /**
+     * The key of flink connector defined in flink table
+     */
+    public static final String CONNECTOR = "connector";
+    /**
+     * Specify what flink connector to use for extract data from Dameng database, here should be 'dm-cdc'
+     */
+    public static final String DM_CDC = "dm-cdc-inlong";
+    /**
+     * Database name of the Dameng server to monitor
+     */
+    public static final String DATABASE_NAME = "database-name";
+    /**
+     * IP address or hostname of the Dameng database server
+     */
+    public static final String HOSTNAME = "hostname";
+    /**
+     * Integer port number of the Dameng database server.
+     */
+    public static final String PORT = "port";
+    /**
+     * Name of the Dameng database to use when connecting to the Dameng database server
+     */
+    public static final String USERNAME = "username";
+    /**
+     * Password to use when connecting to the Dameng database server
+     */
+    public static final String PASSWORD = "password";
+    /**
+     * Table name of the Dameng database to monitor
+     */
+    public static final String TABLE_NAME = "table-name";
+    /**
+     * Schema name of the Dameng database to monitor
+     */
+    public static final String SCHEMA_NAME = "schema-name";
+    /**
+     * <p>The mining strategy controls how Dameng LogMiner builds
+     * and uses a given data dictionary for resolving table and column ids to names.</p>
+     * <p>redo_log_catalog - Writes the data dictionary to the online redo logs
+     * causing more archive logs to be generated over time.
+     * This also enables tracking DDL changes against captured tables,
+     * so if the schema changes frequently this is the ideal choice.</p>
+     * <p>online_catalog - Uses the database’s current data dictionary to resolve object ids
+     * and does not write any extra information to the online redo logs.
+     * This allows LogMiner to mine substantially faster but at the expense that DDL changes cannot be tracked.
+     * If the captured table(s) schema changes infrequently or never, this is the ideal choice.</p>
+     */
+    public static final String LOG_MINING_STRATEGY = "debezium.log.mining.strategy";
+    /**
+     * If true,CONTINUOUS_MINE option will be added to the log mining session.
+     * This will manage log files switches seamlessly.
+     */
+    public static final String LOG_MINING_CONTINUOUS_MINE = "debezium.log.mining.continuous.mine";
+    /**
+     * Deprecated: Case insensitive table names;set to 'true' for Dameng 11g,'false'(default) otherwise.
+     */
+    public static final String TABLENAME_CASE_INSENSITIVE = "debezium.database.tablename.case.insensitive";
+    /**
+     * The key of ${@link ScanStartUpMode}
+     */
+    public static final String SCAN_STARTUP_MODE = "scan.startup.mode";
+
+    /**
+     * Optional startup mode for Dameng CDC consumer,
+     * valid enumerations are "initial" and "latest-offset".
+     * Please see Startup Reading Positionsection for more detailed information.
+     */
+    @Getter
+    public enum ScanStartUpMode {
+
+        /**
+         * Performs an initial snapshot on the monitored database tables upon first startup,
+         * and continue to read the latest binlog.
+         */
+        INITIAL("initial"),
+        /**
+         * Never to perform a snapshot on the monitored database tables upon first startup,
+         * just read from the change since the connector was started.
+         */
+        LATEST_OFFSET("latest-offset");
+
+        final String value;
+
+        ScanStartUpMode(String value) {
+            this.value = value;
+        }
+
+        public static ScanStartUpMode forName(String name) {
+            for (ScanStartUpMode dataType : ScanStartUpMode.values()) {
+                if (dataType.getValue().equals(name)) {
+                    return dataType;
+                }
+            }
+            throw new IllegalArgumentException(String.format("Unsupport ScanStartUpMode for Dameng source:%s", name));
+        }
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.protocol.node;
 
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.node.extract.DamengExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.DorisExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.FileSystemExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.HudiExtractNode;
@@ -66,6 +67,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = DorisExtractNode.class, name = "dorisExtract"),
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
+        @JsonSubTypes.Type(value = DamengExtractNode.class, name = "damengExtract"),
 })
 @Data
 @NoArgsConstructor

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.protocol.node;
 
 import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.node.extract.DamengExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.DorisExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.FileSystemExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.HudiExtractNode;
@@ -80,6 +81,7 @@ import java.util.TreeMap;
         @JsonSubTypes.Type(value = DorisExtractNode.class, name = "dorisExtract"),
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
+        @JsonSubTypes.Type(value = DamengExtractNode.class, name = "damengExtract"),
         @JsonSubTypes.Type(value = TransformNode.class, name = "baseTransform"),
         @JsonSubTypes.Type(value = DistinctNode.class, name = "distinct"),
         @JsonSubTypes.Type(value = KafkaLoadNode.class, name = "kafkaLoad"),

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sort.protocol.node.extract;
 
 import com.google.common.base.Preconditions;

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
@@ -1,0 +1,118 @@
+package org.apache.inlong.sort.protocol.node.extract;
+
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.constant.DMConstant;
+import org.apache.inlong.sort.protocol.constant.DMConstant.ScanStartUpMode;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+import org.apache.inlong.sort.protocol.transformation.WatermarkField;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.inlong.sort.protocol.constant.DMConstant.CONNECTOR;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.DATABASE_NAME;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.HOSTNAME;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.PASSWORD;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.PORT;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.SCAN_STARTUP_MODE;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.SCHEMA_NAME;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.TABLE_NAME;
+import static org.apache.inlong.sort.protocol.constant.DMConstant.USERNAME;
+
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("damengExtract")
+@Data
+public class DamengExtractNode extends ExtractNode implements Serializable {
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Nullable
+    @JsonProperty("primaryKey")
+    private String primaryKey;
+    @Nonnull
+    @JsonProperty("hostname")
+    private String hostname;
+    @Nonnull
+    @JsonProperty("username")
+    private String username;
+    @Nonnull
+    @JsonProperty("password")
+    private String password;
+    @Nonnull
+    @JsonProperty("database")
+    private String database;
+    @Nonnull
+    @JsonProperty("schemaName")
+    private String schemaName;
+    @Nonnull
+    @JsonProperty("tableName")
+    private String tableName;
+    @Nonnull
+    @JsonProperty("scanStartupMode")
+    private ScanStartUpMode scanStartupMode;
+    @Nullable
+    @JsonProperty(value = "port", defaultValue = "5132")
+    private Integer port;
+
+
+    @JsonCreator
+    public DamengExtractNode(@JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("watermark_field") WatermarkField watermarkField,
+            @JsonProperty("properties") Map<String, String> properties,
+            @Nullable @JsonProperty("primaryKey") String primaryKey,
+            @JsonProperty("hostname") String hostname,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @JsonProperty("database") String database,
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty(value = "port", defaultValue = "1521") Integer port,
+            @Nullable @JsonProperty("scanStartupMode") ScanStartUpMode scanStartupMode) {
+        super(id, name, fields, watermarkField, properties);
+        this.primaryKey = primaryKey;
+        this.hostname = Preconditions.checkNotNull(hostname, "hostname is null");
+        this.username = Preconditions.checkNotNull(username, "username is null");
+        this.password = Preconditions.checkNotNull(password, "password is null");
+        this.database = Preconditions.checkNotNull(database, "database is null");
+        this.schemaName = Preconditions.checkNotNull(schemaName, "schemaName is null");
+        this.tableName = Preconditions.checkNotNull(tableName, "tableName is null");
+        this.port = port;
+        this.scanStartupMode = scanStartupMode;
+    }
+
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        //using oracle constants is ok, since dameng is essentially built upon oracle.
+        options.put(CONNECTOR, "dm-cdc");
+        options.put(HOSTNAME, hostname);
+        options.put(USERNAME, username);
+        options.put(PASSWORD, password);
+        options.put(DATABASE_NAME, database);
+        options.put(SCHEMA_NAME, schemaName);
+        options.put(TABLE_NAME, tableName);
+        options.put(SCAN_STARTUP_MODE, scanStartupMode.getValue());
+        if (port != null) {
+            options.put(PORT, port.toString());
+        }
+        return options;
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/DamengExtractNode.java
@@ -17,6 +17,11 @@
 
 package org.apache.inlong.sort.protocol.node.extract;
 
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.constant.DMConstant.ScanStartUpMode;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+import org.apache.inlong.sort.protocol.transformation.WatermarkField;
+
 import com.google.common.base.Preconditions;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -24,14 +29,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCre
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
-import org.apache.inlong.sort.protocol.FieldInfo;
-import org.apache.inlong.sort.protocol.constant.DMConstant;
-import org.apache.inlong.sort.protocol.constant.DMConstant.ScanStartUpMode;
-import org.apache.inlong.sort.protocol.node.ExtractNode;
-import org.apache.inlong.sort.protocol.transformation.WatermarkField;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +81,6 @@ public class DamengExtractNode extends ExtractNode implements Serializable {
     @JsonProperty(value = "port", defaultValue = "5132")
     private Integer port;
 
-
     @JsonCreator
     public DamengExtractNode(@JsonProperty("id") String id,
             @JsonProperty("name") String name,
@@ -108,11 +108,10 @@ public class DamengExtractNode extends ExtractNode implements Serializable {
         this.scanStartupMode = scanStartupMode;
     }
 
-
     @Override
     public Map<String, String> tableOptions() {
         Map<String, String> options = super.tableOptions();
-        //using oracle constants is ok, since dameng is essentially built upon oracle.
+        // using oracle constants is ok, since dameng is essentially built upon oracle.
         options.put(CONNECTOR, "dm-cdc");
         options.put(HOSTNAME, hostname);
         options.put(USERNAME, username);


### PR DESCRIPTION
- Fixes #9559 

### Motivation

This is the inlong manager layer adaptation of the new Dameng Source Connector

### Modifications

Modified constants, jsons and field mappers in order to adapt to dameng cdc connector

### Verifying this change
- [ ] This change added tests and can be verified as follows:
package a sort dist and manager client
run dameng on it.

### Documentation
The feature will be documented by #9558 