### PR TITLE
[INLONG-9666][CVE] Bump wiremock-jre8 to 2.35.1 to fix the CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,7 +181,7 @@
         <mockito.version>3.12.4</mockito.version>
         <powermock.version>2.0.9</powermock.version>
         <assertj.version>3.4.1</assertj.version>
-        <wiremock.version>2.33.2</wiremock.version>
+        <wiremock.version>2.35.1</wiremock.version>
 
         <jakarta.version>2.0.2</jakarta.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #9666

### Motivation

Bump wiremock-jre8 to 2.35.1 to fix the CVE
