### PR TITLE
[INLONG-9862][Manager] Support submit flink job for offline sync

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -141,7 +141,9 @@ public class InlongConstants {
      */
     public static final String DATAFLOW = "dataflow";
 
-    public static final String STREAM_CONFIG_STATUS = "stream.config.status";
+    public static final String REGISTER_SCHEDULE_SUCCESS = "register.schedule.success";
+
+    public static final String TRUE = "true";
 
     public static final String STREAMS = "streams";
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -141,9 +141,9 @@ public class InlongConstants {
      */
     public static final String DATAFLOW = "dataflow";
 
-    public static final String REGISTER_SCHEDULE_SUCCESS = "register.schedule.success";
+    public static final String REGISTER_SCHEDULE_STATUS = "register.schedule.status";
 
-    public static final String TRUE = "true";
+    public static final String REGISTERED = "registered";
 
     public static final String STREAMS = "streams";
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -141,6 +141,8 @@ public class InlongConstants {
      */
     public static final String DATAFLOW = "dataflow";
 
+    public static final String STREAM_CONFIG_STATUS = "stream.config.status";
+
     public static final String STREAMS = "streams";
 
     public static final String RELATIONS = "relations";

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -102,7 +102,7 @@ public class StartupSortListener implements SortOperateListener {
             boolean isOfflineSync = InlongConstants.DATASYNC_OFFLINE_MODE
                     .equals(groupResourceForm.getGroupInfo().getInlongGroupMode());
             // do not submit flink job if the group mode is offline and the stream is not config successfully
-            if (isOfflineSync && !StreamParseUtils.isStreamConfigSuccess(streamInfo)) {
+            if (isOfflineSync && !StreamParseUtils.isRegisterScheduleSuccess(streamInfo)) {
                 log.info("no need to submit flink job for groupId={} streamId={} as the mode is offline "
                         + "and the stream is not config successfully yet", groupId, streamInfo.getInlongStreamId());
                 continue;

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.plugin.listener;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.consts.SinkType;
 import org.apache.inlong.manager.common.enums.GroupOperateType;
-import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.TaskEvent;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.plugin.flink.FlinkOperation;

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -156,7 +156,8 @@ public class StartupSortListener implements SortOperateListener {
             try {
                 flinkOperation.genPath(flinkInfo, dataflow);
                 flinkOperation.start(flinkInfo);
-                log.info("job submit success for groupId = {}, streamId = {}, jobId = {}", groupId,
+                log.info("job submit success for groupId = {}, mode = {}, streamId = {}, jobId = {}",
+                        groupId, groupResourceForm.getGroupInfo().getInlongGroupMode(),
                         streamInfo.getInlongStreamId(), flinkInfo.getJobId());
             } catch (Exception e) {
                 flinkInfo.setException(true);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -17,11 +17,16 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.TransformType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
 import org.apache.inlong.manager.pojo.source.StreamSource;
+import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.stream.StreamNode;
 import org.apache.inlong.manager.pojo.stream.StreamPipeline;
 import org.apache.inlong.manager.pojo.stream.StreamTransform;
@@ -152,6 +157,24 @@ public class StreamParseUtils {
         Preconditions.expectNotBlank(tempView, ErrorCodeEnum.INVALID_PARAMETER,
                 String.format(" should not be null for streamId=%s", inlongStreamId));
         return GSON.fromJson(tempView, StreamPipeline.class);
+    }
+
+    public static String getStreamExtProperty(String key, InlongStreamInfo streamInfo) {
+        if (StringUtils.isEmpty(key)
+                || streamInfo == null || streamInfo.getExtList() == null || streamInfo.getExtList().isEmpty()) {
+            return null;
+        }
+        for (InlongStreamExtInfo ext : streamInfo.getExtList()) {
+            if (key.equalsIgnoreCase(ext.getKeyName())) {
+                return ext.getKeyValue();
+            }
+        }
+        return null;
+    }
+
+    public static boolean isStreamConfigSuccess(InlongStreamInfo streamInfo) {
+        return StreamStatus.CONFIG_SUCCESSFUL.getDescription()
+                .equalsIgnoreCase(getStreamExtProperty(InlongConstants.STREAM_CONFIG_STATUS, streamInfo));
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -171,8 +171,8 @@ public class StreamParseUtils {
     }
 
     public static boolean isRegisterScheduleSuccess(InlongStreamInfo streamInfo) {
-        return InlongConstants.TRUE
-                .equalsIgnoreCase(getStreamExtProperty(InlongConstants.REGISTER_SCHEDULE_SUCCESS, streamInfo));
+        return InlongConstants.REGISTERED
+                .equalsIgnoreCase(getStreamExtProperty(InlongConstants.REGISTER_SCHEDULE_STATUS, streamInfo));
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.TransformType;
@@ -42,6 +41,7 @@ import org.apache.inlong.manager.pojo.transform.splitter.SplitterDefinition;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -17,9 +17,9 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
-import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.TransformType;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
@@ -57,6 +57,7 @@ public class StreamParseUtils {
     public static final String SINK_NAME = "sinkName";
     public static final String TRANSFORM_TYPE = "transformType";
     public static final String TRANSFORM_NAME = "transformName";
+    public static final String TRUE = "true";
 
     private static final Gson GSON = new Gson();
 
@@ -160,21 +161,19 @@ public class StreamParseUtils {
     }
 
     public static String getStreamExtProperty(String key, InlongStreamInfo streamInfo) {
-        if (StringUtils.isEmpty(key)
-                || streamInfo == null || streamInfo.getExtList() == null || streamInfo.getExtList().isEmpty()) {
-            return null;
-        }
-        for (InlongStreamExtInfo ext : streamInfo.getExtList()) {
-            if (key.equalsIgnoreCase(ext.getKeyName())) {
-                return ext.getKeyValue();
+        if (StringUtils.isNotBlank(key) && streamInfo != null && CollectionUtils.isNotEmpty(streamInfo.getExtList())) {
+            for (InlongStreamExtInfo ext : streamInfo.getExtList()) {
+                if (key.equalsIgnoreCase(ext.getKeyName())) {
+                    return ext.getKeyValue();
+                }
             }
         }
         return null;
     }
 
-    public static boolean isStreamConfigSuccess(InlongStreamInfo streamInfo) {
-        return StreamStatus.CONFIG_SUCCESSFUL.getDescription()
-                .equalsIgnoreCase(getStreamExtProperty(InlongConstants.STREAM_CONFIG_STATUS, streamInfo));
+    public static boolean isRegisterScheduleSuccess(InlongStreamInfo streamInfo) {
+        return InlongConstants.TRUE
+                .equalsIgnoreCase(getStreamExtProperty(InlongConstants.REGISTER_SCHEDULE_SUCCESS, streamInfo));
     }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.sort.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.enums.StreamStatus;
@@ -43,6 +42,7 @@ import org.apache.inlong.manager.pojo.transform.splitter.SplitterDefinition;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Utils of stream parse.

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/util/StreamParseUtils.java
@@ -57,7 +57,6 @@ public class StreamParseUtils {
     public static final String SINK_NAME = "sinkName";
     public static final String TRANSFORM_TYPE = "transformType";
     public static final String TRANSFORM_NAME = "transformName";
-    public static final String TRUE = "true";
 
     private static final Gson GSON = new Gson();
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/StreamTaskListenerFactory.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/StreamTaskListenerFactory.java
@@ -20,12 +20,14 @@ package org.apache.inlong.manager.service.listener;
 import org.apache.inlong.manager.common.plugin.Plugin;
 import org.apache.inlong.manager.common.plugin.PluginBinder;
 import org.apache.inlong.manager.service.listener.queue.StreamQueueResourceListener;
+import org.apache.inlong.manager.service.listener.schedule.StreamScheduleResourceListener;
 import org.apache.inlong.manager.service.listener.sink.StreamSinkResourceListener;
 import org.apache.inlong.manager.service.listener.sort.StreamSortConfigListener;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.definition.ServiceTaskType;
 import org.apache.inlong.manager.workflow.definition.TaskListenerFactory;
 import org.apache.inlong.manager.workflow.event.task.QueueOperateListener;
+import org.apache.inlong.manager.workflow.event.task.ScheduleOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SinkOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SortOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SourceOperateListener;
@@ -53,6 +55,7 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
     private List<QueueOperateListener> queueOperateListeners;
     private List<SortOperateListener> sortOperateListeners;
     private List<SinkOperateListener> sinkOperateListeners;
+    private List<ScheduleOperateListener> scheduleOperateListeners;
 
     @Autowired
     private StreamQueueResourceListener queueResourceListener;
@@ -60,6 +63,8 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
     private StreamSortConfigListener streamSortConfigListener;
     @Autowired
     private StreamSinkResourceListener sinkResourceListener;
+    @Autowired
+    private StreamScheduleResourceListener scheduleResourceListener;
 
     @PostConstruct
     public void init() {
@@ -70,6 +75,8 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
         sortOperateListeners.add(streamSortConfigListener);
         sinkOperateListeners = new LinkedList<>();
         sinkOperateListeners.add(sinkResourceListener);
+        scheduleOperateListeners= new LinkedList<>();
+        scheduleOperateListeners.add(scheduleResourceListener);
     }
 
     @Override
@@ -93,6 +100,10 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
         List<SinkOperateListener> pluginSinkOperateListeners = processPlugin.createSinkOperateListeners();
         if (CollectionUtils.isNotEmpty(pluginSinkOperateListeners)) {
             sinkOperateListeners.addAll(pluginSinkOperateListeners);
+        }
+        List<ScheduleOperateListener> pluginScheduleOperateListeners = processPlugin.createScheduleOperateListeners();
+        if (CollectionUtils.isNotEmpty(pluginScheduleOperateListeners)) {
+            scheduleOperateListeners.addAll(pluginScheduleOperateListeners);
         }
     }
 
@@ -118,6 +129,9 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
             case INIT_SINK:
                 List<SinkOperateListener> sinkOperateListeners = getSinkOperateListener(workflowContext);
                 return Lists.newArrayList(sinkOperateListeners);
+            case INIT_SCHEDULE:
+                List<ScheduleOperateListener> scheduleOperateListeners = getScheduleOperateListener(workflowContext);
+                return Lists.newArrayList(scheduleOperateListeners);
             default:
                 throw new IllegalArgumentException(String.format("Unsupported ServiceTaskType %s", taskType));
         }
@@ -131,6 +145,7 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
         queueOperateListeners = new LinkedList<>();
         sortOperateListeners = new LinkedList<>();
         sinkOperateListeners = new LinkedList<>();
+        scheduleOperateListeners = new LinkedList<>();
     }
 
     /**
@@ -178,6 +193,19 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
     private List<SinkOperateListener> getSinkOperateListener(WorkflowContext context) {
         List<SinkOperateListener> listeners = new ArrayList<>();
         for (SinkOperateListener listener : sinkOperateListeners) {
+            if (listener != null && listener.accept(context)) {
+                listeners.add(listener);
+            }
+        }
+        return listeners;
+    }
+
+    /**
+     * Get schedule operate listener list.
+     */
+    private List<ScheduleOperateListener> getScheduleOperateListener(WorkflowContext context) {
+        List<ScheduleOperateListener> listeners = new ArrayList<>();
+        for (ScheduleOperateListener listener : scheduleOperateListeners) {
             if (listener != null && listener.accept(context)) {
                 listeners.add(listener);
             }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/StreamTaskListenerFactory.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/StreamTaskListenerFactory.java
@@ -75,7 +75,7 @@ public class StreamTaskListenerFactory implements PluginBinder, TaskListenerFact
         sortOperateListeners.add(streamSortConfigListener);
         sinkOperateListeners = new LinkedList<>();
         sinkOperateListeners.add(sinkResourceListener);
-        scheduleOperateListeners= new LinkedList<>();
+        scheduleOperateListeners = new LinkedList<>();
         scheduleOperateListeners.add(scheduleResourceListener);
     }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
@@ -74,7 +74,8 @@ public class StreamScheduleResourceListener implements ScheduleOperateListener {
         // todo: register schedule info to schedule service
 
         // after register schedule info successfully, add ext property to stream info
-        saveInfo(streamInfo, InlongConstants.REGISTER_SCHEDULE_SUCCESS, InlongConstants.TRUE, streamInfo.getExtList());
+        saveInfo(streamInfo, InlongConstants.REGISTER_SCHEDULE_STATUS,
+                InlongConstants.REGISTERED, streamInfo.getExtList());
         log.info("success to register schedule info for group [" + groupId + "] and stream [" + streamId + "]");
         return ListenerResult.success();
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
@@ -28,13 +28,15 @@ import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
 import org.apache.inlong.manager.workflow.event.task.ScheduleOperateListener;
 
-import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @Slf4j
 public class StreamScheduleResourceListener implements ScheduleOperateListener {
+
     @Override
     public TaskEvent event() {
         return TaskEvent.COMPLETE;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/StreamScheduleResourceListener.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.listener.schedule;
+
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.common.enums.GroupOperateType;
+import org.apache.inlong.manager.common.enums.TaskEvent;
+import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
+import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
+import org.apache.inlong.manager.workflow.WorkflowContext;
+import org.apache.inlong.manager.workflow.event.ListenerResult;
+import org.apache.inlong.manager.workflow.event.task.ScheduleOperateListener;
+
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class StreamScheduleResourceListener implements ScheduleOperateListener {
+    @Override
+    public TaskEvent event() {
+        return TaskEvent.COMPLETE;
+    }
+
+    @Override
+    public boolean accept(WorkflowContext context) {
+        ProcessForm processForm = context.getProcessForm();
+        String groupId = processForm.getInlongGroupId();
+        if (!(processForm instanceof StreamResourceProcessForm)) {
+            log.info("not add schedule stream listener, not StreamResourceProcessForm for groupId [{}]", groupId);
+            return false;
+        }
+
+        StreamResourceProcessForm streamProcessForm = (StreamResourceProcessForm) processForm;
+        String streamId = streamProcessForm.getStreamInfo().getInlongStreamId();
+        if (streamProcessForm.getGroupOperateType() != GroupOperateType.INIT) {
+            log.info("not add schedule stream listener, as the operate was not INIT for groupId [{}] streamId [{}]",
+                    groupId, streamId);
+            return false;
+        }
+
+        log.info("add startup stream listener for groupId [{}] streamId [{}]", groupId, streamId);
+        return InlongConstants.DATASYNC_OFFLINE_MODE.equals(streamProcessForm.getGroupInfo().getInlongGroupMode());
+    }
+
+    @Override
+    public ListenerResult listen(WorkflowContext context) throws Exception {
+        StreamResourceProcessForm form = (StreamResourceProcessForm) context.getProcessForm();
+        InlongStreamInfo streamInfo = form.getStreamInfo();
+        final String groupId = streamInfo.getInlongGroupId();
+        final String streamId = streamInfo.getInlongStreamId();
+        log.info("begin to register schedule info for groupId={}, streamId={}", groupId, streamId);
+
+        // todo: register schedule info to schedule service
+
+        // after register schedule info successfully, add ext property to stream info
+        saveInfo(streamInfo, InlongConstants.REGISTER_SCHEDULE_SUCCESS, InlongConstants.TRUE, streamInfo.getExtList());
+        log.info("success to register schedule info for group [" + groupId + "] and stream [" + streamId + "]");
+        return ListenerResult.success();
+    }
+
+    /**
+     * Save stream ext info into list.
+     */
+    private void saveInfo(InlongStreamInfo streamInfo, String keyName, String keyValue,
+            List<InlongStreamExtInfo> extInfoList) {
+        InlongStreamExtInfo extInfo = new InlongStreamExtInfo();
+        extInfo.setInlongGroupId(streamInfo.getInlongGroupId());
+        extInfo.setInlongStreamId(streamInfo.getInlongStreamId());
+        extInfo.setKeyName(keyName);
+        extInfo.setKeyValue(keyValue);
+        extInfoList.add(extInfo);
+    }
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.service.listener.sort;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.GroupOperateType;
 import org.apache.inlong.manager.common.enums.GroupStatus;
+import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.TaskEvent;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
@@ -125,6 +126,13 @@ public class SortConfigListener implements SortOperateListener {
 
         try {
             for (InlongStreamInfo streamInfo : streamInfos) {
+                // do not build sort config if the group mode is offline and the stream is not config successfully
+                if (InlongConstants.DATASYNC_OFFLINE_MODE.equals(groupInfo.getInlongGroupMode())
+                        && !StreamStatus.CONFIG_SUCCESSFUL.getCode().equals(streamInfo.getStatus())) {
+                    LOGGER.info("no need to build sort config for groupId={} streamId={} as the mode is offline "
+                            + "and the stream is not config successfully yet", groupId, streamInfo.getInlongStreamId());
+                    continue;
+                }
                 List<StreamSink> sinkList = streamInfo.getSinkList();
                 if (CollectionUtils.isEmpty(sinkList)) {
                     continue;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -20,11 +20,11 @@ package org.apache.inlong.manager.service.listener.sort;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.enums.GroupOperateType;
 import org.apache.inlong.manager.common.enums.GroupStatus;
-import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.enums.TaskEvent;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.sink.StreamSink;
+import org.apache.inlong.manager.pojo.sort.util.StreamParseUtils;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm;
 import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
@@ -128,7 +128,7 @@ public class SortConfigListener implements SortOperateListener {
             for (InlongStreamInfo streamInfo : streamInfos) {
                 // do not build sort config if the group mode is offline and the stream is not config successfully
                 if (InlongConstants.DATASYNC_OFFLINE_MODE.equals(groupInfo.getInlongGroupMode())
-                        && !StreamStatus.CONFIG_SUCCESSFUL.getCode().equals(streamInfo.getStatus())) {
+                        && !StreamParseUtils.isStreamConfigSuccess(streamInfo)) {
                     LOGGER.info("no need to build sort config for groupId={} streamId={} as the mode is offline "
                             + "and the stream is not config successfully yet", groupId, streamInfo.getInlongStreamId());
                     continue;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -128,7 +128,7 @@ public class SortConfigListener implements SortOperateListener {
             for (InlongStreamInfo streamInfo : streamInfos) {
                 // do not build sort config if the group mode is offline and the stream is not config successfully
                 if (InlongConstants.DATASYNC_OFFLINE_MODE.equals(groupInfo.getInlongGroupMode())
-                        && !StreamParseUtils.isStreamConfigSuccess(streamInfo)) {
+                        && !StreamParseUtils.isRegisterScheduleSuccess(streamInfo)) {
                     LOGGER.info("no need to build sort config for groupId={} streamId={} as the mode is offline "
                             + "and the stream is not config successfully yet", groupId, streamInfo.getInlongStreamId());
                     continue;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
@@ -66,13 +66,6 @@ public class InitStreamCompleteListener implements ProcessEventListener {
         try {
             // Update status of other related configs
             streamService.updateStatus(groupId, streamId, StreamStatus.CONFIG_SUCCESSFUL.getCode(), operator);
-            // add status to stream extension info
-            InlongStreamExtInfo extInfo = new InlongStreamExtInfo();
-            extInfo.setInlongGroupId(groupId);
-            extInfo.setInlongStreamId(streamId);
-            extInfo.setKeyName(InlongConstants.STREAM_CONFIG_STATUS);
-            extInfo.setKeyValue(StreamStatus.CONFIG_SUCCESSFUL.getDescription());
-            streamInfo.getExtList().add(extInfo);
             streamService.updateWithoutCheck(streamInfo.genRequest(), operator);
             if (InlongConstants.DATASYNC_REALTIME_MODE.equals(form.getGroupInfo().getInlongGroupMode())
                     || InlongConstants.DATASYNC_OFFLINE_MODE.equals(form.getGroupInfo().getInlongGroupMode())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
@@ -22,6 +22,7 @@ import org.apache.inlong.manager.common.enums.ProcessEvent;
 import org.apache.inlong.manager.common.enums.SourceStatus;
 import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
+import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
 import org.apache.inlong.manager.service.source.StreamSourceService;
@@ -65,6 +66,13 @@ public class InitStreamCompleteListener implements ProcessEventListener {
         try {
             // Update status of other related configs
             streamService.updateStatus(groupId, streamId, StreamStatus.CONFIG_SUCCESSFUL.getCode(), operator);
+            // add status to stream extension info
+            InlongStreamExtInfo extInfo = new InlongStreamExtInfo();
+            extInfo.setInlongGroupId(groupId);
+            extInfo.setInlongStreamId(streamId);
+            extInfo.setKeyName(InlongConstants.STREAM_CONFIG_STATUS);
+            extInfo.setKeyValue(StreamStatus.CONFIG_SUCCESSFUL.getDescription());
+            streamInfo.getExtList().add(extInfo);
             streamService.updateWithoutCheck(streamInfo.genRequest(), operator);
             if (InlongConstants.DATASYNC_REALTIME_MODE.equals(form.getGroupInfo().getInlongGroupMode())
                     || InlongConstants.DATASYNC_OFFLINE_MODE.equals(form.getGroupInfo().getInlongGroupMode())) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/stream/InitStreamCompleteListener.java
@@ -22,7 +22,6 @@ import org.apache.inlong.manager.common.enums.ProcessEvent;
 import org.apache.inlong.manager.common.enums.SourceStatus;
 import org.apache.inlong.manager.common.enums.StreamStatus;
 import org.apache.inlong.manager.common.exceptions.WorkflowListenerException;
-import org.apache.inlong.manager.pojo.stream.InlongStreamExtInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.StreamResourceProcessForm;
 import org.apache.inlong.manager.service.source.StreamSourceService;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/stream/CreateStreamWorkflowDefinition.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/workflow/stream/CreateStreamWorkflowDefinition.java
@@ -102,17 +102,26 @@ public class CreateStreamWorkflowDefinition implements WorkflowDefinition {
         initSourceTask.setListenerFactory(streamTaskListenerFactory);
         process.addTask(initSourceTask);
 
+        // Init Schedule info
+        ServiceTask initScheduleTask = new ServiceTask();
+        initScheduleTask.setName("InitSchedule");
+        initScheduleTask.setDisplayName("Stream-InitSchedule");
+        initScheduleTask.setServiceTaskType(ServiceTaskType.INIT_SCHEDULE);
+        initScheduleTask.setListenerFactory(streamTaskListenerFactory);
+        process.addTask(initScheduleTask);
+
         // End node
         EndEvent endEvent = new EndEvent();
         process.setEndEvent(endEvent);
 
-        // Task dependency order: 1.MQ -> 2.Sink -> 3.Sort -> 4.Source
+        // Task dependency order: 1.MQ -> 2.Sink -> 3.Sort -> 4.Source -> 5.Schedule
         // To ensure that after some tasks fail, data will not start to be collected by source or consumed by sort
         startEvent.addNext(initMQTask);
         initMQTask.addNext(initSinkTask);
         initSinkTask.addNext(initSortTask);
         initSortTask.addNext(initSourceTask);
-        initSourceTask.addNext(endEvent);
+        initSourceTask.addNext(initScheduleTask);
+        initScheduleTask.addNext(endEvent);
 
         return process;
     }

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/event/task/ScheduleOperateListener.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/event/task/ScheduleOperateListener.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.workflow.event.ListenerResult;
 public interface ScheduleOperateListener extends TaskEventListener {
 
     ScheduleOperateListener DEFAULT_SCHEDULE_OPERATE_LISTENER = new ScheduleOperateListener() {
+
         @Override
         public TaskEvent event() {
             return TaskEvent.COMPLETE;

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/event/task/ScheduleOperateListener.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/event/task/ScheduleOperateListener.java
@@ -15,31 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.workflow.definition;
+package org.apache.inlong.manager.workflow.event.task;
 
-import java.util.Locale;
+import org.apache.inlong.manager.common.enums.TaskEvent;
+import org.apache.inlong.manager.workflow.WorkflowContext;
+import org.apache.inlong.manager.workflow.event.ListenerResult;
 
-public enum ServiceTaskType {
+public interface ScheduleOperateListener extends TaskEventListener {
 
-    INIT_SOURCE,
-    INIT_MQ,
-    INIT_SORT,
-    INIT_SINK,
-    INIT_SCHEDULE,
+    ScheduleOperateListener DEFAULT_SCHEDULE_OPERATE_LISTENER = new ScheduleOperateListener() {
+        @Override
+        public TaskEvent event() {
+            return TaskEvent.COMPLETE;
+        }
 
-    STOP_SOURCE,
-    STOP_SORT,
-
-    RESTART_SOURCE,
-    RESTART_SORT,
-
-    DELETE_SOURCE,
-    DELETE_MQ,
-    DELETE_SORT;
-
-    @Override
-    public String toString() {
-        return name().toLowerCase(Locale.ROOT);
-    }
-
+        @Override
+        public ListenerResult listen(WorkflowContext context) {
+            return ListenerResult.success();
+        }
+    };
 }

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/plugin/ProcessPlugin.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/plugin/ProcessPlugin.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.workflow.plugin;
 
 import org.apache.inlong.manager.common.plugin.Plugin;
 import org.apache.inlong.manager.workflow.event.task.QueueOperateListener;
+import org.apache.inlong.manager.workflow.event.task.ScheduleOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SinkOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SortOperateListener;
 import org.apache.inlong.manager.workflow.event.task.SourceOperateListener;
@@ -37,6 +38,11 @@ public interface ProcessPlugin extends Plugin {
     default List<SinkOperateListener> createSinkOperateListeners() {
         return null;
     }
+
+    default List<ScheduleOperateListener> createScheduleOperateListeners() {
+        return null;
+    }
+
 
     default List<QueueOperateListener> createQueueOperateListeners() {
         return null;

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/plugin/ProcessPlugin.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/plugin/ProcessPlugin.java
@@ -43,7 +43,6 @@ public interface ProcessPlugin extends Plugin {
         return null;
     }
 
-
     default List<QueueOperateListener> createQueueOperateListeners() {
         return null;
     }


### PR DESCRIPTION
- Fixes #9862 
### Background

For real-time data sync, the whole procedure is as follows:

![image](https://github.com/apache/inlong/assets/48062889/db68bae8-c50d-4f57-ae4b-03e1666c535d)

Currently, InLong does not support submitting Flink batch jobs for offline data sync.

The main differences between offline sync and real-time sync are as follows:
- Offline synchronization requires corresponding scheduling information to be configured
- Offline task submission is triggered  by the scheduling system instead of manager

The interaction process with the scheduling system is as follows:
- Register the scheduling information at the point of approval 
- The scheduling system generates an instance to submit Flink batch tasks by InLong callback.

Design principles for the association between synchronization tasks and the scheduling system are as follows:

- Management of task configuration and scheduling configuration are independent of each other.
- The granularity of scheduling information configuration is at the stream level: there are multiple streams under a group, fine-grained scheduling control should be at the stream level, and the scheduling information registered with the scheduling system should include groupID and streamID.
- Whether to register scheduling information with the scheduling system depends on the approval status of the task: If the task is in an approved state: save the scheduling information and register it with the scheduling system, otherwise
, only save the scheduling information 

Furthermore, it is important to note the distinction between configuring streams and scheduling. 
- In the configuration process, Flink tasks are not submitted,
- In the scheduling process, Flink tasks are submitted.

This is identified by the status of the stream.

PS: Scheduling management is not covered by this pull request.

### Motivation

Support submit flink job for offline sync

### Modifications

Ensure the Flink batch task will be submitted only if the stream is in the CONFIG_SUCCESSFUL state.


### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)

