### PR TITLE
[INLONG-9936][Manager] Support for parallel acquisition of data preview data from multiple Pulsar clusters

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarQueueResourceOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/PulsarQueueResourceOperator.java
@@ -50,8 +50,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -311,7 +311,7 @@ public class PulsarQueueResourceOperator implements QueueResourceOperator {
             InlongStreamInfo streamInfo, Integer messageCount) throws Exception {
         List<ClusterInfo> pulsarClusterList = clusterService.listByTagAndType(groupInfo.getInlongClusterTag(),
                 ClusterType.PULSAR);
-        List<BriefMQMessage> briefMQMessages = new CopyOnWriteArrayList<>();
+        List<BriefMQMessage> briefMQMessages = Collections.synchronizedList(new ArrayList<>());
         QueryCountDownLatch queryLatch = new QueryCountDownLatch(messageCount, pulsarClusterList.size());
         InlongPulsarInfo inlongPulsarInfo = ((InlongPulsarInfo) groupInfo);
         for (ClusterInfo clusterInfo : pulsarClusterList) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryCountDownLatch.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryCountDownLatch.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.resource.queue.pulsar;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * QueryCountDownLatch
+ */
+public class QueryCountDownLatch {
+
+    private CountDownLatch dataLatch;
+    private CountDownLatch taskLatch;
+    private CountDownLatch flagLatch;
+
+    public QueryCountDownLatch(int dataSize, int taskSize) {
+        this.dataLatch = new CountDownLatch(dataSize);
+        this.taskLatch = new CountDownLatch(taskSize);
+        this.flagLatch = new CountDownLatch(1);
+    }
+
+    public void countDown(int dataDownSize) {
+        this.taskLatch.countDown();
+        for (int i = 0; i < dataDownSize; i++) {
+            this.dataLatch.countDown();
+        }
+        if (this.taskLatch.getCount() == 0 || this.dataLatch.getCount() == 0) {
+            this.flagLatch.countDown();
+        }
+    }
+
+    public void await() throws InterruptedException {
+        this.flagLatch.await();
+    }
+
+    public boolean await(long timeout, TimeUnit unit) throws InterruptedException {
+        return this.flagLatch.await(timeout, unit);
+    }
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
@@ -17,13 +17,14 @@
 
 package org.apache.inlong.manager.service.resource.queue.pulsar;
 
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterInfo;
 import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
 import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
@@ -17,13 +17,13 @@
 
 package org.apache.inlong.manager.service.resource.queue.pulsar;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterInfo;
 import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
 import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
-
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -32,8 +32,6 @@ import java.util.concurrent.CountDownLatch;
  * QueryLatestMessagesRunnable
  */
 public class QueryLatestMessagesRunnable implements Runnable {
-
-    public static final String PULSAR_SUBSCRIPTION = "%s_%s_%s_consumer_group";
 
     public static final String PULSAR_SUBSCRIPTION_REALTIME_REVIEW = "%s_%s_consumer_group_realtime_review";
 
@@ -76,7 +74,7 @@ public class QueryLatestMessagesRunnable implements Runnable {
         boolean serial = InlongConstants.PULSAR_QUEUE_TYPE_SERIAL.equals(inlongPulsarInfo.getQueueModule());
         List<BriefMQMessage> messages = pulsarOperator.queryLatestMessage(clusterInfo, fullTopicName, subs,
                 messageCount, streamInfo, serial);
-        if (messages != null) {
+        if (CollectionUtils.isNotEmpty(messages)) {
             briefMQMessages.addAll(messages);
             messages.forEach(v -> this.latch.countDown());
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
@@ -27,7 +27,6 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 /**
  * QueryLatestMessagesRunnable
@@ -42,7 +41,7 @@ public class QueryLatestMessagesRunnable implements Runnable {
     private PulsarOperator pulsarOperator;
     private Integer messageCount;
     private List<BriefMQMessage> briefMQMessages;
-    private CountDownLatch latch;
+    private QueryCountDownLatch latch;
 
     public QueryLatestMessagesRunnable(InlongPulsarInfo inlongPulsarInfo,
             InlongStreamInfo streamInfo,
@@ -50,7 +49,7 @@ public class QueryLatestMessagesRunnable implements Runnable {
             PulsarOperator pulsarOperator,
             Integer messageCount,
             List<BriefMQMessage> briefMQMessages,
-            CountDownLatch latch) {
+            QueryCountDownLatch latch) {
         this.inlongPulsarInfo = inlongPulsarInfo;
         this.streamInfo = streamInfo;
         this.clusterInfo = clusterInfo;
@@ -77,7 +76,7 @@ public class QueryLatestMessagesRunnable implements Runnable {
                 messageCount, streamInfo, serial);
         if (CollectionUtils.isNotEmpty(messages)) {
             briefMQMessages.addAll(messages);
-            messages.forEach(v -> this.latch.countDown());
+            this.latch.countDown(messages.size());
         }
     }
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/resource/queue/pulsar/QueryLatestMessagesRunnable.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.resource.queue.pulsar;
+
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.pojo.cluster.pulsar.PulsarClusterInfo;
+import org.apache.inlong.manager.pojo.consume.BriefMQMessage;
+import org.apache.inlong.manager.pojo.group.pulsar.InlongPulsarInfo;
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * QueryLatestMessagesRunnable
+ */
+public class QueryLatestMessagesRunnable implements Runnable {
+
+    public static final String PULSAR_SUBSCRIPTION = "%s_%s_%s_consumer_group";
+
+    public static final String PULSAR_SUBSCRIPTION_REALTIME_REVIEW = "%s_%s_consumer_group_realtime_review";
+
+    private InlongPulsarInfo inlongPulsarInfo;
+    private InlongStreamInfo streamInfo;
+    private PulsarClusterInfo clusterInfo;
+    private PulsarOperator pulsarOperator;
+    private Integer messageCount;
+    private List<BriefMQMessage> briefMQMessages;
+    private CountDownLatch latch;
+
+    public QueryLatestMessagesRunnable(InlongPulsarInfo inlongPulsarInfo,
+            InlongStreamInfo streamInfo,
+            PulsarClusterInfo clusterInfo,
+            PulsarOperator pulsarOperator,
+            Integer messageCount,
+            List<BriefMQMessage> briefMQMessages,
+            CountDownLatch latch) {
+        this.inlongPulsarInfo = inlongPulsarInfo;
+        this.streamInfo = streamInfo;
+        this.clusterInfo = clusterInfo;
+        this.pulsarOperator = pulsarOperator;
+        this.messageCount = messageCount;
+        this.briefMQMessages = briefMQMessages;
+        this.latch = latch;
+    }
+
+    @Override
+    public void run() {
+        String tenant = inlongPulsarInfo.getPulsarTenant();
+        if (StringUtils.isBlank(tenant)) {
+            tenant = clusterInfo.getPulsarTenant();
+        }
+
+        String namespace = inlongPulsarInfo.getMqResource();
+        String topicName = streamInfo.getMqResource();
+        String fullTopicName = tenant + "/" + namespace + "/" + topicName;
+        String clusterTag = inlongPulsarInfo.getInlongClusterTag();
+        String subs = String.format(PULSAR_SUBSCRIPTION_REALTIME_REVIEW, clusterTag, topicName);
+        boolean serial = InlongConstants.PULSAR_QUEUE_TYPE_SERIAL.equals(inlongPulsarInfo.getQueueModule());
+        List<BriefMQMessage> messages = pulsarOperator.queryLatestMessage(clusterInfo, fullTopicName, subs,
+                messageCount, streamInfo, serial);
+        if (messages != null) {
+            briefMQMessages.addAll(messages);
+            messages.forEach(v -> this.latch.countDown());
+        }
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9936 

### Motivation

When clusterTag have multiple Pulsar clusters and the amount of data is little, reading the data preview data from only one Pulsar cluster may result in no data being found. If polling all Pulsar clusters, it may cause query timeouts. In this case, it is necessary to query all Pulsar clusters in parallel to avoid timeout exceptions.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
