### PR TITLE
[INLONG-10001][Dashboard] Fix end date time initialization error on audit page

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -178,7 +178,7 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
     type: 'datepicker',
     label: i18n.t('pages.GroupDetail.Audit.EndDate'),
     name: 'endDate',
-    initialValues: dayjs(initialValues.endDate),
+    initialValue: dayjs(initialValues.endDate),
     props: {
       allowClear: false,
       format: 'YYYY-MM-DD',


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #10001 

### Motivation

The end date time on the audit page was initialized incorrectly, causing an error when selecting an audit item.

### Modifications

Fix the initial value label.
