### PR TITLE
[INLONG-9833][Agent] Add module state to distinguish whether the module has been downloaded or installed

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleConfig.java
@@ -58,5 +58,11 @@ public class ModuleConfig {
      * The command to uninstall the module
      */
     private String uninstallCommand;
+
     private PackageConfig packageConfig;
+
+    /**
+     * The state of the module
+     */
+    private ModuleStateEnum state;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleStateEnum.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ModuleStateEnum.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.common.pojo.agent.installer;
+
+/**
+ * Enum of module state.
+ */
+public enum ModuleStateEnum {
+
+    NEW(0),
+    DOWNLOADED(1),
+    INSTALLED(2);
+
+    private final int state;
+
+    ModuleStateEnum(int state) {
+        this.state = state;
+    }
+
+    public static ModuleStateEnum getTaskState(int state) {
+        switch (state) {
+            case 0:
+                return NEW;
+            case 1:
+                return DOWNLOADED;
+            case 2:
+                return INSTALLED;
+            default:
+                throw new RuntimeException("Unsupported module state " + state);
+        }
+    }
+
+    public int getType() {
+        return state;
+    }
+}


### PR DESCRIPTION
[INLONG-9833][Agent] Add module state to distinguish whether the module has been downloaded or installed
- Fixes #9833

### Motivation

Add module state to distinguish whether the module has been downloaded or installed

### Modifications

Add module state to distinguish whether the module has been downloaded or installed

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
