### PR TITLE
[INLONG-9993][Audit] The data protocol adds an audit_version attribute

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/constant/Constants.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/constant/Constants.java
@@ -30,4 +30,7 @@ public class Constants {
     public static final String DEFAULT_KAFKA_TOPIC_FORMAT = "%s.%s";
     public static final String METRICS_AUDIT_PROXY_HOSTS_KEY = "metrics.audit.proxy.hosts";
 
+    // Default audit version is -1
+    public static final long DEFAULT_AUDIT_VERSION = -1;
+
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
@@ -104,4 +104,7 @@ public interface AttributeConstants {
     // calculate the end-to-end message delay; if this field does not exist in the request,
     // it will be added by the Bus with the current time
     public static final String MSG_RPT_TIME = "rtms";
+
+    //  Audit version is used for audit to reconciliation
+    String AUDIT_VERSION = "auditVersion";
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
@@ -103,7 +103,7 @@ public interface AttributeConstants {
     // the downstream by the Bus without modification for the downstream to
     // calculate the end-to-end message delay; if this field does not exist in the request,
     // it will be added by the Bus with the current time
-    public static final String MSG_RPT_TIME = "rtms";
+    String MSG_RPT_TIME = "rtms";
 
     // Audit version is used for audit to reconciliation
     String AUDIT_VERSION = "auditVersion";

--- a/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/msg/AttributeConstants.java
@@ -105,6 +105,6 @@ public interface AttributeConstants {
     // it will be added by the Bus with the current time
     public static final String MSG_RPT_TIME = "rtms";
 
-    //  Audit version is used for audit to reconciliation
+    // Audit version is used for audit to reconciliation
     String AUDIT_VERSION = "auditVersion";
 }


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #9993

### Motivation
![image](https://github.com/apache/inlong/assets/43397300/7081a243-3314-4e97-8606-b3cca1ffad4c)


*There is a scenario where data is re-recorded in the agent. Since each re-record needs to be audited and reconciled, each module of inlong needs to add an audit_version attribute uniformly.*

### Modifications

*The audit_version information is added to the attr attribute by the agent and transparently transmitted to DataProxy and sort.*
