### PR TITLE
[INLONG-9558][Sort] Add Dameng Connector for flink 1.13

### DIFF
--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -240,6 +240,12 @@
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.apache.inlong</groupId>
+                    <artifactId>sort-connector-dm-cdc</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
         <profile>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/pom.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.inlong</groupId>
+        <artifactId>sort-connectors</artifactId>
+        <version>1.6.0</version>
+    </parent>
+
+    <artifactId>sort-connector-dm-cdc</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache InLong - Sort-connector-dm-cdc</name>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-common</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-format-json</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_2.12</artifactId>
+            <version>1.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <version>1.5.4.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>2.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-api</artifactId>
+            <version>2.7.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.dameng</groupId>
+            <artifactId>DmJdbcDriver18</artifactId>
+            <version>8.1.2.79</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-cdc-base</artifactId>
+            <version>1.6.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.ververica</groupId>
+            <artifactId>flink-connector-oracle-cdc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-connector-oracle</artifactId>
+            <version>2.3.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.debezium</groupId>
+            <artifactId>debezium-core</artifactId>
+            <version>1.9.7.Final</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.apache.inlong:*</include>
+                                    <include>io.debezium:debezium-api</include>
+                                    <include>io.debezium:debezium-embedded</include>
+                                    <include>io.debezium:debezium-core</include>
+                                    <incldue>io.debezium:debezium-ddl-parser</incldue>
+                                    <include>io.debezium:debezium-connector-oracle</include>
+                                    <include>com.ververica:flink-connector-debezium</include>
+                                    <include>com.ververica:flink-connector-oracle-cdc</include>
+                                    <include>org.antlr:antlr4-runtime</include>
+                                    <include>com.oracle.ojdbc:*</include>
+                                    <include>com.dameng:*</include>
+                                    <include>org.apache.kafka:*</include>
+                                    <include>com.fasterxml.*:*</include>
+                                    <include>com.google.guava:*</include>
+                                    <!--  Include fixed version 18.0-13.0 of flink shaded guava  -->
+                                    <include>org.apache.flink:flink-shaded-guava</include>
+                                    <include>com.google.protobuf:*</include>
+                                    <include>com.ververica:flink-cdc-base</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.inlong:sort-connector-*</artifact>
+                                    <includes>
+                                        <include>org/apache/inlong/**</include>
+                                        <include>io/debezium/connector/oracle/**</include>
+                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.apache.kafka:*</artifact>
+                                    <excludes>
+                                        <exclude>kafka/kafka-version.properties</exclude>
+                                        <exclude>LICENSE</exclude>
+                                        <!-- Does not contain anything relevant.
+                                            Cites a binary dependency on jersey, but this is neither reflected in the
+                                            dependency graph, nor are any jersey files bundled. -->
+                                        <exclude>NOTICE</exclude>
+                                        <exclude>common/**</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.base</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.sort.base</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.cdc.base</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.sort.cdc.base</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.debezium</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.io.debezium</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.kafka</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.org.apache.kafka</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.antlr</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.org.antlr</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.cdc.dm.model.com.fasterxml</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors</artifactId>
-        <version>1.6.0</version>
+        <version>1.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>sort-connector-dm-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/DMSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/DMSource.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.inlong.sort.cdc.dm.source.DMRichSourceFunction;
+import org.apache.inlong.sort.cdc.dm.table.DMDeserializationSchema;
+import org.apache.inlong.sort.cdc.dm.table.StartupMode;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A builder to build a SourceFunction which can read snapshot and change events of DM. */
+@PublicEvolving
+public class DMSource {
+
+    public static <T> Builder<T> builder() {
+        return new Builder<>();
+    }
+
+    /** Builder class of {@link DMSource}. */
+    public static class Builder<T> {
+
+        // common config
+        private StartupMode startupMode;
+        private String username;
+        private String password;
+        private String databaseName;
+        private String schemaName;
+        private String tableName;
+        private String tableList;
+        private String serverTimeZone;
+        private Duration connectTimeout;
+
+        // snapshot reading config
+        private String hostname;
+        private Integer port;
+        private Properties jdbcProperties;
+        private DMDeserializationSchema<T> deserializer;
+        private Long startupTimestamp;
+
+        // metrics related
+        private String inlongMetric;
+        private String auditHostAndPorts;
+
+        // does not need incremental reading config nor logmnr_dll
+        // use DMBS_LOGMNR to directly access scn.
+
+        public Builder<T> startupMode(StartupMode startupMode) {
+            this.startupMode = startupMode;
+            return this;
+        }
+
+        public Builder<T> username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder<T> password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder<T> databaseName(String databaseName) {
+            this.databaseName = databaseName;
+            return this;
+        }
+
+        public Builder<T> schemaName(String schemaName) {
+            this.schemaName = schemaName;
+            return this;
+        }
+
+        public Builder<T> tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder<T> tableList(String tableList) {
+            this.tableList = tableList;
+            return this;
+        }
+
+        public Builder<T> serverTimeZone(String serverTimeZone) {
+            this.serverTimeZone = serverTimeZone;
+            return this;
+        }
+
+        public Builder<T> connectTimeout(Duration connectTimeout) {
+            this.connectTimeout = connectTimeout;
+            return this;
+        }
+
+        public Builder<T> hostname(String hostname) {
+            this.hostname = hostname;
+            return this;
+        }
+
+        public Builder<T> port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder<T> jdbcProperties(Properties jdbcProperties) {
+            this.jdbcProperties = jdbcProperties;
+            return this;
+        }
+
+        public Builder<T> startupTimestamp(Long startupTimestamp) {
+            this.startupTimestamp = startupTimestamp;
+            return this;
+        }
+
+        public Builder<T> deserializer(DMDeserializationSchema<T> deserializer) {
+            this.deserializer = deserializer;
+            return this;
+        }
+
+        public Builder<T> inlongMetric(String inlongMetric) {
+            this.inlongMetric = inlongMetric;
+            return this;
+        }
+
+        public Builder<T> auditHostAndPorts(String auditHostAndPorts) {
+            this.auditHostAndPorts = auditHostAndPorts;
+            return this;
+        }
+
+        public SourceFunction<T> build() {
+            switch (startupMode) {
+                case INITIAL:
+                    checkNotNull(hostname, "hostname shouldn't be null on startup mode 'initial'");
+                    checkNotNull(port, "port shouldn't be null on startup mode 'initial'");
+                    startupTimestamp = 0L;
+                    break;
+                case LATEST_OFFSET:
+                    startupTimestamp = 0L;
+                    break;
+                case TIMESTAMP:
+                    checkNotNull(
+                            startupTimestamp,
+                            "startupTimestamp shouldn't be null on startup mode 'timestamp'");
+                    break;
+                default:
+                    throw new UnsupportedOperationException(
+                            startupMode + " mode is not supported.");
+            }
+
+            if (StringUtils.isNotEmpty(databaseName) || StringUtils.isNotEmpty(tableName)) {
+                if (StringUtils.isEmpty(databaseName) || StringUtils.isEmpty(tableName)) {
+                    throw new IllegalArgumentException(
+                            "'database-name' and 'table-name' should be configured at the same time");
+                }
+            } else {
+                checkNotNull(
+                        tableList,
+                        "'database-name', 'table-name' or 'table-list' should be configured");
+            }
+
+            if (serverTimeZone == null) {
+                serverTimeZone = "+00:00";
+            }
+
+            if (connectTimeout == null) {
+                connectTimeout = Duration.ofSeconds(30);
+            }
+
+            return new DMRichSourceFunction<>(
+                    StartupMode.INITIAL.equals(startupMode),
+                    username,
+                    password,
+                    databaseName,
+                    schemaName,
+                    tableName,
+                    tableList,
+                    connectTimeout,
+                    hostname,
+                    port,
+                    jdbcProperties,
+                    deserializer,
+                    inlongMetric,
+                    auditHostAndPorts);
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMConnection.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMConnection.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.source;
+
+import io.debezium.jdbc.JdbcConfiguration;
+import io.debezium.jdbc.JdbcConnection;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class DMConnection extends JdbcConnection {
+
+    private static final String QUOTED_CHARACTER = "\"";
+
+    private static final Properties DEFAULT_JDBC_PROPERTIES = initializeDefaultJdbcProperties();
+
+    private static final String DM_URL_PATTERN =
+            "jdbc:dm://${hostname}:${port}/${database}";
+
+    public DMConnection(
+            String hostname,
+            Integer port,
+            String user,
+            String password,
+            Duration timeout,
+            String jdbcDriver,
+            Properties jdbcProperties,
+            ClassLoader classLoader) {
+        super(
+                config(hostname, port, user, password, timeout),
+                factory(jdbcDriver, jdbcProperties, classLoader),
+                QUOTED_CHARACTER,
+                QUOTED_CHARACTER);
+    }
+
+    private static Properties initializeDefaultJdbcProperties() {
+        Properties defaultJdbcProperties = new Properties();
+        defaultJdbcProperties.setProperty("useInformationSchema", "true");
+        defaultJdbcProperties.setProperty("nullCatalogMeansCurrent", "false");
+        defaultJdbcProperties.setProperty("useUnicode", "true");
+        defaultJdbcProperties.setProperty("zeroDateTimeBehavior", "convertToNull");
+        defaultJdbcProperties.setProperty("characterEncoding", "UTF-8");
+        defaultJdbcProperties.setProperty("characterSetResults", "UTF-8");
+        return defaultJdbcProperties;
+    }
+
+    private static JdbcConfiguration config(
+            String hostname, Integer port, String user, String password, Duration timeout) {
+        return JdbcConfiguration.create()
+                .with("hostname", hostname)
+                .with("port", port)
+                .with("user", user)
+                .with("password", password)
+                .with("connectTimeout", timeout)
+                .build();
+    }
+
+    private static JdbcConnection.ConnectionFactory factory(
+            String jdbcDriver, Properties jdbcProperties, ClassLoader classLoader) {
+        return JdbcConnection.patternBasedFactory(
+                formatJdbcUrl(jdbcProperties), jdbcDriver, classLoader);
+    }
+
+    private static String formatJdbcUrl(Properties jdbcProperties) {
+        Properties combinedProperties = new Properties();
+        combinedProperties.putAll(DEFAULT_JDBC_PROPERTIES);
+        if (jdbcProperties != null) {
+            combinedProperties.putAll(jdbcProperties);
+        }
+        String urlPattern = DM_URL_PATTERN;
+        StringBuilder jdbcUrlStringBuilder = new StringBuilder(urlPattern);
+        combinedProperties.forEach(
+                (key, value) -> {
+                    jdbcUrlStringBuilder.append("&").append(key).append("=").append(value);
+                });
+        return jdbcUrlStringBuilder.toString();
+    }
+
+    /**
+     * Get table list by database name pattern and table name pattern.
+     *
+     * @param dbPattern Database name pattern.
+     * @param tbPattern Table name pattern.
+     * @return Table list.
+     * @throws SQLException If a database access error occurs.
+     */
+    public List<String> getTables(String dbPattern, String tbPattern) throws SQLException {
+        List<String> result = new ArrayList<>();
+        DatabaseMetaData metaData = connection().getMetaData();
+        List<String> dbNames = getResultList(metaData.getSchemas(), "TABLE_SCHEM");
+        dbNames = dbNames.stream()
+                .filter(dbName -> Pattern.matches(dbPattern, dbName))
+                .collect(Collectors.toList());
+        for (String dbName : dbNames) {
+            List<String> tableNames =
+                    getResultList(
+                            metaData.getTables(null, dbName, null, new String[]{"TABLE"}),
+                            "TABLE_NAME");
+            tableNames.stream()
+                    .filter(tbName -> Pattern.matches(tbPattern, tbName))
+                    .forEach(tbName -> result.add(dbName + "." + tbName));
+        }
+        return result;
+    }
+
+    private List<String> getResultList(ResultSet resultSet, String columnName) throws SQLException {
+        List<String> result = new ArrayList<>();
+        while (resultSet.next()) {
+            result.add(resultSet.getString(columnName));
+        }
+        return result;
+    }
+
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMDeserializationRuntimeConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMDeserializationRuntimeConverter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.source;
+
+import java.io.Serializable;
+
+/**
+ * Runtime converter that converts objects of DM into objects of Flink Table & SQL internal
+ * data structures.
+ */
+public interface DMDeserializationRuntimeConverter extends Serializable {
+
+    Object convert(Object object) throws Exception;
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMRichSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/DMRichSourceFunction.java
@@ -1,0 +1,440 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.source;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricOption.RegisteredMetric;
+import org.apache.inlong.sort.base.metric.MetricState;
+import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.util.MetricStateUtils;
+import org.apache.inlong.sort.cdc.dm.table.DMDeserializationSchema;
+import org.apache.inlong.sort.cdc.dm.table.DMRecord;
+import org.apache.inlong.sort.cdc.dm.utils.DMSQLClient;
+import org.apache.inlong.sort.cdc.dm.utils.LogMinerDmlParser;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Method;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC_STATE_NAME;
+import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
+import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN;
+
+/**
+ * The source implementation for DM that read snapshot events first and then read the change
+ * event.
+ *
+ * @param <T> The type created by the deserializer.
+ */
+public class DMRichSourceFunction<T> extends RichSourceFunction<T>
+        implements
+            CheckpointListener,
+            CheckpointedFunction,
+            ResultTypeQueryable<T> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(DMRichSourceFunction.class);
+
+    // reading snapshot
+    private final String username;
+    private final String password;
+    private final String databaseName;
+    private final String schemaName;
+    private final String tableName;
+    private final Duration connectTimeout;
+    private final String hostname;
+    private final Integer port;
+    private final Properties jdbcProperties;
+
+    // one single connection used to handle incremental records
+    private transient volatile DMConnection snapshotConnection;
+    private transient volatile DMSQLClient client;
+    private final DMDeserializationSchema<T> deserializer;
+
+    // state related parameters
+    private volatile long scn;
+    private volatile boolean snapshot;
+
+    private transient Set<String> tableSet;
+    private transient ListState<Long> offsetState;
+    private transient OutputCollector<T> outputCollector;
+    private transient LogMinerDmlParser logMinerDmlParser;
+    private boolean isRunning;
+
+    // inlong metric related configs
+    private final String inlongMetric;
+    private final String inlongAudit;
+    private SourceMetricData metricData;
+    private transient ListState<MetricState> metricStateListState;
+    private MetricState metricState;
+
+    // reserved for whole db migration
+    private final boolean sourceMultipleEnable = false;
+
+    public DMRichSourceFunction(
+            boolean snapshot,
+            String username,
+            String password,
+            String databaseName,
+            String schemaName,
+            String tableName,
+            String tableList,
+            Duration connectTimeout,
+            String hostname,
+            Integer port,
+            Properties jdbcProperties,
+            DMDeserializationSchema<T> deserializer,
+            String inlongMetric,
+            String inlongAudit) {
+        this.snapshot = snapshot;
+        this.username = username;
+        this.password = password;
+        this.databaseName = databaseName;
+        this.tableName = tableName;
+        this.schemaName = schemaName;
+        this.connectTimeout = connectTimeout;
+        this.hostname = hostname;
+        this.port = port;
+        this.jdbcProperties = jdbcProperties;
+        this.deserializer = deserializer;
+        this.inlongMetric = inlongMetric;
+        this.inlongAudit = inlongAudit;
+    }
+
+    @Override
+    public void open(final Configuration config) throws Exception {
+        LOG.info("starting to open");
+        super.open(config);
+        this.outputCollector = new OutputCollector<>();
+    }
+
+    @Override
+    public void run(SourceContext<T> ctx) throws Exception {
+        LOG.info("starting to open logminer");
+        instantiateStates(ctx);
+        DMConnection incrementalConnection = new DMConnection(
+                hostname,
+                port,
+                username,
+                password,
+                connectTimeout,
+                "dm.jdbc.driver.DmDriver",
+                jdbcProperties,
+                getClass().getClassLoader());
+
+        // logs related to this part are printed in dmsqlclient, not here.
+        this.client = new DMSQLClient(incrementalConnection, tableName);
+        outputCollector.context = ctx;
+        try {
+            LOG.info("Start to initialize table whitelist");
+            initTableWhiteList();
+            // check where to do the snapshot phase
+            LOG.info("Snapshot reading started");
+            readSnapshotRecords();
+            LOG.info("Snapshot reading finished, start readChangeRecords process");
+            scn = client.openlogminer();
+            isRunning = true;
+            readChangeRecords();
+        } finally {
+            isRunning = false;
+            cancel();
+        }
+    }
+
+    private void instantiateStates(SourceContext<T> ctx) {
+        try {
+            final Method getMetricGroupMethod =
+                    getRuntimeContext().getClass().getMethod("getMetricGroup");
+            getMetricGroupMethod.setAccessible(true);
+            final MetricGroup metricGroup =
+                    (MetricGroup) getMetricGroupMethod.invoke(getRuntimeContext());
+            MetricOption metricOption = MetricOption.builder()
+                    .withInlongLabels(inlongMetric)
+                    .withInlongAudit(inlongAudit)
+                    .withInitRecords(metricState != null ? metricState.getMetricValue(NUM_RECORDS_IN) : 0L)
+                    .withInitBytes(metricState != null ? metricState.getMetricValue(NUM_BYTES_IN) : 0L)
+                    .withRegisterMetric(RegisteredMetric.ALL)
+                    .build();
+            if (metricOption != null) {
+                metricData = new SourceMetricData(metricOption, metricGroup);
+            }
+        } catch (Throwable e) {
+            LOG.error("initialize inlong metric failed ", e);
+        }
+    }
+
+    private DMConnection getSnapshotConnection() {
+        if (snapshotConnection == null) {
+            snapshotConnection =
+                    new DMConnection(
+                            hostname,
+                            port,
+                            username,
+                            password,
+                            connectTimeout,
+                            "dm.jdbc.driver.DmDriver",
+                            jdbcProperties,
+                            getClass().getClassLoader());
+        }
+        return snapshotConnection;
+    }
+
+    private void closeSnapshotConnection() {
+        if (snapshotConnection != null) {
+            try {
+                snapshotConnection.close();
+            } catch (SQLException e) {
+                LOG.error("Failed to close snapshotConnection", e);
+            }
+            snapshotConnection = null;
+        }
+    }
+
+    private void initTableWhiteList() {
+        if (tableSet != null && !tableSet.isEmpty()) {
+            return;
+        }
+
+        final Set<String> localTableSet = new HashSet<>();
+        localTableSet.add(schemaName + "." + tableName);
+
+        LOG.info("Table list: {}", localTableSet);
+        this.tableSet = localTableSet;
+    }
+
+    protected void readSnapshotRecords() {
+        tableSet.forEach(
+                table -> {
+                    String[] schema = table.split("\\.");
+                    readSnapshotRecordsByTable(databaseName, schema[0], schema[1]);
+                });
+        snapshot = false;
+    }
+
+    private void readSnapshotRecordsByTable(String databaseName, String schemaName, String tableName) {
+        // snapshot phase can't determine exact scn, assign 0 to all.
+        DMRecord.SourceInfo sourceInfo = new DMRecord.SourceInfo(databaseName, schemaName, tableName, 0);
+        String fullName = String.format("%s.%s", schemaName, tableName);
+        StringBuilder queryString = new StringBuilder("SELECT * FROM " + fullName);
+        // for incremental mode, just read one snapshot to get the table schema
+        if (!snapshot) {
+            queryString.append(" LIMIT 1");
+        }
+        try {
+            LOG.info("Start to read snapshot from {}", fullName);
+            getSnapshotConnection()
+                    .query(queryString.toString(),
+                            rs -> {
+                                ResultSetMetaData metaData = rs.getMetaData();
+                                List<String> columns = new ArrayList<>();
+                                while (rs.next()) {
+                                    Map<String, Object> fieldMap = new HashMap<>();
+                                    for (int i = 0; i < metaData.getColumnCount(); i++) {
+                                        fieldMap.put(
+                                                metaData.getColumnName(i + 1), rs.getObject(i + 1));
+                                        if (logMinerDmlParser == null) {
+                                            columns.add(metaData.getColumnName(i + 1));
+                                        }
+                                    }
+
+                                    if (logMinerDmlParser == null) {
+                                        // the actual columns are the reverse of the actual order for dm, error-prone.
+                                        Collections.reverse(columns);
+                                        this.logMinerDmlParser = new LogMinerDmlParser(columns);
+                                        // dml parser must be initialized, so snapshot phase must be executed.
+                                        if (!snapshot) {
+                                            return;
+                                        }
+                                    }
+                                    DMRecord record = new DMRecord(sourceInfo, OperationType.INSERT, fieldMap);
+                                    if (metricData != null) {
+                                        metricData.outputMetrics(1, record.toString().getBytes().length * 8L);
+                                    }
+                                    try {
+                                        deserializer.deserialize(record, outputCollector);
+                                    } catch (Exception e) {
+                                        LOG.error("Deserialize snapshot record failed ", e);
+                                        throw new FlinkRuntimeException(e);
+                                    }
+
+                                }
+                            });
+            LOG.info("Read snapshot from {} finished", fullName);
+        } catch (SQLException e) {
+            LOG.error("Read snapshot from table " + fullName + " failed", e);
+            throw new FlinkRuntimeException(e);
+        }
+    }
+
+    private void readChangeRecords() {
+        LOG.info("starting to read change records");
+        while (isRunning) {
+            // TODO: make this multithreaded (one connection per thread), and improve performance
+            final CountDownLatch latch = new CountDownLatch(1);
+            List<DMRecord> records = getNewRecords();
+            // wait for timeout and restart logminer if current session has no incremental records.
+            if (!records.isEmpty()) {
+                latch.countDown();
+            } else {
+                LOG.warn("no change detected, restarting logminer");
+                // if the last redo log is exhausted, no new change will come, so restart logminer.
+                try {
+                    client.closelogminer();
+                    client.openlogminer();
+                    latch.countDown();
+                    LOG.info("restart logminer success");
+                } catch (Throwable e) {
+                    LOG.error("restart logminer failed ", e);
+                }
+            }
+        }
+    }
+
+    private List<DMRecord> getNewRecords() {
+        List<DMRecord> records = client.processIncrementalRecords(databaseName, schemaName, scn, logMinerDmlParser);
+        try {
+            records.forEach(
+                    r -> {
+                        try {
+                            deserializer.deserialize(r, outputCollector);
+                            scn = r.getSourceInfo().getSCN();
+                        } catch (Exception e) {
+                            throw new FlinkRuntimeException(e);
+                        }
+                    });
+        } catch (Throwable e) {
+            LOG.error("read change records failed ", e);
+        }
+
+        // add record size, process specially for update records
+        int size = 0;
+        for (DMRecord record : records) {
+            if (record.getOpt().equals(OperationType.UPDATE)) {
+                size += 2;
+            } else {
+                size++;
+            }
+        }
+
+        if (metricData != null) {
+            metricData.outputMetrics(size, records.size() * 8L);
+            LOG.info("registering metrics {}", records.size());
+        }
+        LOG.info("finished processing {} incremental records", records.size());
+        return records;
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long l) {
+        // do nothing
+    }
+
+    @Override
+    public TypeInformation<T> getProducedType() {
+        return this.deserializer.getProducedType();
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        LOG.info(
+                "snapshotState checkpoint: {} at scn: {}",
+                context.getCheckpointId(),
+                scn);
+        offsetState.clear();
+        offsetState.add(scn);
+        if (metricData != null && metricStateListState != null) {
+            MetricStateUtils.snapshotMetricStateForSourceMetricData(metricStateListState, metricData,
+                    getRuntimeContext().getIndexOfThisSubtask());
+        }
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        LOG.info("initialize checkpoint");
+        OperatorStateStore stateStore = context.getOperatorStateStore();
+        offsetState = stateStore.getListState(
+                new ListStateDescriptor<>(
+                        "scnState", LongSerializer.INSTANCE));
+
+        if (this.inlongMetric != null) {
+            this.metricStateListState =
+                    stateStore.getUnionListState(
+                            new ListStateDescriptor<>(
+                                    INLONG_METRIC_STATE_NAME, TypeInformation.of(new TypeHint<MetricState>() {
+                                    })));
+        }
+
+        if (context.isRestored()) {
+            for (final Long offset : offsetState.get()) {
+                scn = offset;
+                LOG.info("Restore State from scn: {}", scn);
+                return;
+            }
+        }
+    }
+
+    @Override
+    public void cancel() {
+        closeSnapshotConnection();
+        client.closelogminer();
+    }
+
+    private static class OutputCollector<T> implements Collector<T> {
+
+        private SourceContext<T> context;
+
+        @Override
+        public void collect(T record) {
+            context.collect(record);
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/RowDataDMDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/source/RowDataDMDeserializationSchema.java
@@ -1,0 +1,660 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.source;
+
+import akka.protobuf.ByteString;
+import com.ververica.cdc.debezium.utils.TemporalConversions;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.cdc.dm.table.DMAppendMetadataCollector;
+import org.apache.inlong.sort.cdc.dm.table.DMDeserializationSchema;
+import org.apache.inlong.sort.cdc.dm.table.DMMetadataConverter;
+import org.apache.inlong.sort.cdc.dm.table.DMRecord;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Date;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Deserialization schema from DM object to Flink Table/SQL internal data structure {@link
+ * RowData}.
+ */
+@Slf4j
+public class RowDataDMDeserializationSchema
+        implements
+            DMDeserializationSchema<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** TypeInformation of the produced {@link RowData}. * */
+    private final TypeInformation<RowData> resultTypeInfo;
+
+    /**
+     * Runtime converter that DM record data into {@link RowData} consisted of physical
+     * column values.
+     */
+    private final DMDeserializationRuntimeConverter physicalConverter;
+
+    /** Whether the deserializer needs to handle metadata columns. */
+    private final boolean hasMetadata;
+
+    /**
+     * A wrapped output collector which is used to append metadata columns after physical columns.
+     */
+    private final DMAppendMetadataCollector appendMetadataCollector;
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    RowDataDMDeserializationSchema(
+            RowType physicalDataType,
+            DMMetadataConverter[] metadataConverters,
+            TypeInformation<RowData> resultTypeInfo,
+            ZoneId serverTimeZone) {
+        this.hasMetadata = checkNotNull(metadataConverters).length > 0;
+        this.appendMetadataCollector = new DMAppendMetadataCollector(metadataConverters);
+        this.physicalConverter = createConverter(checkNotNull(physicalDataType), serverTimeZone);
+        this.resultTypeInfo = checkNotNull(resultTypeInfo);
+    }
+
+    @Override
+    public void deserialize(DMRecord record, Collector<RowData> out) throws Exception {
+        log.debug("deserializing record: " + record);
+        RowData physicalRow;
+        if (record.isSnapshotRecord()) {
+            physicalRow = (GenericRowData) physicalConverter.convert(record.getJdbcFields());
+            physicalRow.setRowKind(RowKind.INSERT);
+            emit(record, physicalRow, out);
+        } else {
+            switch (record.getOpt()) {
+                case INSERT:
+                    physicalRow =
+                            (GenericRowData) physicalConverter.convert(record.getLogMessageFieldsAfter());
+                    physicalRow.setRowKind(RowKind.INSERT);
+                    emit(record, physicalRow, out);
+                    break;
+                case DELETE:
+                    physicalRow =
+                            (GenericRowData) physicalConverter.convert(record.getLogMessageFieldsBefore());
+                    physicalRow.setRowKind(RowKind.DELETE);
+                    emit(record, physicalRow, out);
+                    break;
+                case UPDATE:
+                    physicalRow =
+                            (GenericRowData) physicalConverter.convert(record.getLogMessageFieldsBefore());
+                    physicalRow.setRowKind(RowKind.UPDATE_BEFORE);
+                    emit(record, physicalRow, out);
+                    physicalRow =
+                            (GenericRowData) physicalConverter.convert(record.getLogMessageFieldsAfter());
+                    physicalRow.setRowKind(RowKind.UPDATE_AFTER);
+                    emit(record, physicalRow, out);
+                    break;
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported log message record type: " + record.getOpt());
+            }
+        }
+    }
+
+    private void emit(DMRecord row, RowData physicalRow, Collector<RowData> collector) {
+        if (!hasMetadata) {
+            collector.collect(physicalRow);
+            return;
+        }
+
+        appendMetadataCollector.inputRecord = row;
+        appendMetadataCollector.outputCollector = collector;
+        appendMetadataCollector.collect(physicalRow);
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return resultTypeInfo;
+    }
+
+    /** Builder class of {@link RowDataDMDeserializationSchema}. */
+    public static class Builder {
+
+        private RowType physicalRowType;
+        private TypeInformation<RowData> resultTypeInfo;
+        private DMMetadataConverter[] metadataConverters = new DMMetadataConverter[0];
+        private ZoneId serverTimeZone = ZoneId.of("UTC");
+
+        public Builder setPhysicalRowType(
+                RowType physicalRowType) {
+            this.physicalRowType = physicalRowType;
+            return this;
+        }
+
+        public Builder setMetadataConverters(
+                DMMetadataConverter[] metadataConverters) {
+            this.metadataConverters = metadataConverters;
+            return this;
+        }
+
+        public Builder setResultTypeInfo(
+                TypeInformation<RowData> resultTypeInfo) {
+            this.resultTypeInfo = resultTypeInfo;
+            return this;
+        }
+
+        public Builder setServerTimeZone(
+                ZoneId serverTimeZone) {
+            this.serverTimeZone = serverTimeZone;
+            return this;
+        }
+
+        public RowDataDMDeserializationSchema build() {
+            return new RowDataDMDeserializationSchema(
+                    physicalRowType, metadataConverters, resultTypeInfo, serverTimeZone);
+        }
+    }
+
+    private static DMDeserializationRuntimeConverter createConverter(
+            LogicalType type, ZoneId serverTimeZone) {
+        return wrapIntoNullableConverter(createNotNullConverter(type, serverTimeZone));
+    }
+
+    private static DMDeserializationRuntimeConverter wrapIntoNullableConverter(
+            DMDeserializationRuntimeConverter converter) {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) throws Exception {
+                if (object == null) {
+                    return null;
+                }
+                return converter.convert(object);
+            }
+        };
+    }
+
+    public static DMDeserializationRuntimeConverter createNotNullConverter(
+            LogicalType type, ZoneId serverTimeZone) {
+        switch (type.getTypeRoot()) {
+            case ROW:
+                return createRowConverter((RowType) type, serverTimeZone);
+            case NULL:
+                return convertToNull();
+            case BOOLEAN:
+                return convertToBoolean();
+            case TINYINT:
+                return convertToTinyInt();
+            case SMALLINT:
+                return convertToSmallInt();
+            case INTEGER:
+            case INTERVAL_YEAR_MONTH:
+                return convertToInt();
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return convertToLong();
+            case DATE:
+                return convertToDate();
+            case TIME_WITHOUT_TIME_ZONE:
+                return convertToTime();
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return convertToTimestamp();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return convertToLocalTimeZoneTimestamp(serverTimeZone);
+            case FLOAT:
+                return convertToFloat();
+            case DOUBLE:
+                return convertToDouble();
+            case CHAR:
+            case VARCHAR:
+                return convertToString();
+            case BINARY:
+                return convertToBinary();
+            case VARBINARY:
+                return convertToBytes();
+            case DECIMAL:
+                return createDecimalConverter((DecimalType) type);
+            case ARRAY:
+                return createArrayConverter();
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    private static DMDeserializationRuntimeConverter createRowConverter(
+            RowType rowType, ZoneId serverTimeZone) {
+        final DMDeserializationRuntimeConverter[] fieldConverters =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .map(logicType -> createConverter(logicType, serverTimeZone))
+                        .toArray(DMDeserializationRuntimeConverter[]::new);
+        final String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                int arity = fieldNames.length;
+                GenericRowData row = new GenericRowData(arity);
+                Map<String, Object> fieldMap = (Map<String, Object>) object;
+                for (int i = 0; i < arity; i++) {
+                    String fieldName = fieldNames[i];
+                    Object value = fieldMap.get(fieldName);
+                    try {
+                        row.setField(i, fieldConverters[i].convert(value));
+                    } catch (Exception e) {
+                        throw new RuntimeException(
+                                "Failed to convert field '" + fieldName + "' with value: " + value,
+                                e);
+                    }
+                }
+                return row;
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToNull() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                return null;
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToBoolean() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof byte[]) {
+                    return "1".equals(new String((byte[]) object, StandardCharsets.UTF_8));
+                }
+                return Boolean.parseBoolean(object.toString()) || "1".equals(object.toString());
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToTinyInt() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                return Byte.parseByte(object.toString());
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToSmallInt() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                return Short.parseShort(object.toString());
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToInt() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof Integer) {
+                    return object;
+                } else if (object instanceof Long) {
+                    return ((Long) object).intValue();
+                } else if (object instanceof Date) {
+                    return ((Date) object).toLocalDate().getYear();
+                } else {
+                    return Integer.parseInt(object.toString());
+                }
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToLong() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof Integer) {
+                    return ((Integer) object).longValue();
+                } else if (object instanceof Long) {
+                    return object;
+                } else {
+                    return Long.parseLong(object.toString());
+                }
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToDouble() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof Float) {
+                    return ((Float) object).doubleValue();
+                } else if (object instanceof Double) {
+                    return object;
+                } else {
+                    return Double.parseDouble(object.toString());
+                }
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToFloat() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof Float) {
+                    return object;
+                } else if (object instanceof Double) {
+                    return ((Double) object).floatValue();
+                } else {
+                    return Float.parseFloat(object.toString());
+                }
+            }
+        };
+    }
+
+    // for supplemental logs, dm will include the type before the actual value. remove the type.
+    private static String cleanTime(String strValue) {
+        if (strValue.startsWith("DATE'")) {
+            return strValue.substring(5, strValue.length() - 1);
+        } else if (strValue.startsWith("TIMESTAMP'")) {
+            return strValue.substring(10, strValue.length() - 1);
+        } else if (strValue.startsWith("DATETIME'")) {
+            return strValue.substring(9, strValue.length() - 1);
+        } else if (strValue.startsWith("TIME'")) {
+            return strValue.substring(5, strValue.length() - 1);
+        } else if (strValue.startsWith("ATE'")) {
+            return strValue.substring(4);
+        } else if (strValue.startsWith("IMESTAMP'")) {
+            return strValue.substring(9);
+        } else if (strValue.startsWith("ATETIME'")) {
+            return strValue.substring(8);
+        } else if (strValue.startsWith("IME'")) {
+            return strValue.substring(4);
+        } else {
+            return strValue;
+        }
+    }
+
+    private static DMDeserializationRuntimeConverter convertToDate() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof String) {
+                    object = Date.valueOf(cleanTime((String) object));
+                }
+                return (int) TemporalConversions.toLocalDate(object).toEpochDay();
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToTime() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof Long) {
+                    return (int) ((Long) object / 1000_000);
+                }
+                if (object instanceof String) {
+                    object = Time.valueOf(cleanTime((String) object));
+                }
+                return TemporalConversions.toLocalTime(object).toSecondOfDay() * 1000;
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToTimestamp() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof String) {
+                    object = Timestamp.valueOf(cleanTime((String) object));
+                }
+                if (object instanceof Timestamp) {
+                    return TimestampData.fromTimestamp((Timestamp) object);
+                }
+                if (object instanceof LocalDateTime) {
+                    return TimestampData.fromLocalDateTime((LocalDateTime) object);
+                }
+                throw new IllegalArgumentException(
+                        "Unable to convert to TimestampData from unexpected value '"
+                                + object
+                                + "' of type "
+                                + object.getClass().getName());
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToLocalTimeZoneTimestamp(
+            ZoneId serverTimeZone) {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof String) {
+                    object = Timestamp.valueOf(cleanTime((String) object));
+                }
+                if (object instanceof Timestamp) {
+                    return TimestampData.fromInstant(
+                            ((Timestamp) object)
+                                    .toLocalDateTime()
+                                    .atZone(serverTimeZone)
+                                    .toInstant());
+                }
+                if (object instanceof LocalDateTime) {
+                    return TimestampData.fromInstant(
+                            ((LocalDateTime) object).atZone(serverTimeZone).toInstant());
+                }
+                throw new IllegalArgumentException(
+                        "Unable to convert to TimestampData from unexpected value '"
+                                + object
+                                + "' of type "
+                                + object.getClass().getName());
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToString() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                String data = object.toString();
+                if (data.startsWith("'") && data.endsWith("'")) {
+                    data = data.substring(1, data.length() - 1);
+                }
+                return StringData.fromString(data);
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToBinary() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof String) {
+                    try {
+                        long v = Long.parseLong((String) object);
+                        byte[] bytes = ByteBuffer.allocate(8).putLong(v).array();
+                        int i = 0;
+                        while (i < Long.BYTES - 1 && bytes[i] == 0) {
+                            i++;
+                        }
+                        return Arrays.copyOfRange(bytes, i, Long.BYTES);
+                    } catch (NumberFormatException e) {
+                        return ((String) object).getBytes(StandardCharsets.UTF_8);
+                    }
+                } else if (object instanceof byte[]) {
+                    String str = new String((byte[]) object, StandardCharsets.US_ASCII);
+                    return str.getBytes(StandardCharsets.UTF_8);
+                } else if (object instanceof ByteBuffer) {
+                    ByteBuffer byteBuffer = (ByteBuffer) object;
+                    byte[] bytes = new byte[byteBuffer.remaining()];
+                    byteBuffer.get(bytes);
+                    return bytes;
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unsupported BINARY value type: " + object.getClass().getSimpleName());
+                }
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter convertToBytes() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                if (object instanceof String) {
+                    return ((String) object).getBytes(StandardCharsets.UTF_8);
+                } else if (object instanceof byte[]) {
+                    return object;
+                } else if (object instanceof ByteBuffer) {
+                    ByteBuffer byteBuffer = (ByteBuffer) object;
+                    byte[] bytes = new byte[byteBuffer.remaining()];
+                    byteBuffer.get(bytes);
+                    return bytes;
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Unsupported BYTES value type: " + object.getClass().getSimpleName());
+                }
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter createDecimalConverter(
+            DecimalType decimalType) {
+        final int precision = decimalType.getPrecision();
+        final int scale = decimalType.getScale();
+
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) {
+                BigDecimal bigDecimal;
+                if (object instanceof String) {
+                    bigDecimal = new BigDecimal((String) object);
+                } else if (object instanceof Long) {
+                    bigDecimal = new BigDecimal((Long) object);
+                } else if (object instanceof BigInteger) {
+                    bigDecimal = new BigDecimal((BigInteger) object);
+                } else if (object instanceof Double) {
+                    bigDecimal = BigDecimal.valueOf((Double) object);
+                } else if (object instanceof BigDecimal) {
+                    bigDecimal = (BigDecimal) object;
+                } else {
+                    throw new IllegalArgumentException(
+                            "Unable to convert to decimal from unexpected value '"
+                                    + object
+                                    + "' of type "
+                                    + object.getClass());
+                }
+                return DecimalData.fromBigDecimal(bigDecimal, precision, scale);
+            }
+        };
+    }
+
+    private static DMDeserializationRuntimeConverter createArrayConverter() {
+        return new DMDeserializationRuntimeConverter() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(Object object) throws UnsupportedEncodingException {
+                String s;
+                if (object instanceof ByteString) {
+                    s = ((ByteString) object).toString(StandardCharsets.UTF_8.name());
+                } else {
+                    s = object.toString();
+                }
+                String[] strArray = s.split(",");
+                StringData[] stringDataArray = new StringData[strArray.length];
+                for (int i = 0; i < strArray.length; i++) {
+                    stringDataArray[i] = StringData.fromString(strArray[i]);
+                }
+                return new GenericArrayData(stringDataArray);
+            }
+        };
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMAppendMetadataCollector.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMAppendMetadataCollector.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.JoinedRowData;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+/** Emits a row with physical fields and metadata fields. */
+@Internal
+public class DMAppendMetadataCollector implements Collector<RowData>, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DMMetadataConverter[] metadataConverters;
+
+    public transient DMRecord inputRecord;
+    public transient Collector<RowData> outputCollector;
+
+    public DMAppendMetadataCollector(DMMetadataConverter[] metadataConverters) {
+        this.metadataConverters = metadataConverters;
+    }
+
+    @Override
+    public void collect(RowData physicalRow) {
+        GenericRowData metaRow = new GenericRowData(metadataConverters.length);
+        for (int i = 0; i < metadataConverters.length; i++) {
+            Object meta = metadataConverters[i].read(inputRecord);
+            metaRow.setField(i, meta);
+        }
+        RowData outRow = new JoinedRowData(physicalRow.getRowKind(), physicalRow, metaRow);
+        outputCollector.collect(outRow);
+    }
+
+    @Override
+    public void close() {
+        // nothing to do
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMDeserializationSchema.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
+
+import java.io.Serializable;
+
+/**
+ * The deserialization schema describes how to turn the DM record into data types (Java/Scala
+ * objects) that are processed by Flink.
+ *
+ * @param <T> The type created by the deserialization schema.
+ */
+@PublicEvolving
+public interface DMDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /** Deserialize the DM record, it is represented in {@link DMRecord}. */
+    void deserialize(DMRecord record, Collector<T> out) throws Exception;
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMMetadataConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMMetadataConverter.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.Serializable;
+
+/** A converter converts DM record metadata into Flink internal data structures. */
+@FunctionalInterface
+@Internal
+public interface DMMetadataConverter extends Serializable {
+
+    Object read(DMRecord record);
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMReadableMetadata.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMReadableMetadata.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.DataType;
+
+public enum DMReadableMetadata {
+
+    /** Name of the database that contains the row. */
+    DATABASE(
+            "database_name",
+            DataTypes.STRING().notNull(),
+            new DMMetadataConverter() {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(DMRecord record) {
+                    return StringData.fromString(record.getSourceInfo().getDatabase());
+                }
+            }),
+
+    /** Name of the database that contains the row. */
+    SCHEMA(
+            "schema_name",
+            DataTypes.STRING().notNull(),
+            new DMMetadataConverter() {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(DMRecord record) {
+                    return StringData.fromString(record.getSourceInfo().getSchema());
+                }
+            }),
+
+    /** Name of the table that contains the row. */
+    TABLE(
+            "table_name",
+            DataTypes.STRING().notNull(),
+            new DMMetadataConverter() {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(DMRecord record) {
+                    return StringData.fromString(record.getSourceInfo().getTable());
+                }
+            }),
+
+    /**
+     * It indicates the scn that the change was made in the database. If the record is read from
+     * snapshot of the table instead of the change stream, the value is always 0.
+     */
+    SCN(
+            "scn",
+            DataTypes.BIGINT().notNull(),
+            new DMMetadataConverter() {
+
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public Object read(DMRecord record) {
+                    return record.getSourceInfo().getSCN();
+                }
+            });
+
+    private final String key;
+
+    private final DataType dataType;
+
+    private final DMMetadataConverter converter;
+
+    DMReadableMetadata(String key, DataType dataType, DMMetadataConverter converter) {
+        this.key = key;
+        this.dataType = dataType;
+        this.converter = converter;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public DMMetadataConverter getConverter() {
+        return converter;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMRecord.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMRecord.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** An internal data structure representing record of DM. */
+public class DMRecord implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SourceInfo sourceInfo;
+    private final boolean isSnapshotRecord;
+
+    // four fields represents a rowdata
+    private final OperationType opt;
+    private final Map<String, Object> jdbcFields;
+    private final Map<String, Object> logMessageFieldsBefore;
+    private final Map<String, Object> logMessageFieldsAfter;
+
+    public DMRecord(
+            SourceInfo sourceInfo,
+            OperationType opt,
+            Map<String, Object> jdbcFields) {
+        this.sourceInfo = sourceInfo;
+        this.isSnapshotRecord = true;
+        this.jdbcFields = jdbcFields;
+        this.opt = opt;
+        this.logMessageFieldsBefore = new HashMap<>();
+        this.logMessageFieldsAfter = new HashMap<>();
+    }
+
+    public DMRecord(
+            SourceInfo sourceInfo,
+            OperationType opt,
+            Map<String, Object> logMessageFieldsBefore,
+            Map<String, Object> logMessageFieldsAfter) {
+        this.sourceInfo = sourceInfo;
+        this.isSnapshotRecord = false;
+        this.jdbcFields = new HashMap<>();
+        this.opt = opt;
+        this.logMessageFieldsBefore = logMessageFieldsBefore;
+        this.logMessageFieldsAfter = logMessageFieldsAfter;
+    }
+
+    public SourceInfo getSourceInfo() {
+        return sourceInfo;
+    }
+
+    public boolean isSnapshotRecord() {
+        return isSnapshotRecord;
+    }
+
+    public Map<String, Object> getJdbcFields() {
+        return jdbcFields;
+    }
+
+    public OperationType getOpt() {
+        return opt;
+    }
+
+    public Map<String, Object> getLogMessageFieldsBefore() {
+        return logMessageFieldsBefore;
+    }
+
+    public Map<String, Object> getLogMessageFieldsAfter() {
+        return logMessageFieldsAfter;
+    }
+
+    @Override
+    public String toString() {
+        return "DMRecord{"
+                + "sourceInfo="
+                + sourceInfo
+                + ", isSnapshotRecord='"
+                + isSnapshotRecord
+                + '\''
+                + ", jdbcFields="
+                + jdbcFields
+                + ", logMessageFieldsBefore="
+                + logMessageFieldsBefore
+                + ", logMessageFieldsAfter="
+                + logMessageFieldsAfter
+                + ", opt="
+                + opt
+                + '}';
+    }
+
+    /** Information about the source of record. */
+    public static class SourceInfo implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String database;
+        private final String schema;
+        private final String table;
+        private final long scn;
+
+        public SourceInfo(String database, String schema, String table, long scn) {
+            this.database = database;
+            this.schema = schema;
+            this.table = table;
+            this.scn = scn;
+        }
+
+        public String getDatabase() {
+            return database;
+        }
+
+        public String getTable() {
+            return table;
+        }
+
+        public String getSchema() {
+            return schema;
+        }
+
+        public long getSCN() {
+            return scn;
+        }
+
+        @Override
+        public String toString() {
+            return "sourceInfo{"
+                    + getSCN() + ","
+                    + getDatabase() + ","
+                    + getSchema() + ","
+                    + getTable()
+                    + '}';
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMTableSource.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.inlong.sort.cdc.dm.DMSource;
+import org.apache.inlong.sort.cdc.dm.source.RowDataDMDeserializationSchema;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A {@link DynamicTableSource} implementation for DM. */
+public class DMTableSource implements ScanTableSource, SupportsReadingMetadata {
+
+    private final ResolvedSchema physicalSchema;
+
+    private final StartupMode startupMode;
+    private final String username;
+    private final String password;
+    private final String databaseName;
+    private final String schemaName;
+    private final String tableName;
+    private final String tableList;
+    private final Duration connectTimeout;
+    private final String serverTimeZone;
+    private final String hostname;
+    private final Integer port;
+    private final Properties jdbcProperties;
+    private final Long startupTimestamp;
+    private final String inlongMetrics;
+    private final String inlongAudit;
+
+    // --------------------------------------------------------------------------------------------
+    // Mutable attributes
+    // --------------------------------------------------------------------------------------------
+
+    /** Data type that describes the final output of the source. */
+    protected DataType producedDataType;
+
+    /** Metadata that is appended at the end of a physical source row. */
+    protected List<String> metadataKeys;
+
+    public DMTableSource(
+            ResolvedSchema physicalSchema,
+            StartupMode startupMode,
+            String username,
+            String password,
+            String databaseName,
+            String schemaName,
+            String tableName,
+            String tableList,
+            String serverTimeZone,
+            Duration connectTimeout,
+            String hostname,
+            Integer port,
+            Properties jdbcProperties,
+            Long startupTimestamp,
+            String inlongMetrics,
+            String inlongAudit) {
+        this.physicalSchema = physicalSchema;
+        this.startupMode = checkNotNull(startupMode);
+        this.username = checkNotNull(username);
+        this.password = checkNotNull(password);
+        this.databaseName = databaseName;
+        this.schemaName = schemaName;
+        this.tableName = tableName;
+        this.tableList = tableList;
+        this.serverTimeZone = serverTimeZone;
+        this.connectTimeout = connectTimeout;
+        this.hostname = hostname;
+        this.port = port;
+        this.jdbcProperties = jdbcProperties;
+        this.startupTimestamp = startupTimestamp;
+        this.producedDataType = physicalSchema.toPhysicalRowDataType();
+        this.metadataKeys = Collections.emptyList();
+        this.inlongMetrics = inlongMetrics;
+        this.inlongAudit = inlongAudit;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.all();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
+        RowType physicalDataType =
+                (RowType) physicalSchema.toPhysicalRowDataType().getLogicalType();
+        DMMetadataConverter[] metadataConverters = getMetadataConverters();
+        TypeInformation<RowData> resultTypeInfo = context.createTypeInformation(producedDataType);
+
+        RowDataDMDeserializationSchema deserializer =
+                RowDataDMDeserializationSchema.newBuilder()
+                        .setPhysicalRowType(physicalDataType)
+                        .setMetadataConverters(metadataConverters)
+                        .setResultTypeInfo(resultTypeInfo)
+                        .setServerTimeZone(ZoneId.of(serverTimeZone))
+                        .build();
+
+        DMSource.Builder<RowData> builder =
+                DMSource.<RowData>builder()
+                        .startupMode(startupMode)
+                        .username(username)
+                        .password(password)
+                        .databaseName(databaseName)
+                        .schemaName(schemaName)
+                        .tableName(tableName)
+                        .tableList(tableList)
+                        .serverTimeZone(serverTimeZone)
+                        .connectTimeout(connectTimeout)
+                        .hostname(hostname)
+                        .port(port)
+                        .jdbcProperties(jdbcProperties)
+                        .startupTimestamp(startupTimestamp)
+                        .deserializer(deserializer)
+                        .inlongMetric(inlongMetrics)
+                        .auditHostAndPorts(inlongAudit);
+        return SourceFunctionProvider.of(builder.build(), false);
+    }
+
+    protected DMMetadataConverter[] getMetadataConverters() {
+        if (metadataKeys.isEmpty()) {
+            return new DMMetadataConverter[0];
+        }
+        return metadataKeys.stream()
+                .map(
+                        key -> Stream.of(DMReadableMetadata.values())
+                                .filter(m -> m.getKey().equals(key))
+                                .findFirst()
+                                .orElseThrow(IllegalStateException::new))
+                .map(DMReadableMetadata::getConverter)
+                .toArray(DMMetadataConverter[]::new);
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        return Stream.of(DMReadableMetadata.values())
+                .collect(
+                        Collectors.toMap(
+                                DMReadableMetadata::getKey,
+                                DMReadableMetadata::getDataType));
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        this.metadataKeys = metadataKeys;
+        this.producedDataType = producedDataType;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        DMTableSource source =
+                new DMTableSource(
+                        physicalSchema,
+                        startupMode,
+                        username,
+                        password,
+                        databaseName,
+                        schemaName,
+                        tableName,
+                        tableList,
+                        serverTimeZone,
+                        connectTimeout,
+                        hostname,
+                        port,
+                        jdbcProperties,
+                        startupTimestamp,
+                        inlongMetrics,
+                        inlongAudit);
+        source.metadataKeys = metadataKeys;
+        source.producedDataType = producedDataType;
+        return source;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DMTableSource that = (DMTableSource) o;
+        return Objects.equals(this.physicalSchema, that.physicalSchema)
+                && Objects.equals(this.startupMode, that.startupMode)
+                && Objects.equals(this.username, that.username)
+                && Objects.equals(this.password, that.password)
+                && Objects.equals(this.databaseName, that.databaseName)
+                && Objects.equals(this.schemaName, that.schemaName)
+                && Objects.equals(this.tableName, that.tableName)
+                && Objects.equals(this.tableList, that.tableList)
+                && Objects.equals(this.serverTimeZone, that.serverTimeZone)
+                && Objects.equals(this.connectTimeout, that.connectTimeout)
+                && Objects.equals(this.hostname, that.hostname)
+                && Objects.equals(this.port, that.port)
+                && Objects.equals(this.jdbcProperties, that.jdbcProperties)
+                && Objects.equals(this.startupTimestamp, that.startupTimestamp)
+                && Objects.equals(this.producedDataType, that.producedDataType)
+                && Objects.equals(this.metadataKeys, that.metadataKeys)
+                && Objects.equals(this.inlongMetrics, that.inlongMetrics)
+                && Objects.equals(this.inlongAudit, that.inlongAudit);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                physicalSchema,
+                startupMode,
+                username,
+                password,
+                databaseName,
+                tableName,
+                tableList,
+                serverTimeZone,
+                connectTimeout,
+                hostname,
+                port,
+                jdbcProperties,
+                startupTimestamp,
+                producedDataType,
+                metadataKeys,
+                inlongMetrics,
+                inlongAudit);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "DM-CDC";
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMTableSourceFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/DMTableSourceFactory.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import com.ververica.cdc.debezium.utils.JdbcUrlUtils;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.inlong.sort.cdc.dm.utils.OptionUtils;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
+import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.base.Constants.SOURCE_MULTIPLE_ENABLE;
+
+/** Factory for creating configured instance of {@link DMTableSource}. */
+public class DMTableSourceFactory implements DynamicTableSourceFactory {
+
+    private static final String IDENTIFIER = "dm-cdc";
+
+    public static final ConfigOption<String> SCAN_STARTUP_MODE =
+            ConfigOptions.key("scan.startup.mode")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional startup mode for DM CDC consumer, valid enumerations are "
+                                    + "\"initial\", \"latest-offset\" or \"timestamp\"");
+
+    public static final ConfigOption<String> USERNAME =
+            ConfigOptions.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Username to be used when connecting to DM.");
+
+    public static final ConfigOption<String> PASSWORD =
+            ConfigOptions.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Password to be used when connecting to DM.");
+
+    public static final ConfigOption<String> DATABASE_NAME =
+            ConfigOptions.key("database-name")
+                    .stringType()
+                    .defaultValue("SYSDBA")
+                    .withDescription(
+                            "Database name of DM to monitor, should be regular expression. Only can be used with 'initial' mode.");
+
+    public static final ConfigOption<String> SCHEMA_NAME =
+            ConfigOptions.key("schema-name")
+                    .stringType()
+                    .defaultValue("SYSDBA")
+                    .withDescription(
+                            "Schema name of DM to monitor, should be regular expression. Only can be used with 'initial' mode.");
+
+    public static final ConfigOption<String> TABLE_NAME =
+            ConfigOptions.key("table-name")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Table name of DM to monitor, should be regular expression. Only can be used with 'initial' mode.");
+
+    public static final ConfigOption<String> TABLE_LIST =
+            ConfigOptions.key("table-list")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "List of full names of tables, separated by commas, e.g. \"db1.table1, db2.table2\".");
+
+    public static final ConfigOption<String> SERVER_TIME_ZONE =
+            ConfigOptions.key("server-time-zone")
+                    .stringType()
+                    .defaultValue("+00:00")
+                    .withDescription("The session time zone in database server.");
+
+    public static final ConfigOption<Duration> CONNECT_TIMEOUT =
+            ConfigOptions.key("connect.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription(
+                            "The maximum time that the connector should wait after trying to connect to the database server or log proxy server before timing out.");
+
+    public static final ConfigOption<String> HOSTNAME =
+            ConfigOptions.key("hostname")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "IP address or hostname of the DM database server or DM proxy server.");
+
+    public static final ConfigOption<Integer> PORT =
+            ConfigOptions.key("port")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Integer port number of DM database server or DM proxy server.");
+
+    public static final ConfigOption<String> JDBC_DRIVER =
+            ConfigOptions.key("jdbc.driver")
+                    .stringType()
+                    .defaultValue("dm.jdbc.driver.DmDriver")
+                    .withDescription("JDBC driver class name, use 'com.mysql.jdbc.Driver' by default.");
+
+    public static final ConfigOption<Long> SCAN_STARTUP_TIMESTAMP =
+            ConfigOptions.key("scan.startup.timestamp")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Optional timestamp in seconds used in case of \"timestamp\" startup mode.");
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(JdbcUrlUtils.PROPERTIES_PREFIX);
+
+        ResolvedSchema physicalSchema = context.getCatalogTable().getResolvedSchema();
+
+        ReadableConfig config = helper.getOptions();
+        StartupMode startupMode = StartupMode.getStartupMode(config.get(SCAN_STARTUP_MODE));
+
+        String username = config.get(USERNAME);
+        String password = config.get(PASSWORD);
+        String databaseName = config.get(DATABASE_NAME);
+        String schemaName = config.get(SCHEMA_NAME);
+        String tableName = config.get(TABLE_NAME);
+        String tableList = config.get(TABLE_LIST);
+
+        String serverTimeZone = config.get(SERVER_TIME_ZONE);
+        Duration connectTimeout = config.get(CONNECT_TIMEOUT);
+
+        String hostname = config.get(HOSTNAME);
+        Integer port = config.get(PORT);
+
+        Long startupTimestamp = config.get(SCAN_STARTUP_TIMESTAMP);
+
+        String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
+        String auditHostAndPorts = config.get(INLONG_AUDIT);
+
+        OptionUtils.printOptions(IDENTIFIER, ((Configuration) config).toMap());
+
+        return new DMTableSource(
+                physicalSchema,
+                startupMode,
+                username,
+                password,
+                databaseName,
+                schemaName,
+                tableName,
+                tableList,
+                serverTimeZone,
+                connectTimeout,
+                hostname,
+                port,
+                JdbcUrlUtils.getJdbcProperties(context.getCatalogTable().getOptions()),
+                startupTimestamp,
+                inlongMetric,
+                auditHostAndPorts);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(SCAN_STARTUP_MODE);
+        options.add(USERNAME);
+        options.add(PASSWORD);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(SCAN_STARTUP_TIMESTAMP);
+        options.add(DATABASE_NAME);
+        options.add(SCHEMA_NAME);
+        options.add(TABLE_NAME);
+        options.add(TABLE_LIST);
+        options.add(HOSTNAME);
+        options.add(PORT);
+        options.add(JDBC_DRIVER);
+        options.add(CONNECT_TIMEOUT);
+        options.add(SERVER_TIME_ZONE);
+        options.add(INLONG_METRIC);
+        options.add(INLONG_AUDIT);
+        options.add(AUDIT_KEYS);
+        options.add(SOURCE_MULTIPLE_ENABLE);
+        return options;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/StartupMode.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/table/StartupMode.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.table;
+
+import org.apache.flink.table.api.ValidationException;
+
+/** Startup modes for the DM CDC Consumer. */
+public enum StartupMode {
+
+    /**
+     * Performs an initial snapshot on the monitored database tables upon first startup, and
+     * continue to read the commit log.
+     */
+    INITIAL,
+
+    /**
+     * Never to perform snapshot on the monitored database tables upon first startup, just read from
+     * the end of the commit log which means only have the changes since the connector was started.
+     */
+    LATEST_OFFSET,
+
+    /**
+     * Never to perform snapshot on the monitored database tables upon first startup, and directly
+     * read commit log from the specified timestamp.
+     */
+    TIMESTAMP;
+
+    public static StartupMode getStartupMode(String modeString) {
+        switch (modeString.toLowerCase()) {
+            case "initial":
+                return INITIAL;
+            case "latest-offset":
+                return LATEST_OFFSET;
+            case "timestamp":
+                return TIMESTAMP;
+            default:
+                throw new ValidationException(
+                        String.format("Invalid startup mode '%s'.", modeString));
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/DMSQLClient.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/DMSQLClient.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.inlong.sort.cdc.dm.source.DMConnection;
+import org.apache.inlong.sort.cdc.dm.table.DMRecord;
+import org.apache.inlong.sort.cdc.dm.table.DMRecord.SourceInfo;
+import org.apache.inlong.sort.protocol.ddl.enums.OperationType;
+
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+// interact with DBMS_LOGMNR, one connection per client
+@Slf4j
+public class DMSQLClient {
+
+    public DMConnection connection;
+    // the tables involved in incremental changes. for now implement only one table
+    private final String tablename;
+    private volatile long scn;
+    // fetch size per scan
+    private static final int BATCH_SIZE = 100000;
+
+    public DMSQLClient(DMConnection globalConnection, String tablename) {
+        // before the actual execution, first find the latest scn.
+        this.connection = globalConnection;
+        this.tablename = tablename;
+    }
+
+    public long openlogminer() {
+        // a flag to indicate if the logminer is runnable
+        boolean runnable = true;
+
+        // before the actual execution, first find the latest scn.
+        String querySCN = "select CUR_LSN from v$rlog";
+        try {
+            connection.query(querySCN,
+                    rs -> {
+                        // handle the result set
+                        while (rs.next()) {
+                            log.info("found current lsn: " + rs.getLong("CUR_LSN"));
+                            scn = rs.getLong("CUR_LSN");
+                        }
+                    });
+        } catch (Throwable e) {
+            log.error("select lsn failed ", e);
+            runnable = false;
+        }
+
+        log.info("selecting archived logs");
+        List<String> paths = new ArrayList<>();
+        // then, find all redo log paths. Only those incremental logs which are after current scn are added
+        String queryLogPaths =
+                "SELECT NAME, FIRST_TIME, NEXT_TIME, FIRST_CHANGE#, NEXT_CHANGE# FROM V$ARCHIVED_LOG WHERE STATUS = 'A'"
+                        + "AND NEXT_CHANGE# > " + (scn - 2000000);
+        try {
+            connection.query(queryLogPaths,
+                    rs -> {
+                        // handle the result set
+                        while (rs.next()) {
+                            paths.add(rs.getString("NAME"));
+                        }
+                    });
+        } catch (Throwable e) {
+            log.error("query log paths failed ", e);
+            runnable = false;
+        }
+
+        // add all paths to logminer, path need to have ''
+        log.info("adding {} log files", paths.size());
+        try {
+            connection.setAutoCommit(false);
+            for (String path : paths) {
+                String addLogFileSql = "DBMS_LOGMNR.ADD_LOGFILE('" + path + "')";
+                connection.execute(addLogFileSql);
+            }
+        } catch (Throwable e) {
+            log.error("add logminer file failed ", e);
+            runnable = false;
+        }
+
+        if (!runnable) {
+            return 0;
+        }
+
+        log.info("executing start logminer");
+        // start log miner, and commit everything.
+        String startLogmnrSql = "DBMS_LOGMNR.START_LOGMNR(OPTIONS=>2066)";
+        try {
+            connection.execute(startLogmnrSql);
+            connection.commit();
+        } catch (Throwable e) {
+            log.error("start logminer failed ", e);
+        }
+
+        log.info("finished to open logminer");
+        return scn;
+    }
+
+    public boolean closelogminer() {
+        String closeLogmnrSql = "DBMS_LOGMNR.END_LOGMNR()";
+        try {
+            connection.execute(closeLogmnrSql);
+        } catch (Throwable e) {
+            log.error("close logminer failed ", e);
+            return false;
+        }
+        return true;
+    }
+
+    // read incremental records and send them downwards.
+    public List<DMRecord> processIncrementalRecords(String database, String schema, long scn,
+            LogMinerDmlParser parser) {
+        ArrayList<DMRecord> list = new ArrayList<>();
+
+        // limit the number of scns read to avoid oom
+        String readSCNSql = "SELECT OPERATION, SCN, SQL_REDO, TIMESTAMP, TABLE_NAME FROM "
+                + "V$LOGMNR_CONTENTS WHERE TABLE_NAME = '" + tablename + "' AND SCN > " + scn + " LIMIT " + BATCH_SIZE;
+
+        // read and process the records
+        try {
+            log.info("read scn sql is " + readSCNSql);
+            connection.query(readSCNSql,
+                    rs -> {
+                        while (rs.next()) {
+                            DMRecord record = generateDMRecord(database, schema, rs, parser);
+                            list.add(record);
+                        }
+                    });
+        } catch (Throwable e) {
+            log.error("process incremental snapshot failed ", e);
+        }
+
+        log.info("successfully fetched {} incremental records", list.size());
+        return list;
+    }
+
+    // a helper which generates the actual record given a result set.
+    // OPERATION, SCN, SQL_REDO, TIMESTAMP, TABLE_NAME FROM V$LOGMNR_CONTENTS WHERE TABLE_NAME
+    private DMRecord generateDMRecord(String database, String schema, ResultSet rs, LogMinerDmlParser parser) {
+        try {
+            String table = rs.getString("TABLE_NAME");
+            long scn = rs.getLong("SCN");
+            String operation = rs.getString("OPERATION");
+            OperationType opt = generateOperationType(operation);
+            SourceInfo sourceInfo = new SourceInfo(database, schema, table, scn);
+            // no need for jdbc fields in snapshot phase anymore, instead we need update before & after fields
+            // TODO: use metadata to generate the schema
+            List<Map<String, Object>> fields = parser.parse(rs.getString("SQL_REDO"), operation);
+            DMRecord record = new DMRecord(sourceInfo, opt, fields.get(0), fields.get(1));
+            return record;
+        } catch (Throwable e) {
+            log.error("generate DM record failed ", e);
+            return null;
+        }
+    }
+
+    private OperationType generateOperationType(String operation) {
+        switch (operation) {
+            case "INSERT":
+                return OperationType.INSERT;
+            case "DELETE":
+                return OperationType.DELETE;
+            case "UPDATE":
+                return OperationType.UPDATE;
+            default:
+                throw new RuntimeException("operation type is not supported " + operation);
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/LogMinerDmlParser.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/LogMinerDmlParser.java
@@ -1,0 +1,613 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.utils;
+
+import io.debezium.DebeziumException;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *  copied from Debezium LogMiner DMLParser and modified locally to parse incoming sql.
+ *  the original oracle redo log has many slight differences (like how quotes and white spaces are used) from dm,
+ *  so this part is very error-prone and modified heavily.
+ */
+@Slf4j
+public class LogMinerDmlParser {
+
+    private static final String NULL_SENTINEL = "${DBZ_NULL}";
+    private static final String NULL = "NULL";
+    private static final String INSERT_INTO = "INSERT INTO ";
+    private static final String UPDATE = "UPDATE ";
+    private static final String DELETE_FROM = "DELETE FROM ";
+    private static final String AND = "AND ";
+    private static final String OR = "OR ";
+    private static final String SET = " SET ";
+    private static final String WHERE = " WHERE ";
+    private static final String VALUES = " VALUES";
+    private static final String IS_NULL = "IS NULL";
+    // Use by Oracle for specific data types that cannot be represented in SQL
+    private static final String UNSUPPORTED = "Unsupported";
+    private static final String UNSUPPORTED_TYPE = "Unsupported Type";
+
+    private static final int INSERT_INTO_LENGTH = INSERT_INTO.length();
+    private static final int UPDATE_LENGTH = UPDATE.length();
+    private static final int DELETE_FROM_LENGTH = DELETE_FROM.length();
+    private static final int VALUES_LENGTH = VALUES.length();
+    private static final int SET_LENGTH = SET.length();
+    private static final int WHERE_LENGTH = WHERE.length();
+
+    private final List<String> columns;
+
+    public LogMinerDmlParser(List<String> columns) {
+        log.info("parse columns: " + columns);
+        this.columns = columns;
+    }
+
+    public List<String> getColumns() {
+        return this.columns;
+    }
+
+    public List<Map<String, Object>> parse(String sql, String operation) {
+        log.debug("sql parser incoming sql is: " + sql);
+        try {
+            switch (operation) {
+                case "INSERT":
+                    return parseInsert(sql, columns);
+                case "DELETE":
+                    return parseDelete(sql, columns);
+                case "UPDATE":
+                    return parseUpdate(sql, columns);
+                default:
+                    throw new RuntimeException("operation type is not supported " + operation);
+            }
+        } catch (Throwable e) {
+            log.error("dm sql parse field error ", e);
+        }
+        return null;
+    }
+
+    /**
+     * Parse an {@code INSERT} SQL statement.
+     */
+    public List<Map<String, Object>> parseInsert(String sql, List<String> columns) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        result.add(new HashMap<>());
+        try {
+            Map<String, Object> after = new HashMap<>();
+            result.add(after);
+            // advance beyond "insert into "
+            int index = INSERT_INTO_LENGTH;
+            // parse table
+            index = parseTableName(sql, index);
+            // capture column names
+            String[] columnNames = new String[columns.size()];
+            index = parseColumnListClause(sql, index, columnNames);
+            // capture values
+            Object[] newValues = new Object[columns.size()];
+            parseColumnValuesClause(sql, index, columnNames, newValues, Arrays.asList(columnNames));
+
+            for (int i = 0; i < columns.size(); i++) {
+                after.put(columnNames[i], newValues[i]);
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse insert DML: '" + sql + "'", e);
+        }
+    }
+
+    /**
+     * Parse an {@code UPDATE} SQL statement.
+     */
+    public List<Map<String, Object>> parseUpdate(String sql, List<String> columns) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        try {
+            Map<String, Object> before = new HashMap<>();
+            Map<String, Object> after = new HashMap<>();
+            result.add(before);
+            result.add(after);
+            // advance beyond "update "
+            int index = UPDATE_LENGTH;
+
+            // parse table
+            index = parseTableName(sql, index);
+
+            // parse set
+            Object[] newValues = new Object[columns.size()];
+            index = parseSetClause(sql, index, newValues, columns);
+
+            // parse where
+            Object[] oldValues = new Object[columns.size()];
+            parseWhereClause(sql, index, oldValues, columns);
+
+            // For each after state field that is either a NULL_SENTINEL (explicitly wants NULL) or
+            // that wasn't specified and therefore remained null, correctly adapt the after state
+            // accordingly, leaving any field's after value alone if it isn't null or a sentinel.
+            for (int i = 0; i < oldValues.length; ++i) {
+                if (newValues[i] == NULL_SENTINEL) {
+                    // field is explicitly set to NULL, clear the sentinel and continue
+                    newValues[i] = null;
+                } else if (newValues[i] == null) {
+                    // field wasn't specified in set-clause, copy before state to after state
+                    newValues[i] = oldValues[i];
+                }
+
+                String columnName = columns.get(i);
+                before.put(columnName, oldValues[i]);
+                after.put(columnName, newValues[i]);
+            }
+
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse update DML: '" + sql + "'", e);
+        }
+    }
+
+    /**
+     * Parses a SQL {@code DELETE} statement.
+     */
+    public List<Map<String, Object>> parseDelete(String sql, List<String> columns) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        Map<String, Object> before = new HashMap<>();
+        result.add(before);
+        result.add(new HashMap<>());
+        try {
+            // advance beyond "delete from "
+            int index = DELETE_FROM_LENGTH;
+
+            // parse table
+            index = parseTableName(sql, index);
+
+            // parse where
+            Object[] oldValues = new Object[columns.size()];
+            parseWhereClause(sql, index, oldValues, columns);
+
+            for (int i = 0; i < columns.size(); i++) {
+                before.put(columns.get(i), oldValues[i]);
+            }
+            return result;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse delete DML: '" + sql + "'", e);
+        }
+    }
+
+    /**
+     * Parses a table-name in the SQL clause
+     *
+     * @param sql the sql statement
+     * @param index the index into the sql statement to begin parsing
+     * @return the index into the sql string where the table name ended
+     */
+    private static int parseTableName(String sql, int index) {
+        boolean inQuote = false;
+
+        for (; index < sql.length(); ++index) {
+            char c = sql.charAt(index);
+            if (c == '"') {
+                if (inQuote) {
+                    inQuote = false;
+                    continue;
+                }
+                inQuote = true;
+            } else if ((c == ' ' || c == '(') && !inQuote) {
+                break;
+            }
+        }
+
+        return index;
+    }
+
+    /**
+     * Parse an {@code INSERT} statement's column-list clause.
+     *
+     * @param sql the sql statement
+     * @param start the index into the sql statement to begin parsing
+     * @param columnNames the list that will be populated with the column names
+     * @return the index into the sql string where the column-list clause ended
+     */
+    private static int parseColumnListClause(String sql, int start, String[] columnNames) {
+        int index = start;
+        boolean inQuote = false;
+        int columnIndex = 0;
+        for (; index < sql.length(); ++index) {
+            char c = sql.charAt(index);
+            if (c == '(' && !inQuote) {
+                start = index + 1;
+            } else if (c == ')' && !inQuote) {
+                index++;
+                break;
+            } else if (c == '\"') {
+                if (inQuote) {
+                    inQuote = false;
+                    // remove the double quotes
+                    columnNames[columnIndex++] = sql.substring(start + 1, index).replace("\"", "");
+                    start = index + 2;
+                    continue;
+                }
+                inQuote = true;
+            }
+        }
+        return index;
+    }
+
+    /**
+     * Parse an {@code INSERT} statement's column-values clause.
+     *
+     * @param sql the sql statement
+     * @param start the index into the sql statement to begin parsing
+     * @param columnNames the column names array, already indexed based on relational table column order
+     * @param values the values array that will be populated with column values
+     * @return the index into the sql string where the column-values clause ended
+     */
+    private int parseColumnValuesClause(String sql, int start, String[] columnNames, Object[] values,
+            List<String> columns) {
+        int index = start;
+        int nested = 0;
+        boolean inQuote = false;
+        boolean inValues = false;
+
+        int value = sql.indexOf(VALUES, index);
+        if (value == -1) {
+            throw new DebeziumException(
+                    "parse value clause failed to parse DML: " + sql + start + sql.indexOf(VALUES, index));
+        } else if (value != index) {
+            // find table alias
+            index = value;
+        }
+
+        index += VALUES_LENGTH;
+
+        int columnIndex = 0;
+        for (; index < sql.length(); ++index) {
+            char c = sql.charAt(index);
+            if (c == '(' && !inQuote && !inValues) {
+                inValues = true;
+                start = index + 1;
+            } else if (c == '(' && !inQuote) {
+                nested++;
+            } else if (c == '\"') {
+                if (inQuote) {
+                    inQuote = false;
+                    continue;
+                }
+                inQuote = true;
+            } else if (!inQuote && (c == ',' || c == ')')) {
+                if (c == ')' && nested != 0) {
+                    nested--;
+                    continue;
+                }
+                if (c == ',' && nested != 0) {
+                    continue;
+                }
+
+                if (sql.charAt(start) == '\"' && sql.charAt(index - 1) == '\"') {
+                    log.info("quoted strings");
+                    // value is single-quoted at the start/end, substring without the quotes.
+                    int position = getColumnIndexByName(columnNames[columnIndex], columns);
+                    if (position == 0) {
+                        values[position] = sql.substring(start + 1, index - 1);
+                    } else if (position > 0) {
+                        values[position] = sql.substring(start + 2, index - 1);
+                    }
+                } else {
+                    // use value as-is
+                    String s = sql.substring(start, index);
+                    if (!s.equals(UNSUPPORTED_TYPE) && !s.equals(NULL)) {
+                        int position = getColumnIndexByName(columnNames[columnIndex], columns);
+                        // log.info("print debug index: " + position + columnNames[columnIndex]);
+                        // remove the leading whitespace, except for the first one
+                        if (position == 0) {
+                            values[position] = s;
+                        } else {
+                            String strValue = s.substring(1);
+                            values[position] = strValue;
+                        }
+                    }
+                }
+
+                columnIndex++;
+                start = index + 1;
+            }
+        }
+
+        return index;
+    }
+
+    private int getColumnIndexByName(String columnName, List<String> columns) {
+        int index = columns.indexOf(columnName);
+        if (index == -1) {
+            throw new RuntimeException(("failed to get column index by name:" + columnName + ", " + columns));
+        }
+        return index;
+    }
+
+    /**
+     * Parse an {@code UPDATE} statement's {@code SET} clause.
+     *
+     * @param sql the sql statement
+     * @param start the index into the sql statement to begin parsing
+     * @param newValues the new values array to be populated
+     * @return the index into the sql string where the set-clause ended
+     */
+    private int parseSetClause(String sql, int start, Object[] newValues, List<String> columns) {
+        boolean inDoubleQuote = false;
+        boolean inSingleQuote = false;
+        boolean inColumnName = true;
+        boolean inColumnValue = false;
+        boolean inSpecial = false;
+        int nested = 0;
+
+        // verify entering set-clause
+        int set = sql.indexOf(SET, start);
+        if (set == -1) {
+            throw new DebeziumException(
+                    "parse set clause failed to parse DML: " + sql + start + sql.indexOf(SET, start));
+        } else if (set != start) {
+            // find table alias
+            start = set;
+        }
+        start += SET_LENGTH;
+
+        int index = start;
+        String currentColumnName = null;
+        for (; index < sql.length(); ++index) {
+            char c = sql.charAt(index);
+            char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
+            if (c == '"' && inColumnName) {
+                // Set clause column names are double-quoted
+                if (inDoubleQuote) {
+                    inDoubleQuote = false;
+                    currentColumnName = sql.substring(start + 1, index);
+                    start = index + 1;
+                    inColumnName = false;
+                    continue;
+                }
+                inDoubleQuote = true;
+                start = index;
+            } else if (c == '=' && !inColumnName && !inColumnValue) {
+                inColumnValue = true;
+                // Oracle SQL generated is always ' = ', skipping following space
+                index += 1;
+                start = index + 1;
+            } else if (nested == 0 & c == ' ' && lookAhead == '|') {
+                // Possible concatenation, nothing to do yet
+            } else if (nested == 0 & c == '|' && lookAhead == '|') {
+                // Concatenation
+                for (int i = index + 2; i < sql.length(); ++i) {
+                    if (sql.charAt(i) != ' ') {
+                        // found next non-whitespace character
+                        index = i - 1;
+                        break;
+                    }
+                }
+            } else if (c == '\'' && inColumnValue) {
+                // Skip over double single quote
+                if (inSingleQuote && lookAhead == '\'') {
+                    index += 1;
+                    continue;
+                }
+                // Set clause single-quoted column value
+                if (inSingleQuote) {
+                    inSingleQuote = false;
+                    if (nested == 0) {
+                        int position = getColumnIndexByName(currentColumnName, columns);
+                        newValues[position] = sql.substring(start + 1, index);
+                        start = index + 1;
+                        inColumnValue = false;
+                        inColumnName = false;
+                    }
+                    continue;
+                }
+                if (!inSpecial) {
+                    start = index;
+                }
+                inSingleQuote = true;
+            } else if (c == ',' && !inColumnValue && !inColumnName) {
+                // Set clause uses ', ' skip following space
+                inColumnName = true;
+                index += 1;
+                start = index;
+            } else if (inColumnValue && !inSingleQuote) {
+                if (!inSpecial) {
+                    start = index;
+                    inSpecial = true;
+                }
+                // characters as a part of the value
+                if (c == '(') {
+                    nested++;
+                } else if (c == ')' && nested > 0) {
+                    nested--;
+                } else if ((c == ',' || c == ' ' || c == ';') && nested == 0) {
+                    String value = sql.substring(start, index);
+                    if (value.equals(NULL) || value.equals(UNSUPPORTED_TYPE)) {
+                        if (value.equals(NULL)) {
+                            // In order to identify when a field is not present in the set-clause or when
+                            // a field is explicitly set to null, the NULL_SENTINEL value is used to then
+                            // indicate that the field is explicitly being cleared to NULL.
+                            // This sentinel value will be cleared later when we reconcile before/after
+                            // state in parseUpdate()
+                            int position = getColumnIndexByName(currentColumnName, columns);
+                            newValues[position] = NULL_SENTINEL;
+                        }
+                        start = index + 1;
+                        inColumnValue = false;
+                        inSpecial = false;
+                        inColumnName = true;
+                        continue;
+                    } else if (value.equals(UNSUPPORTED)) {
+                        continue;
+                    }
+                    int position = getColumnIndexByName(currentColumnName, columns);
+                    newValues[position] = value;
+                    start = index + 1;
+                    inColumnValue = false;
+                    inSpecial = false;
+                    inColumnName = true;
+                }
+            } else if (!inDoubleQuote && !inSingleQuote) {
+                if (c == 'W' && lookAhead == 'H' && sql.indexOf(WHERE, index - 1) == index - 1) {
+                    index -= 1;
+                    break;
+                }
+            }
+        }
+
+        return index;
+    }
+
+    /**
+     * Parses a {@code WHERE} clause populates the provided column names and values arrays.
+     *
+     * @param sql the sql statement
+     * @param start the index into the sql statement to begin parsing
+     * @param values the column values to be parsed from the where clause
+     * @return the index into the sql string to continue parsing
+     */
+    private int parseWhereClause(String sql, int start, Object[] values, List<String> columns) {
+        int nested = 0;
+        boolean inColumnName = true;
+        boolean inColumnValue = false;
+        boolean inDoubleQuote = false;
+        boolean inSingleQuote = false;
+        boolean inSpecial = false;
+
+        // DBZ-3235
+        // LogMiner can generate SQL without a WHERE condition under some circumstances and if it does
+        // we shouldn't immediately fail DML parsing.
+        if (start >= sql.length()) {
+            return start;
+        }
+
+        // verify entering where-clause
+        int where = sql.indexOf(WHERE, start);
+        if (where == -1) {
+            throw new DebeziumException("Failed to parse DML: " + sql);
+        } else if (where != start) {
+            // find table alias
+            start = where;
+        }
+        start += WHERE_LENGTH;
+
+        int index = start;
+        String currentColumnName = null;
+        for (; index < sql.length(); ++index) {
+            char c = sql.charAt(index);
+            char lookAhead = (index + 1 < sql.length()) ? sql.charAt(index + 1) : 0;
+            if (c == '"' && inColumnName) {
+                // Where clause column names are double-quoted
+                if (inDoubleQuote) {
+                    inDoubleQuote = false;
+                    currentColumnName = sql.substring(start + 1, index);
+                    start = index + 1;
+                    inColumnName = false;
+                    continue;
+                }
+                inDoubleQuote = true;
+                start = index;
+            } else if (c == '=' && !inColumnName && !inColumnValue) {
+                inColumnValue = true;
+                // Oracle SQL generated is always ' = ', skipping following space
+                index += 1;
+                start = index + 1;
+            } else if (c == 'I' && !inColumnName && !inColumnValue) {
+                if (sql.indexOf(IS_NULL, index) == index) {
+                    index += 6;
+                    start = index;
+                    continue;
+                }
+            } else if (c == '\'' && inColumnValue) {
+                // Skip over double single quote
+                if (inSingleQuote && lookAhead == '\'') {
+                    index += 1;
+                    continue;
+                }
+                // Where clause single-quoted column value
+                if (inSingleQuote) {
+                    inSingleQuote = false;
+                    if (nested == 0) {
+                        int position = getColumnIndexByName(currentColumnName, columns);
+                        values[position] = sql.substring(start + 1, index);
+                        start = index + 1;
+                        inColumnValue = false;
+                        inColumnName = false;
+                    }
+                    continue;
+                }
+                if (!inSpecial) {
+                    start = index;
+                }
+                inSingleQuote = true;
+            } else if (inColumnValue && !inSingleQuote) {
+                if (!inSpecial) {
+                    start = index;
+                    inSpecial = true;
+                }
+                if (c == '(') {
+                    nested++;
+                } else if (c == ')' && nested > 0) {
+                    nested--;
+                } else if (nested == 0 & c == ' ' && lookAhead == '|') {
+                    // Possible concatenation, nothing to do yet
+                } else if (nested == 0 & c == '|' && lookAhead == '|') {
+                    // Concatenation
+                    for (int i = index + 2; i < sql.length(); ++i) {
+                        if (sql.charAt(i) != ' ') {
+                            // found next non-whitespace character
+                            index = i - 1;
+                            break;
+                        }
+                    }
+                } else if ((c == ';' || c == ' ') && nested == 0) {
+                    String value = sql.substring(start, index);
+                    if (value.equals(NULL) || value.equals(UNSUPPORTED_TYPE)) {
+                        start = index + 1;
+                        inColumnValue = false;
+                        inSpecial = false;
+                        inColumnName = true;
+                        continue;
+                    } else if (value.equals(UNSUPPORTED)) {
+                        continue;
+                    }
+                    int position = getColumnIndexByName(currentColumnName, columns);
+                    values[position] = value;
+                    start = index + 1;
+                    inColumnValue = false;
+                    inSpecial = false;
+                    inColumnName = true;
+                }
+            } else if (!inColumnValue && !inColumnName) {
+                if (c == 'A' && lookAhead == 'N' && sql.indexOf(AND, index) == index) {
+                    index += 3;
+                    start = index;
+                    inColumnName = true;
+                } else if (c == 'O' && lookAhead == 'R' && sql.indexOf(OR, index) == index) {
+                    index += 2;
+                    start = index;
+                    inColumnName = true;
+                }
+            }
+        }
+
+        return index;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/OptionUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/java/org/apache/inlong/sort/cdc/dm/utils/OptionUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.cdc.dm.utils;
+
+import org.apache.flink.configuration.ConfigurationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/** A utility class to print configuration of connectors. */
+public class OptionUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OptionUtils.class);
+
+    /** Utility class can not be instantiated. */
+    private OptionUtils() {
+    }
+
+    public static void printOptions(String identifier, Map<String, String> config) {
+        Map<String, String> hideMap = ConfigurationUtils.hideSensitiveValues(config);
+        LOG.info("Print {} connector configuration:", identifier);
+        for (String key : hideMap.keySet()) {
+            LOG.info("{} = {}", key, hideMap.get(key));
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/dm-cdc/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.inlong.sort.cdc.dm.table.DMTableSourceFactory

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
@@ -54,6 +54,7 @@
         <module>starrocks</module>
         <module>hudi</module>
         <module>kudu</module>
+        <module>dm-cdc</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #9558

### Motivation
Dameng, Oceanbase and GaussDB are three widely used datasources which Inlong does not have support yet.
This pr supports dm datasource. 


### Modifications
Added the DM datasource

### Verifying this change
This datasource has been tested in the production environment.

### Documentation
The design doc is as follows:
https://doc.weixin.qq.com/doc/w3_AUcANQaJAFk4a11n0ZlRR0aTTeiHa?scode=AJEAIQdfAAod9AStYjAUcANQaJAFk

A more detailed doc will be introduced in later stages, after the code has been reviewed and is about to be merged.

