### PR TITLE
[INLONG-9963][Dashboard][Agent] Add agentIp fields to Kafka and Pulsar source

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
@@ -145,7 +145,7 @@ public class KafkaSource extends AbstractSource {
             props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, profile.get(TASK_KAFKA_AUTO_COMMIT_OFFSET_RESET));
             props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
 
-            allPartitionOffsets = profile.get(TASK_KAFKA_OFFSET);
+            allPartitionOffsets = profile.get(TASK_KAFKA_OFFSET, null);
             isRestoreFromDB = profile.getBoolean(RESTORE_FROM_DB, false);
             if (!isRestoreFromDB && StringUtils.isNotBlank(allPartitionOffsets)) {
                 // example:0#110_1#666_2#222

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -27,7 +27,7 @@
   "meta.Sources.NameRule": "Only English letters, numbers, dots(.), minus(-), and underscores(_)",
   "meta.Sources.Type": "Type",
   "meta.Sources.File.SerializationType": "File type",
-  "meta.Sources.File.DataSourceIP": "Data source IP",
+  "meta.Sources.File.DataSourceIP": "Source IP",
   "meta.Sources.File.ClusterName": "Cluster name",
   "meta.Sources.File.FilePath": "File path",
   "meta.Sources.File.FilePathHelp": "Must be an absolute path and support regular expressions, such as: /data/.*log",


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9963 

### Motivation

`Kafka` and `Pulsar source` are missing agent IP fields.

### Modifications

Add agent IP field to `Kafka` and `Pulsar source`

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/e6569d57-e4c7-4cb5-ac4f-c0afa7cbdf89)

![image](https://github.com/apache/inlong/assets/58519431/b20991da-a33c-4487-aebd-14c6dbb00f02)

