### PR TITLE
[INLONG-9580][Agent] Add unit testing to taskmanager to test their ability to recover tasks from DB

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
@@ -418,6 +418,7 @@ public class TaskManager extends AbstractDaemon {
     }
 
     private void restoreFromDb() {
+        LOGGER.info("restoreFromDb start");
         List<TaskProfile> taskProfileList = taskDb.getTasks();
         taskProfileList.forEach((profile) -> {
             if (profile.getState() == TaskStateEnum.RUNNING) {
@@ -425,6 +426,7 @@ public class TaskManager extends AbstractDaemon {
                 addToMemory(profile);
             }
         });
+        LOGGER.info("restoreFromDb end");
     }
 
     private void stopAllTasks() {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/file/TaskManager.java
@@ -418,15 +418,15 @@ public class TaskManager extends AbstractDaemon {
     }
 
     private void restoreFromDb() {
-        LOGGER.info("restoreFromDb start");
+        LOGGER.info("restore from db start");
         List<TaskProfile> taskProfileList = taskDb.getTasks();
         taskProfileList.forEach((profile) -> {
             if (profile.getState() == TaskStateEnum.RUNNING) {
-                LOGGER.info("restoreFromDb taskId {}", profile.getTaskId());
+                LOGGER.info("restore from db taskId {}", profile.getTaskId());
                 addToMemory(profile);
             }
         });
-        LOGGER.info("restoreFromDb end");
+        LOGGER.info("restore from db end");
     }
 
     private void stopAllTasks() {

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/TestTaskManager.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/TestTaskManager.java
@@ -65,7 +65,9 @@ public class TestTaskManager {
             }
             manager.start();
             for (int i = 1; i <= 10; i++) {
-                Assert.assertTrue(manager.getTask(String.valueOf(i)) != null);
+                String taskId = String.valueOf(i);
+                await().atMost(3, TimeUnit.SECONDS).until(() -> manager.getTask(taskId) != null);
+                Assert.assertTrue(manager.getTask(taskId) != null);
             }
         } catch (Exception e) {
             LOGGER.error("manager start error: ", e);
@@ -89,6 +91,8 @@ public class TestTaskManager {
         manager.submitTaskProfiles(taskProfiles1);
         await().atMost(3, TimeUnit.SECONDS).until(() -> manager.getTask(taskId1) == null);
         Assert.assertTrue(manager.getTaskProfile(taskId1).getState() == TaskStateEnum.FROZEN);
+
+        // test restore from froze
         taskProfile1.setState(TaskStateEnum.RUNNING);
         manager.submitTaskProfiles(taskProfiles1);
         await().atMost(3, TimeUnit.SECONDS).until(() -> manager.getTask(taskId1) != null);

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/TestTaskManager.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/task/TestTaskManager.java
@@ -20,6 +20,7 @@ package org.apache.inlong.agent.core.task;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.core.AgentBaseTestsHelper;
 import org.apache.inlong.agent.core.task.file.TaskManager;
+import org.apache.inlong.agent.db.TaskProfileDb;
 import org.apache.inlong.common.enums.TaskStateEnum;
 
 import org.junit.AfterClass;
@@ -44,24 +45,35 @@ public class TestTaskManager {
     @BeforeClass
     public static void setup() {
         helper = new AgentBaseTestsHelper(TestTaskManager.class.getName()).setupAgentHome();
-        try {
-            manager = new TaskManager();
-            manager.start();
-        } catch (Exception e) {
-            Assert.assertTrue("manager start error", false);
-        }
     }
 
     @AfterClass
     public static void teardown() throws Exception {
-        manager.stop();
-        helper.teardownAgentHome();
     }
 
     @Test
     public void testTaskManager() {
         String pattern = helper.getTestRootDir() + "/YYYYMMDD.log_[0-9]+";
-        TaskProfile taskProfile1 = helper.getTaskProfile(1, pattern, false, 0L, 0L, TaskStateEnum.RUNNING, "GMT+8:00");
+        try {
+            manager = new TaskManager();
+            TaskProfileDb taskProfileDb = manager.getTaskDb();
+            for (int i = 1; i <= 10; i++) {
+                TaskProfile taskProfile = helper.getTaskProfile(i, pattern, false, 0L, 0L, TaskStateEnum.RUNNING,
+                        "GMT+8:00");
+                taskProfile.setTaskClass(MockTask.class.getCanonicalName());
+                taskProfileDb.storeTask(taskProfile);
+            }
+            manager.start();
+            for (int i = 1; i <= 10; i++) {
+                Assert.assertTrue(manager.getTask(String.valueOf(i)) != null);
+            }
+        } catch (Exception e) {
+            LOGGER.error("manager start error: ", e);
+            Assert.assertTrue("manager start error", false);
+        }
+
+        TaskProfile taskProfile1 = helper.getTaskProfile(100, pattern, false, 0L, 0L, TaskStateEnum.RUNNING,
+                "GMT+8:00");
         String taskId1 = taskProfile1.getTaskId();
         taskProfile1.setTaskClass(MockTask.class.getCanonicalName());
         List<TaskProfile> taskProfiles1 = new ArrayList<>();
@@ -83,7 +95,8 @@ public class TestTaskManager {
         Assert.assertTrue(manager.getTaskProfile(taskId1).getState() == TaskStateEnum.RUNNING);
 
         // test delete
-        TaskProfile taskProfile2 = helper.getTaskProfile(2, pattern, false, 0L, 0L, TaskStateEnum.RUNNING, "GMT+8:00");
+        TaskProfile taskProfile2 = helper.getTaskProfile(200, pattern, false, 0L, 0L, TaskStateEnum.RUNNING,
+                "GMT+8:00");
         taskProfile2.setTaskClass(MockTask.class.getCanonicalName());
         List<TaskProfile> taskProfiles2 = new ArrayList<>();
         taskProfiles2.add(taskProfile2);
@@ -93,5 +106,12 @@ public class TestTaskManager {
         String taskId2 = taskProfile2.getTaskId();
         await().atMost(3, TimeUnit.SECONDS).until(() -> manager.getTask(taskId2) != null);
         Assert.assertTrue(manager.getTaskProfile(taskId2).getState() == TaskStateEnum.RUNNING);
+
+        try {
+            manager.stop();
+            helper.teardownAgentHome();
+        } catch (Exception e) {
+            Assert.assertTrue("manager stop error", false);
+        }
     }
 }


### PR DESCRIPTION
[INLONG-9580][Agent] Add unit testing to taskmanager to test their ability to recover tasks from DB
- Fixes #9580 

### Motivation
Add unit testing to taskmanager to test their ability to recover tasks from DB
### Modifications
Add unit testing to taskmanager to test their ability to recover tasks from DB
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
