### PR TITLE
[INLONG-9712][Agent] Adjust task configuration verification logic

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/TaskProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/TaskProfile.java
@@ -121,9 +121,7 @@ public class TaskProfile extends AbstractConfiguration {
     public boolean allRequiredKeyExist() {
         return hasKey(TaskConstants.TASK_ID) && hasKey(TaskConstants.TASK_SOURCE)
                 && hasKey(TaskConstants.TASK_SINK) && hasKey(TaskConstants.TASK_CHANNEL)
-                && hasKey(TaskConstants.TASK_GROUP_ID) && hasKey(TaskConstants.TASK_STREAM_ID)
-                && hasKey(TaskConstants.TASK_CYCLE_UNIT)
-                && hasKey(TaskConstants.TASK_FILE_TIME_ZONE);
+                && hasKey(TaskConstants.TASK_GROUP_ID) && hasKey(TaskConstants.TASK_STREAM_ID);
     }
 
     public String toJsonStr() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -134,6 +134,14 @@ public class LogFileTask extends Task {
             LOGGER.error("task profile needs all required key");
             return false;
         }
+        if (!profile.hasKey(TaskConstants.TASK_CYCLE_UNIT)) {
+            LOGGER.error("task profile needs cycle unit");
+            return false;
+        }
+        if (!profile.hasKey(TaskConstants.TASK_FILE_TIME_ZONE)) {
+            LOGGER.error("task profile needs time zone");
+            return false;
+        }
         boolean ret =
                 profile.hasKey(TaskConstants.FILE_DIR_FILTER_PATTERNS)
                         && profile.hasKey(TaskConstants.FILE_MAX_NUM);


### PR DESCRIPTION
[INLONG-9712][Agent] Adjust task configuration verification logic
- Fixes #9712 

### Motivation

Adjust task configuration verification logic, file class task fields need to be independent
### Modifications

Adjust task configuration verification logic, file class task fields need to be independent

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
