### PR TITLE
[INLONG-9999][Agent] Handle scenarios where the module list is empty to prevent accidental deletion

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -115,6 +115,10 @@ public class ModuleManager extends AbstractDaemon {
         if (config == null) {
             return;
         }
+        if (config.getModuleList().isEmpty()) {
+            LOGGER.error("module list should not be empty!");
+            return;
+        }
         configQueue.clear();
         for (int i = 0; i < config.getModuleList().size(); i++) {
             LOGGER.info("submitModules index {} total {} {}", i, config.getModuleList().size(),
@@ -405,6 +409,10 @@ public class ModuleManager extends AbstractDaemon {
 
     private boolean isProcessAllStarted(ModuleConfig module) {
         String ret = ExcuteLinux.exeCmd(module.getCheckCommand());
+        if (ret == null) {
+            LOGGER.error("get module process num {} failed", module.getName());
+            return false;
+        }
         String[] processArray = ret.split("\n");
         int cnt = 0;
         for (int i = 0; i < processArray.length; i++) {


### PR DESCRIPTION
[INLONG-9999][Agent] Handle scenarios where the module list is empty to prevent accidental deletion
- Fixes #9999

### Motivation

Handle scenarios where the module list is empty to prevent accidental deletion

### Modifications

Directly return when the module list is empty

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
