### PR TITLE
[INLONG-9925][Sort] Add if statement to solve continuously printing logs

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -609,7 +609,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     @Override
     public synchronized void flush() throws IOException {
         checkFlushException();
-        if(batchCount>0){
+        if(batchCount > 0){
             attemptFlush();
             batchCount = 0;
         }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -608,11 +608,13 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
 
     @Override
     public synchronized void flush() throws IOException {
-        checkFlushException();
-        if (batchCount > 0) {
-            attemptFlush();
-            batchCount = 0;
+        // when batch count > 0, execute flush operation
+        if (batchCount == 0) {
+            return;
         }
+        checkFlushException();
+        attemptFlush();
+        batchCount = 0;
     }
 
     /**

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -609,7 +609,7 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     @Override
     public synchronized void flush() throws IOException {
         checkFlushException();
-        if(batchCount > 0){
+        if (batchCount > 0) {
             attemptFlush();
             batchCount = 0;
         }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/internal/JdbcMultiBatchingOutputFormat.java
@@ -609,8 +609,10 @@ public class JdbcMultiBatchingOutputFormat<In, JdbcIn, JdbcExec extends JdbcBatc
     @Override
     public synchronized void flush() throws IOException {
         checkFlushException();
-        attemptFlush();
-        batchCount = 0;
+        if(batchCount>0){
+            attemptFlush();
+            batchCount = 0;
+        }
     }
 
     /**


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-XYZ][Sort] Add if statement to solve continuously printing logs

- Fixes #9925 

### Motivation

The log keeps printing the same message. This message should be printed when there is update or delete operation for ck and should not appear so many times.And because it continuously write log files, the disk will not has free space soon.

### Modifications

I found that the program through JDBC module continuously  batch write to clickhouse. But when batch count equals 0, the program still execute batch write command. So the log nonstop print. I add  if statement. Only batch count greater than 0, it will execute batch write command.
