### PR TITLE
[INLONG-9944][Dashboard] Add Agent and Installer for Agent Cluster Node

### DIFF
--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -751,6 +751,8 @@
   "pages.Clusters.Node.Name": "节点",
   "pages.Clusters.Node.Port": "端口",
   "pages.Clusters.Node.ProtocolType": "协议类型",
+  "pages.Clusters.Node.Agent": "Agent",
+  "pages.Clusters.Node.AgentInstaller": "Installer",
   "pages.Clusters.Node.Status": "状态",
   "pages.Clusters.Node.Status.Normal": "正常",
   "pages.Clusters.Node.Status.Timeout": "心跳超时",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -751,6 +751,8 @@
   "pages.Clusters.Node.Name": "Node",
   "pages.Clusters.Node.Port": "Port",
   "pages.Clusters.Node.ProtocolType": "Protocol type",
+  "pages.Clusters.Node.Agent": "Agent",
+  "pages.Clusters.Node.AgentInstaller": "Installer",
   "pages.Clusters.Node.Status": "Status",
   "pages.Clusters.Node.Status.Normal": "Normal",
   "pages.Clusters.Node.Status.Timeout": "Timeout",

--- a/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
@@ -42,6 +42,11 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
     {
       manual: true,
       onSuccess: result => {
+        if (type === 'AGENT') {
+          // Only keep the first element and give the rest to the 'installer'
+          result.installer = result?.moduleIdList.slice(1);
+          result.moduleIdList = result?.moduleIdList.slice(0, 1);
+        }
         form.setFieldsValue(result);
       },
     },
@@ -58,6 +63,14 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
     if (isUpdate) {
       submitData.id = id;
       submitData.version = savedData?.version;
+    }
+    if (type === 'AGENT') {
+      if (submitData.installer !== undefined) {
+        submitData.moduleIdList = submitData.moduleIdList.concat(submitData.installer);
+      }
+      if (isUpdate === undefined) {
+        submitData.isInstall = true;
+      }
     }
     await request({
       url: `/cluster/node/${isUpdate ? 'update' : 'save'}`,

--- a/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
@@ -146,6 +146,71 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
         },
       },
       {
+        type: 'select',
+        label: i18n.t('pages.Clusters.Node.Agent'),
+        name: 'moduleIdList',
+        rules: [{ required: false }],
+        hidden: type !== 'AGENT',
+        props: {
+          options: {
+            requestAuto: true,
+            requestTrigger: ['onOpen'],
+            requestService: keyword => ({
+              url: '/module/list',
+              method: 'POST',
+              data: {
+                keyword,
+                pageNum: 1,
+                pageSize: 9999,
+              },
+            }),
+            requestParams: {
+              formatResult: result =>
+                result?.list
+                  ?.filter(item => item.type === 'AGENT')
+                  .map(item => ({
+                    ...item,
+                    label: `${item.name} ${item.version}`,
+                    value: item.id,
+                  })),
+            },
+          },
+        },
+      },
+      {
+        type: 'select',
+        label: i18n.t('pages.Clusters.Node.AgentInstaller'),
+        name: 'installer',
+        rules: [{ required: false }],
+        hidden: type !== 'AGENT',
+        props: {
+          mode: 'multiple',
+          options: {
+            requestAuto: true,
+            requestTrigger: ['onOpen'],
+            requestService: keyword => ({
+              url: '/module/list',
+              method: 'POST',
+              data: {
+                keyword,
+                pageNum: 1,
+                pageSize: 9999,
+              },
+            }),
+            requestParams: {
+              formatResult: result =>
+                result?.list
+                  ?.filter(item => item.type === 'INSTALLER')
+                  .map(item => ({
+                    ...item,
+                    label: `${item.name} ${item.version}`,
+                    value: item.id,
+                  })),
+            },
+          },
+        },
+      },
+      {
         type: 'textarea',
         label: i18n.t('pages.Clusters.Description'),
         name: 'description',

--- a/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
@@ -162,7 +162,6 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
         type: 'select',
         label: i18n.t('pages.Clusters.Node.Agent'),
         name: 'moduleIdList',
-        rules: [{ required: false }],
         hidden: type !== 'AGENT',
         props: {
           options: {
@@ -194,7 +193,6 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
         type: 'select',
         label: i18n.t('pages.Clusters.Node.AgentInstaller'),
         name: 'installer',
-        rules: [{ required: false }],
         hidden: type !== 'AGENT',
         props: {
           mode: 'multiple',


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9944 

### Motivation

Add `Agent` and `Installer` for Agent Cluster Node.

### Modifications

1. Get node info and only keep the first element to `Agent` and give the rest to the `Installer`.

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/24f52e93-153e-489a-8c9b-9fed123e2a5f)

