### PR TITLE
[INLONG-9907][Audit] Audit-service add codes of entities

### DIFF
--- a/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
+++ b/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
@@ -21,5 +21,16 @@ package entities;
  * Audit cycle
  */
 public enum AuditCycle {
-    MINUTE_10, MINUTE_30, HOUR, DAY;
+
+    MINUTE_5(5), MINUTE_10(10), MINUTE_30(30), HOUR(60), DAY(1440);
+
+    private final int cycle;
+
+    AuditCycle(int cycle) {
+        this.cycle = cycle;
+    }
+
+    public int getValue() {
+        return cycle;
+    }
 }

--- a/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
+++ b/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entities;
+
+public enum AuditCycle {
+    HOUR, DAY;
+}

--- a/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
+++ b/inlong-audit/audit-service/src/main/java/entities/AuditCycle.java
@@ -17,6 +17,9 @@
 
 package entities;
 
+/**
+ * Audit cycle
+ */
 public enum AuditCycle {
-    HOUR, DAY;
+    MINUTE_10, MINUTE_30, HOUR, DAY;
 }

--- a/inlong-audit/audit-service/src/main/java/entities/Request.java
+++ b/inlong-audit/audit-service/src/main/java/entities/Request.java
@@ -26,6 +26,6 @@ public class Request {
     String endTime;
     String auditId;
     String auditTag;
-    String inLongGroupId;
-    String inLongStreamId;
+    String inlongGroupId;
+    String inlongStreamId;
 }

--- a/inlong-audit/audit-service/src/main/java/entities/Request.java
+++ b/inlong-audit/audit-service/src/main/java/entities/Request.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entities;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Request {
+
+    String startTime;
+    String endTime;
+    String auditId;
+    String auditTag;
+    String inLongGroupId;
+    String inLongStreamId;
+}

--- a/inlong-audit/audit-service/src/main/java/entities/Request.java
+++ b/inlong-audit/audit-service/src/main/java/entities/Request.java
@@ -17,11 +17,9 @@
 
 package entities;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
-@Getter
-@Setter
+@Data
 public class Request {
 
     String startTime;

--- a/inlong-audit/audit-service/src/main/java/entities/SourceEntities.java
+++ b/inlong-audit/audit-service/src/main/java/entities/SourceEntities.java
@@ -22,13 +22,13 @@ import lombok.Data;
 @Data
 public class SourceEntities {
 
-    AuditCycle auditCycle;
-    String sourceTable;
-    int stepCount;
+    private AuditCycle auditCycle;
+    private String sourceTable;
+    private int beforeTimes;
 
-    public SourceEntities(AuditCycle auditCycle, String sourceTable, int stepCount) {
+    public SourceEntities(AuditCycle auditCycle, String sourceTable, int beforeTimes) {
         this.auditCycle = auditCycle;
         this.sourceTable = sourceTable;
-        this.stepCount = stepCount;
+        this.beforeTimes = beforeTimes;
     }
 }

--- a/inlong-audit/audit-service/src/main/java/entities/SourceEntities.java
+++ b/inlong-audit/audit-service/src/main/java/entities/SourceEntities.java
@@ -20,9 +20,15 @@ package entities;
 import lombok.Data;
 
 @Data
-public class StartEndTime {
+public class SourceEntities {
 
-    String startTime;
-    String endTime;
-    long endTimeStamp;
+    AuditCycle auditCycle;
+    String sourceTable;
+    int stepCount;
+
+    public SourceEntities(AuditCycle auditCycle, String sourceTable, int stepCount) {
+        this.auditCycle = auditCycle;
+        this.sourceTable = sourceTable;
+        this.stepCount = stepCount;
+    }
 }

--- a/inlong-audit/audit-service/src/main/java/entities/StartEndTime.java
+++ b/inlong-audit/audit-service/src/main/java/entities/StartEndTime.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entities;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StartEndTime {
+
+    String startTime;
+    String endTime;
+    long endTimeStamp;
+}

--- a/inlong-audit/audit-service/src/main/java/entities/StatData.java
+++ b/inlong-audit/audit-service/src/main/java/entities/StatData.java
@@ -17,13 +17,11 @@
 
 package entities;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.Data;
 
 import java.sql.Timestamp;
 
-@Getter
-@Setter
+@Data
 public class StatData {
 
     private String logTs;

--- a/inlong-audit/audit-service/src/main/java/entities/StatData.java
+++ b/inlong-audit/audit-service/src/main/java/entities/StatData.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entities;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.sql.Timestamp;
+
+@Getter
+@Setter
+public class StatData {
+
+    private String logTs;
+    private String inlongGroupId;
+    private String inlongStreamId;
+    private String auditId;
+    private String auditTag;
+    private Long count;
+    private Long size;
+    private Long delay;
+    private Timestamp updateTime;
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9907 

### Motivation

*The audit-service service is a brand-new service that supports audit peripheral functions, including real-time aggregation, backtracking aggregation, openapi, etc.*

### Modifications

*Audit-service add codes of entities.*
