### PR TITLE
[INLONG-9632][Manager] ensure every stream in group will be processed

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -102,7 +102,7 @@ public class StartupSortListener implements SortOperateListener {
             List<String> sinkTypes = sinkList.stream().map(StreamSink::getSinkType).collect(Collectors.toList());
             if (CollectionUtils.isEmpty(sinkList) || !SinkType.containSortFlinkSink(sinkTypes)) {
                 log.warn("not any valid sink configured for groupId {} and streamId {}, reason: {},"
-                                + " skip launching sort job",
+                        + " skip launching sort job",
                         CollectionUtils.isEmpty(sinkList) ? "no sink configured" : "no sort flink sink configured",
                         groupId, streamInfo.getInlongStreamId());
                 continue;

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -101,7 +101,11 @@ public class StartupSortListener implements SortOperateListener {
             List<StreamSink> sinkList = streamInfo.getSinkList();
             List<String> sinkTypes = sinkList.stream().map(StreamSink::getSinkType).collect(Collectors.toList());
             if (CollectionUtils.isEmpty(sinkList) || !SinkType.containSortFlinkSink(sinkTypes)) {
-                return ListenerResult.success();
+                log.warn("not any valid sink configured for groupId {} and streamId {}, reason: {},"
+                                + " skip launching sort job",
+                        CollectionUtils.isEmpty(sinkList) ? "no sink configured" : "no sort flink sink configured",
+                        groupId, streamInfo.getInlongStreamId());
+                continue;
             }
 
             List<InlongStreamExtInfo> extList = streamInfo.getExtList();


### PR DESCRIPTION
- Fixes #9632 

### Motivation

fix the problem of miss checking all streams in StartupSortListener

### Modifications

add logs for the illegal stream and continue to check the remaining streams

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? ( no)

