### PR TITLE
[INLONG-9904][Audit] SDK support checkpoint feature

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -107,6 +107,6 @@ public class AuditUtils {
         if (!IS_AUDIT) {
             return;
         }
-        AuditOperator.getInstance().send();
+        AuditOperator.getInstance().flush();
     }
 }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -76,12 +76,27 @@ public class AuditReporterImpl implements Serializable {
     private final ScheduledExecutorService timeoutExecutor = Executors.newSingleThreadScheduledExecutor();
     private AuditConfig auditConfig = null;
     private SocketAddressListLoader loader = null;
+
+    // Resource isolation key is used in checkpoint and other scenarios.DEFAULT 0.
     private static final long DEFAULT_ISOLATE_KEY = 0;
     private int flushStatThreshold = 100;
     private boolean autoFlush = true;
+
+    /**
+     * Set stat threshold
+     *
+     * @param flushStatThreshold
+     */
     public void setFlushStatThreshold(int flushStatThreshold) {
         this.flushStatThreshold = flushStatThreshold;
     }
+
+    /**
+     * When the caller needs to isolate resources, please call this method and pass the parameter true.
+     * For example, in scenarios such as flink checkpoint
+     *
+     * @param autoFlush
+     */
     public void setAutoFlush(boolean autoFlush) {
         this.autoFlush = autoFlush;
     }
@@ -222,6 +237,13 @@ public class AuditReporterImpl implements Serializable {
         addByKey(DEFAULT_ISOLATE_KEY, keyJoiner.toString(), count, size, delayTime);
     }
 
+    /**
+     * When the caller needs to isolate resources, please call this method.
+     * For example, in scenarios such as flink checkpoint
+     *
+     * @param dimensions
+     * @param values
+     */
     public void add(AuditDimensions dimensions, AuditValues values) {
         StringJoiner keyJoiner = new StringJoiner(FIELD_SEPARATORS);
         keyJoiner.add(String.valueOf(dimensions.getLogTime() / PERIOD));

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -78,16 +78,13 @@ public class AuditReporterImpl implements Serializable {
     private SocketAddressListLoader loader = null;
     private static final long DEFAULT_ISOLATE_KEY = 0;
     private int flushStatThreshold = 100;
-
+    private boolean autoFlush = true;
     public void setFlushStatThreshold(int flushStatThreshold) {
         this.flushStatThreshold = flushStatThreshold;
     }
-
     public void setAutoFlush(boolean autoFlush) {
         this.autoFlush = autoFlush;
     }
-
-    private boolean autoFlush = true;
 
     /**
      * Init

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -201,20 +201,20 @@ public class AuditReporterImpl implements Serializable {
     }
 
     public void add(int auditID, String auditTag, String inlongGroupID, String inlongStreamID, Long logTime,
-                    long count, long size) {
+            long count, long size) {
         long delayTime = System.currentTimeMillis() - logTime;
         add(auditID, auditTag, inlongGroupID, inlongStreamID, logTime, count, size,
                 delayTime * count, DEFAULT_AUDIT_VERSION);
     }
 
     public void add(int auditID, String inlongGroupID, String inlongStreamID, Long logTime, long count, long size,
-                    long delayTime) {
+            long delayTime) {
         add(auditID, DEFAULT_AUDIT_TAG, inlongGroupID, inlongStreamID, logTime, count, size,
                 delayTime, DEFAULT_AUDIT_VERSION);
     }
 
     public void add(int auditID, String auditTag, String inlongGroupID, String inlongStreamID, Long logTime,
-                    long count, long size, long delayTime, long auditVersion) {
+            long count, long size, long delayTime, long auditVersion) {
         StringJoiner keyJoiner = new StringJoiner(FIELD_SEPARATORS);
         keyJoiner.add(String.valueOf(logTime / PERIOD));
         keyJoiner.add(inlongGroupID);

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -262,7 +262,7 @@ public class AuditReporterImpl implements Serializable {
      * Flush audit data
      */
     public synchronized void flush(long isolateKey) {
-        if (flushTime.putIfAbsent(isolateKey, Calendar.getInstance().getTimeInMillis()) != null
+        if (flushTime.putIfAbsent(isolateKey, System.currentTimeMillis()) != null
                 || flushStat.addAndGet(1) > flushStatThreshold) {
             return;
         }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
@@ -139,24 +139,7 @@ public class SenderManager {
         // cache first
         Long requestId = baseCommand.getAuditRequest().getRequestId();
         this.dataMap.putIfAbsent(requestId, data);
-        // requestIdQueue.offer(requestId);
         this.sendData(data.getDataByte());
-        // resend
-        // long newTime = System.currentTimeMillis() - 10000;
-        // if (newTime > lastCheckTime) {
-        // for (int i = 0; i < requestIdQueue.size(); i++) {
-        // Long current = requestIdQueue.poll();
-        // AuditData auditData = this.dataMap.get(current);
-        // if (auditData == null) {
-        // continue;
-        // } else {
-        // requestIdQueue.offer(current);
-        // if (newTime > auditData.getSendTime()) {
-        // this.sendData(auditData.getDataByte());
-        // }
-        // }
-        // }
-        // }
     }
 
     /**

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
@@ -139,24 +139,24 @@ public class SenderManager {
         // cache first
         Long requestId = baseCommand.getAuditRequest().getRequestId();
         this.dataMap.putIfAbsent(requestId, data);
-        requestIdQueue.offer(requestId);
+        // requestIdQueue.offer(requestId);
         this.sendData(data.getDataByte());
         // resend
-        long newTime = System.currentTimeMillis() - 10000;
-        if (newTime > lastCheckTime) {
-            for (int i = 0; i < requestIdQueue.size(); i++) {
-                Long current = requestIdQueue.poll();
-                AuditData auditData = this.dataMap.get(current);
-                if (auditData == null) {
-                    continue;
-                } else {
-                    requestIdQueue.offer(current);
-                    if (newTime > auditData.getSendTime()) {
-                        this.sendData(auditData.getDataByte());
-                    }
-                }
-            }
-        }
+        // long newTime = System.currentTimeMillis() - 10000;
+        // if (newTime > lastCheckTime) {
+        // for (int i = 0; i < requestIdQueue.size(); i++) {
+        // Long current = requestIdQueue.poll();
+        // AuditData auditData = this.dataMap.get(current);
+        // if (auditData == null) {
+        // continue;
+        // } else {
+        // requestIdQueue.offer(current);
+        // if (newTime > auditData.getSendTime()) {
+        // this.sendData(auditData.getDataByte());
+        // }
+        // }
+        // }
+        // }
     }
 
     /**
@@ -179,7 +179,7 @@ public class SenderManager {
      * Clean up the backlog of unsent message packets
      */
     public void clearBuffer() {
-        LOG.info("audit failed cache size: {}", this.dataMap.size());
+        LOG.info("Audit failed cache size: {}", this.dataMap.size());
         for (AuditData data : this.dataMap.values()) {
             this.sendData(data.getDataByte());
             this.sleep();
@@ -286,6 +286,9 @@ public class SenderManager {
             if (data == null) {
                 LOG.error("Can not find the request id onMessageReceived {},message: {}",
                         requestId, baseCommand.getAuditReply().getMessage());
+                for (Map.Entry<Long, AuditData> entry : this.dataMap.entrySet()) {
+                    LOG.debug("Data map key:{},request id:{}", entry.getKey(), requestId);
+                }
                 return;
             }
             // check resp

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/send/SenderManager.java
@@ -269,8 +269,10 @@ public class SenderManager {
             if (data == null) {
                 LOG.error("Can not find the request id onMessageReceived {},message: {}",
                         requestId, baseCommand.getAuditReply().getMessage());
-                for (Map.Entry<Long, AuditData> entry : this.dataMap.entrySet()) {
-                    LOG.debug("Data map key:{},request id:{}", entry.getKey(), requestId);
+                if (LOG.isDebugEnabled()) {
+                    for (Map.Entry<Long, AuditData> entry : this.dataMap.entrySet()) {
+                        LOG.debug("Data map key:{},request id:{}", entry.getKey(), requestId);
+                    }
                 }
                 return;
             }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditDimensions.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditDimensions.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.audit.util;
 
+/**
+ * Audit dimensions
+ */
 public class AuditDimensions {
 
     private int auditID;

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditDimensions.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditDimensions.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.util;
+
+public class AuditDimensions {
+
+    private int auditID;
+    private long logTime;
+    private long auditVersion;
+    private long isolateKey;
+    private String auditTag;
+    private String inlongGroupID;
+    private String inlongStreamID;
+
+    public AuditDimensions(int auditID, long logTime, long auditVersion, long isolateKey, String auditTag,
+            String inlongGroupID, String inlongStreamID) {
+        this.auditID = auditID;
+        this.logTime = logTime;
+        this.auditVersion = auditVersion;
+        this.isolateKey = isolateKey;
+        this.auditTag = auditTag;
+        this.inlongGroupID = inlongGroupID;
+        this.inlongStreamID = inlongStreamID;
+    }
+
+    public int getAuditID() {
+        return auditID;
+    }
+
+    public void setAuditID(int auditID) {
+        this.auditID = auditID;
+    }
+
+    public long getLogTime() {
+        return logTime;
+    }
+
+    public void setLogTime(long logTime) {
+        this.logTime = logTime;
+    }
+
+    public long getAuditVersion() {
+        return auditVersion;
+    }
+
+    public void setAuditVersion(long auditVersion) {
+        this.auditVersion = auditVersion;
+    }
+
+    public long getIsolateKey() {
+        return isolateKey;
+    }
+
+    public void setIsolateKey(long isolateKey) {
+        this.isolateKey = isolateKey;
+    }
+
+    public String getAuditTag() {
+        return auditTag;
+    }
+
+    public void setAuditTag(String auditTag) {
+        this.auditTag = auditTag;
+    }
+
+    public String getInlongGroupID() {
+        return inlongGroupID;
+    }
+
+    public void setInlongGroupID(String inlongGroupID) {
+        this.inlongGroupID = inlongGroupID;
+    }
+
+    public String getInlongStreamID() {
+        return inlongStreamID;
+    }
+
+    public void setInlongStreamID(String inlongStreamID) {
+        this.inlongStreamID = inlongStreamID;
+    }
+}

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditValues.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditValues.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.audit.util;
 
+/**
+ * Audit values
+ */
 public class AuditValues {
 
     private long count;

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditValues.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditValues.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.util;
+
+public class AuditValues {
+
+    private long count;
+    private long size;
+    private long delayTime;
+
+    public AuditValues(long count, long size, long delayTime) {
+        this.count = count;
+        this.size = size;
+        this.delayTime = delayTime;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public void setSize(long size) {
+        this.size = size;
+    }
+
+    public long getDelayTime() {
+        return delayTime;
+    }
+
+    public void setDelayTime(long delayTime) {
+        this.delayTime = delayTime;
+    }
+}

--- a/inlong-audit/sql/apache_inlong_audit.sql
+++ b/inlong-audit/sql/apache_inlong_audit.sql
@@ -43,6 +43,7 @@ CREATE TABLE IF NOT EXISTS `audit_data`
     `inlong_stream_id` varchar(100) NOT NULL DEFAULT '' COMMENT 'The target inlong stream id',
     `audit_id`         varchar(100) NOT NULL DEFAULT '' COMMENT 'Audit id',
     `audit_tag`        varchar(100) DEFAULT '' COMMENT 'Audit tag',
+    `audit_version`    BIGINT       DEFAULT -1  COMMENT 'Audit version',
     `count`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message count',
     `size`             BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message size',
     `delay`            BIGINT       NOT NULL DEFAULT '0' COMMENT 'Message delay count',

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
@@ -123,6 +123,6 @@ public class AuditUtils {
      * Send audit data
      */
     public static void send() {
-        AuditOperator.getInstance().send();
+        AuditOperator.getInstance().flush();
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/audit/AuditUtils.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/audit/AuditUtils.java
@@ -104,6 +104,6 @@ public class AuditUtils {
      * Send audit data
      */
     public static void send() {
-        AuditOperator.getInstance().send();
+        AuditOperator.getInstance().flush();
     }
 }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -285,7 +285,7 @@ public class SinkMetricData implements MetricData, Serializable {
      */
     public void flushAuditData() {
         if (auditOperator != null) {
-            auditOperator.send();
+            auditOperator.flush();
         }
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -341,7 +341,7 @@ public class SourceMetricData implements MetricData, Serializable {
      */
     public void flushAuditData() {
         if (auditOperator != null) {
-            auditOperator.send();
+            auditOperator.flush();
         }
     }
 

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/audit/AuditUtils.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/audit/AuditUtils.java
@@ -112,6 +112,6 @@ public class AuditUtils {
         if (!auditConfig.isAuditEnable()) {
             return;
         }
-        AuditOperator.getInstance().send();
+        AuditOperator.getInstance().flush();
     }
 }


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #9904

### Motivation

*Flink checkpoint requires the audit SDK to support the isolation of audit data and ensure that each checkpoint cycle can be accurately reconciled.*

### Modifications

*The audit SDK supports checkpoint by adding resource isolation logic.*