### PR TITLE
[INLONG-9402][Sort] Solve errors in UT test logs for sort-end-to-end-tests, but UT results show as successful

### DIFF
--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
@@ -129,7 +129,7 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
     public static void before() {
         LOG.info("Starting containers...");
         jobManager =
-                new GenericContainer<>("flink:1.13.5-scala_2.11")
+                new GenericContainer<>("flink:1.13.5-scala_2.11-java8")
                         .withCommand("jobmanager")
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
@@ -137,7 +137,7 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
                         .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
                         .withLogConsumer(new Slf4jLogConsumer(JM_LOG));
         taskManager =
-                new GenericContainer<>("flink:1.13.5-scala_2.11")
+                new GenericContainer<>("flink:1.13.5-scala_2.11-java8")
                         .withCommand("taskmanager")
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_TM_ALIAS)
@@ -185,8 +185,8 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
         ExecResult execResult =
                 jobManager.execInContainer("bash", "-c", String.join(" ", commands));
         LOG.info(execResult.getStdout());
-        LOG.error(execResult.getStderr());
         if (execResult.getExitCode() != 0) {
+            LOG.error(execResult.getStderr());
             throw new AssertionError("Failed when submitting the SQL job.");
         }
     }

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Kafka2StarRocksTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Kafka2StarRocksTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE8;
 import org.apache.inlong.sort.tests.utils.JdbcProxy;
 import org.apache.inlong.sort.tests.utils.MySqlContainer;
 import org.apache.inlong.sort.tests.utils.PlaceholderResolver;
@@ -62,7 +62,7 @@ import static org.apache.inlong.sort.tests.utils.StarRocksManager.initializeStar
 /**
  * End-to-end tests for sort-connector-kafka uber jar.
  */
-public class Kafka2StarRocksTest extends FlinkContainerTestEnv {
+public class Kafka2StarRocksTest extends FlinkContainerTestEnvJRE8 {
 
     private static final Logger LOG = LoggerFactory.getLogger(Kafka2StarRocksTest.class);
 

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Mongodb2StarRocksTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Mongodb2StarRocksTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE8;
 import org.apache.inlong.sort.tests.utils.JdbcProxy;
 import org.apache.inlong.sort.tests.utils.StarRocksContainer;
 import org.apache.inlong.sort.tests.utils.TestUtils;
@@ -60,7 +60,7 @@ import static com.mongodb.client.model.Updates.*;
  * End-to-end tests for sort-connector-mongodb-cdc-v1.15 uber jar.
  * Test flink sql Mongodb cdc to StarRocks
  */
-public class Mongodb2StarRocksTest extends FlinkContainerTestEnv {
+public class Mongodb2StarRocksTest extends FlinkContainerTestEnvJRE8 {
 
     private static final Logger LOG = LoggerFactory.getLogger(Mongodb2StarRocksTest.class);
 

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Mysql2StarRocksTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Mysql2StarRocksTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE8;
 import org.apache.inlong.sort.tests.utils.JdbcProxy;
 import org.apache.inlong.sort.tests.utils.MySqlContainer;
 import org.apache.inlong.sort.tests.utils.StarRocksContainer;
@@ -51,7 +51,7 @@ import static org.apache.inlong.sort.tests.utils.StarRocksManager.initializeStar
  * End-to-end tests for sort-connector-postgres-cdc-v1.15 uber jar.
  * Test flink sql Mysql cdc to StarRocks
  */
-public class Mysql2StarRocksTest extends FlinkContainerTestEnv {
+public class Mysql2StarRocksTest extends FlinkContainerTestEnvJRE8 {
 
     private static final Logger LOG = LoggerFactory.getLogger(Mysql2StarRocksTest.class);
 

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Postgres2StarRocksTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Postgres2StarRocksTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE11;
 import org.apache.inlong.sort.tests.utils.JdbcProxy;
 import org.apache.inlong.sort.tests.utils.StarRocksContainer;
 import org.apache.inlong.sort.tests.utils.TestUtils;
@@ -49,7 +49,7 @@ import static org.apache.inlong.sort.tests.utils.StarRocksManager.*;
  * End-to-end tests for sort-connector-postgres-cdc-v1.15 uber jar.
  * Test flink sql Postgres cdc to StarRocks
  */
-public class Postgres2StarRocksTest extends FlinkContainerTestEnv {
+public class Postgres2StarRocksTest extends FlinkContainerTestEnvJRE11 {
 
     private static final Logger PG_LOG = LoggerFactory.getLogger(PostgreSQLContainer.class);
     private static final Logger LOG = LoggerFactory.getLogger(Postgres2StarRocksTest.class);

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/RedisToRedisTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/RedisToRedisTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE8;
 import org.apache.inlong.sort.tests.utils.RedisContainer;
 import org.apache.inlong.sort.tests.utils.TestUtils;
 
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
-public class RedisToRedisTest extends FlinkContainerTestEnv {
+public class RedisToRedisTest extends FlinkContainerTestEnvJRE8 {
 
     private static final Logger LOG = LoggerFactory.getLogger(RedisContainer.class);
     private static final Path redisJar = TestUtils.getResource("sort-connector-redis.jar");

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Sqlserver2StarRocksTest.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Sqlserver2StarRocksTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sort.tests;
 
-import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnv;
+import org.apache.inlong.sort.tests.utils.FlinkContainerTestEnvJRE8;
 import org.apache.inlong.sort.tests.utils.JdbcProxy;
 import org.apache.inlong.sort.tests.utils.MSSQLServerContainer;
 import org.apache.inlong.sort.tests.utils.StarRocksContainer;
@@ -48,7 +48,7 @@ import static org.apache.inlong.sort.tests.utils.StarRocksManager.STAR_ROCKS_LOG
 import static org.apache.inlong.sort.tests.utils.StarRocksManager.getNewStarRocksImageName;
 import static org.apache.inlong.sort.tests.utils.StarRocksManager.initializeStarRocksTable;
 
-public class Sqlserver2StarRocksTest extends FlinkContainerTestEnv {
+public class Sqlserver2StarRocksTest extends FlinkContainerTestEnvJRE8 {
 
     private static final Logger LOG = LoggerFactory.getLogger(Sqlserver2StarRocksTest.class);
 

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.util.TestLogger;
 import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -39,9 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.builder.Transferable;
-import org.testcontainers.lifecycle.Startables;
 
 import javax.annotation.Nullable;
 
@@ -62,7 +59,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import java.util.jar.JarOutputStream;
-import java.util.stream.Stream;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -72,20 +68,20 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public abstract class FlinkContainerTestEnv extends TestLogger {
 
-    private static final Logger JM_LOG = LoggerFactory.getLogger(JobMaster.class);
-    private static final Logger TM_LOG = LoggerFactory.getLogger(TaskExecutor.class);
-    private static final Logger LOG = LoggerFactory.getLogger(FlinkContainerTestEnv.class);
+    static final Logger JM_LOG = LoggerFactory.getLogger(JobMaster.class);
+    static final Logger TM_LOG = LoggerFactory.getLogger(TaskExecutor.class);
+    static final Logger LOG = LoggerFactory.getLogger(FlinkContainerTestEnv.class);
 
     private static final Path SORT_DIST_JAR = TestUtils.getResource("sort-dist.jar");
     // ------------------------------------------------------------------------------------------
     // Flink Variables
     // ------------------------------------------------------------------------------------------
-    private static final int JOB_MANAGER_REST_PORT = 8081;
-    private static final int DEBUG_PORT = 20000;
-    private static final String FLINK_BIN = "bin";
-    private static final String INTER_CONTAINER_JM_ALIAS = "jobmanager";
-    private static final String INTER_CONTAINER_TM_ALIAS = "taskmanager";
-    private static final String FLINK_PROPERTIES = String.join("\n", Arrays.asList(
+    static final int JOB_MANAGER_REST_PORT = 8081;
+    static final int DEBUG_PORT = 20000;
+    static final String FLINK_BIN = "bin";
+    static final String INTER_CONTAINER_JM_ALIAS = "jobmanager";
+    static final String INTER_CONTAINER_TM_ALIAS = "taskmanager";
+    static final String FLINK_PROPERTIES = String.join("\n", Arrays.asList(
             "jobmanager.rpc.address: jobmanager",
             "taskmanager.numberOfTaskSlots: 10",
             "parallelism.default: 4",
@@ -104,35 +100,8 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
     @Nullable
     private static RestClusterClient<StandaloneClusterId> restClusterClient;
 
-    private static GenericContainer<?> jobManager;
-    private static GenericContainer<?> taskManager;
-
-    @BeforeClass
-    public static void before() {
-        LOG.info("Starting containers...");
-        jobManager =
-                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
-                        .withCommand("jobmanager")
-                        .withNetwork(NETWORK)
-                        .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
-                        .withExposedPorts(JOB_MANAGER_REST_PORT, DEBUG_PORT)
-                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
-                        .withExposedPorts(JOB_MANAGER_REST_PORT)
-                        .withLogConsumer(new Slf4jLogConsumer(JM_LOG));
-        taskManager =
-                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
-                        .withCommand("taskmanager")
-                        .withNetwork(NETWORK)
-                        .withNetworkAliases(INTER_CONTAINER_TM_ALIAS)
-                        .withExposedPorts(DEBUG_PORT)
-                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
-                        .dependsOn(jobManager)
-                        .withLogConsumer(new Slf4jLogConsumer(TM_LOG));
-
-        Startables.deepStart(Stream.of(jobManager)).join();
-        Startables.deepStart(Stream.of(taskManager)).join();
-        LOG.info("Containers are started.");
-    }
+    static GenericContainer<?> jobManager;
+    static GenericContainer<?> taskManager;
 
     @AfterClass
     public static void after() {

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
@@ -165,8 +165,8 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
         ExecResult execResult =
                 jobManager.execInContainer("bash", "-c", String.join(" ", commands));
         LOG.info(execResult.getStdout());
-        LOG.error(execResult.getStderr());
         if (execResult.getExitCode() != 0) {
+            LOG.error(execResult.getStderr());
             throw new AssertionError("Failed when submitting the SQL job.");
         }
     }

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnv.java
@@ -111,7 +111,7 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
     public static void before() {
         LOG.info("Starting containers...");
         jobManager =
-                new GenericContainer<>("flink:1.15.4-scala_2.12")
+                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
                         .withCommand("jobmanager")
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
@@ -120,7 +120,7 @@ public abstract class FlinkContainerTestEnv extends TestLogger {
                         .withExposedPorts(JOB_MANAGER_REST_PORT)
                         .withLogConsumer(new Slf4jLogConsumer(JM_LOG));
         taskManager =
-                new GenericContainer<>("flink:1.15.4-scala_2.12")
+                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
                         .withCommand("taskmanager")
                         .withNetwork(NETWORK)
                         .withNetworkAliases(INTER_CONTAINER_TM_ALIAS)

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnvJRE11.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnvJRE11.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.tests.utils;
+
+import org.junit.BeforeClass;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.stream.Stream;
+
+public abstract class FlinkContainerTestEnvJRE11 extends FlinkContainerTestEnv {
+
+    @BeforeClass
+    public static void before() {
+        LOG.info("Starting containers...");
+        jobManager =
+                new GenericContainer<>("flink:1.15.4-scala_2.12")
+                        .withCommand("jobmanager")
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
+                        .withExposedPorts(JOB_MANAGER_REST_PORT, DEBUG_PORT)
+                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
+                        .withExposedPorts(JOB_MANAGER_REST_PORT)
+                        .withLogConsumer(new Slf4jLogConsumer(JM_LOG));
+        taskManager =
+                new GenericContainer<>("flink:1.15.4-scala_2.12")
+                        .withCommand("taskmanager")
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(INTER_CONTAINER_TM_ALIAS)
+                        .withExposedPorts(DEBUG_PORT)
+                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
+                        .dependsOn(jobManager)
+                        .withLogConsumer(new Slf4jLogConsumer(TM_LOG));
+
+        Startables.deepStart(Stream.of(jobManager)).join();
+        Startables.deepStart(Stream.of(taskManager)).join();
+        LOG.info("Containers are started.");
+    }
+}

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnvJRE8.java
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/utils/FlinkContainerTestEnvJRE8.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.tests.utils;
+
+import org.junit.BeforeClass;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.stream.Stream;
+
+public abstract class FlinkContainerTestEnvJRE8 extends FlinkContainerTestEnv {
+
+    @BeforeClass
+    public static void before() {
+        LOG.info("Starting containers...");
+        jobManager =
+                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
+                        .withCommand("jobmanager")
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(INTER_CONTAINER_JM_ALIAS)
+                        .withExposedPorts(JOB_MANAGER_REST_PORT, DEBUG_PORT)
+                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
+                        .withExposedPorts(JOB_MANAGER_REST_PORT)
+                        .withLogConsumer(new Slf4jLogConsumer(JM_LOG));
+        taskManager =
+                new GenericContainer<>("flink:1.15.4-scala_2.12-java8")
+                        .withCommand("taskmanager")
+                        .withNetwork(NETWORK)
+                        .withNetworkAliases(INTER_CONTAINER_TM_ALIAS)
+                        .withExposedPorts(DEBUG_PORT)
+                        .withEnv("FLINK_PROPERTIES", FLINK_PROPERTIES)
+                        .dependsOn(jobManager)
+                        .withLogConsumer(new Slf4jLogConsumer(TM_LOG));
+
+        Startables.deepStart(Stream.of(jobManager)).join();
+        Startables.deepStart(Stream.of(taskManager)).join();
+        LOG.info("Containers are started.");
+    }
+}


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-9402][Sort] Solve errors in UT test logs for sort-end-to-end-tests, but UT results show as successful

- Fixes #9402 

### Motivation

As issue #9402 description, there were two case encountered error but the final result show as successful.

### Modifications

- Case1

Question: Warning: Illegal reflective access by org.apache.flink.api.java.ClosureCleaner (file:/opt/flink/lib/flink-dist-1.15.4.jar) to field java.lang.String.value.

Reason: This error message indicates an illegal reflective access operation occurring while using Apache Flink, which is an open-source framework for processing streaming and batch data. Specifically, the error occurs because org.apache.flink.api.java.ClosureCleaner attempts to access the value field of the java.lang.String class illegally. This is more common with higher versions of Java, starting from Java 9 onwards, as the JDK has imposed stricter access controls on internal APIs to enhance security and modularity.

Solve: Change the flink docker java version from 11(flink:1.15.4-scala_2.12) to 8(flink:1.15.4-scala_2.12-java8).

- Case2

Question: Can't connect the mysql server and through errors in logs, the results show as successful.

Reason:The issue which run end-to-end-tests use ci_ut.yaml, so it will lead to some network problem. Because ahead module test maybe change the newort adapter.

Solve: Now, the project add ci_ut_flink13.yaml and ci_ut_flink15.yaml. The 1.13 and 1.15 end-to-end test can be tested without other module influence.The detail of yaml file as PR #9924 and #9869 .
