### PR TITLE
[INLONG-9850][Agent] Add a function to retrieve HttpManager in the ModuleManager class

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ManagerFetcher.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ManagerFetcher.java
@@ -40,12 +40,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_FETCHER_INTERVAL;
-import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_REQUEST_TIMEOUT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_RETURN_PARAM_DATA;
-import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_PREFIX_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_FETCHER_INTERVAL;
-import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT;
-import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_INSTALLER_MANAGER_CONFIG_HTTP_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.INSTALLER_MANAGER_CONFIG_HTTP_PATH;
 import static org.apache.inlong.agent.installer.ManagerResultFormatter.getResultData;
@@ -57,9 +53,6 @@ import static org.apache.inlong.agent.utils.AgentUtils.fetchLocalUuid;
  */
 public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
 
-    public static final String MANAGER_ADDR = "manager.addr";
-    public static final String MANAGER_AUTH_SECRET_ID = "manager.auth.secretId";
-    public static final String MANAGER_AUTH_SECRET_KEY = "manager.auth.secretKey";
     public static final String CLUSTER_NAME = "cluster.name";
     public static final String CLUSTER_TAG = "cluster.tag";
     private static final Logger LOGGER = LoggerFactory.getLogger(ManagerFetcher.class);
@@ -78,26 +71,11 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     public ManagerFetcher(Manager manager) {
         this.manager = manager;
         this.conf = InstallerConfiguration.getInstallerConf();
-        if (requiredKeys(conf)) {
-            String managerAddr = conf.get(MANAGER_ADDR);
-            String managerHttpPrefixPath = conf.get(AGENT_MANAGER_VIP_HTTP_PREFIX_PATH,
-                    DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH);
-            int timeout = conf.getInt(AGENT_MANAGER_REQUEST_TIMEOUT,
-                    DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT);
-            String secretId = conf.get(MANAGER_AUTH_SECRET_ID);
-            String secretKey = conf.get(MANAGER_AUTH_SECRET_KEY);
-            httpManager = new HttpManager(managerAddr, managerHttpPrefixPath, timeout, secretId, secretKey);
-            baseManagerUrl = httpManager.getBaseUrl();
-            staticConfigUrl = buildStaticConfigUrl(baseManagerUrl);
-            clusterTag = conf.get(CLUSTER_TAG);
-            clusterName = conf.get(CLUSTER_NAME);
-        } else {
-            throw new RuntimeException("init manager error, cannot find required key");
-        }
-    }
-
-    private boolean requiredKeys(InstallerConfiguration conf) {
-        return conf.hasKey(MANAGER_ADDR);
+        httpManager = manager.getModuleManager().getHttpManager(conf);
+        baseManagerUrl = httpManager.getBaseUrl();
+        staticConfigUrl = buildStaticConfigUrl(baseManagerUrl);
+        clusterTag = conf.get(CLUSTER_TAG);
+        clusterName = conf.get(CLUSTER_NAME);
     }
 
     /**

--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -21,10 +21,13 @@ import org.apache.inlong.agent.common.AbstractDaemon;
 import org.apache.inlong.agent.installer.conf.InstallerConfiguration;
 import org.apache.inlong.agent.metrics.audit.AuditUtils;
 import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.HttpManager;
 import org.apache.inlong.agent.utils.ThreadUtils;
 import org.apache.inlong.common.pojo.agent.installer.ConfigResult;
 import org.apache.inlong.common.pojo.agent.installer.ModuleConfig;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,23 +35,59 @@ import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_REQUEST_TIMEOUT;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_VIP_HTTP_PREFIX_PATH;
+import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT;
+import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH;
+
 /**
  * Installer Manager, the bridge for job manager, task manager, db e.t.c it manages agent level operations and
  * communicates with outside system.
  */
 public class ModuleManager extends AbstractDaemon {
 
+    public static final String MANAGER_ADDR = "manager.addr";
+    public static final String MANAGER_AUTH_SECRET_ID = "manager.auth.secretId";
+    public static final String MANAGER_AUTH_SECRET_KEY = "manager.auth.secretKey";
     public static final int CONFIG_QUEUE_CAPACITY = 1;
     public static final int CORE_THREAD_SLEEP_TIME = 1000;
     private static final Logger LOGGER = LoggerFactory.getLogger(ModuleManager.class);
     private final InstallerConfiguration conf;
     private final BlockingQueue<ConfigResult> configQueue;
-
-    private String currentMd5;
+    private String currentMd5 = "";
+    private String currentStoragePath = "/tmp";
+    private ClassLoader classLoader;
+    private static final GsonBuilder gsonBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final Gson GSON = gsonBuilder.create();
+    private final HttpManager httpManager;
 
     public ModuleManager() {
         conf = InstallerConfiguration.getInstallerConf();
         configQueue = new LinkedBlockingQueue<>(CONFIG_QUEUE_CAPACITY);
+        classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = ModuleManager.class.getClassLoader();
+        }
+        if (requiredKeys(conf)) {
+            httpManager = getHttpManager(conf);
+        } else {
+            throw new RuntimeException("init module manager error, cannot find required key");
+        }
+    }
+
+    public HttpManager getHttpManager(InstallerConfiguration conf) {
+        String managerAddr = conf.get(MANAGER_ADDR);
+        String managerHttpPrefixPath = conf.get(AGENT_MANAGER_VIP_HTTP_PREFIX_PATH,
+                DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH);
+        int timeout = conf.getInt(AGENT_MANAGER_REQUEST_TIMEOUT,
+                DEFAULT_AGENT_MANAGER_REQUEST_TIMEOUT);
+        String secretId = conf.get(MANAGER_AUTH_SECRET_ID);
+        String secretKey = conf.get(MANAGER_AUTH_SECRET_KEY);
+        return new HttpManager(managerAddr, managerHttpPrefixPath, timeout, secretId, secretKey);
+    }
+
+    private boolean requiredKeys(InstallerConfiguration conf) {
+        return conf.hasKey(MANAGER_ADDR);
     }
 
     public void submitConfig(ConfigResult config) {


### PR DESCRIPTION
[INLONG-9850][Agent] Add a function to retrieve HttpManager in the ModuleManager class
- Fixes #9850

### Motivation
Add a function to retrieve HttpManager in the ModuleManager class, which needs to be used when downloading and installing packages
### Modifications
Add a function to retrieve HttpManager in the ModuleManager class, which needs to be used when downloading and installing packages

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
