### PR TITLE
[INLONG-9702][Agent] Change the data transmission interval to depend on local file configuration

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/AbstractSink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/AbstractSink.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sinks;
 
+import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.message.file.ProxyMessageCache;
 import org.apache.inlong.agent.metrics.AgentMetricItem;
@@ -58,6 +59,7 @@ public abstract class AbstractSink implements Sink {
     protected int batchFlushInterval;
     // key is stream id, value is a batch of messages belong to the same stream id
     protected ProxyMessageCache cache;
+    private static final AgentConfiguration agentConf = AgentConfiguration.getAgentConf();
 
     @Override
     public void setSourceName(String sourceFileName) {
@@ -71,7 +73,7 @@ public abstract class AbstractSink implements Sink {
         inlongGroupId = profile.getInlongGroupId();
         inlongStreamId = profile.getInlongStreamId();
         cache = new ProxyMessageCache(this.profile, inlongGroupId, inlongStreamId);
-        batchFlushInterval = profile.getInt(PROXY_BATCH_FLUSH_INTERVAL, DEFAULT_PROXY_BATCH_FLUSH_INTERVAL);
+        batchFlushInterval = agentConf.getInt(PROXY_BATCH_FLUSH_INTERVAL, DEFAULT_PROXY_BATCH_FLUSH_INTERVAL);
 
         this.dimensions = new HashMap<>();
         dimensions.put(KEY_PLUGIN_ID, this.getClass().getSimpleName());


### PR DESCRIPTION
[INLONG-9702][Agent] Change the data transmission interval to depend on local file configuration
- Fixes #9702 

### Motivation

Change the data transmission interval to depend on local file configuration
### Modifications

Change the data transmission interval to depend on local file configuration

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
