### PR TITLE
[INLONG-9946][Agent] Verify the return code, only proceed with the subsequent process if the return code is successful

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ManagerFetcher.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ManagerFetcher.java
@@ -25,6 +25,7 @@ import org.apache.inlong.agent.utils.HttpManager;
 import org.apache.inlong.agent.utils.ThreadUtils;
 import org.apache.inlong.common.pojo.agent.installer.ConfigRequest;
 import org.apache.inlong.common.pojo.agent.installer.ConfigResult;
+import org.apache.inlong.common.pojo.agent.installer.InstallerCode;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -123,7 +124,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
             while (isRunnable()) {
                 try {
                     ConfigResult config = getConfig();
-                    if (config != null) {
+                    if (config != null && config.getCode().equals(InstallerCode.SUCCESS)) {
                         manager.getModuleManager().submitConfig(config);
                     }
                 } catch (Throwable ex) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -44,7 +44,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_UNIQ_ID;
@@ -177,7 +176,6 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
             Thread.currentThread().setName("ManagerFetcher");
             while (isRunnable()) {
                 try {
-                    int configSleepTime = conf.getInt(AGENT_FETCHER_INTERVAL, DEFAULT_AGENT_FETCHER_INTERVAL);
                     TaskResult taskResult = getStaticConfig();
                     if (taskResult != null) {
                         List<TaskProfile> taskProfiles = new ArrayList<>();
@@ -187,10 +185,12 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
                         });
                         agentManager.getTaskManager().submitTaskProfiles(taskProfiles);
                     }
-                    TimeUnit.SECONDS.sleep(AgentUtils.getRandomBySeed(configSleepTime));
                 } catch (Throwable ex) {
                     LOGGER.warn("exception caught", ex);
                     ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
+                } finally {
+                    AgentUtils.silenceSleepInSeconds(AgentUtils.getRandomBySeed(
+                            conf.getInt(AGENT_FETCHER_INTERVAL, DEFAULT_AGENT_FETCHER_INTERVAL)));
                 }
             }
         };


### PR DESCRIPTION
[INLONG-9946][Agent] Verify the return code, only proceed with the subsequent process if the return code is successful
- Fixes #9946

### Motivation

The manager will verify MD5, and if no changes are found in MD5, a no update return code will be returned

### Modifications

Verify the return code, only proceed with the subsequent process if the return code is successful

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation
  no doc needed
