### PR TITLE
[INLONG-9934][doc] update copyright date to 2024

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/NOTICE
+++ b/licenses/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-agent/NOTICE
+++ b/licenses/inlong-agent/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-audit/NOTICE
+++ b/licenses/inlong-audit/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-dashboard/NOTICE
+++ b/licenses/inlong-dashboard/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-dataproxy/NOTICE
+++ b/licenses/inlong-dataproxy/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-manager/NOTICE
+++ b/licenses/inlong-manager/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-sort-connectors/NOTICE
+++ b/licenses/inlong-sort-connectors/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-sort-standalone/NOTICE
+++ b/licenses/inlong-sort-standalone/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-sort/NOTICE
+++ b/licenses/inlong-sort/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-tubemq-manager/NOTICE
+++ b/licenses/inlong-tubemq-manager/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).

--- a/licenses/inlong-tubemq-server/NOTICE
+++ b/licenses/inlong-tubemq-server/NOTICE
@@ -1,5 +1,5 @@
 Apache InLong
-Copyright 2019-2023 The Apache Software Foundation.
+Copyright 2019-2024 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).


### PR DESCRIPTION
- Fixes #9934 

### Motivation

Copyright date in NOTICE is still 2019-2023, which needs updating.

### Modifications

update Copyright date in NOTICE to 2024

### Verifying this change



- [x] This change is a trivial rework/code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)
