### PR TITLE
[INLONG-9848][Agent] Add the getAuthHeader function in the HttpManager class

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
@@ -231,7 +231,7 @@ public class HttpManager {
         try {
             header.put(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
         } catch (Exception e) {
-            LOGGER.error("getAuthHeader error", e);
+            LOGGER.error("Get auth header error", e);
         }
         return header;
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/HttpManager.java
@@ -42,6 +42,8 @@ import javax.net.ssl.SSLContext;
 import java.nio.charset.Charset;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_HTTP_APPLICATION_JSON;
@@ -158,7 +160,10 @@ public class HttpManager {
     public String doSentPost(String url, Object dto) {
         try {
             HttpPost post = getHttpPost(url);
-            post.addHeader(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
+            Map<String, String> authHeader = getAuthHeader();
+            authHeader.forEach((k, v) -> {
+                post.addHeader(k, v);
+            });
             StringEntity stringEntity = new StringEntity(toJsonStr(dto), Charset.forName("UTF-8"));
             stringEntity.setContentType(AGENT_HTTP_APPLICATION_JSON);
             post.setEntity(stringEntity);
@@ -190,7 +195,10 @@ public class HttpManager {
     public String doSendPost(String url) {
         try {
             HttpPost post = getHttpPost(url);
-            post.addHeader(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
+            Map<String, String> authHeader = getAuthHeader();
+            authHeader.forEach((k, v) -> {
+                post.addHeader(k, v);
+            });
             CloseableHttpResponse response = httpClient.execute(post);
             String returnStr = EntityUtils.toString(response.getEntity());
             if (returnStr != null && !returnStr.isEmpty()
@@ -218,4 +226,13 @@ public class HttpManager {
         return new HttpGet(url);
     }
 
+    public Map<String, String> getAuthHeader() {
+        Map<String, String> header = new HashMap<>();
+        try {
+            header.put(BasicAuth.BASIC_AUTH_HEADER, BasicAuth.genBasicAuthCredential(secretId, secretKey));
+        } catch (Exception e) {
+            LOGGER.error("getAuthHeader error", e);
+        }
+        return header;
+    }
 }


### PR DESCRIPTION
[INLONG-9848][Agent] Add the getAuthHeader function in the HttpManager class
- Fixes #9848

### Motivation

Add the getAuthHeader function in the HttpManager class

### Modifications
Add the getAuthHeader function in the HttpManager class to separate the authorization related logic. The installer needs to use authorization to download files

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
