### PR TITLE
[INLONG-9876][Manager] optimize the format of error message

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/util/ClientUtils.java
@@ -118,6 +118,6 @@ public class ClientUtils {
      * @param response response
      */
     public static void assertRespSuccess(Response<?> response) {
-        Preconditions.expectTrue(response.isSuccess(), String.format(REQUEST_FAILED_MSG, response.getErrMsg(), null));
+        Preconditions.expectTrue(response.isSuccess(), String.format(REQUEST_FAILED_MSG, "", response.getErrMsg()));
     }
 }


### PR DESCRIPTION
- Fixes #9876

### Motivation

optimize the format of error message

### Modifications

optimize the format of error message. 
With this pul request, the error msg will be `Request to Inlong  failed: Inlong group already exists` instead of 
`Request to Inlong Inlong group already exists failed: null`

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)
  