### PR TITLE
[INLONG-9582][Agent] Add unit testing to instance manager to test their ability to recover tasks from DB

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -132,6 +132,10 @@ public class InstanceManager extends AbstractDaemon {
         return taskId;
     }
 
+    public InstanceDb getInstanceDb() {
+        return instanceDb;
+    }
+
     public Instance getInstance(String instanceId) {
         return instanceMap.get(instanceId);
     }
@@ -167,7 +171,7 @@ public class InstanceManager extends AbstractDaemon {
                     AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_INSTANCE_MGR_HEARTBEAT, inlongGroupId, inlongStreamId,
                             AgentUtils.getCurrentTime(), 1, 1);
                 } catch (Throwable ex) {
-                    LOGGER.error("coreThread {}", ex);
+                    LOGGER.error("coreThread error: ", ex);
                     ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
                 }
                 runAtLeastOneTime = true;


### PR DESCRIPTION
[INLONG-9582][Agent] Add unit testing to instance manager to test their ability to recover tasks from DB
- Fixes #9582

### Motivation
Add unit testing to instance manager to test their ability to recover tasks from DB
### Modifications
Add unit testing to instance manager to test their ability to recover tasks from DB

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
