### PR TITLE
[INLONG-9816][Agent] Add config class for installer

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
@@ -33,8 +33,20 @@ import java.util.List;
 @AllArgsConstructor
 public class ConfigResult {
 
+    /**
+     * The md5 of the config result
+     */
     private String md5;
-    private Integer moduleCount;
+    /**
+     * Number of module
+     */
+    private Integer moduleNum;
+    /**
+     * The list of module config list
+     */
     private List<ModuleConfig> moduleList;
+    /**
+     * Download storage path
+     */
     private String downloadPath;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.pojo.agent.installer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * The config result pulled by the agent from the manager.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConfigResult {
+
+    private String md5;
+    private Integer moduleCount;
+    private List<ModuleConfig> moduleList;
+    private String downloadPath;
+}

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
@@ -46,7 +46,7 @@ public class ConfigResult {
      */
     private List<ModuleConfig> moduleList;
     /**
-     * Download storage path
+     * Installation package storage path
      */
-    private String downloadPath;
+    private String storagePath;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.pojo.agent.installer;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The Module config for installer.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ModuleConfig {
+
+    private Integer id;
+    private String name;
+    private String md5;
+    private String version;
+    private Integer procCount;
+    private String startCommand;
+    private String stopCommand;
+    private String checkCommand;
+    private String uninstallCommand;
+    private PackageConfig packageConfig;
+}

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
@@ -33,12 +33,30 @@ public class ModuleConfig {
 
     private Integer id;
     private String name;
+    /**
+     * The md5 of the module config
+     */
     private String md5;
     private String version;
-    private Integer procCount;
+    /**
+     * Number of processes in one node
+     */
+    private Integer processesNum;
+    /**
+     * The command to start the module
+     */
     private String startCommand;
+    /**
+     * The command to stop the module
+     */
     private String stopCommand;
+    /**
+     * The command to check the processes num of the module
+     */
     private String checkCommand;
+    /**
+     * The command to uninstall the module
+     */
     private String uninstallCommand;
     private PackageConfig packageConfig;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.pojo.agent.installer;
+
+import lombok.Data;
+
+/**
+ * The package config for installer.
+ */
+@Data
+public class PackageConfig {
+
+    private String md5;
+    private String fileName;
+    private String downloadUrl;
+}

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
@@ -25,7 +25,16 @@ import lombok.Data;
 @Data
 public class PackageConfig {
 
+    /**
+     * The md5 of the package config
+     */
     private String md5;
+    /**
+     * The file name saved after downloading the installation package
+     */
     private String fileName;
+    /**
+     * The download url of the installation package
+     */
     private String downloadUrl;
 }


### PR DESCRIPTION
[INLONG-9816][Agent] Add config class for installer
- Fixes #9816 

### Motivation
Add config class for installer
### Modifications

Add config class for installer

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
