### PR TITLE
[INLONG-9980][Manager] Remove the derby.jar file from the manager project

### DIFF
--- a/inlong-manager/manager-service/pom.xml
+++ b/inlong-manager/manager-service/pom.xml
@@ -224,6 +224,12 @@
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-standalone-metastore</artifactId>
             <version>${hive3x.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -467,6 +473,12 @@
             <groupId>org.apache.inlong</groupId>
             <artifactId>sdk-common</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.derby</groupId>
+                    <artifactId>derby</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9980 

### Motivation

The manager project does not use derby.jar, and the inclusion of derby.jar in the project may add new security shares, so remove it.