### PR TITLE
[INLONG-9756][Manager] add separator between groupId and streamId in JobName

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/RestartSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/RestartSortListener.java
@@ -122,7 +122,8 @@ public class RestartSortListener implements SortOperateListener {
             }
 
             FlinkInfo flinkInfo = new FlinkInfo();
-            String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + streamInfo.getInlongStreamId();
+            String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + InlongConstants.HYPHEN
+                    + streamInfo.getInlongStreamId();
             flinkInfo.setJobName(jobName);
             String sortUrl = kvConf.get(InlongConstants.SORT_URL);
             flinkInfo.setEndpoint(sortUrl);

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -133,7 +133,8 @@ public class StartupSortListener implements SortOperateListener {
 
             FlinkInfo flinkInfo = new FlinkInfo();
 
-            String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + streamInfo.getInlongStreamId();
+            String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + InlongConstants.HYPHEN
+                    + streamInfo.getInlongStreamId();
             flinkInfo.setJobName(jobName);
             String sortUrl = kvConf.get(InlongConstants.SORT_URL);
             flinkInfo.setEndpoint(sortUrl);

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupStreamListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupStreamListener.java
@@ -126,7 +126,8 @@ public class StartupStreamListener implements SortOperateListener {
 
         FlinkInfo flinkInfo = new FlinkInfo();
 
-        String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + streamInfo.getInlongStreamId();
+        String jobName = Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + InlongConstants.HYPHEN
+                + streamInfo.getInlongStreamId();
         flinkInfo.setJobName(jobName);
         String sortUrl = kvConf.get(InlongConstants.SORT_URL);
         flinkInfo.setEndpoint(sortUrl);


### PR DESCRIPTION

- Fixes #9756

### Motivation

Make jobName more readable

### Modifications

dd separator between groupId and streamId

### Verifying this change
This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  no doc needed
