### PR TITLE
[INLONG-9795][Sort] Regarding the format optimization of the data type definition

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/common/config/RedisDataType.java
@@ -47,6 +47,5 @@ public enum RedisDataType {
      * Since strings are binary safe blobs and their maximum length is 512 MB, <br/>
      * they are suitable to set up to 2^32 different bits.
      */
-    BITMAP,
-    ;
+    BITMAP;
 }


### PR DESCRIPTION

### Prepare a Pull Request

- Title Example: [INLONG-9795][Sort] Regarding the format optimization of the data typ…


- Fixes #9795 

### Motivation

The current enumeration class org.apache.inlong.sort.redis.common.config.RedisDataType is defined as,
; symbol ends. Although there is no grammatical problem with this, the code looks confusing, so it is recommended to modify it and remove it.
; symbol and add ";"  that makes the code look clearer.

### Modifications

Removed the trailing symbol "" of the enumeration class org.apache.inlong.sort.redis.common.config.RedisDataType,
;".

### Verifying this change

None

### Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
