### PR TITLE
[INLONG-9852][Agent] Place the configuration item for the installation package storage path in the installation package configuration

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
@@ -45,8 +45,4 @@ public class ConfigResult {
      * The list of module config list
      */
     private List<ModuleConfig> moduleList;
-    /**
-     * Installation package storage path
-     */
-    private String storagePath;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/PackageConfig.java
@@ -37,4 +37,8 @@ public class PackageConfig {
      * The download url of the installation package
      */
     private String downloadUrl;
+    /**
+     * Installation package storage path
+     */
+    private String storagePath;
 }


### PR DESCRIPTION
[INLONG-9852][Agent] Place the configuration item for the installation package storage path in the installation package configuration
- Fixes #9852

### Motivation

Place the configuration item for the installation package storage path in the installation package configuration
### Modifications

Place the configuration item for the installation package storage path in the installation package configuration

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
