### PR TITLE
[INLONG-9859][Agent] Increase installation package download capability and local MD5 computing power

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -220,9 +220,8 @@ public class ModuleManager extends AbstractDaemon {
     }
 
     private boolean downloadModule(ModuleConfig module) {
-        LOGGER.info("download module {} begin", module.getId());
+        LOGGER.info("download module {} begin with url {}", module.getId(), module.getPackageConfig().getDownloadUrl());
         try {
-            LOGGER.info("download url {}", module.getPackageConfig().getDownloadUrl());
             URL url = new URL(module.getPackageConfig().getDownloadUrl());
             URLConnection conn = url.openConnection();
             Map<String, String> authHeader = httpManager.getAuthHeader();


### PR DESCRIPTION
[INLONG-9859][Agent] Increase installation package download capability and local MD5 computing power
- Fixes #9859

### Motivation

Increase installation package download capability and local MD5 computing power
### Modifications

Increase installation package download capability and local MD5 computing power

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
