### PR TITLE
[INLONG-9721][Agent] Add a common cycle parameter to the task configuration

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -66,7 +66,8 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_FILE_TIME_OFFSET = "task.fileTask.timeOffset";
     public static final String TASK_FILE_TIME_ZONE = "task.fileTask.timeZone";
     public static final String TASK_FILE_MAX_WAIT = "task.fileTask.file.max.wait";
-    public static final String TASK_CYCLE_UNIT = "task.fileTask.cycleUnit";
+    public static final String TASK_CYCLE_UNIT = "task.cycleUnit";
+    public static final String FILE_TASK_CYCLE_UNIT = "task.fileTask.cycleUnit";
     public static final String TASK_FILE_TRIGGER_TYPE = "task.fileTask.collectType";
     public static final String JOB_FILE_LINE_END_PATTERN = "job.fileTask.line.endPattern";
     public static final String JOB_FILE_CONTENT_COLLECT_TYPE = "job.fileTask.contentCollectType";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -19,6 +19,7 @@ package org.apache.inlong.agent.pojo;
 
 import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.TaskProfile;
+import org.apache.inlong.agent.constant.CycleUnitType;
 import org.apache.inlong.agent.pojo.FileTask.FileTaskConfig;
 import org.apache.inlong.agent.pojo.FileTask.Line;
 import org.apache.inlong.common.constant.MQType;
@@ -411,6 +412,7 @@ public class TaskProfileDto {
         task.setVersion(dataConfig.getVersion());
         task.setState(dataConfig.getState());
         task.setPredefinedFields(dataConfig.getPredefinedFields());
+        task.setCycleUnit(CycleUnitType.REAL_TIME);
 
         // set sink type
         if (dataConfig.getDataReportType() == NORMAL_SEND_TO_DATAPROXY.ordinal()) {
@@ -443,6 +445,7 @@ public class TaskProfileDto {
             case FILE:
                 task.setTaskClass(DEFAULT_FILE_TASK);
                 FileTask fileTask = getFileJob(dataConfig);
+                task.setCycleUnit(fileTask.getCycleUnit());
                 task.setFileTask(fileTask);
                 task.setSource(DEFAULT_SOURCE);
                 profileDto.setTask(task);
@@ -519,6 +522,7 @@ public class TaskProfileDto {
         private String taskClass;
         private String predefinedFields;
         private Integer state;
+        private String cycleUnit;
 
         private FileTask fileTask;
         private BinlogJob binlogJob;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -134,8 +134,17 @@ public class LogFileTask extends Task {
             LOGGER.error("task profile needs all required key");
             return false;
         }
+        if (!profile.hasKey(TaskConstants.FILE_TASK_CYCLE_UNIT)) {
+            LOGGER.error("task profile needs file cycle unit");
+            return false;
+        }
         if (!profile.hasKey(TaskConstants.TASK_CYCLE_UNIT)) {
             LOGGER.error("task profile needs cycle unit");
+            return false;
+        }
+        if (profile.get(TaskConstants.TASK_CYCLE_UNIT)
+                .compareTo(profile.get(TaskConstants.FILE_TASK_CYCLE_UNIT)) != 0) {
+            LOGGER.error("task profile cycle unit must be consistent");
             return false;
         }
         if (!profile.hasKey(TaskConstants.TASK_FILE_TIME_ZONE)) {

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/TestLogFileTask.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/TestLogFileTask.java
@@ -52,10 +52,10 @@ import static org.awaitility.Awaitility.await;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(LogFileTask.class)
 @PowerMockIgnore({"javax.management.*"})
-public class TestLogfileCollectTask {
+public class TestLogFileTask {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TestLogfileCollectTask.class);
-    private static final ClassLoader LOADER = TestLogfileCollectTask.class.getClassLoader();
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestLogFileTask.class);
+    private static final ClassLoader LOADER = TestLogFileTask.class.getClassLoader();
     private static LogFileTask task;
     private static AgentBaseTestsHelper helper;
     private static final Gson GSON = new Gson();
@@ -73,7 +73,7 @@ public class TestLogfileCollectTask {
 
     @BeforeClass
     public static void setup() {
-        helper = new AgentBaseTestsHelper(TestLogfileCollectTask.class.getName()).setupAgentHome();
+        helper = new AgentBaseTestsHelper(TestLogFileTask.class.getName()).setupAgentHome();
         Db basicDb = TaskManager.initDb("/localdb");
         resourceName = LOADER.getResource("testScan/20230928_1/test_1.txt").getPath();
         tempResourceName = LOADER.getResource("testScan/temp.txt").getPath();
@@ -96,6 +96,7 @@ public class TestLogfileCollectTask {
                 dataTime = invocation.getArgument(1);
                 return null;
             }).when(task, "addToEvenMap", Mockito.anyString(), Mockito.anyString());
+            Assert.assertTrue(task.isProfileValid(taskProfile));
             task.init(manager, taskProfile, basicDb);
             EXECUTOR_SERVICE.submit(task);
         } catch (Exception e) {


### PR DESCRIPTION
[INLONG-9721][Agent] Add a common cycle parameter to the task configuration
- Fixes #9721 

### Motivation

Add a common cycle parameter to the task configuration, with the default cycle set to real-time; The cycle of the file type task is obtained from the extension parameters in the manager task configuration
### Modifications
Add a common cycle parameter to the task configuration, with the default cycle set to real-time; The cycle of the file type task is obtained from the extension parameters in the manager task configuration
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
