### PR TITLE
[INLONG-9997][Agent] Handling situations where the installation package md5 remains unchanged and other parameters md5 change

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -318,8 +318,10 @@ public class ModuleManager extends AbstractDaemon {
     private void updateModule(ModuleConfig localModule, ModuleConfig managerModule) {
         LOGGER.info("update module {} start", localModule.getId());
         if (localModule.getPackageConfig().getMd5().equals(managerModule.getPackageConfig().getMd5())) {
-            LOGGER.info("module {} package md5 no change, will restart", localModule.getId());
+            LOGGER.info("module {} package md5 no change, will restart and save config", localModule.getId());
             restartModule(localModule, managerModule);
+            managerModule.setState(ModuleStateEnum.INSTALLED);
+            updateModuleConfig(managerModule);
         } else {
             LOGGER.info("module {} package md5 changed, will reinstall", localModule.getId());
             deleteModule(localModule);
@@ -343,6 +345,11 @@ public class ModuleManager extends AbstractDaemon {
             return;
         }
         currentModules.remove(module.getId());
+        saveToLocalFile(confPath);
+    }
+
+    private void updateModuleConfig(ModuleConfig module) {
+        currentModules.put(module.getId(), module);
         saveToLocalFile(confPath);
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/CommonInstance.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/CommonInstance.java
@@ -70,6 +70,7 @@ public abstract class CommonInstance extends Instance {
                     profile.getInstanceId(), profile.toJsonStr());
             source = (Source) Class.forName(profile.getSourceClass()).newInstance();
             source.init(profile);
+            source.start();
             sink = (Sink) Class.forName(profile.getSinkClass()).newInstance();
             sink.init(profile);
             inited = true;


### PR DESCRIPTION
[INLONG-9997][Agent] Handling situations where the installation package md5 remains unchanged and other parameters md5 change
- Fixes #9997

### Motivation

Handling situations where the installation package md5 remains unchanged and other parameters md5 change

### Modifications

Save config and restart the module

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
