### PR TITLE
[INLONG-9972][Sort] Pulsar connector support authentication when connecting to Pulsar cluster

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/PulsarProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/PulsarProvider.java
@@ -80,7 +80,9 @@ public class PulsarProvider implements ExtractNodeProvider {
                 startupMode.getValue(),
                 primaryKey,
                 pulsarSource.getSubscription(),
-                scanStartupSubStartOffset);
+                scanStartupSubStartOffset,
+                "",
+                "");
     }
 
     @Override

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNode.java
@@ -146,7 +146,8 @@ public class PulsarExtractNode extends ExtractNode implements InlongMetric, Meta
             options.put("scan.startup.sub-name", scanStartupSubName);
             options.put("scan.startup.sub-start-offset", scanStartupSubStartOffset);
         }
-        if (StringUtils.isNotBlank(clientAuthPluginClassName)) {
+        if (StringUtils.isNotBlank(clientAuthPluginClassName)
+                && StringUtils.isNotBlank(clientAuthParams)) {
             options.put("pulsar.client.authPluginClassName", clientAuthPluginClassName);
             options.put("pulsar.client.authParams", clientAuthParams);
         }

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNode.java
@@ -73,6 +73,22 @@ public class PulsarExtractNode extends ExtractNode implements InlongMetric, Meta
     @JsonProperty("scanStartupSubStartOffset")
     private String scanStartupSubStartOffset;
 
+    /**
+     * pulsar client auth plugin class name
+     * e.g. org.apache.pulsar.client.impl.auth.AuthenticationToken
+     */
+    @JsonProperty("clientAuthPluginClassName")
+    private String clientAuthPluginClassName;
+
+    /**
+     * pulsar client auth params
+     * e.g. token:{tokenString}
+     * the tokenString should be compatible with the clientAuthPluginClassName see also in:
+     * <a href="https://pulsar.apache.org/docs/next/security-jwt/"> pulsar auth </a>
+     */
+    @JsonProperty("clientAuthParams")
+    private String clientAuthParams;
+
     @JsonCreator
     public PulsarExtractNode(@JsonProperty("id") String id,
             @JsonProperty("name") String name,
@@ -86,7 +102,10 @@ public class PulsarExtractNode extends ExtractNode implements InlongMetric, Meta
             @Nonnull @JsonProperty("scanStartupMode") String scanStartupMode,
             @JsonProperty("primaryKey") String primaryKey,
             @JsonProperty("scanStartupSubName") String scanStartupSubName,
-            @JsonProperty("scanStartupSubStartOffset") String scanStartupSubStartOffset) {
+            @JsonProperty("scanStartupSubStartOffset") String scanStartupSubStartOffset,
+            @JsonProperty("clientAuthPluginClassName") String clientAuthPluginClassName,
+            @JsonProperty("clientAuthParams") String clientAuthParams) {
+
         super(id, name, fields, watermarkField, properties);
         this.topic = Preconditions.checkNotNull(topic, "pulsar topic is null.");
         this.serviceUrl = Preconditions.checkNotNull(serviceUrl, "pulsar serviceUrl is null.");
@@ -97,6 +116,9 @@ public class PulsarExtractNode extends ExtractNode implements InlongMetric, Meta
         this.primaryKey = primaryKey;
         this.scanStartupSubName = scanStartupSubName;
         this.scanStartupSubStartOffset = scanStartupSubStartOffset;
+        this.clientAuthPluginClassName = clientAuthPluginClassName;
+        this.clientAuthParams = clientAuthParams;
+
     }
 
     /**
@@ -107,22 +129,26 @@ public class PulsarExtractNode extends ExtractNode implements InlongMetric, Meta
     @Override
     public Map<String, String> tableOptions() {
         Map<String, String> options = super.tableOptions();
-        if (StringUtils.isEmpty(this.primaryKey)) {
+        if (StringUtils.isBlank(this.primaryKey)) {
             options.put("connector", "pulsar-inlong");
             options.putAll(format.generateOptions(false));
         } else {
             options.put("connector", "upsert-pulsar-inlong");
             options.putAll(format.generateOptions(true));
         }
-        if (adminUrl != null) {
+        if (StringUtils.isNotBlank(adminUrl)) {
             options.put("admin-url", adminUrl);
         }
         options.put("service-url", serviceUrl);
         options.put("topic", topic);
         options.put("scan.startup.mode", scanStartupMode);
-        if (scanStartupSubName != null) {
+        if (StringUtils.isNotBlank(scanStartupSubName)) {
             options.put("scan.startup.sub-name", scanStartupSubName);
             options.put("scan.startup.sub-start-offset", scanStartupSubStartOffset);
+        }
+        if (StringUtils.isNotBlank(clientAuthPluginClassName)) {
+            options.put("pulsar.client.authPluginClassName", clientAuthPluginClassName);
+            options.put("pulsar.client.authParams", clientAuthParams);
         }
         return options;
     }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNodeTest.java
@@ -54,6 +54,5 @@ public class PulsarExtractNodeTest extends SerializeBaseTest<Node> {
                 "earliest",
                 "org.apache.pulsar.client.impl.auth.AuthenticationToken",
                 "token auth params");
-        );
     }
 }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/PulsarExtractNodeTest.java
@@ -51,6 +51,9 @@ public class PulsarExtractNodeTest extends SerializeBaseTest<Node> {
                 "earliest",
                 null,
                 "subscription",
-                "earliest");
+                "earliest",
+                "org.apache.pulsar.client.impl.auth.AuthenticationToken",
+                "token auth params");
+        );
     }
 }

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/PulsarSqlParserTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/PulsarSqlParserTest.java
@@ -77,7 +77,9 @@ public class PulsarSqlParserTest extends AbstractTestBase {
                 "earliest",
                 null,
                 "test",
-                "earliest");
+                "earliest",
+                "org.apache.pulsar.client.impl.auth.AuthenticationToken",
+                "token auth params");
     }
 
     private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {

--- a/inlong-sort/sort-dist/pom.xml
+++ b/inlong-sort/sort-dist/pom.xml
@@ -197,6 +197,11 @@
                     <artifactId>flink-sql-avro</artifactId>
                     <version>${flink.version}</version>
                 </dependency>
+                <dependency>
+                    <groupId>org.apache.inlong</groupId>
+                    <artifactId>audit-sdk</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
             </dependencies>
         </profile>
     </profiles>

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -429,4 +429,18 @@ public final class Constants {
                     .withDescription(
                             "Inner format");
 
+    public static final ConfigOption<String> PULSAR_CLIENT_AUTH_PLUGIN_CLASSNAME =
+            ConfigOptions.key("pulsar.client.authPluginClassName")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "pulsar client auth plugin class name");
+
+    public static final ConfigOption<String> PULSAR_AUTH_PARAMS =
+            ConfigOptions.key("pulsar.client.authParams")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "pulsar client auth params");
+
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarDynamicTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarDynamicTableFactory.java
@@ -79,6 +79,8 @@ import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
 import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.base.Constants.PULSAR_AUTH_PARAMS;
+import static org.apache.inlong.sort.base.Constants.PULSAR_CLIENT_AUTH_PLUGIN_CLASSNAME;
 
 /**
  * Copy from io.streamnative.connectors:pulsar-flink-connector_2.11:1.13.6.1-rc9
@@ -333,6 +335,8 @@ public class PulsarDynamicTableFactory
         options.add(INLONG_METRIC);
         options.add(INLONG_AUDIT);
         options.add(AUDIT_KEYS);
+        options.add(PULSAR_AUTH_PARAMS);
+        options.add(PULSAR_CLIENT_AUTH_PLUGIN_CLASSNAME);
 
         return options;
     }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableSource.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -54,6 +56,8 @@ public class PulsarTableSource implements ScanTableSource, SupportsReadingMetada
     // --------------------------------------------------------------------------------------------
     // Format attributes
     // --------------------------------------------------------------------------------------------
+
+    private static final Logger LOG = LoggerFactory.getLogger(PulsarTableSource.class);
 
     private static final String FORMAT_METADATA_PREFIX = "value.";
 
@@ -111,6 +115,7 @@ public class PulsarTableSource implements ScanTableSource, SupportsReadingMetada
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext context) {
         PulsarDeserializationSchema<RowData> deserializationSchema =
                 deserializationSchemaFactory.createPulsarDeserialization(context);
+        LOG.info("pulsar source init with properties: {}", properties);
         PulsarSource<RowData> source =
                 PulsarSource.builder()
                         .setTopics(topics)


### PR DESCRIPTION
- Fixes #9972

### Motivation

According to https://pulsar.apache.org/docs/next/security-jwt/
Some pulsar cluster have authentication opened in some cases, the sort connector should support authentication

### Modifications

Added two parameter used in authentication
1、pulsar client auth plugin class name, e.g. org.apache.pulsar.client.impl.auth.AuthenticationToken
2、pulsar client auth params, the value should be compatible with the clientAuthPluginClassName, see also in 
https://pulsar.apache.org/docs/next/security-jwt/

### Verifying this change

Tested in pulsar cluster with authentication and the ExtractNode teste in PulsarSqlParserTest
