### PR TITLE
[INLONG-9950][Dashboard] Fix audit query using incorrect end time

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -117,7 +117,7 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
             setQuery({
               ...allValues,
               startDate: +allValues.startDate.$d,
-              endDate: +allValues.startDate.$d,
+              endDate: +allValues.endDate.$d,
             })
           }
         />


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9950

### Motivation

The end time and start time used by the audit query are the same.

### Modifications

Fix the end time.

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/61bc44de-cdce-4647-9edb-a650605c5ff6)

