### PR TITLE
[INLONG-9804][Agent] Add Pulsar source for Agent

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -117,13 +117,13 @@ public class TaskConstants extends CommonConstants {
     public static final String JOB_KAFKA_READ_TIMEOUT = "job.kafkaJob.read.timeout";
     public static final String TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET = "task.kafkaJob.autoOffsetReset";
 
-    // Pulsar task
-    public static final String TASK_PULSAR_TENANT = "task.pulsarTask.tenant";
-    public static final String TASK_PULSAR_NAMESPACE = "task.pulsarTask.namespace";
-    public static final String TASK_PULSAR_TOPIC = "task.pulsarTask.topic";
-    public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarTask.serviceUrl";
-    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarTask.scanStartupMode";
-    public static final String TASK_PULSAR_RESET_TIME = "task.pulsarTask.resetTime";
+    // Pulsar job
+    public static final String TASK_PULSAR_TENANT = "task.pulsarJob.tenant";
+    public static final String TASK_PULSAR_NAMESPACE = "task.pulsarJob.namespace";
+    public static final String TASK_PULSAR_TOPIC = "task.pulsarJob.topic";
+    public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarJob.serviceUrl";
+    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarJob.scanStartupMode";
+    public static final String TASK_PULSAR_RESET_TIME = "task.pulsarJob.resetTime";
 
     public static final String JOB_MONGO_HOSTS = "job.mongoJob.hosts";
     public static final String JOB_MONGO_USER = "job.mongoJob.user";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -117,7 +117,7 @@ public class TaskConstants extends CommonConstants {
     public static final String JOB_KAFKA_READ_TIMEOUT = "job.kafkaJob.read.timeout";
     public static final String TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET = "task.kafkaJob.autoOffsetReset";
 
-    // Pulsar job
+    // Pulsar task
     public static final String TASK_PULSAR_TENANT = "task.pulsarTask.tenant";
     public static final String TASK_PULSAR_NAMESPACE = "task.pulsarTask.namespace";
     public static final String TASK_PULSAR_TOPIC = "task.pulsarTask.topic";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -121,8 +121,10 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_PULSAR_TENANT = "task.pulsarTask.tenant";
     public static final String TASK_PULSAR_NAMESPACE = "task.pulsarTask.namespace";
     public static final String TASK_PULSAR_TOPIC = "task.pulsarTask.topic";
+    public static final String TASK_PULSAR_SUBSCRIPTION = "task.pulsarTask.subscription";
+    public static final String TASK_PULSAR_SUBSCRIPTION_TYPE = "task.pulsarTask.subscriptionType";
     public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarTask.serviceUrl";
-    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarTask.scanStartupMode";
+    public static final String TASK_PULSAR_SUBSCRIPTION_POSITION = "task.pulsarTask.subscriptionPosition";
     public static final String TASK_PULSAR_RESET_TIME = "task.pulsarTask.resetTime";
 
     public static final String JOB_MONGO_HOSTS = "job.mongoJob.hosts";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -117,6 +117,14 @@ public class TaskConstants extends CommonConstants {
     public static final String JOB_KAFKA_READ_TIMEOUT = "job.kafkaJob.read.timeout";
     public static final String TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET = "task.kafkaJob.autoOffsetReset";
 
+    // Pulsar task
+    public static final String TASK_PULSAR_TENANT = "task.pulsarTask.tenant";
+    public static final String TASK_PULSAR_NAMESPACE = "task.pulsarTask.namespace";
+    public static final String TASK_PULSAR_TOPIC = "task.pulsarTask.topic";
+    public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarTask.serviceUrl";
+    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarTask.scanStartupMode";
+    public static final String TASK_PULSAR_RESET_TIME = "task.pulsarTask.resetTime";
+
     public static final String JOB_MONGO_HOSTS = "job.mongoJob.hosts";
     public static final String JOB_MONGO_USER = "job.mongoJob.user";
     public static final String JOB_MONGO_PASSWORD = "job.mongoJob.password";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -118,12 +118,12 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET = "task.kafkaJob.autoOffsetReset";
 
     // Pulsar job
-    public static final String TASK_PULSAR_TENANT = "task.pulsarJob.tenant";
-    public static final String TASK_PULSAR_NAMESPACE = "task.pulsarJob.namespace";
-    public static final String TASK_PULSAR_TOPIC = "task.pulsarJob.topic";
-    public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarJob.serviceUrl";
-    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarJob.scanStartupMode";
-    public static final String TASK_PULSAR_RESET_TIME = "task.pulsarJob.resetTime";
+    public static final String TASK_PULSAR_TENANT = "task.pulsarTask.tenant";
+    public static final String TASK_PULSAR_NAMESPACE = "task.pulsarTask.namespace";
+    public static final String TASK_PULSAR_TOPIC = "task.pulsarTask.topic";
+    public static final String TASK_PULSAR_SERVICE_URL = "task.pulsarTask.serviceUrl";
+    public static final String TASK_PULSAR_SCAN_STARTUP_MODE = "task.pulsarTask.scanStartupMode";
+    public static final String TASK_PULSAR_RESET_TIME = "task.pulsarTask.resetTime";
 
     public static final String JOB_MONGO_HOSTS = "job.mongoJob.hosts";
     public static final String JOB_MONGO_USER = "job.mongoJob.user";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarJob.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarJob.java
@@ -20,7 +20,7 @@ package org.apache.inlong.agent.pojo;
 import lombok.Data;
 
 @Data
-public class PulsarTask {
+public class PulsarJob {
 
     private String tenant;
     private String namespace;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
@@ -20,7 +20,7 @@ package org.apache.inlong.agent.pojo;
 import lombok.Data;
 
 @Data
-public class PulsarJob {
+public class PulsarTask {
 
     private String tenant;
     private String namespace;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.pojo;
+
+import lombok.Data;
+
+@Data
+public class PulsarTask {
+
+    private String tenant;
+    private String namespace;
+    private String topic;
+    private String serviceUrl;
+    private String scanStartupMode;
+    private String resetTime;
+
+    @Data
+    public static class PulsarJobTaskConfig {
+
+        private String pulsarTenant;
+        private String namespace;
+        private String topic;
+        private String serviceUrl;
+        private String scanStartupMode;
+        private String resetTime;
+    }
+}

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
@@ -30,7 +30,7 @@ public class PulsarTask {
     private String resetTime;
 
     @Data
-    public static class PulsarJobTaskConfig {
+    public static class PulsarTaskConfig {
 
         private String pulsarTenant;
         private String namespace;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/PulsarTask.java
@@ -25,8 +25,10 @@ public class PulsarTask {
     private String tenant;
     private String namespace;
     private String topic;
+    private String subscription;
+    private String subscriptionType;
     private String serviceUrl;
-    private String scanStartupMode;
+    private String subscriptionPosition;
     private String resetTime;
 
     @Data
@@ -35,8 +37,10 @@ public class PulsarTask {
         private String pulsarTenant;
         private String namespace;
         private String topic;
+        private String subscription;
+        private String subscriptionType;
         private String serviceUrl;
-        private String scanStartupMode;
+        private String subscriptionPosition;
         private String resetTime;
     }
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -221,8 +221,10 @@ public class TaskProfileDto {
         pulsarTask.setTenant(pulsarTaskConfig.getPulsarTenant());
         pulsarTask.setNamespace(pulsarTaskConfig.getNamespace());
         pulsarTask.setTopic(pulsarTaskConfig.getTopic());
+        pulsarTask.setSubscription(pulsarTaskConfig.getSubscription());
+        pulsarTask.setSubscriptionType(pulsarTaskConfig.getSubscriptionType());
         pulsarTask.setServiceUrl(pulsarTaskConfig.getServiceUrl());
-        pulsarTask.setScanStartupMode(pulsarTaskConfig.getScanStartupMode());
+        pulsarTask.setSubscriptionPosition(pulsarTaskConfig.getSubscriptionPosition());
         pulsarTask.setResetTime(pulsarTaskConfig.getResetTime());
 
         return pulsarTask;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -213,7 +213,7 @@ public class TaskProfileDto {
         return kafkaJob;
     }
 
-    private static PulsarTask getPulsarJob(DataConfig dataConfig) {
+    private static PulsarTask getPulsarTask(DataConfig dataConfig) {
         PulsarTaskConfig pulsarTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
                 PulsarTaskConfig.class);
         PulsarTask pulsarTask = new PulsarTask();
@@ -477,7 +477,7 @@ public class TaskProfileDto {
                 break;
             case PULSAR:
                 task.setTaskClass(DEFAULT_PULSAR_TASK);
-                PulsarTask pulsarTask = getPulsarJob(dataConfig);
+                PulsarTask pulsarTask = getPulsarTask(dataConfig);
                 task.setPulsarTask(pulsarTask);
                 task.setSource(PULSAR_SOURCE);
                 profileDto.setTask(task);

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -39,6 +39,7 @@ public class TaskProfileDto {
 
     public static final String DEFAULT_FILE_TASK = "org.apache.inlong.agent.plugin.task.file.LogFileTask";
     public static final String DEFAULT_KAFKA_TASK = "org.apache.inlong.agent.plugin.task.KafkaTask";
+    public static final String DEFAULT_PULSAR_TASK = "org.apache.inlong.agent.plugin.task.PulsarTask";
     public static final String DEFAULT_CHANNEL = "org.apache.inlong.agent.plugin.channel.MemoryChannel";
     public static final String MANAGER_JOB = "MANAGER_JOB";
     public static final String DEFAULT_DATA_PROXY_SINK = "org.apache.inlong.agent.plugin.sinks.ProxySink";
@@ -57,6 +58,8 @@ public class TaskProfileDto {
      * kafka source
      */
     public static final String KAFKA_SOURCE = "org.apache.inlong.agent.plugin.sources.KafkaSource";
+    // pulsar source
+    public static final String PULSAR_SOURCE = "org.apache.inlong.agent.plugin.sources.PulsarSource";
     /**
      * PostgreSQL source
      */
@@ -207,6 +210,21 @@ public class TaskProfileDto {
         kafkaJob.setTopic(kafkaJobTaskConfig.getTopic());
 
         return kafkaJob;
+    }
+
+    private static PulsarTask getPulsarJob(DataConfig dataConfig) {
+        PulsarTask.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
+                PulsarTask.PulsarJobTaskConfig.class);
+        PulsarTask pulsarTask = new PulsarTask();
+
+        pulsarTask.setTenant(pulsarJobTaskConfig.getPulsarTenant());
+        pulsarTask.setNamespace(pulsarJobTaskConfig.getNamespace());
+        pulsarTask.setTopic(pulsarJobTaskConfig.getTopic());
+        pulsarTask.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
+        pulsarTask.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
+        pulsarTask.setResetTime(pulsarJobTaskConfig.getResetTime());
+
+        return pulsarTask;
     }
 
     private static PostgreSQLJob getPostgresJob(DataConfig dataConfigs) {
@@ -456,6 +474,13 @@ public class TaskProfileDto {
                 task.setSource(KAFKA_SOURCE);
                 profileDto.setTask(task);
                 break;
+            case PULSAR:
+                task.setTaskClass(DEFAULT_PULSAR_TASK);
+                PulsarTask pulsarTask = getPulsarJob(dataConfig);
+                task.setPulsarTask(pulsarTask);
+                task.setSource(PULSAR_SOURCE);
+                profileDto.setTask(task);
+                break;
             case POSTGRES:
                 PostgreSQLJob postgreSQLJob = getPostgresJob(dataConfig);
                 task.setPostgreSQLJob(postgreSQLJob);
@@ -528,6 +553,7 @@ public class TaskProfileDto {
         private FileTask fileTask;
         private BinlogJob binlogJob;
         private KafkaJob kafkaJob;
+        private PulsarTask pulsarTask;
         private PostgreSQLJob postgreSQLJob;
         private OracleJob oracleJob;
         private MongoJob mongoJob;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -39,7 +39,7 @@ public class TaskProfileDto {
 
     public static final String DEFAULT_FILE_TASK = "org.apache.inlong.agent.plugin.task.file.LogFileTask";
     public static final String DEFAULT_KAFKA_TASK = "org.apache.inlong.agent.plugin.task.KafkaTask";
-    public static final String DEFAULT_PULSAR_TASK = "org.apache.inlong.agent.plugin.task.PulsarTask";
+    public static final String DEFAULT_PULSAR_TASK = "org.apache.inlong.agent.plugin.task.PulsarJob";
     public static final String DEFAULT_CHANNEL = "org.apache.inlong.agent.plugin.channel.MemoryChannel";
     public static final String MANAGER_JOB = "MANAGER_JOB";
     public static final String DEFAULT_DATA_PROXY_SINK = "org.apache.inlong.agent.plugin.sinks.ProxySink";
@@ -212,19 +212,19 @@ public class TaskProfileDto {
         return kafkaJob;
     }
 
-    private static PulsarTask getPulsarJob(DataConfig dataConfig) {
-        PulsarTask.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
-                PulsarTask.PulsarJobTaskConfig.class);
-        PulsarTask pulsarTask = new PulsarTask();
+    private static PulsarJob getPulsarJob(DataConfig dataConfig) {
+        PulsarJob.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
+                PulsarJob.PulsarJobTaskConfig.class);
+        PulsarJob pulsarJob = new PulsarJob();
 
-        pulsarTask.setTenant(pulsarJobTaskConfig.getPulsarTenant());
-        pulsarTask.setNamespace(pulsarJobTaskConfig.getNamespace());
-        pulsarTask.setTopic(pulsarJobTaskConfig.getTopic());
-        pulsarTask.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
-        pulsarTask.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
-        pulsarTask.setResetTime(pulsarJobTaskConfig.getResetTime());
+        pulsarJob.setTenant(pulsarJobTaskConfig.getPulsarTenant());
+        pulsarJob.setNamespace(pulsarJobTaskConfig.getNamespace());
+        pulsarJob.setTopic(pulsarJobTaskConfig.getTopic());
+        pulsarJob.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
+        pulsarJob.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
+        pulsarJob.setResetTime(pulsarJobTaskConfig.getResetTime());
 
-        return pulsarTask;
+        return pulsarJob;
     }
 
     private static PostgreSQLJob getPostgresJob(DataConfig dataConfigs) {
@@ -476,8 +476,8 @@ public class TaskProfileDto {
                 break;
             case PULSAR:
                 task.setTaskClass(DEFAULT_PULSAR_TASK);
-                PulsarTask pulsarTask = getPulsarJob(dataConfig);
-                task.setPulsarTask(pulsarTask);
+                PulsarJob pulsarJob = getPulsarJob(dataConfig);
+                task.setPulsarJob(pulsarJob);
                 task.setSource(PULSAR_SOURCE);
                 profileDto.setTask(task);
                 break;
@@ -553,7 +553,7 @@ public class TaskProfileDto {
         private FileTask fileTask;
         private BinlogJob binlogJob;
         private KafkaJob kafkaJob;
-        private PulsarTask pulsarTask;
+        private PulsarJob pulsarJob;
         private PostgreSQLJob postgreSQLJob;
         private OracleJob oracleJob;
         private MongoJob mongoJob;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -22,6 +22,7 @@ import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.constant.CycleUnitType;
 import org.apache.inlong.agent.pojo.FileTask.FileTaskConfig;
 import org.apache.inlong.agent.pojo.FileTask.Line;
+import org.apache.inlong.agent.pojo.PulsarTask.PulsarTaskConfig;
 import org.apache.inlong.common.constant.MQType;
 import org.apache.inlong.common.enums.TaskTypeEnum;
 import org.apache.inlong.common.pojo.agent.DataConfig;
@@ -213,16 +214,16 @@ public class TaskProfileDto {
     }
 
     private static PulsarTask getPulsarJob(DataConfig dataConfig) {
-        PulsarTask.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
-                PulsarTask.PulsarJobTaskConfig.class);
+        PulsarTaskConfig pulsarTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
+                PulsarTaskConfig.class);
         PulsarTask pulsarTask = new PulsarTask();
 
-        pulsarTask.setTenant(pulsarJobTaskConfig.getPulsarTenant());
-        pulsarTask.setNamespace(pulsarJobTaskConfig.getNamespace());
-        pulsarTask.setTopic(pulsarJobTaskConfig.getTopic());
-        pulsarTask.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
-        pulsarTask.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
-        pulsarTask.setResetTime(pulsarJobTaskConfig.getResetTime());
+        pulsarTask.setTenant(pulsarTaskConfig.getPulsarTenant());
+        pulsarTask.setNamespace(pulsarTaskConfig.getNamespace());
+        pulsarTask.setTopic(pulsarTaskConfig.getTopic());
+        pulsarTask.setServiceUrl(pulsarTaskConfig.getServiceUrl());
+        pulsarTask.setScanStartupMode(pulsarTaskConfig.getScanStartupMode());
+        pulsarTask.setResetTime(pulsarTaskConfig.getResetTime());
 
         return pulsarTask;
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -39,7 +39,7 @@ public class TaskProfileDto {
 
     public static final String DEFAULT_FILE_TASK = "org.apache.inlong.agent.plugin.task.file.LogFileTask";
     public static final String DEFAULT_KAFKA_TASK = "org.apache.inlong.agent.plugin.task.KafkaTask";
-    public static final String DEFAULT_PULSAR_TASK = "org.apache.inlong.agent.plugin.task.PulsarJob";
+    public static final String DEFAULT_PULSAR_TASK = "org.apache.inlong.agent.plugin.task.PulsarTask";
     public static final String DEFAULT_CHANNEL = "org.apache.inlong.agent.plugin.channel.MemoryChannel";
     public static final String MANAGER_JOB = "MANAGER_JOB";
     public static final String DEFAULT_DATA_PROXY_SINK = "org.apache.inlong.agent.plugin.sinks.ProxySink";
@@ -212,19 +212,19 @@ public class TaskProfileDto {
         return kafkaJob;
     }
 
-    private static PulsarJob getPulsarJob(DataConfig dataConfig) {
-        PulsarJob.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
-                PulsarJob.PulsarJobTaskConfig.class);
-        PulsarJob pulsarJob = new PulsarJob();
+    private static PulsarTask getPulsarJob(DataConfig dataConfig) {
+        PulsarTask.PulsarJobTaskConfig pulsarJobTaskConfig = GSON.fromJson(dataConfig.getExtParams(),
+                PulsarTask.PulsarJobTaskConfig.class);
+        PulsarTask pulsarTask = new PulsarTask();
 
-        pulsarJob.setTenant(pulsarJobTaskConfig.getPulsarTenant());
-        pulsarJob.setNamespace(pulsarJobTaskConfig.getNamespace());
-        pulsarJob.setTopic(pulsarJobTaskConfig.getTopic());
-        pulsarJob.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
-        pulsarJob.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
-        pulsarJob.setResetTime(pulsarJobTaskConfig.getResetTime());
+        pulsarTask.setTenant(pulsarJobTaskConfig.getPulsarTenant());
+        pulsarTask.setNamespace(pulsarJobTaskConfig.getNamespace());
+        pulsarTask.setTopic(pulsarJobTaskConfig.getTopic());
+        pulsarTask.setServiceUrl(pulsarJobTaskConfig.getServiceUrl());
+        pulsarTask.setScanStartupMode(pulsarJobTaskConfig.getScanStartupMode());
+        pulsarTask.setResetTime(pulsarJobTaskConfig.getResetTime());
 
-        return pulsarJob;
+        return pulsarTask;
     }
 
     private static PostgreSQLJob getPostgresJob(DataConfig dataConfigs) {
@@ -476,8 +476,8 @@ public class TaskProfileDto {
                 break;
             case PULSAR:
                 task.setTaskClass(DEFAULT_PULSAR_TASK);
-                PulsarJob pulsarJob = getPulsarJob(dataConfig);
-                task.setPulsarJob(pulsarJob);
+                PulsarTask pulsarTask = getPulsarJob(dataConfig);
+                task.setPulsarTask(pulsarTask);
                 task.setSource(PULSAR_SOURCE);
                 profileDto.setTask(task);
                 break;
@@ -553,7 +553,7 @@ public class TaskProfileDto {
         private FileTask fileTask;
         private BinlogJob binlogJob;
         private KafkaJob kafkaJob;
-        private PulsarJob pulsarJob;
+        private PulsarTask pulsarTask;
         private PostgreSQLJob postgreSQLJob;
         private OracleJob oracleJob;
         private MongoJob mongoJob;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/PulsarInstance.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/PulsarInstance.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.instance;
+
+import org.apache.inlong.agent.conf.InstanceProfile;
+import org.apache.inlong.agent.constant.TaskConstants;
+import org.apache.inlong.agent.core.instance.ActionType;
+import org.apache.inlong.agent.core.instance.InstanceAction;
+import org.apache.inlong.agent.core.instance.InstanceManager;
+import org.apache.inlong.agent.metrics.audit.AuditUtils;
+import org.apache.inlong.agent.plugin.Instance;
+import org.apache.inlong.agent.plugin.Message;
+import org.apache.inlong.agent.plugin.file.Sink;
+import org.apache.inlong.agent.plugin.file.Source;
+import org.apache.inlong.agent.state.State;
+import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.ThreadUtils;
+import org.apache.inlong.common.enums.InstanceStateEnum;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.agent.plugin.instance.FileInstance.HEARTBEAT_CHECK_GAP;
+
+public class PulsarInstance extends Instance {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarInstance.class);
+    private Source source;
+    private Sink sink;
+    private InstanceProfile profile;
+    private InstanceManager instanceManager;
+    private volatile boolean running = false;
+    private volatile boolean inited = false;
+    private int checkFinishCount = 0;
+
+    public static final int CORE_THREAD_SLEEP_TIME = 1;
+    private static final int DESTROY_LOOP_WAIT_TIME_MS = 10;
+    private static final int CHECK_FINISH_AT_LEAST_COUNT = 5;
+    private final int WRITE_FAILED_WAIT_TIME_MS = 10;
+    private int heartBreakCheckCount = 0;
+    private long heartBeatStartTime = AgentUtils.getCurrentTime();
+
+    @Override
+    public boolean init(Object srcManager, InstanceProfile srcProfile) {
+        try {
+            instanceManager = (InstanceManager) srcManager;
+            profile = srcProfile;
+            profile.set(TaskConstants.INODE_INFO, "");
+            LOGGER.info("task id: {} submit new instance {} profile detail {}.", profile.getTaskId(),
+                    profile.getInstanceId(), profile.toJsonStr());
+            source = (Source) Class.forName(profile.getSourceClass()).newInstance();
+            source.init(profile);
+            sink = (Sink) Class.forName(profile.getSinkClass()).newInstance();
+            sink.init(profile);
+            inited = true;
+            return true;
+        } catch (Throwable e) {
+            handleSourceDeleted();
+            doChangeState(State.FATAL);
+            LOGGER.error("init instance {} for task {} failed", profile.getInstanceId(), profile.getInstanceId(), e);
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);
+            return false;
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (!inited) {
+            return;
+        }
+        doChangeState(State.SUCCEEDED);
+        while (running) {
+            AgentUtils.silenceSleepInMs(DESTROY_LOOP_WAIT_TIME_MS);
+        }
+        this.source.destroy();
+        this.sink.destroy();
+    }
+
+    @Override
+    public InstanceProfile getProfile() {
+        return profile;
+    }
+
+    @Override
+    public String getTaskId() {
+        return profile.getTaskId();
+    }
+
+    @Override
+    public String getInstanceId() {
+        return profile.getInstanceId();
+    }
+
+    @Override
+    public void run() {
+        while (!isFinished()) {
+            if (!source.sourceExist()) {
+                handleSourceDeleted();
+                break;
+            }
+
+            Message msg = source.read();
+            if (msg == null) {
+                if (source.sourceFinish() && sink.sinkFinish()) {
+                    checkFinishCount++;
+                    if (checkFinishCount > CHECK_FINISH_AT_LEAST_COUNT) {
+                        handleReadEnd();
+                        break;
+                    }
+                } else {
+                    checkFinishCount = 0;
+                }
+                heartbeatStatic();
+                AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME);
+            } else {
+                boolean suc = false;
+                while (!isFinished() && !suc) {
+                    suc = sink.write(msg);
+                    if (!suc) {
+                        heartbeatStatic();
+                        AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);
+                    }
+                }
+                heartBreakCheckCount++;
+                if (heartBreakCheckCount > HEARTBEAT_CHECK_GAP) {
+                    heartbeatStatic();
+                }
+            }
+        }
+    }
+
+    private void handleSourceDeleted() {
+        profile.setState(InstanceStateEnum.DELETE);
+        profile.setModifyTime(AgentUtils.getCurrentTime());
+        InstanceAction action = new InstanceAction(ActionType.DELETE, profile);
+        while (!isFinished() && !instanceManager.submitAction(action)) {
+            LOGGER.error("instance manager action queue is full: taskId {}", instanceManager.getTaskId());
+            AgentUtils.silenceSleepInSeconds(CORE_THREAD_SLEEP_TIME);
+        }
+    }
+
+    private void handleReadEnd() {
+        InstanceAction action = new InstanceAction(ActionType.FINISH, profile);
+        while (!isFinished() && !instanceManager.submitAction(action)) {
+            LOGGER.error("instance manager action queue is full: taskId {}",
+                    instanceManager.getTaskId());
+            AgentUtils.silenceSleepInSeconds(CORE_THREAD_SLEEP_TIME);
+        }
+    }
+
+    private void heartbeatStatic() {
+        String inlongGroupId = profile.getInlongGroupId();
+        String inlongStreamId = profile.getInlongStreamId();
+        if (AgentUtils.getCurrentTime() - heartBeatStartTime > TimeUnit.SECONDS.toMillis(1)) {
+            AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_INSTANCE_HEARTBEAT, inlongGroupId, inlongStreamId,
+                    AgentUtils.getCurrentTime(), 1, 1);
+            heartBreakCheckCount = 0;
+            heartBeatStartTime = AgentUtils.getCurrentTime();
+        }
+    }
+
+    @Override
+    public void addCallbacks() {
+
+    }
+}

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -171,7 +171,7 @@ public class LogFileSource extends AbstractSource {
             if (DEFAULT_FILE_SOURCE_EXTEND_CLASS.compareTo(ExtendedHandler.class.getCanonicalName()) != 0) {
                 Constructor<?> constructor =
                         Class.forName(
-                                profile.get(TaskConstants.FILE_SOURCE_EXTEND_CLASS, DEFAULT_FILE_SOURCE_EXTEND_CLASS))
+                                        profile.get(TaskConstants.FILE_SOURCE_EXTEND_CLASS, DEFAULT_FILE_SOURCE_EXTEND_CLASS))
                                 .getDeclaredConstructor(InstanceProfile.class);
                 constructor.setAccessible(true);
                 extendedHandler = (ExtendedHandler) constructor.newInstance(profile);
@@ -476,7 +476,6 @@ public class LogFileSource extends AbstractSource {
             } catch (IOException e) {
                 LOGGER.error("readFromPos error: ", e);
             }
-
             MemoryManager.getInstance().release(AGENT_GLOBAL_READER_SOURCE_PERMIT, BATCH_READ_LINE_TOTAL_LEN);
             if (lines.isEmpty()) {
                 if (queue.isEmpty()) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -171,7 +171,7 @@ public class LogFileSource extends AbstractSource {
             if (DEFAULT_FILE_SOURCE_EXTEND_CLASS.compareTo(ExtendedHandler.class.getCanonicalName()) != 0) {
                 Constructor<?> constructor =
                         Class.forName(
-                                        profile.get(TaskConstants.FILE_SOURCE_EXTEND_CLASS, DEFAULT_FILE_SOURCE_EXTEND_CLASS))
+                                profile.get(TaskConstants.FILE_SOURCE_EXTEND_CLASS, DEFAULT_FILE_SOURCE_EXTEND_CLASS))
                                 .getDeclaredConstructor(InstanceProfile.class);
                 constructor.setAccessible(true);
                 extendedHandler = (ExtendedHandler) constructor.newInstance(profile);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -476,6 +476,7 @@ public class LogFileSource extends AbstractSource {
             } catch (IOException e) {
                 LOGGER.error("readFromPos error: ", e);
             }
+
             MemoryManager.getInstance().release(AGENT_GLOBAL_READER_SOURCE_PERMIT, BATCH_READ_LINE_TOTAL_LEN);
             if (lines.isEmpty()) {
                 if (queue.isEmpty()) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -108,8 +108,8 @@ public class PulsarSource extends AbstractSource {
     private final Integer READ_WAIT_TIMEOUT_MS = 10;
     private final Integer EMPTY_CHECK_COUNT_AT_LEAST = 5 * 60;
     private final Integer BATCH_TOTAL_LEN = 1024 * 1024;
-
     private final Integer CORE_THREAD_PRINT_INTERVAL_MS = 1000;
+    private final static String INLONG_AGENT = "inlong-agent-";
     private boolean isRealTime = false;
     private boolean isRestoreFromDB = false;
 
@@ -134,7 +134,7 @@ public class PulsarSource extends AbstractSource {
             instanceId = profile.getInstanceId();
             topic = profile.getInstanceId();
             serviceUrl = profile.get(TASK_PULSAR_SERVICE_URL);
-            subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, "inlong-agent-" + inlongStreamId);
+            subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, INLONG_AGENT + inlongStreamId);
             subscriptionPosition = profile.get(TASK_PULSAR_SUBSCRIPTION_POSITION,
                     SubscriptionInitialPosition.Latest.name());
             subscriptionType = profile.get(TASK_PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.name());

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -35,22 +35,18 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.PartitionInfo;
-import org.apache.kafka.common.TopicPartition;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.SynchronousQueue;
@@ -65,19 +61,13 @@ import static org.apache.inlong.agent.constant.CommonConstants.PROXY_PACKAGE_MAX
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_SEND_PARTITION_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_QUEUE_PERMIT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_SOURCE_PERMIT;
-import static org.apache.inlong.agent.constant.TaskConstants.JOB_KAFKA_PARTITION_OFFSET_DELIMITER;
-import static org.apache.inlong.agent.constant.TaskConstants.JOB_OFFSET_DELIMITER;
 import static org.apache.inlong.agent.constant.TaskConstants.OFFSET;
-import static org.apache.inlong.agent.constant.TaskConstants.RESTORE_FROM_DB;
 import static org.apache.inlong.agent.constant.TaskConstants.TASK_CYCLE_UNIT;
-import static org.apache.inlong.agent.constant.TaskConstants.TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET;
-import static org.apache.inlong.agent.constant.TaskConstants.TASK_KAFKA_BOOTSTRAP_SERVERS;
-import static org.apache.inlong.agent.constant.TaskConstants.TASK_KAFKA_OFFSET;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_RESET_TIME;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_SCAN_STARTUP_MODE;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_SERVICE_URL;
 
-/**
- * kafka source, split kafka source job into multi readers
- */
-public class KafkaSource extends AbstractSource {
+public class PulsarSource extends AbstractSource {
 
     @Data
     @AllArgsConstructor
@@ -88,20 +78,22 @@ public class KafkaSource extends AbstractSource {
         private Long offset;
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(KafkaSource.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarSource.class);
     private static final ThreadPoolExecutor EXECUTOR_SERVICE = new ThreadPoolExecutor(
             0, Integer.MAX_VALUE,
             1L, TimeUnit.SECONDS,
             new SynchronousQueue<>(),
-            new AgentThreadFactory("kafka-source"));
-    private BlockingQueue<KafkaSource.SourceData> queue;
+            new AgentThreadFactory("pulsar-source"));
+    private BlockingQueue<SourceData> queue;
     public InstanceProfile profile;
     private int maxPackSize;
     private String taskId;
     private String instanceId;
     private String topic;
-    private Properties props = new Properties();
-    private String allPartitionOffsets;
+    private String serviceUrl;
+    private String scanStartupMode;
+    private PulsarClient pulsarClient;
+    private Long timestamp;
     Map<Integer, Long> partitionOffsets = new HashMap<>();
     private volatile boolean running = false;
     private volatile boolean runnable = true;
@@ -112,20 +104,17 @@ public class KafkaSource extends AbstractSource {
     private final Integer EMPTY_CHECK_COUNT_AT_LEAST = 5 * 60;
     private final Integer BATCH_TOTAL_LEN = 1024 * 1024;
 
-    private static final String KAFKA_DESERIALIZER_METHOD =
-            "org.apache.kafka.common.serialization.ByteArrayDeserializer";
-    private static final String KAFKA_SESSION_TIMEOUT = "session.timeout.ms";
     private final Integer CORE_THREAD_PRINT_INTERVAL_MS = 1000;
     private boolean isRealTime = false;
     private boolean isRestoreFromDB = false;
 
-    public KafkaSource() {
+    public PulsarSource() {
     }
 
     @Override
     public void init(InstanceProfile profile) {
         try {
-            LOGGER.info("KafkaSource init: {}", profile.toJsonStr());
+            LOGGER.info("PulsarSource init: {}", profile.toJsonStr());
             this.profile = profile;
             super.init(profile);
             String cycleUnit = profile.get(TASK_CYCLE_UNIT);
@@ -138,23 +127,10 @@ public class KafkaSource extends AbstractSource {
             taskId = profile.getTaskId();
             instanceId = profile.getInstanceId();
             topic = profile.getInstanceId();
-            props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, profile.get(TASK_KAFKA_BOOTSTRAP_SERVERS));
-            props.put(ConsumerConfig.GROUP_ID_CONFIG, taskId);
-            props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, KAFKA_DESERIALIZER_METHOD);
-            props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, KAFKA_DESERIALIZER_METHOD);
-            props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, profile.get(TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET));
-            props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-
-            allPartitionOffsets = profile.get(TASK_KAFKA_OFFSET);
-            isRestoreFromDB = profile.getBoolean(RESTORE_FROM_DB, false);
-            if (!isRestoreFromDB && StringUtils.isNotBlank(allPartitionOffsets)) {
-                // example:0#110_1#666_2#222
-                String[] offsets = allPartitionOffsets.split(JOB_OFFSET_DELIMITER);
-                for (String offset : offsets) {
-                    partitionOffsets.put(Integer.valueOf(offset.split(JOB_KAFKA_PARTITION_OFFSET_DELIMITER)[0]),
-                            Long.valueOf(offset.split(JOB_KAFKA_PARTITION_OFFSET_DELIMITER)[1]));
-                }
-            }
+            serviceUrl = profile.get(TASK_PULSAR_SERVICE_URL);
+            scanStartupMode = profile.get(TASK_PULSAR_SCAN_STARTUP_MODE);
+            timestamp = profile.getLong(TASK_PULSAR_RESET_TIME, 0);
+            pulsarClient = PulsarClient.builder().serviceUrl(serviceUrl).build();
 
             EXECUTOR_SERVICE.execute(run());
         } catch (Exception ex) {
@@ -165,56 +141,42 @@ public class KafkaSource extends AbstractSource {
 
     private Runnable run() {
         return () -> {
-            AgentThreadFactory.nameThread("kafka-source-" + taskId + "-" + instanceId);
+            AgentThreadFactory.nameThread("pulsar-source-" + taskId + "-" + instanceId);
             running = true;
             try {
-                List<PartitionInfo> partitionInfoList;
-                try (KafkaConsumer<String, String> consumer = new KafkaConsumer<>(props)) {
-                    partitionInfoList = consumer.partitionsFor(topic);
-                }
+                try (Consumer<byte[]> consumer = pulsarClient.newConsumer(Schema.BYTES)
+                        .topic(topic)
+                        .subscriptionName("inlong-agent-" + taskId)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(scanStartupMode))
+                        .subscriptionType(SubscriptionType.Exclusive)
+                        .subscribe()) {
 
-                props.put(KAFKA_SESSION_TIMEOUT, 30000);
-
-                try (KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(props)) {
-                    if (null != partitionInfoList) {
-                        List<TopicPartition> topicPartitions = new ArrayList<>();
-                        for (PartitionInfo partitionInfo : partitionInfoList) {
-                            TopicPartition topicPartition = new TopicPartition(partitionInfo.topic(),
-                                    partitionInfo.partition());
-                            topicPartitions.add(topicPartition);
-                        }
-                        kafkaConsumer.assign(topicPartitions);
-
-                        if (!isRestoreFromDB && StringUtils.isNotBlank(allPartitionOffsets)) {
-                            for (TopicPartition topicPartition : topicPartitions) {
-                                Long offset = partitionOffsets.get(topicPartition.partition());
-                                if (ObjectUtils.isNotEmpty(offset)) {
-                                    kafkaConsumer.seek(topicPartition, offset);
-                                }
-                            }
-                        } else {
-                            LOGGER.info("Skip to seek offset");
-                        }
+                    if (!isRestoreFromDB && timestamp != 0L) {
+                        consumer.seek(timestamp);
+                        LOGGER.info("Reset consume from {}", timestamp);
+                    } else {
+                        LOGGER.info("Skip to reset consume");
                     }
-                    doRun(kafkaConsumer);
+
+                    doRun(consumer);
                 }
             } catch (Throwable e) {
-                LOGGER.error("do run error maybe topic is configured incorrectly: ", e);
+                LOGGER.error("do run error maybe pulsar client is configured incorrectly: ", e);
             }
             running = false;
         };
     }
 
-    private void doRun(KafkaConsumer<String, byte[]> kafkaConsumer) {
+    private void doRun(Consumer<byte[]> consumer) throws PulsarClientException {
         long lastPrintTime = 0;
         while (isRunnable()) {
             boolean suc = waitForPermit(AGENT_GLOBAL_READER_SOURCE_PERMIT, BATCH_TOTAL_LEN);
             if (!suc) {
                 break;
             }
-            ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(Duration.ofMillis(1000));
+            org.apache.pulsar.client.api.Message<byte[]> message = consumer.receive(0, TimeUnit.MILLISECONDS);
             MemoryManager.getInstance().release(AGENT_GLOBAL_READER_SOURCE_PERMIT, BATCH_TOTAL_LEN);
-            if (records.isEmpty()) {
+            if (ObjectUtils.isEmpty(message)) {
                 if (queue.isEmpty()) {
                     emptyCount.incrementAndGet();
                 } else {
@@ -225,22 +187,24 @@ public class KafkaSource extends AbstractSource {
             }
             emptyCount.set(0);
             long offset = 0L;
-            for (ConsumerRecord<String, byte[]> record : records) {
-                SourceData sourceData = new SourceData(record.value(), record.offset());
-                boolean suc4Queue = waitForPermit(AGENT_GLOBAL_READER_QUEUE_PERMIT, record.value().length);
-                if (!suc4Queue) {
-                    break;
-                }
-                putIntoQueue(sourceData);
-                offset = record.offset();
+            LOGGER.info("message: {}", message.getValue());
+            SourceData sourceData = new SourceData(message.getValue(), 0L);
+            boolean suc4Queue = waitForPermit(AGENT_GLOBAL_READER_QUEUE_PERMIT, message.getValue().length);
+            if (!suc4Queue) {
+                break;
             }
-            kafkaConsumer.commitSync();
+            putIntoQueue(sourceData);
+            consumer.acknowledge(message);
 
             if (AgentUtils.getCurrentTime() - lastPrintTime > CORE_THREAD_PRINT_INTERVAL_MS) {
                 lastPrintTime = AgentUtils.getCurrentTime();
-                LOGGER.info("kafka topic is {}, offset is {}", topic, offset);
+                LOGGER.info("pulsar topic is {}, offset is {}", topic, offset);
             }
         }
+    }
+
+    public boolean isRunnable() {
+        return runnable;
     }
 
     private boolean waitForPermit(String permitName, int permitLen) {
@@ -280,17 +244,6 @@ public class KafkaSource extends AbstractSource {
         }
     }
 
-    public boolean isRunnable() {
-        return runnable;
-    }
-
-    /**
-     * Stop running threads.
-     */
-    public void stopRunning() {
-        runnable = false;
-    }
-
     @Override
     public List<Reader> split(TaskProfile conf) {
         return null;
@@ -298,7 +251,7 @@ public class KafkaSource extends AbstractSource {
 
     @Override
     public Message read() {
-        KafkaSource.SourceData sourceData = null;
+        PulsarSource.SourceData sourceData = null;
         try {
             sourceData = queue.poll(READ_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
@@ -312,14 +265,14 @@ public class KafkaSource extends AbstractSource {
         return finalMsg;
     }
 
-    private Message createMessage(SourceData sourceData) {
+    private Message createMessage(PulsarSource.SourceData sourceData) {
         String proxyPartitionKey = profile.get(PROXY_SEND_PARTITION_KEY, DigestUtils.md5Hex(inlongGroupId));
         Map<String, String> header = new HashMap<>();
         header.put(PROXY_KEY_DATA, proxyPartitionKey);
         header.put(OFFSET, sourceData.offset.toString());
         header.put(PROXY_KEY_STREAM_ID, inlongStreamId);
 
-        long auditTime = 0;
+        long auditTime;
         if (isRealTime) {
             auditTime = AgentUtils.getCurrentTime();
         } else {
@@ -349,5 +302,12 @@ public class KafkaSource extends AbstractSource {
     @Override
     public boolean sourceExist() {
         return true;
+    }
+
+    /**
+     * Stop running threads.
+     */
+    public void stopRunning() {
+        runnable = false;
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -187,7 +187,6 @@ public class PulsarSource extends AbstractSource {
             }
             emptyCount.set(0);
             long offset = 0L;
-            LOGGER.info("message: {}", message.getValue());
             SourceData sourceData = new SourceData(message.getValue(), 0L);
             boolean suc4Queue = waitForPermit(AGENT_GLOBAL_READER_QUEUE_PERMIT, message.getValue().length);
             if (!suc4Queue) {
@@ -237,7 +236,7 @@ public class PulsarSource extends AbstractSource {
             if (!offerSuc) {
                 MemoryManager.getInstance().release(AGENT_GLOBAL_READER_QUEUE_PERMIT, sourceData.data.length);
             }
-            LOGGER.debug("Read {} from kafka topic {}", sourceData.getData(), topic);
+            LOGGER.debug("Read {} from pulsar topic {}", sourceData.getData(), topic);
         } catch (InterruptedException e) {
             MemoryManager.getInstance().release(AGENT_GLOBAL_READER_QUEUE_PERMIT, sourceData.data.length);
             LOGGER.error("fetchData offer failed {}", e.getMessage());

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -109,7 +109,7 @@ public class PulsarSource extends AbstractSource {
     private final Integer EMPTY_CHECK_COUNT_AT_LEAST = 5 * 60;
     private final Integer BATCH_TOTAL_LEN = 1024 * 1024;
     private final Integer CORE_THREAD_PRINT_INTERVAL_MS = 1000;
-    private final static String INLONG_AGENT = "inlong-agent-";
+    private final static String PULSAR_SUBSCRIPTION_PREFIX = "inlong-agent-";
     private boolean isRealTime = false;
     private boolean isRestoreFromDB = false;
 
@@ -134,7 +134,7 @@ public class PulsarSource extends AbstractSource {
             instanceId = profile.getInstanceId();
             topic = profile.getInstanceId();
             serviceUrl = profile.get(TASK_PULSAR_SERVICE_URL);
-            subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, INLONG_AGENT + inlongStreamId);
+            subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, PULSAR_SUBSCRIPTION_PREFIX + inlongStreamId);
             subscriptionPosition = profile.get(TASK_PULSAR_SUBSCRIPTION_POSITION,
                     SubscriptionInitialPosition.Latest.name());
             subscriptionType = profile.get(TASK_PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.name());

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/PulsarTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/PulsarTask.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.task;
+
+import org.apache.inlong.agent.conf.InstanceProfile;
+import org.apache.inlong.agent.conf.TaskProfile;
+import org.apache.inlong.agent.constant.CycleUnitType;
+import org.apache.inlong.agent.core.instance.ActionType;
+import org.apache.inlong.agent.core.instance.InstanceAction;
+import org.apache.inlong.agent.core.instance.InstanceManager;
+import org.apache.inlong.agent.core.task.TaskManager;
+import org.apache.inlong.agent.db.Db;
+import org.apache.inlong.agent.metrics.audit.AuditUtils;
+import org.apache.inlong.agent.plugin.file.Task;
+import org.apache.inlong.agent.state.State;
+import org.apache.inlong.agent.utils.AgentUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.apache.inlong.agent.constant.TaskConstants.RESTORE_FROM_DB;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_NAMESPACE;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_TENANT;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_PULSAR_TOPIC;
+
+public class PulsarTask extends Task {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PulsarTask.class);
+    public static final String DEFAULT_PULSAR_INSTANCE = "org.apache.inlong.agent.plugin.instance.PulsarInstance";
+    public static final int CORE_THREAD_SLEEP_TIME = 5000;
+    public static final int CORE_THREAD_PRINT_TIME = 10000;
+
+    private TaskProfile taskProfile;
+    private Db basicDb;
+    private TaskManager taskManager;
+    private InstanceManager instanceManager;
+    private long lastPrintTime = 0;
+    private boolean initOK = false;
+    private volatile boolean running = false;
+    private boolean isAdded = false;
+    private boolean isRestoreFromDB = false;
+
+    private String tenant;
+    private String namespace;
+    private String topic;
+    private String instanceId;
+
+    @Override
+    public void init(Object srcManager, TaskProfile taskProfile, Db basicDb) throws IOException {
+        taskManager = (TaskManager) srcManager;
+        commonInit(taskProfile, basicDb);
+        initOK = true;
+    }
+
+    private void commonInit(TaskProfile taskProfile, Db basicDb) {
+        LOGGER.info("pulsar commonInit: {}", taskProfile.toJsonStr());
+        this.taskProfile = taskProfile;
+        this.basicDb = basicDb;
+        this.tenant = taskProfile.get(TASK_PULSAR_TENANT);
+        this.namespace = taskProfile.get(TASK_PULSAR_NAMESPACE);
+        this.topic = taskProfile.get(TASK_PULSAR_TOPIC);
+        this.instanceId = tenant + "/" + namespace + "/" + topic;
+
+        this.isRestoreFromDB = taskProfile.getBoolean(RESTORE_FROM_DB, false);
+        instanceManager = new InstanceManager(taskProfile.getTaskId(), 1,
+                basicDb, taskManager.getTaskDb());
+        try {
+            instanceManager.start();
+        } catch (Exception e) {
+            LOGGER.error("start instance manager error: ", e);
+        }
+    }
+
+    @Override
+    public void destroy() {
+        doChangeState(State.SUCCEEDED);
+        if (instanceManager != null) {
+            instanceManager.stop();
+        }
+    }
+
+    @Override
+    public TaskProfile getProfile() {
+        return taskProfile;
+    }
+
+    @Override
+    public String getTaskId() {
+        if (taskProfile == null) {
+            return "";
+        }
+        return taskProfile.getTaskId();
+    }
+
+    @Override
+    public boolean isProfileValid(TaskProfile profile) {
+        if (!profile.allRequiredKeyExist()) {
+            LOGGER.error("task profile needs all required key");
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void addCallbacks() {
+
+    }
+
+    @Override
+    public void run() {
+        Thread.currentThread().setName("pulsar-task-core-" + getTaskId());
+        running = true;
+        try {
+            doRun();
+        } catch (Throwable e) {
+            LOGGER.error("do run error: ", e);
+        }
+        running = false;
+    }
+
+    private void doRun() {
+        while (!isFinished()) {
+            if (AgentUtils.getCurrentTime() - lastPrintTime > CORE_THREAD_PRINT_TIME) {
+                LOGGER.info("pulsar task running! taskId {}", getTaskId());
+                lastPrintTime = AgentUtils.getCurrentTime();
+            }
+            AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME);
+            if (!initOK) {
+                continue;
+            }
+
+            // Add instance profile to instance manager
+            addInstanceProfile();
+
+            String inlongGroupId = taskProfile.getInlongGroupId();
+            String inlongStreamId = taskProfile.getInlongStreamId();
+            AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_TASK_HEARTBEAT, inlongGroupId, inlongStreamId,
+                    AgentUtils.getCurrentTime(), 1, 1);
+        }
+    }
+
+    private void addInstanceProfile() {
+        if (isAdded) {
+            return;
+        }
+        String dataTime = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHH"));
+        InstanceProfile instanceProfile = taskProfile.createInstanceProfile(DEFAULT_PULSAR_INSTANCE, instanceId,
+                CycleUnitType.HOUR, dataTime, AgentUtils.getCurrentTime());
+        LOGGER.info("taskProfile.createInstanceProfile: {}", instanceProfile.toJsonStr());
+        InstanceAction action = new InstanceAction(ActionType.ADD, instanceProfile);
+        while (!isFinished() && !instanceManager.submitAction(action)) {
+            LOGGER.error("instance manager action queue is full: taskId {}", instanceManager.getTaskId());
+            AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME);
+        }
+        this.isAdded = true;
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9804 

### Motivation

1. Add `resetTime` in `PulsarTask`, used to reset consume.
2. Add `PulsarSource` to consume message.
3. Add `PulsarTask` and `PulsarInstance` to manage `PulsarSource`.

### Modifications
When the dataproxy is invalid for a period of time and restarted, the data will be sent later and the memory will be restored.
![image](https://github.com/apache/inlong/assets/58519431/364b091a-c5a9-48ee-8ed2-d6f641cd108a)

