### PR TITLE
[INLONG-9618][Manager] Fix the problem of httpUtils did not process 307 status code

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/FieldType.java
@@ -54,6 +54,9 @@ public enum FieldType {
     MAP,
     STRUCT,
     FUNCTION,
+    CHAR,
+    LARGEINT,
+    JSON,
     KEYWORD;
 
     public static FieldType forName(String name) {

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
@@ -22,7 +22,7 @@ import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -90,7 +90,7 @@ public class HttpUtils {
                 log.error("request error for {}, status code {}, body {}", url, statusCode, body);
             }
             if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())
-                    && CollectionUtils.isNotEmpty(exchange.getHeaders().get(HttpHeaders.LOCATION))) {
+                    && StringUtils.isNotBlank(exchange.getHeaders().getFirst(HttpHeaders.LOCATION))) {
                 exchange = restTemplate.exchange(exchange.getHeaders().getFirst(HttpHeaders.LOCATION), method, request,
                         String.class);
                 body = exchange.getBody();
@@ -122,7 +122,7 @@ public class HttpUtils {
                 log.debug("send request to {}, param {}", urls[i], param);
                 exchange = restTemplate.exchange(urls[i], method, request, String.class);
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())
-                        && CollectionUtils.isNotEmpty(exchange.getHeaders().get(HttpHeaders.LOCATION))) {
+                        && StringUtils.isNotBlank(exchange.getHeaders().getFirst(HttpHeaders.LOCATION))) {
                     return request(restTemplate, exchange.getHeaders().getFirst(HttpHeaders.LOCATION), method, param,
                             header, cls);
                 } else {
@@ -158,7 +158,7 @@ public class HttpUtils {
         ResponseEntity<T> response = restTemplate.exchange(url, httpMethod, requestEntity, typeReference);
 
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())
-                && CollectionUtils.isNotEmpty(response.getHeaders().get(HttpHeaders.LOCATION))) {
+                && StringUtils.isNotBlank(response.getHeaders().getFirst(HttpHeaders.LOCATION))) {
             return request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod, requestBody,
                     header, typeReference);
         } else {
@@ -178,7 +178,7 @@ public class HttpUtils {
         HttpEntity<Object> requestEntity = new HttpEntity<>(requestBody, header);
         ResponseEntity<String> response = restTemplate.exchange(url, httpMethod, requestEntity, String.class);
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())
-                && CollectionUtils.isNotEmpty(response.getHeaders().get(HttpHeaders.LOCATION))) {
+                && StringUtils.isNotBlank(response.getHeaders().getFirst(HttpHeaders.LOCATION))) {
             request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod, requestBody,
                     header);
         } else {
@@ -202,7 +202,7 @@ public class HttpUtils {
                         String.class);
 
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())
-                        && CollectionUtils.isNotEmpty(response.getHeaders().get(HttpHeaders.LOCATION))) {
+                        && StringUtils.isNotBlank(response.getHeaders().getFirst(HttpHeaders.LOCATION))) {
                     request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod, requestBody,
                             header);
                 } else {

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 public class HttpUtils {
 
     private static final Gson GSON = new GsonBuilder().create(); // thread safe
+    public static final String HTTP_PREFIX = "http://";
 
     /**
      * Check whether the host and port can connect
@@ -91,7 +92,7 @@ public class HttpUtils {
             }
             if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())) {
                 String redirectUrl = exchange.getHeaders().getFirst(HttpHeaders.LOCATION);
-                if (StringUtils.isNotBlank(redirectUrl)) {
+                if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
                     exchange = restTemplate.exchange(redirectUrl, method, request, String.class);
                     body = exchange.getBody();
                     statusCode = exchange.getStatusCode();
@@ -124,7 +125,7 @@ public class HttpUtils {
                 exchange = restTemplate.exchange(urls[i], method, request, String.class);
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())) {
                     String redirectUrl = exchange.getHeaders().getFirst(HttpHeaders.LOCATION);
-                    if (StringUtils.isNotBlank(redirectUrl)) {
+                    if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
                         return request(restTemplate, exchange.getHeaders().getFirst(HttpHeaders.LOCATION), method,
                                 param,
                                 header, cls);
@@ -162,7 +163,7 @@ public class HttpUtils {
 
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
             String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-            if (StringUtils.isNotBlank(redirectUrl)) {
+            if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
                 return request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod,
                         requestBody,
                         header, typeReference);
@@ -184,7 +185,7 @@ public class HttpUtils {
         ResponseEntity<String> response = restTemplate.exchange(url, httpMethod, requestEntity, String.class);
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
             String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-            if (StringUtils.isNotBlank(redirectUrl)) {
+            if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
                 request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod, requestBody,
                         header);
                 return;
@@ -211,7 +212,7 @@ public class HttpUtils {
 
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
                     String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-                    if (StringUtils.isNotBlank(redirectUrl)) {
+                    if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
                         request(restTemplate, redirectUrl, httpMethod, requestBody, header);
                         return;
                     }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
@@ -92,7 +92,7 @@ public class HttpUtils {
             }
             if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())) {
                 String redirectUrl = exchange.getHeaders().getFirst(HttpHeaders.LOCATION);
-                if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
+                if (validUrl(redirectUrl)) {
                     exchange = restTemplate.exchange(redirectUrl, method, request, String.class);
                     body = exchange.getBody();
                     statusCode = exchange.getStatusCode();
@@ -125,10 +125,9 @@ public class HttpUtils {
                 exchange = restTemplate.exchange(urls[i], method, request, String.class);
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(exchange.getStatusCode())) {
                     String redirectUrl = exchange.getHeaders().getFirst(HttpHeaders.LOCATION);
-                    if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
+                    if (validUrl(redirectUrl)) {
                         return request(restTemplate, exchange.getHeaders().getFirst(HttpHeaders.LOCATION), method,
-                                param,
-                                header, cls);
+                                param, header, cls);
                     }
                 }
                 String body = exchange.getBody();
@@ -163,7 +162,7 @@ public class HttpUtils {
 
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
             String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-            if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
+            if (validUrl(redirectUrl)) {
                 return request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod,
                         requestBody,
                         header, typeReference);
@@ -185,7 +184,7 @@ public class HttpUtils {
         ResponseEntity<String> response = restTemplate.exchange(url, httpMethod, requestEntity, String.class);
         if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
             String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-            if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
+            if (validUrl(redirectUrl)) {
                 request(restTemplate, response.getHeaders().getFirst(HttpHeaders.LOCATION), httpMethod, requestBody,
                         header);
                 return;
@@ -212,7 +211,7 @@ public class HttpUtils {
 
                 if (HttpStatus.TEMPORARY_REDIRECT.equals(response.getStatusCode())) {
                     String redirectUrl = response.getHeaders().getFirst(HttpHeaders.LOCATION);
-                    if (StringUtils.isNotBlank(redirectUrl) && redirectUrl.startsWith(HTTP_PREFIX)) {
+                    if (validUrl(redirectUrl)) {
                         request(restTemplate, redirectUrl, httpMethod, requestBody, header);
                         return;
                     }
@@ -263,6 +262,10 @@ public class HttpUtils {
         params.entrySet().stream().filter(e -> e.getValue() != null)
                 .forEach(e -> builder.queryParam(e.getKey(), e.getValue()));
         return builder.build(false).toUriString();
+    }
+
+    private static Boolean validUrl(String url) {
+        return StringUtils.isNotBlank(url) && url.startsWith(HTTP_PREFIX);
     }
 
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/util/HttpUtils.java
@@ -164,7 +164,7 @@ public class HttpUtils {
         } else {
             log.debug("success request to {}, status code {}", url, response.getStatusCode());
             Preconditions.expectTrue(response.getStatusCode().is2xxSuccessful(),
-                    "Request failed: " + response.getBody());
+                    "Request failed: " + response.getBody() + ", Status code: " + response.getStatusCode());
             return response.getBody();
         }
     }
@@ -184,7 +184,7 @@ public class HttpUtils {
         } else {
             log.debug("success request to {}, status code {}", url, response.getStatusCode());
             Preconditions.expectTrue(response.getStatusCode().is2xxSuccessful(),
-                    "Request failed: " + response.getBody());
+                    "Request failed: " + response.getBody() + ", Status code: " + response.getStatusCode());
         }
     }
 
@@ -208,7 +208,7 @@ public class HttpUtils {
                 } else {
                     log.debug("success request to {}, status code {}", urls[i], response.getStatusCode());
                     Preconditions.expectTrue(response.getStatusCode().is2xxSuccessful(),
-                            "Request failed: " + response.getBody() + "status code" + response.getStatusCode());
+                            "Request failed: " + response.getBody() + ", Status code: " + response.getStatusCode());
                 }
                 return;
             } catch (Exception e) {

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -101,7 +101,7 @@ public class StartupSortListener implements SortOperateListener {
             List<StreamSink> sinkList = streamInfo.getSinkList();
             List<String> sinkTypes = sinkList.stream().map(StreamSink::getSinkType).collect(Collectors.toList());
             if (CollectionUtils.isEmpty(sinkList) || !SinkType.containSortFlinkSink(sinkTypes)) {
-                continue;
+                return ListenerResult.success();
             }
 
             List<InlongStreamExtInfo> extList = streamInfo.getExtList();

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -101,7 +101,7 @@ public class StartupSortListener implements SortOperateListener {
             List<StreamSink> sinkList = streamInfo.getSinkList();
             List<String> sinkTypes = sinkList.stream().map(StreamSink::getSinkType).collect(Collectors.toList());
             if (CollectionUtils.isEmpty(sinkList) || !SinkType.containSortFlinkSink(sinkTypes)) {
-                return ListenerResult.success();
+                continue;
             }
 
             List<InlongStreamExtInfo> extList = streamInfo.getExtList();

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/FieldInfoUtils.java
@@ -291,13 +291,14 @@ public class FieldInfoUtils {
                 }
                 break;
             case TIME:
+            case TIMESTAMPTZ:
+            case TIMESTAMP:
                 if (StringUtils.isNotBlank(format)) {
                     formatInfo = new TimeFormatInfo(convertTimestampOrDataFormat(format));
                 } else {
                     formatInfo = new TimeFormatInfo();
                 }
                 break;
-            case TIMESTAMP:
             case DATETIME:
                 if (StringUtils.isNotBlank(format)) {
                     formatInfo = new TimestampFormatInfo(convertTimestampOrDataFormat(format));


### PR DESCRIPTION

### Prepare a Pull Request

- Fixes #9618

### Motivation

Fix the problem of httpUtils did not process 307 status code.
When the status code is 307, response. `getStatusCode(). is2xSuccessfull()` is null, resulting in NPE,  and no rewinding operation is performed.
### Modifications

Fix the problem of httpUtils did not process 307 status code.

