### PR TITLE
[INLONG-9784][Audit] Optimize sending memory management when the audit-proxy config is null

### DIFF
--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
@@ -81,6 +81,9 @@ public class SenderGroup {
      * @return
      */
     public SenderResult send(ByteBuf dataBuf) {
+        if (dataBuf == null) {
+            return new SenderResult("dataBuf is null", 0, false);
+        }
         LinkedBlockingQueue<SenderChannel> channels = channelGroups.get(mIndex);
         SenderChannel channel = null;
         boolean dataBufReleased = false;
@@ -163,7 +166,7 @@ public class SenderGroup {
                 channel.release();
                 channels.offer(channel);
             }
-            if (!dataBufReleased && dataBuf != null) {
+            if (!dataBufReleased) {
                 dataBuf.release();
             }
         }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
@@ -83,12 +83,12 @@ public class SenderGroup {
     public SenderResult send(ByteBuf dataBuf) {
         LinkedBlockingQueue<SenderChannel> channels = channelGroups.get(mIndex);
         SenderChannel channel = null;
-        boolean dataBuffReleased = false;
+        boolean dataBufReleased = false;
         try {
             if (channels.size() <= 0) {
                 LOG.error("channels is empty");
                 dataBuf.release();
-                dataBuffReleased = true;
+                dataBufReleased = true;
                 return new SenderResult("channels is empty", 0, false);
             }
             boolean isOk = false;
@@ -135,7 +135,7 @@ public class SenderGroup {
             if (channel == null) {
                 LOG.error("can not get a channel");
                 dataBuf.release();
-                dataBuffReleased = true;
+                dataBufReleased = true;
                 return new SenderResult("can not get a channel", 0, false);
             }
 
@@ -148,10 +148,10 @@ public class SenderGroup {
                     }
                     t = channel.getChannel().writeAndFlush(dataBuf).sync().await();
                 }
-                dataBuffReleased = true;
+                dataBufReleased = true;
             } else {
                 dataBuf.release();
-                dataBuffReleased = true;
+                dataBufReleased = true;
             }
             return new SenderResult(channel.getAddr().getHostString(), channel.getAddr().getPort(), t.isSuccess());
         } catch (Throwable ex) {
@@ -163,7 +163,7 @@ public class SenderGroup {
                 channel.release();
                 channels.offer(channel);
             }
-            if (!dataBuffReleased && dataBuf != null) {
+            if (!dataBufReleased && dataBuf != null) {
                 dataBuf.release();
             }
         }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
@@ -83,12 +83,12 @@ public class SenderGroup {
     public SenderResult send(ByteBuf dataBuf) {
         LinkedBlockingQueue<SenderChannel> channels = channelGroups.get(mIndex);
         SenderChannel channel = null;
-        boolean dataBufHasRelease = false;
+        boolean dataBufHasReleased = false;
         try {
             if (channels.size() <= 0) {
                 LOG.error("channels is empty");
                 dataBuf.release();
-                dataBufHasRelease = true;
+                dataBufHasReleased = true;
                 return new SenderResult("channels is empty", 0, false);
             }
             boolean isOk = false;
@@ -135,7 +135,7 @@ public class SenderGroup {
             if (channel == null) {
                 LOG.error("can not get a channel");
                 dataBuf.release();
-                dataBufHasRelease = true;
+                dataBufHasReleased = true;
                 return new SenderResult("can not get a channel", 0, false);
             }
 
@@ -148,10 +148,10 @@ public class SenderGroup {
                     }
                     t = channel.getChannel().writeAndFlush(dataBuf).sync().await();
                 }
-                dataBufHasRelease = true;
+                dataBufHasReleased = true;
             } else {
                 dataBuf.release();
-                dataBufHasRelease = true;
+                dataBufHasReleased = true;
             }
             return new SenderResult(channel.getAddr().getHostString(), channel.getAddr().getPort(), t.isSuccess());
         } catch (Throwable ex) {
@@ -163,7 +163,7 @@ public class SenderGroup {
                 channel.release();
                 channels.offer(channel);
             }
-            if (!dataBufHasRelease && dataBuf != null) {
+            if (!dataBufHasReleased && dataBuf != null) {
                 dataBuf.release();
             }
         }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderGroup.java
@@ -83,12 +83,12 @@ public class SenderGroup {
     public SenderResult send(ByteBuf dataBuf) {
         LinkedBlockingQueue<SenderChannel> channels = channelGroups.get(mIndex);
         SenderChannel channel = null;
-        boolean dataBufHasReleased = false;
+        boolean dataBuffReleased = false;
         try {
             if (channels.size() <= 0) {
                 LOG.error("channels is empty");
                 dataBuf.release();
-                dataBufHasReleased = true;
+                dataBuffReleased = true;
                 return new SenderResult("channels is empty", 0, false);
             }
             boolean isOk = false;
@@ -135,7 +135,7 @@ public class SenderGroup {
             if (channel == null) {
                 LOG.error("can not get a channel");
                 dataBuf.release();
-                dataBufHasReleased = true;
+                dataBuffReleased = true;
                 return new SenderResult("can not get a channel", 0, false);
             }
 
@@ -148,10 +148,10 @@ public class SenderGroup {
                     }
                     t = channel.getChannel().writeAndFlush(dataBuf).sync().await();
                 }
-                dataBufHasReleased = true;
+                dataBuffReleased = true;
             } else {
                 dataBuf.release();
-                dataBufHasReleased = true;
+                dataBuffReleased = true;
             }
             return new SenderResult(channel.getAddr().getHostString(), channel.getAddr().getPort(), t.isSuccess());
         } catch (Throwable ex) {
@@ -163,7 +163,7 @@ public class SenderGroup {
                 channel.release();
                 channels.offer(channel);
             }
-            if (!dataBufHasReleased && dataBuf != null) {
+            if (!dataBuffReleased && dataBuf != null) {
                 dataBuf.release();
             }
         }


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #9784
### Motivation

*Optimize sending memory management when the audit-proxy config is null.*

### Modifications

*Add memory release logic when the audit-proxy config is null.*