### PR TITLE
[INLONG-9739][Sort] onParsingBodyFailure function in FailureHandler class need add 'head' paramete to generate failure metric

### DIFF
--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
@@ -40,7 +40,7 @@ public interface FailureHandler extends Serializable {
      * @param exception the thrown exception
      * @throws Exception the exception
      */
-    void onParsingBodyFailure(byte[] body, Exception exception) throws Exception;
+    void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception;
 
     /**
      * This method is called when there is a failure occurred while converting head and body to row.

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/IgnoreFailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/IgnoreFailureHandler.java
@@ -33,8 +33,8 @@ public class IgnoreFailureHandler implements FailureHandler {
     }
 
     @Override
-    public void onParsingBodyFailure(byte[] body, Exception exception) {
-        LOG.warn("Cannot properly parse the body: {}.", new String(body), exception);
+    public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) {
+        LOG.warn("Cannot properly parse the head: {}, body: {}.", head, new String(body), exception);
     }
 
     @Override

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/NoOpFailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/NoOpFailureHandler.java
@@ -34,8 +34,8 @@ public class NoOpFailureHandler implements FailureHandler {
     }
 
     @Override
-    public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
-        LOG.error("Cannot properly parse the body: {}.", new String(body), exception);
+    public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
+        LOG.error("Cannot properly parse the head: {}, the body: {}.", head, new String(body), exception);
         throw exception;
     }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/AbstractInLongMsgFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/AbstractInLongMsgFormatDeserializer.java
@@ -103,7 +103,7 @@ public abstract class AbstractInLongMsgFormatDeserializer extends TableFormatDes
                 try {
                     bodyList = parseBodyList(bodyBytes);
                 } catch (Exception e) {
-                    failureHandler.onParsingBodyFailure(bodyBytes, e);
+                    failureHandler.onParsingBodyFailure(head, bodyBytes, e);
                     continue;
                 }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
@@ -725,7 +725,7 @@ public class InLongMsgCsvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
@@ -319,7 +319,7 @@ public class InLongMsgKvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
@@ -272,7 +272,7 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
@@ -200,7 +200,7 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/AbstractInLongMsgFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/AbstractInLongMsgFormatDeserializer.java
@@ -111,7 +111,7 @@ public abstract class AbstractInLongMsgFormatDeserializer implements ResultTypeQ
                     bodyList = parseBodyList(bodyBytes);
                 } catch (Exception e) {
                     reportDeSerializeErrorMetrics();
-                    failureHandler.onParsingBodyFailure(bodyBytes, e);
+                    failureHandler.onParsingBodyFailure(head, bodyBytes, e);
                     continue;
                 }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
@@ -848,7 +848,7 @@ public class InLongMsgCsvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
@@ -332,7 +332,7 @@ public class InLongMsgKvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
@@ -324,7 +324,7 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
         }
 
         @Override
-        public void onParsingBodyFailure(byte[] body, Exception exception) throws Exception {
+        public void onParsingBodyFailure(InLongMsgHead head, byte[] body, Exception exception) throws Exception {
             bodyCount++;
         }
 


### PR DESCRIPTION

- Fixes #9739