### PR TITLE
[INLONG-9829][Agent] Add guardian scripts

### DIFF
--- a/inlong-agent/agent-installer/assembly.xml
+++ b/inlong-agent/agent-installer/assembly.xml
@@ -30,13 +30,10 @@
     <fileSets>
         <!-- for bin -->
         <fileSet>
-            <directory>../bin</directory>
+            <directory>bin</directory>
             <includes>
                 <include>*.*</include>
             </includes>
-            <excludes>
-                <exclude>*rock*</exclude>
-            </excludes>
             <fileMode>0755</fileMode>
             <outputDirectory>bin</outputDirectory>
             <lineEnding>unix</lineEnding>

--- a/inlong-agent/agent-installer/assembly.xml
+++ b/inlong-agent/agent-installer/assembly.xml
@@ -52,7 +52,7 @@
     <!-- for sub-module dependencies -->
     <dependencySets>
         <dependencySet>
-            <useProjectArtifact>false</useProjectArtifact>
+            <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveDependencies>true</useTransitiveDependencies>
             <outputDirectory>lib</outputDirectory>
         </dependencySet>

--- a/inlong-agent/agent-installer/bin/installer-env.sh
+++ b/inlong-agent/agent-installer/bin/installer-env.sh
@@ -19,10 +19,9 @@
 #project directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 
-AS_USER=`whoami`
 export LOG_DIR="$BASE_DIR/logs"
-
 mkdir -p $LOG_DIR
+AS_USER=`whoami`
 chown -R $AS_USER $LOG_DIR
 
 # find java home
@@ -35,7 +34,7 @@ else
 fi
 
 if [ -z "$AGENT_JVM_HEAP_OPTS" ]; then
-  HEAP_OPTS="-Xmx512m -Xss512k"
+  HEAP_OPTS="-Xmx512m -Xss256m"
 else
   HEAP_OPTS="$AGENT_JVM_HEAP_OPTS"
 fi

--- a/inlong-agent/agent-installer/bin/installer-env.sh
+++ b/inlong-agent/agent-installer/bin/installer-env.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-#project directory
+# project base directory
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 
 export LOG_DIR="$BASE_DIR/logs"

--- a/inlong-agent/agent-installer/bin/installer-env.sh
+++ b/inlong-agent/agent-installer/bin/installer-env.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#project directory
+BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
+
+AS_USER=`whoami`
+export LOG_DIR="$BASE_DIR/logs"
+
+mkdir -p $LOG_DIR
+chown -R $AS_USER $LOG_DIR
+
+# find java home
+if [ -z "$JAVA_HOME" ]; then
+  export JAVA=$(which java)
+  export JPS=$(which jps)
+else
+  export JAVA="$JAVA_HOME/bin/java"
+  export JPS="$JAVA_HOME/bin/jps"
+fi
+
+if [ -z "$AGENT_JVM_HEAP_OPTS" ]; then
+  HEAP_OPTS="-Xmx512m -Xss512k"
+else
+  HEAP_OPTS="$AGENT_JVM_HEAP_OPTS"
+fi
+GC_OPTS="-XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:InitiatingHeapOccupancyPercent=60 -Djava.net.preferIPv4Stack=true -Dfile.encoding=UTF-8"
+LOG_OPTS="-Xloggc:$BASE_DIR/logs/gc.log -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=20M"
+if [ -n "$NEED_TRACK_NATIVE_MEMORY" ] && [ "$NEED_TRACK_NATIVE_MEMORY" = "true" ]; then
+    GC_OPTS="$GC_OPTS -XX:NativeMemoryTracking"
+fi
+INSTALLER_JVM_ARGS="$HEAP_OPTS $GC_OPTS $LOG_OPTS"
+
+# Add installer Rmi args when necessary
+INSTALLER_RMI_ARGS="-Dcom.sun.management.jmxremote \
+-Dcom.sun.management.jmxremote.port=18080 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false"
+CONFIG_DIR=${BASE_DIR}"/conf/"
+JAR_LIBS=${BASE_DIR}"/lib/*"
+CLASSPATH=${CONFIG_DIR}:${JAR_LIBS}
+
+JMX_ENABLED=$(grep -c "agent.domainListeners=org.apache.inlong.agent.metrics.AgentJmxMetricListener" $BASE_DIR/conf/installer.properties)
+if [[ $JMX_ENABLED == 1 ]]; then
+  export INSTALLER_ARGS="$INSTALLER_JVM_ARGS $INSTALLER_RMI_ARGS -cp $CLASSPATH -Dagent.home=$BASE_DIR"
+else
+  export INSTALLER_ARGS="$INSTALLER_JVM_ARGS -cp $CLASSPATH -Dagent.home=$BASE_DIR"
+fi

--- a/inlong-agent/agent-installer/bin/installer.sh
+++ b/inlong-agent/agent-installer/bin/installer.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+BASE_DIR=$(dirname $0)/..
+
+source "${BASE_DIR}"/bin/installer-env.sh
+CONSOLE_OUTPUT_FILE="${LOG_DIR}/agent-out.log"
+
+function help() {
+  echo "Usage: agent.sh {status|start|stop|restart|clean}" >&2
+  echo "       status:     the status of inlong agent"
+  echo "       start:      start the inlong agent"
+  echo "       stop:       stop the inlong agent"
+  echo "       restart:    restart the inlong agent"
+  echo "       clean:      unregister this node in manager"
+  echo "       help:       get help from inlong agent"
+}
+
+function running() {
+  process=$("$JPS" -l| grep "installer.Main" | grep -v grep)
+  if [ "${process}" = "" ]; then
+    return 1;
+  else
+    return 0;
+  fi
+}
+
+# start installer
+function start_installer() {
+  if running; then
+    echo "installer is running."
+    exit 1
+  fi
+  nohup ${JAVA} ${INSTALLER_ARGS} org.apache.inlong.agent.installer.Main > /dev/null 2>&1 &
+}
+
+# stop installer
+function stop_installer() {
+  if ! running; then
+    echo "installer is not running."
+    exit 1
+  fi
+  count=0
+  pid=$("$JPS" -l| grep "installer.Main"| grep -v grep | awk '{print $1}')
+  while running;
+  do
+    (( count++ ))
+    echo "Stopping installer $count times"
+    if [ "${count}" -gt 10 ]; then
+        echo "kill -9 $pid"
+        kill -9 "${pid}"
+    else
+        kill "${pid}"
+    fi
+    sleep 6;
+  done
+  echo "Stop installer successfully."
+}
+
+# get status of installer
+function status_installer() {
+  if running; then
+    echo "installer is running."
+    exit 0
+  else
+    echo "installer is not running."
+    exit 1
+  fi
+}
+
+# clean installer
+function clean_installer() {
+  if running; then
+    echo "installer is running. please stop it first."
+    exit 0
+  fi
+  ${JAVA} ${INSTALLER_ARGS} org.apache.inlong.agent.core.HeartbeatManager
+}
+
+function help_installer() {
+  ${JAVA} ${INSTALLER_ARGS} org.apache.inlong.agent.installer.Main -h
+}
+
+command=$1
+shift 1
+case $command in
+  status)
+    status_installer $@;
+    ;;
+  start)
+    start_installer $@;
+    ;;
+  stop)
+    stop_installer $@;
+    ;;
+  restart)
+    $0 stop $@
+    $0 start $@
+    ;;
+  clean)
+    clean_installer $@;
+    ;;
+  help)
+    help_installer;
+    ;;
+  *)
+    help;
+    exit 1;
+    ;;
+esac

--- a/inlong-agent/agent-installer/pom.xml
+++ b/inlong-agent/agent-installer/pom.xml
@@ -35,7 +35,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.inlong</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>agent-common</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>
@@ -47,7 +47,7 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.inlong</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>agent-core</artifactId>
             <version>${project.version}</version>
             <scope>compile</scope>


### PR DESCRIPTION
[INLONG-9829][Agent] Add guardian scripts
- Fixes #9829 

### Motivation

Add guardian scripts
### Modifications
Add guardian scripts

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
