### PR TITLE
[INLONG-9863][Agent] To avoid data loss caused by too many supplementary files

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -299,9 +299,9 @@ public class LogFileTask extends Task {
     private void runForRetry() {
         if (!runAtLeastOneTime) {
             scanExistingFile();
-            dealWithEventMap();
             runAtLeastOneTime = true;
         }
+        dealWithEventMap();
         if (instanceManager.allInstanceFinished()) {
             LOGGER.info("retry task finished, send action to task manager, taskId {}", getTaskId());
             TaskAction action = new TaskAction(org.apache.inlong.agent.core.task.ActionType.FINISH, taskProfile);


### PR DESCRIPTION
[INLONG-9863][Agent] To avoid data loss caused by too many supplementary files
- Fixes #9863
### Motivation
To avoid data loss caused by too many supplementary files:
     The dealWithEventMap function will submit all the file information that needs to be collected to the instanceManager, but the instanceManager will limit the number of files to be processed. If the limit of the instanceManager is exceeded, the dealWithEventMap will end prematurely, and any file information that cannot be submitted will be retained in the internal memory, waiting for the next execution of the dealWithEventMap to submit.
### Modifications

 To avoid data loss caused by too many supplementary files
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
