### PR TITLE
[INLONG-9922][Agent] Add a script to copy the configuration from the installer to the agent

### DIFF
--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+managerAddr=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'manager.addr'|awk -F = '{print $2}')
+localIp=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'local.ip'|awk -F = '{print $2}')
+clusterTag=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
+clusterName=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
+
+if [ ${#managerAddr} -gt 0 ]; then
+  sed -i "/manager.addr/s#default#$managerAddr#g" ~/inlong/inlong-agent/conf/agent.properties
+else
+  echo "manager addr empty"
+fi
+
+if [ ${#localIp} -gt 0 ]; then
+  sed -i "/local.ip/s#default#$localIp#g" ~/inlong/inlong-agent/conf/agent.properties
+else
+  echo "local ip empty"
+fi
+
+if [ ${#clusterTag} -gt 0 ]; then
+   sed -i "/agent.cluster.tag/s#default#$clusterTag#g" ~/inlong/inlong-agent/conf/agent.properties
+else
+  echo "cluster tag empty"
+fi
+
+if [ ${#clusterName} -gt 0 ]; then
+   sed -i "/agent.cluster.name/s#default#$clusterName#g" ~/inlong/inlong-agent/conf/agent.properties
+else
+   echo "cluster name empty"
+fi

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -19,51 +19,52 @@ BASE_DIR=$(cd "$(dirname "$0")"/../../;pwd)
 installerConfigFile=$BASE_DIR/agent-installer/conf/installer.properties
 agentConfigFile=$BASE_DIR/inlong-agent/conf/agent.properties
 
-managerAddr=$(cat $installerConfigFile|grep -i 'manager.addr'|awk -F = '{print $2}')
-localIp=$(cat $installerConfigFile|grep -i 'local.ip'|awk -F = '{print $2}')
+managerAddr=$(cat $installerConfigFile|grep -i 'agent.manager.addr'|awk -F = '{print $2}')
+localIp=$(cat $installerConfigFile|grep -i 'agent.local.ip'|awk -F = '{print $2}')
 clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
 clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
+tdwSecurityUrl=$(cat $installerConfigFile|grep -i 'tdw.security.url'|awk -F = '{print $2}')
 auditFlag=$(cat $installerConfigFile|grep -i 'audit.enable'|awk -F = '{print $2}')
 auditProxy=$(cat $installerConfigFile|grep -i 'audit.proxys'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
-  sed -i "/manager.addr/s#default#$managerAddr#g" $agentConfigFile
+  sed -i "/agent.manager.addr=*/c\agent.manager.addr=$managerAddr" $agentConfigFile
 else
   echo "manager addr empty"
 fi
 
 if [ ${#localIp} -gt 0 ]; then
-  sed -i "/local.ip/s#default#$localIp#g" $agentConfigFile
+  sed -i "/agent.local.ip=*/c\agent.local.ip=$localIp" $agentConfigFile
 else
-  echo "local ip empty"
+  echo "agent local ip empty"
 fi
 
 if [ ${#clusterTag} -gt 0 ]; then
-   sed -i "/agent.cluster.tag/s#default#$clusterTag#g" $agentConfigFile
+   sed -i "/agent.cluster.tag=*/c\agent.cluster.tag=$clusterTag" $agentConfigFile
 else
   echo "cluster tag empty"
 fi
 
 if [ ${#clusterName} -gt 0 ]; then
-   sed -i "/agent.cluster.name/s#default#$clusterName#g" $agentConfigFile
+   sed -i "/agent.cluster.name=*/c\agent.cluster.name=$clusterName" $agentConfigFile
 else
    echo "cluster name empty"
 fi
 
 if [ ${#tdwSecurityUrl} -gt 0 ]; then
-  sed -i "/export OTEL_EXPORTER_OTLP_ENDPOINT=/a export TDW_SECURITY_URL=$tdwSecurityUrl" ~/inlong/inlong-agent/bin/agent-env.sh
+  sed -i "/tdw.security.url=*/c\tdw.security.url=$tdwSecurityUrl" $BASE_DIR/inlong-agent/bin/agent-env.sh
 else
   echo "tdw security url empty"
 fi
 
 if [ ${#auditFlag} -gt 0 ]; then
-  sed -i "/audit.enable/s#default#$auditFlag#g" $agentConfigFile
+  sed -i "/audit.enable=*/c\audit.enable=$auditFlag" $agentConfigFile
 else
   echo "audit flag empty"
 fi
 
 if [ ${#auditProxy} -gt 0 ]; then
-  sed -i "/audit.proxys/s#default#$auditProxy#g" $agentConfigFile
+  sed -i "/audit.proxys=*/c\audit.proxys=$auditProxy" $agentConfigFile
 else
   echo "audit proxy empty"
 fi

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -15,13 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-installerConfigFile=~/inlong/agent-installer/conf/installer.properties
-agentConfigFile=~/inlong/inlong-agent/conf/agent.properties
+BASE_DIR=$(cd "$(dirname "$0")"/../../;pwd)
+installerConfigFile=$BASE_DIR/agent-installer/conf/installer.properties
+agentConfigFile=$BASE_DIR/inlong-agent/conf/agent.properties
 
 managerAddr=$(cat $installerConfigFile|grep -i 'manager.addr'|awk -F = '{print $2}')
 localIp=$(cat $installerConfigFile|grep -i 'local.ip'|awk -F = '{print $2}')
 clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
 clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
+auditFlag=$(cat $installerConfigFile|grep -i 'audit.enable'|awk -F = '{print $2}')
+auditProxy=$(cat $installerConfigFile|grep -i 'audit.proxys'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
   sed -i "/manager.addr/s#default#$managerAddr#g" $agentConfigFile
@@ -51,4 +54,16 @@ if [ ${#tdwSecurityUrl} -gt 0 ]; then
   sed -i "/export OTEL_EXPORTER_OTLP_ENDPOINT=/a export TDW_SECURITY_URL=$tdwSecurityUrl" ~/inlong/inlong-agent/bin/agent-env.sh
 else
   echo "tdw security url empty"
+fi
+
+if [ ${#auditFlag} -gt 0 ]; then
+  sed -i "/audit.enable/s#default#$auditFlag#g" $agentConfigFile
+else
+  echo "audit flag empty"
+fi
+
+if [ ${#auditProxy} -gt 0 ]; then
+  sed -i "/audit.proxys/s#default#$auditProxy#g" $agentConfigFile
+else
+  echo "audit proxy empty"
 fi

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -22,7 +22,6 @@ managerAddr=$(cat $installerConfigFile|grep -i 'manager.addr'|awk -F = '{print $
 localIp=$(cat $installerConfigFile|grep -i 'local.ip'|awk -F = '{print $2}')
 clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
 clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
-tdwSecurityUrl=$(cat $installerConfigFile|grep -i 'tdw.security.url'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
   sed -i "/manager.addr/s#default#$managerAddr#g" $agentConfigFile

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -15,32 +15,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+installerConfigFile=~/inlong/agent-installer/conf/installer.properties
+agentConfigFile=~/inlong/inlong-agent/conf/agent.properties
 
-managerAddr=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'manager.addr'|awk -F = '{print $2}')
-localIp=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'local.ip'|awk -F = '{print $2}')
-clusterTag=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
-clusterName=$(cat ~/inlong/agent-installer/conf/installer.properties|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
+managerAddr=$(cat $installerConfigFile|grep -i 'manager.addr'|awk -F = '{print $2}')
+localIp=$(cat $installerConfigFile|grep -i 'local.ip'|awk -F = '{print $2}')
+clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{print $2}')
+clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
+tdwSecurityUrl=$(cat $installerConfigFile|grep -i 'tdw.security.url'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
-  sed -i "/manager.addr/s#default#$managerAddr#g" ~/inlong/inlong-agent/conf/agent.properties
+  sed -i "/manager.addr/s#default#$managerAddr#g" $agentConfigFile
 else
   echo "manager addr empty"
 fi
 
 if [ ${#localIp} -gt 0 ]; then
-  sed -i "/local.ip/s#default#$localIp#g" ~/inlong/inlong-agent/conf/agent.properties
+  sed -i "/local.ip/s#default#$localIp#g" $agentConfigFile
 else
   echo "local ip empty"
 fi
 
 if [ ${#clusterTag} -gt 0 ]; then
-   sed -i "/agent.cluster.tag/s#default#$clusterTag#g" ~/inlong/inlong-agent/conf/agent.properties
+   sed -i "/agent.cluster.tag/s#default#$clusterTag#g" $agentConfigFile
 else
   echo "cluster tag empty"
 fi
 
 if [ ${#clusterName} -gt 0 ]; then
-   sed -i "/agent.cluster.name/s#default#$clusterName#g" ~/inlong/inlong-agent/conf/agent.properties
+   sed -i "/agent.cluster.name/s#default#$clusterName#g" $agentConfigFile
 else
    echo "cluster name empty"
+fi
+
+if [ ${#tdwSecurityUrl} -gt 0 ]; then
+  sed -i "/export OTEL_EXPORTER_OTLP_ENDPOINT=/a export TDW_SECURITY_URL=$tdwSecurityUrl" ~/inlong/inlong-agent/bin/agent-env.sh
+else
+  echo "tdw security url empty"
 fi

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -101,6 +101,6 @@ agent.prometheus.exporter.port=9080
 # audit config
 ############################
 # whether to enable audit
-audit.enable=true
+audit.enable=default
 # audit proxy address
-audit.proxys=127.0.0.1:10081
+audit.proxys=default

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -39,7 +39,7 @@ agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
 #######################
 # max wait time(s) for thread pool to terminate running
 thread.pool.await.time=30
-agent.local.ip=default
+agent.local.ip=127.0.0.1
 agent.local.uuid=
 agent.local.uuid.open=false
 agent.node.group=default_group
@@ -75,15 +75,15 @@ task.pull.maxSecond=2
 ############################
 # manager config
 ############################
-agent.manager.addr=default
+agent.manager.addr=http://127.0.0.1:8083
 agent.manager.auth.secretId=
 agent.manager.auth.secretKey=
 
 ############################
 # cluster config for automatically report and register
 ############################
-agent.cluster.tag=default
-agent.cluster.name=default
+agent.cluster.tag=default_cluster
+agent.cluster.name=default_agent
 agent.cluster.inCharges=admin
 
 ############################
@@ -101,6 +101,6 @@ agent.prometheus.exporter.port=9080
 # audit config
 ############################
 # whether to enable audit
-audit.enable=default
+audit.enable=true
 # audit proxy address
-audit.proxys=default
+audit.proxys=127.0.0.1:10081

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -39,7 +39,7 @@ agent.fetcher.classname=org.apache.inlong.agent.plugin.fetcher.ManagerFetcher
 #######################
 # max wait time(s) for thread pool to terminate running
 thread.pool.await.time=30
-agent.local.ip=127.0.0.1
+agent.local.ip=default
 agent.local.uuid=
 agent.local.uuid.open=false
 agent.node.group=default_group
@@ -75,15 +75,15 @@ task.pull.maxSecond=2
 ############################
 # manager config
 ############################
-agent.manager.addr=http://127.0.0.1:8083
+agent.manager.addr=default
 agent.manager.auth.secretId=
 agent.manager.auth.secretKey=
 
 ############################
 # cluster config for automatically report and register
 ############################
-agent.cluster.tag=default_cluster
-agent.cluster.name=default_agent
+agent.cluster.tag=default
+agent.cluster.name=default
 agent.cluster.inCharges=admin
 
 ############################


### PR DESCRIPTION
[INLONG-9922][Agent] Add a configuration copy script to copy the configuration from the installer to the agent
- Fixes #9922

### Motivation
Enable the installer to automatically synchronize configuration with the agent during installation
### Modifications
Add a configuration copy script to copy the configuration from the installer to the agent

### Verifying this change

This change is a trivial rework/code cleanup without any test coverage.

### Documentation

 no doc needed
