### PR TITLE
[INLONG-9990][Agent] Avoid MD5 calculation functions directly returning

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -478,7 +478,7 @@ public class ModuleManager extends AbstractDaemon {
     private static String calcFileMd5(String path) {
         byte[] buffer = new byte[DOWNLOAD_PACKAGE_READ_BUFF_SIZE];
         int len = 0;
-        String ret = "";
+        String ret = null;
         try (FileInputStream fileInputStream = new FileInputStream(path)) {
             MessageDigest md = MessageDigest.getInstance("MD5");
             while ((len = fileInputStream.read(buffer)) != -1) {

--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -478,18 +478,19 @@ public class ModuleManager extends AbstractDaemon {
     private static String calcFileMd5(String path) {
         byte[] buffer = new byte[DOWNLOAD_PACKAGE_READ_BUFF_SIZE];
         int len = 0;
+        String ret = "";
         try (FileInputStream fileInputStream = new FileInputStream(path)) {
             MessageDigest md = MessageDigest.getInstance("MD5");
             while ((len = fileInputStream.read(buffer)) != -1) {
                 md.update(buffer, 0, len);
             }
-            return new String(Hex.encodeHex(md.digest()));
+            ret = new String(Hex.encodeHex(md.digest()));
         } catch (NoSuchAlgorithmException e) {
             LOGGER.error("calc file md5 NoSuchAlgorithmException", e);
-            return "";
+
         } catch (IOException e) {
             LOGGER.error("calc file md5 IOException", e);
-            return "";
         }
+        return ret;
     }
 }


### PR DESCRIPTION
[INLONG-9990][Agent] Avoid MD5 calculation functions directly returning
- Fixes #9990

### Motivation

Avoid MD5 calculation functions directly returning

### Modifications

Avoid MD5 calculation functions directly returning

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
