### PR TITLE
[INLONG-9704][Agent] Modify the default value of memory control semaphores to adapt to businesses with large amounts of data

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -76,11 +76,8 @@ public class FetcherConstants {
     public static final int DEFAULT_AGENT_GLOBAL_READER_SOURCE_PERMIT = 16 * 1000 * 1000;
 
     public static final String AGENT_GLOBAL_READER_QUEUE_PERMIT = "agent.global.reader.queue.permit";
-    public static final int DEFAULT_AGENT_GLOBAL_READER_QUEUE_PERMIT = 16 * 1000 * 1000;
-
-    public static final String AGENT_GLOBAL_CHANNEL_PERMIT = "agent.global.channel.permit";
-    public static final int DEFAULT_AGENT_GLOBAL_CHANNEL_PERMIT = 16 * 1000 * 1000;
+    public static final int DEFAULT_AGENT_GLOBAL_READER_QUEUE_PERMIT = 128 * 1000 * 1000;
 
     public static final String AGENT_GLOBAL_WRITER_PERMIT = "agent.global.writer.permit";
-    public static final int DEFAULT_AGENT_GLOBAL_WRITER_PERMIT = 96 * 1000 * 1000;
+    public static final int DEFAULT_AGENT_GLOBAL_WRITER_PERMIT = 128 * 1000 * 1000;
 }


### PR DESCRIPTION
[INLONG-9704][Agent] Modify the default value of memory control semaphores to adapt to businesses with large amounts of data
- Fixes #9704 

### Motivation
Modify the default value of memory control semaphores to adapt to businesses with large amounts of data
### Modifications

Modify the default value of memory control semaphores to adapt to businesses with large amounts of data

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
