### PR TITLE
[INLONG-10003][Audit] Audit-service supports multiple data source clusters

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/consts/ConfigConstants.java
@@ -72,4 +72,5 @@ public class ConfigConstants {
     public static final String MANAGER_GET_CONFIG_PATH = "/audit/getConfig";
 
     public static final String MSG_VALID_THRESHOLD_DAYS = "msg.valid.threshold.days";
+    public static final String DEFAULT_AUDIT_TAG = "-1";
 }

--- a/inlong-audit/audit-release/pom.xml
+++ b/inlong-audit/audit-release/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>audit-proxy</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-service</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.apache.inlong.audit.consts.ConfigConstants.DEFAULT_AUDIT_TAG;
 import static org.apache.inlong.audit.protocol.AuditApi.BaseCommand.Type.AUDIT_REQUEST;
 
 public class AuditReporterImpl implements Serializable {
@@ -53,7 +54,6 @@ public class AuditReporterImpl implements Serializable {
     private static final long serialVersionUID = 1L;
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditReporterImpl.class);
     private static final String FIELD_SEPARATORS = ":";
-    private static final String DEFAULT_AUDIT_TAG = "-1";
     private static final long DEFAULT_AUDIT_VERSION = -1;
     private static final int BATCH_NUM = 100;
     private final ReentrantLock GLOBAL_LOCK = new ReentrantLock();

--- a/inlong-audit/audit-service/pom.xml
+++ b/inlong-audit/audit-service/pom.xml
@@ -35,6 +35,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/AbstractCache.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/AbstractCache.java
@@ -37,6 +37,7 @@ import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_CACHE_
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_CACHE_MAX_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_CACHE_EXPIRED_HOURS;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_CACHE_MAX_SIZE;
+import static org.apache.inlong.audit.consts.ConfigConstants.DEFAULT_AUDIT_TAG;
 
 /**
  * Abstract cache.
@@ -84,9 +85,10 @@ public class AbstractCache {
     public List<StatData> getData(String key) {
         StatData statData = cache.getIfPresent(key);
         if (null == statData) {
-            return new LinkedList<>();
+            // Compatible with scenarios where the auditTag openapi parameter can be empty.
+            statData = cache.getIfPresent(key + DEFAULT_AUDIT_TAG);
         }
-        return Collections.singletonList(statData);
+        return statData == null ? new LinkedList<>() : Collections.singletonList(statData);
     }
 
     /**

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/DayCache.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/DayCache.java
@@ -91,11 +91,10 @@ public class DayCache implements AutoCloseable {
      * @param inlongGroupId
      * @param inlongStreamId
      * @param auditId
-     * @param auditTag
      * @return
      */
     public List<StatData> getData(String startTime, String endTime, String inlongGroupId,
-            String inlongStreamId, String auditId, String auditTag) {
+            String inlongStreamId, String auditId) {
         List<StatData> result = new LinkedList<>();
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement pstat = connection.prepareStatement(querySql)) {

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -73,7 +73,6 @@ public class RealTimeQuery {
     private RealTimeQuery() {
         List<JdbcConfig> jdbcConfigList = ConfigService.getInstance().getAllAuditSource();
         for (JdbcConfig jdbcConfig : jdbcConfigList) {
-            assert false;
             dataSourceList.add(createDataSource(jdbcConfig));
         }
 

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -178,10 +178,10 @@ public class RealTimeQuery {
                     result.add(data);
                 }
             } catch (SQLException sqlException) {
-                LOGGER.error("Query has SQL exception! ", sqlException);
+                LOGGER.error("Query log time has SQL exception!, datasource={} ", dataSource, sqlException);
             }
         } catch (Exception exception) {
-            LOGGER.error("Query has exception! ", exception);
+            LOGGER.error("Query log time has exception!, datasource={} ", dataSource, exception);
         }
         return result;
     }
@@ -202,8 +202,6 @@ public class RealTimeQuery {
             if (!statDataList.isEmpty()) {
                 break;
             }
-            LOGGER.info("Change another audit source to query data! Params is: {} {} {} {}",
-                    startTime, endTime, ip, auditId);
         }
         return statDataList;
     }
@@ -240,10 +238,10 @@ public class RealTimeQuery {
                     result.add(data);
                 }
             } catch (SQLException sqlException) {
-                LOGGER.error("Query has SQL exception! ", sqlException);
+                LOGGER.error("Query inLongGroupIds has SQL exception!, datasource={} ", dataSource, sqlException);
             }
         } catch (Exception exception) {
-            LOGGER.error("Query has exception! ", exception);
+            LOGGER.error("Query inLongGroupIds has exception!, datasource={} ", dataSource, exception);
         }
         return result;
     }
@@ -302,10 +300,10 @@ public class RealTimeQuery {
                     result.add(data);
                 }
             } catch (SQLException sqlException) {
-                LOGGER.error("Query has SQL exception! ", sqlException);
+                LOGGER.error("Query ips has SQL exception!, datasource={} ", dataSource, sqlException);
             }
         } catch (Exception exception) {
-            LOGGER.error("Query has exception! ", exception);
+            LOGGER.error("Query ips has exception! ", exception);
         }
         return result;
     }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.cache;
+
+import org.apache.inlong.audit.config.Configuration;
+import org.apache.inlong.audit.entities.JdbcConfig;
+import org.apache.inlong.audit.entities.StatData;
+import org.apache.inlong.audit.service.ConfigService;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.apache.inlong.audit.config.ConfigConstants.CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CONNECTION_TIMEOUT;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_DATASOURCE_POOL_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_CONNECTION_TIMEOUT;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_POOL_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_SOURCE_QUERY_IDS_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_SOURCE_QUERY_IPS_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_SOURCE_QUERY_MINUTE_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.KEY_SOURCE_QUERY_IDS_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.KEY_SOURCE_QUERY_IPS_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.KEY_SOURCE_QUERY_MINUTE_SQL;
+
+/**
+ * Real time query data from audit source.
+ */
+public class RealTimeQuery {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RealTimeQuery.class);
+    private static volatile RealTimeQuery realTimeQuery = null;
+
+    private final List<DataSource> dataSourceList = new LinkedList<>();
+
+    private final String queryLogTsSql;
+    private final String queryIdsByIpSql;
+    private final String queryReportIpsSql;
+
+    private RealTimeQuery() {
+        List<JdbcConfig> jdbcConfigList = ConfigService.getInstance().getAllAuditSource();
+        for (JdbcConfig jdbcConfig : jdbcConfigList) {
+            assert false;
+            dataSourceList.add(createDataSource(jdbcConfig));
+        }
+
+        queryLogTsSql = Configuration.getInstance().get(KEY_SOURCE_QUERY_MINUTE_SQL,
+                DEFAULT_SOURCE_QUERY_MINUTE_SQL);
+        queryIdsByIpSql = Configuration.getInstance().get(KEY_SOURCE_QUERY_IDS_SQL,
+                DEFAULT_SOURCE_QUERY_IDS_SQL);
+        queryReportIpsSql = Configuration.getInstance().get(KEY_SOURCE_QUERY_IPS_SQL,
+                DEFAULT_SOURCE_QUERY_IPS_SQL);
+    }
+
+    public static RealTimeQuery getInstance() {
+        if (realTimeQuery == null) {
+            synchronized (Configuration.class) {
+                if (realTimeQuery == null) {
+                    realTimeQuery = new RealTimeQuery();
+                }
+            }
+        }
+        return realTimeQuery;
+    }
+
+    /**
+     * Create data source.
+     */
+    private DataSource createDataSource(JdbcConfig jdbcConfig) {
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName(jdbcConfig.getDriverClass());
+        config.setJdbcUrl(jdbcConfig.getJdbcUrl());
+        config.setUsername(jdbcConfig.getUserName());
+        config.setPassword(jdbcConfig.getPassword());
+        config.setConnectionTimeout(Configuration.getInstance().get(KEY_DATASOURCE_CONNECTION_TIMEOUT,
+                DEFAULT_CONNECTION_TIMEOUT));
+        config.addDataSourceProperty(CACHE_PREP_STMTS,
+                Configuration.getInstance().get(KEY_CACHE_PREP_STMTS, DEFAULT_CACHE_PREP_STMTS));
+        config.addDataSourceProperty(PREP_STMT_CACHE_SIZE,
+                Configuration.getInstance().get(KEY_PREP_STMT_CACHE_SIZE, DEFAULT_PREP_STMT_CACHE_SIZE));
+        config.addDataSourceProperty(PREP_STMT_CACHE_SQL_LIMIT,
+                Configuration.getInstance().get(KEY_PREP_STMT_CACHE_SQL_LIMIT, DEFAULT_PREP_STMT_CACHE_SQL_LIMIT));
+        config.setMaximumPoolSize(
+                Configuration.getInstance().get(KEY_DATASOURCE_POOL_SIZE,
+                        DEFAULT_DATASOURCE_POOL_SIZE));
+        return new HikariDataSource(config);
+    }
+
+    /**
+     * Query data which log time.
+     *
+     * @param startTime
+     * @param endTime
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param auditId
+     * @return
+     */
+    public List<StatData> queryLogTs(String startTime, String endTime, String inlongGroupId,
+            String inlongStreamId, String auditId) {
+        List<StatData> statDataList = new LinkedList<>();
+        for (DataSource dataSource : dataSourceList) {
+            statDataList =
+                    doQueryLogTs(dataSource, startTime, endTime, inlongGroupId, inlongStreamId, auditId);
+            if (!statDataList.isEmpty()) {
+                break;
+            }
+            LOGGER.info("Change another audit source to query data! Params is: {} {} {} {} {}",
+                    startTime, endTime, inlongGroupId, inlongStreamId, auditId);
+        }
+        return statDataList;
+    }
+
+    /**
+     * Do query log time.
+     *
+     * @param dataSource
+     * @param startTime
+     * @param endTime
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param auditId
+     * @return
+     */
+    private List<StatData> doQueryLogTs(DataSource dataSource, String startTime, String endTime, String inlongGroupId,
+            String inlongStreamId, String auditId) {
+        List<StatData> result = new LinkedList<>();
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement pstat = connection.prepareStatement(queryLogTsSql)) {
+            pstat.setString(1, startTime);
+            pstat.setString(2, endTime);
+            pstat.setString(3, inlongGroupId);
+            pstat.setString(4, inlongStreamId);
+            pstat.setString(5, auditId);
+            try (ResultSet resultSet = pstat.executeQuery()) {
+                while (resultSet.next()) {
+                    StatData data = new StatData();
+                    data.setLogTs(resultSet.getString(1));
+                    data.setInlongGroupId(resultSet.getString(2));
+                    data.setInlongStreamId(resultSet.getString(3));
+                    data.setAuditId(resultSet.getString(4));
+                    data.setAuditTag(resultSet.getString(5));
+                    data.setCount(resultSet.getLong(6));
+                    data.setSize(resultSet.getLong(7));
+                    data.setDelay(resultSet.getLong(8));
+                    result.add(data);
+                }
+            } catch (SQLException sqlException) {
+                LOGGER.error("Query has SQL exception! ", sqlException);
+            }
+        } catch (Exception exception) {
+            LOGGER.error("Query has exception! ", exception);
+        }
+        return result;
+    }
+
+    /**
+     * Query inlong group id by report ip.
+     *
+     * @param startTime
+     * @param endTime
+     * @param ip
+     * @param auditId
+     * @return
+     */
+    public List<StatData> queryIdsByIp(String startTime, String endTime, String ip, String auditId) {
+        List<StatData> statDataList = new LinkedList<>();
+        for (DataSource dataSource : dataSourceList) {
+            statDataList = doQueryIdsByIp(dataSource, startTime, endTime, ip, auditId);
+            if (!statDataList.isEmpty()) {
+                break;
+            }
+            LOGGER.info("Change another audit source to query data! Params is: {} {} {} {}",
+                    startTime, endTime, ip, auditId);
+        }
+        return statDataList;
+    }
+
+    /**
+     * Do query inlong group id by report ip.
+     *
+     * @param dataSource
+     * @param startTime
+     * @param endTime
+     * @param ip
+     * @param auditId
+     * @return
+     */
+    private List<StatData> doQueryIdsByIp(DataSource dataSource, String startTime, String endTime, String ip,
+            String auditId) {
+        List<StatData> result = new LinkedList<>();
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement pstat = connection.prepareStatement(queryIdsByIpSql)) {
+            pstat.setString(1, startTime);
+            pstat.setString(2, endTime);
+            pstat.setString(3, auditId);
+            pstat.setString(4, ip);
+            LOGGER.info("doQueryIdsByIp {}", pstat.toString());
+            try (ResultSet resultSet = pstat.executeQuery()) {
+                while (resultSet.next()) {
+                    StatData data = new StatData();
+                    data.setInlongGroupId(resultSet.getString(1));
+                    data.setInlongStreamId(resultSet.getString(2));
+                    data.setAuditId(resultSet.getString(3));
+                    data.setAuditTag(resultSet.getString(4));
+                    data.setCount(resultSet.getLong(5));
+                    data.setSize(resultSet.getLong(6));
+                    data.setDelay(resultSet.getLong(7));
+                    result.add(data);
+                }
+            } catch (SQLException sqlException) {
+                LOGGER.error("Query has SQL exception! ", sqlException);
+            }
+        } catch (Exception exception) {
+            LOGGER.error("Query has exception! ", exception);
+        }
+        return result;
+    }
+
+    /**
+     * Query report ips.
+     *
+     * @param startTime
+     * @param endTime
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param auditId
+     * @return
+     */
+    public List<StatData> queryReportIps(String startTime, String endTime, String inlongGroupId,
+            String inlongStreamId, String auditId) {
+        List<StatData> statDataList = new LinkedList<>();
+        for (DataSource dataSource : dataSourceList) {
+            statDataList = doQueryReportIps(dataSource, startTime, endTime, inlongGroupId, inlongStreamId, auditId);
+            if (!statDataList.isEmpty()) {
+                break;
+            }
+        }
+        return statDataList;
+    }
+
+    /**
+     * Do query report ips.
+     *
+     * @param dataSource
+     * @param startTime
+     * @param endTime
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param auditId
+     * @return
+     */
+    private List<StatData> doQueryReportIps(DataSource dataSource, String startTime, String endTime,
+            String inlongGroupId,
+            String inlongStreamId, String auditId) {
+        List<StatData> result = new LinkedList<>();
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement pstat = connection.prepareStatement(queryReportIpsSql)) {
+            pstat.setString(1, startTime);
+            pstat.setString(2, endTime);
+            pstat.setString(3, inlongGroupId);
+            pstat.setString(4, inlongStreamId);
+            pstat.setString(5, auditId);
+            try (ResultSet resultSet = pstat.executeQuery()) {
+                while (resultSet.next()) {
+                    StatData data = new StatData();
+                    data.setIp(resultSet.getString(1));
+                    data.setCount(resultSet.getLong(2));
+                    data.setSize(resultSet.getLong(3));
+                    data.setDelay(resultSet.getLong(4));
+                    result.add(data);
+                }
+            } catch (SQLException sqlException) {
+                LOGGER.error("Query has SQL exception! ", sqlException);
+            }
+        } catch (Exception exception) {
+            LOGGER.error("Query has exception! ", exception);
+        }
+        return result;
+    }
+}

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -120,7 +120,7 @@ public class RealTimeQuery {
     }
 
     /**
-     * Query data which log time.
+     * Query the audit data of log time.
      *
      * @param startTime
      * @param endTime
@@ -145,7 +145,7 @@ public class RealTimeQuery {
     }
 
     /**
-     * Do query log time.
+     * Do query the audit data of log time.
      *
      * @param dataSource
      * @param startTime

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -228,7 +228,6 @@ public class RealTimeQuery {
             pstat.setString(2, endTime);
             pstat.setString(3, auditId);
             pstat.setString(4, ip);
-            LOGGER.info("doQueryIdsByIp {}", pstat.toString());
             try (ResultSet resultSet = pstat.executeQuery()) {
                 while (resultSet.next()) {
                     StatData data = new StatData();
@@ -261,7 +260,7 @@ public class RealTimeQuery {
      * @return
      */
     public List<StatData> queryIpsById(String startTime, String endTime, String inlongGroupId,
-                                       String inlongStreamId, String auditId) {
+            String inlongStreamId, String auditId) {
         List<StatData> statDataList = new LinkedList<>();
         for (DataSource dataSource : dataSourceList) {
             statDataList = doQueryIpsById(dataSource, startTime, endTime, inlongGroupId, inlongStreamId, auditId);
@@ -284,8 +283,8 @@ public class RealTimeQuery {
      * @return
      */
     private List<StatData> doQueryIpsById(DataSource dataSource, String startTime, String endTime,
-                                          String inlongGroupId,
-                                          String inlongStreamId, String auditId) {
+            String inlongGroupId,
+            String inlongStreamId, String auditId) {
         List<StatData> result = new LinkedList<>();
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement pstat = connection.prepareStatement(queryReportIpsSql)) {

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -188,7 +188,7 @@ public class RealTimeQuery {
     }
 
     /**
-     * Query inlong group id by report ip.
+     * Query InLong group id by report ip.
      *
      * @param startTime
      * @param endTime
@@ -210,7 +210,7 @@ public class RealTimeQuery {
     }
 
     /**
-     * Do query inlong group id by report ip.
+     * Do query InLong group id by report ip.
      *
      * @param dataSource
      * @param startTime
@@ -260,11 +260,11 @@ public class RealTimeQuery {
      * @param auditId
      * @return
      */
-    public List<StatData> queryReportIps(String startTime, String endTime, String inlongGroupId,
-            String inlongStreamId, String auditId) {
+    public List<StatData> queryIpsById(String startTime, String endTime, String inlongGroupId,
+                                       String inlongStreamId, String auditId) {
         List<StatData> statDataList = new LinkedList<>();
         for (DataSource dataSource : dataSourceList) {
-            statDataList = doQueryReportIps(dataSource, startTime, endTime, inlongGroupId, inlongStreamId, auditId);
+            statDataList = doQueryIpsById(dataSource, startTime, endTime, inlongGroupId, inlongStreamId, auditId);
             if (!statDataList.isEmpty()) {
                 break;
             }
@@ -283,9 +283,9 @@ public class RealTimeQuery {
      * @param auditId
      * @return
      */
-    private List<StatData> doQueryReportIps(DataSource dataSource, String startTime, String endTime,
-            String inlongGroupId,
-            String inlongStreamId, String auditId) {
+    private List<StatData> doQueryIpsById(DataSource dataSource, String startTime, String endTime,
+                                          String inlongGroupId,
+                                          String inlongStreamId, String auditId) {
         List<StatData> result = new LinkedList<>();
         try (Connection connection = dataSource.getConnection();
                 PreparedStatement pstat = connection.prepareStatement(queryReportIpsSql)) {

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
@@ -22,13 +22,6 @@ package org.apache.inlong.audit.config;
  */
 public class ConfigConstants {
 
-    // Source config
-    public static final String KEY_CLICKHOUSE_DRIVER = "clickhouse.driver";
-    public static final String DEFAULT_CLICKHOUSE_DRIVER = "ru.yandex.clickhouse.ClickHouseDriver";
-    public static final String KEY_CLICKHOUSE_JDBC_URL = "clickhouse.jdbc.url";
-    public static final String KEY_CLICKHOUSE_USERNAME = "clickhouse.username";
-    public static final String KEY_CLICKHOUSE_PASSWORD = "clickhouse.password";
-
     // DB config
     public static final String KEY_MYSQL_DRIVER = "mysql.driver";
     public static final String KEY_DEFAULT_MYSQL_DRIVER = "com.mysql.cj.jdbc.Driver";
@@ -49,14 +42,14 @@ public class ConfigConstants {
     public static final int DEFAULT_SOURCE_DB_SINK_INTERVAL = 100;
     public static final String KEY_SOURCE_DB_SINK_BATCH = "sink.db.batch";
     public static final int DEFAULT_SOURCE_DB_SINK_BATCH = 1000;
+    public static final String KEY_UPDATE_CONFIG_INTERVAL_SECONDS = "update.config.interval.seconds";
+    public static final int DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS = 60;
 
     public static final String KEY_DATASOURCE_POOL_SIZE = "datasource.pool.size";
-    public static final int DEFAULT_DATASOURCE_POOL_SIZE = 1000;
+    public static final int DEFAULT_DATASOURCE_POOL_SIZE = 2;
 
     public static final String KEY_DATA_QUEUE_SIZE = "data.queue.size";
     public static final int DEFAULT_DATA_QUEUE_SIZE = 1000000;
-    public static final String KEY_AUDIT_IDS = "audit.ids";
-    public static final String DEFAULT_AUDIT_IDS = "3;4;5;6";
 
     // Summary config
     public static final String KEY_SUMMARY_REALTIME_STAT_BACK_TIMES = "summary.realtime.stat.back.times";

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
@@ -42,8 +42,8 @@ public class ConfigConstants {
     public static final int DEFAULT_SOURCE_DB_SINK_INTERVAL = 100;
     public static final String KEY_SOURCE_DB_SINK_BATCH = "sink.db.batch";
     public static final int DEFAULT_SOURCE_DB_SINK_BATCH = 1000;
-    public static final String KEY_UPDATE_CONFIG_INTERVAL_SECONDS = "update.config.interval.seconds";
-    public static final int DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS = 60;
+    public static final String KEY_CONFIG_UPDATE_INTERVAL_SECONDS = "config.update.interval.seconds";
+    public static final int DEFAULT_CONFIG_UPDATE_INTERVAL_SECONDS = 60;
 
     public static final String KEY_DATASOURCE_POOL_SIZE = "datasource.pool.size";
     public static final int DEFAULT_DATASOURCE_POOL_SIZE = 2;

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/Configuration.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/Configuration.java
@@ -74,7 +74,7 @@ public class Configuration {
 
     public boolean get(String key, boolean defaultValue) {
         Object value = properties.get(key);
-        return value == null ? defaultValue : (Boolean) value;
+        return value == null ? defaultValue : Boolean.parseBoolean((String) value);
     }
 
     /**
@@ -84,7 +84,7 @@ public class Configuration {
      */
     public int get(String key, int defaultValue) {
         Object value = properties.get(key);
-        return value == null ? defaultValue : (Integer) value;
+        return value == null ? defaultValue : Integer.parseInt((String) value);
     }
 
     /**
@@ -96,7 +96,7 @@ public class Configuration {
      */
     public double get(String key, double defaultValue) {
         Object value = properties.get(key);
-        return value == null ? defaultValue : (Double) value;
+        return value == null ? defaultValue : Double.parseDouble((String) value);
     }
 
     /**

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
@@ -27,7 +27,7 @@ public class OpenApiConstants {
     public static final String DEFAULT_API_HOUR_PATH = "/audit/query/hour";
     public static final String KEY_API_DAY_PATH = "api.day.path";
     public static final String DEFAULT_API_DAY_PATH = "/audit/query/day";
-    public static final String KEY_API_MINUTES_PATH = "api.minute.path";
+    public static final String KEY_API_MINUTES_PATH = "api.minutes.path";
     public static final String DEFAULT_API_MINUTES_PATH = "/audit/query/minutes";
     public static final String KEY_API_GET_IPS_PATH = "api.get.ips.path";
     public static final String DEFAULT_API_GET_IPS_PATH = "/audit/query/getIps";
@@ -48,14 +48,14 @@ public class OpenApiConstants {
     public static final int DEFAULT_API_CACHE_EXPIRED_HOURS = 12;
 
     // Http config
-    public static final String START_TIME = "startTime";
-    public static final String END_TIME = "endTime";
-    public static final String AUDIT_ID = "auditId";
-    public static final String AUDIT_TAG = "auditTag";
-    public static final String INLONG_GROUP_Id = "inlongGroupId";
-    public static final String INLONG_STREAM_Id = "inlongStreamId";
-    public static final String IP = "ip";
-    public static final String AUDIT_CYCLE = "auditCycle";
+    public static final String PARAMS_START_TIME = "startTime";
+    public static final String PARAMS_END_TIME = "endTime";
+    public static final String PARAMS_AUDIT_ID = "auditId";
+    public static final String PARAMS_AUDIT_TAG = "auditTag";
+    public static final String PARAMS_INLONG_GROUP_Id = "inlongGroupId";
+    public static final String PARAMS_INLONG_STREAM_Id = "inlongStreamId";
+    public static final String PARAMS_IP = "ip";
+    public static final String PARAMS_AUDIT_CYCLE = "auditCycle";
     public static final String KEY_HTTP_BODY_SUCCESS = "success";
     public static final String KEY_HTTP_BODY_ERR_MSG = "errMsg";
     public static final String KEY_HTTP_BODY_ERR_DATA = "data";

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
@@ -27,10 +27,12 @@ public class OpenApiConstants {
     public static final String DEFAULT_API_HOUR_PATH = "/audit/query/hour";
     public static final String KEY_API_DAY_PATH = "api.day.path";
     public static final String DEFAULT_API_DAY_PATH = "/audit/query/day";
-    public static final String KEY_API_MINUTE_10_PATH = "api.minute.10.path";
-    public static final String DEFAULT_API_MINUTE_10_PATH = "/audit/query/minute/10";
-    public static final String KEY_API_MINUTE_30_PATH = "api.minute.30.path";
-    public static final String DEFAULT_API_MINUTE_30_PATH = "/audit/query/minute/30";
+    public static final String KEY_API_MINUTES_PATH = "api.minute.path";
+    public static final String DEFAULT_API_MINUTES_PATH = "/audit/query/minutes";
+    public static final String KEY_API_GET_IPS_PATH = "api.get.ips.path";
+    public static final String DEFAULT_API_GET_IPS_PATH = "/audit/query/getIps";
+    public static final String KEY_API_GET_IDS_PATH = "api.get.ids.path";
+    public static final String DEFAULT_API_GET_IDS_PATH = "/audit/query/getIds";
     public static final String KEY_API_POOL_SIZE = "api.pool.size";
     public static final int DEFAULT_POOL_SIZE = 10;
     public static final String KEY_API_BACKLOG_SIZE = "api.backlog.size";
@@ -52,6 +54,8 @@ public class OpenApiConstants {
     public static final String AUDIT_TAG = "auditTag";
     public static final String INLONG_GROUP_Id = "inlongGroupId";
     public static final String INLONG_STREAM_Id = "inlongStreamId";
+    public static final String IP = "ip";
+    public static final String AUDIT_CYCLE = "auditCycle";
     public static final String KEY_HTTP_BODY_SUCCESS = "success";
     public static final String KEY_HTTP_BODY_ERR_MSG = "errMsg";
     public static final String KEY_HTTP_BODY_ERR_DATA = "data";

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
@@ -63,5 +63,5 @@ public class OpenApiConstants {
     public static final String VALUE_HTTP_HEADER_CONTENT_TYPE = "application/json;charset=utf-8";
     public static final int BIND_PORT = 80;
     public static final int HTTP_RESPOND_CODE = 200;
-    public static final String DEFAULT_AUDIT_TAG = "";
+    public static final String DEFAULT_PARAMS_AUDIT_TAG = "";
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/SqlConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/SqlConstants.java
@@ -34,9 +34,9 @@ public class SqlConstants {
             "select leader_id as leader from {0} where service_id=''{1}''";
     public static final String SELECT_TEST_SQL = "SELECT 1 ";
 
-    // ClickHouse query sql
-    public static final String KEY_CLICKHOUSE_SOURCE_QUERY_SQL = "clickhouse.source.query.sql";
-    public static final String DEFAULT_CLICKHOUSE_SOURCE_QUERY_SQL =
+    // Source query sql
+    public static final String KEY_SOURCE_STAT_SQL = "source.stat.sql";
+    public static final String DEFAULT_SOURCE_STAT_SQL =
             "SELECT inlong_group_id, inlong_stream_id, audit_id\n" +
                     "\t, audit_tag, cnt, size, delay,MAX(audit_version)\n" +
                     "FROM (\n" +
@@ -50,12 +50,59 @@ public class SqlConstants {
                     "\t\tFROM audit_data\n" +
                     "\t\tWHERE log_ts BETWEEN ? AND ? \n" +
                     "\t\t\tAND audit_id = ? \n" +
-                    "\t\tGROUP BY audit_version, docker_id, thread_id, sdk_ts, packet_id, log_ts, ip, inlong_group_id, inlong_stream_id, audit_id, audit_tag, count, size, delay\n"
+                    "\t\tGROUP BY audit_version, docker_id, thread_id, sdk_ts, packet_id, log_ts, ip, inlong_group_id, inlong_stream_id, audit_id, audit_tag, count, size, delay\n "
                     +
                     "\t) t1\n" +
                     "\tGROUP BY audit_version, inlong_group_id, inlong_stream_id, audit_id, audit_tag\n" +
                     ") t2\n" +
                     "GROUP BY inlong_group_id, inlong_stream_id, audit_id, audit_tag, cnt, size, delay";
+
+    public static final String KEY_SOURCE_QUERY_IPS_SQL = "source.query.ips.sql";
+    public static final String DEFAULT_SOURCE_QUERY_IPS_SQL =
+            "SELECT ip, sum(count) AS cnt, sum(size) AS size\n" +
+                    "\t, sum(delay) AS delay\n" +
+                    "FROM audit_data\n" +
+                    "WHERE log_ts BETWEEN ? AND ?\n" +
+                    "\tAND inlong_group_id = ? \n" +
+                    "\tAND inlong_stream_id =  ? \n" +
+                    "\tAND audit_id =  ? \n" +
+                    "GROUP BY ip ";
+
+    public static final String KEY_SOURCE_QUERY_IDS_SQL = "source.query.ids.sql";
+    public static final String DEFAULT_SOURCE_QUERY_IDS_SQL =
+            "SELECT inlong_group_id, inlong_stream_id, audit_id, audit_tag\n" +
+                    "\t, sum(count) AS cnt, sum(size) AS size\n" +
+                    "\t, sum(delay) AS delay\n" +
+                    "FROM audit_data\n" +
+                    "WHERE log_ts BETWEEN ? AND ? \n" +
+                    "\tAND audit_id = ? \n" +
+                    "\tAND ip = ? \n" +
+                    "GROUP BY inlong_group_id, inlong_stream_id, audit_id, audit_tag";
+
+    public static final String KEY_SOURCE_QUERY_MINUTE_SQL = "source.query.minute.sql";
+    public static final String DEFAULT_SOURCE_QUERY_MINUTE_SQL =
+            "SELECT log_ts, inlong_group_id, inlong_stream_id, audit_id, audit_tag\n" +
+                    "\t, cnt, size, delay, max(audit_version)\n" +
+                    "FROM (\n" +
+                    "\tSELECT audit_version, log_ts, inlong_group_id, inlong_stream_id, audit_id\n" +
+                    "\t\t, audit_tag, sum(count) AS cnt, sum(size) AS size\n" +
+                    "\t\t, sum(delay) AS delay\n" +
+                    "\tFROM (\n" +
+                    "\t\tSELECT audit_version, docker_id, thread_id, sdk_ts, packet_id\n" +
+                    "\t\t\t, log_ts, ip, inlong_group_id, inlong_stream_id, audit_id\n" +
+                    "\t\t\t, audit_tag, count, size, delay\n" +
+                    "\t\tFROM audit_data\n" +
+                    "\t\tWHERE log_ts BETWEEN ? AND ?\n" +
+                    "\t\t\tAND inlong_group_id = ?\n" +
+                    "\t\t\tAND inlong_stream_id = ?\n" +
+                    "\t\t\tAND audit_id = ? \n" +
+                    "\t\tGROUP BY audit_version, docker_id, thread_id, sdk_ts, packet_id, log_ts, ip, inlong_group_id, inlong_stream_id, audit_id, audit_tag, count, size, delay\n"
+                    +
+                    "\t) t1\n" +
+                    "\tGROUP BY audit_version, log_ts, inlong_group_id, inlong_stream_id, audit_id, audit_tag\n" +
+                    ") t2\n" +
+                    "GROUP BY log_ts, inlong_group_id, inlong_stream_id, audit_id, audit_tag, cnt, size, delay \n" +
+                    "limit 1440 ";
 
     // Mysql query sql
     public static final String KEY_MYSQL_SOURCE_QUERY_TEMP_SQL = "mysql.query.temp.sql";
@@ -72,6 +119,14 @@ public class SqlConstants {
     public static final String DEFAULT_MYSQL_SOURCE_QUERY_DAY_SQL =
             "select log_ts,inlong_group_id,inlong_stream_id,audit_id,audit_tag,count,size,delay " +
                     "from audit_data_day where log_ts between ? and ? and inlong_group_id=? and inlong_stream_id=? and audit_id =? ";
+
+    public static final String KEY_MYSQL_QUERY_AUDIT_ID_SQL = "mysql.query.audit.id.sql";
+    public static final String DEFAULT_MYSQL_QUERY_AUDIT_ID_SQL =
+            "select audit_id from audit_id_config where status=1 ";
+
+    public static final String KEY_MYSQL_QUERY_AUDIT_SOURCE_SQL = "mysql.query.audit.source.sql";
+    public static final String DEFAULT_MYSQL_QUERY_AUDIT_SOURCE_SQL =
+            "select jdbc_driver_class, jdbc_url, jdbc_user_name, jdbc_password, service_id from audit_source_config where status=1 ";
 
     // Mysql insert sql
     public static final String KEY_MYSQL_SINK_INSERT_DAY_SQL = "mysql.sink.insert.day.sql";

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/ApiType.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/ApiType.java
@@ -15,20 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.audit.utils;
+package org.apache.inlong.audit.entities;
 
 /**
- * Cache utils
+ * Openapi type
  */
-public class CacheUtils {
-
-    public static String buildCacheKey(String logTs, String inlongGroupId, String inlongStreamId,
-            String auditId) {
-        return new StringBuilder()
-                .append(logTs)
-                .append(inlongGroupId)
-                .append(inlongStreamId)
-                .append(auditId)
-                .toString();
-    }
+public enum ApiType {
+    MINUTES, HOUR, DAY, GET_IPS, GET_IDS;
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/ApiType.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/ApiType.java
@@ -18,7 +18,7 @@
 package org.apache.inlong.audit.entities;
 
 /**
- * Openapi type
+ * OpenAPI type
  */
 public enum ApiType {
     MINUTES, HOUR, DAY, GET_IPS, GET_IDS;

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/AuditCycle.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/AuditCycle.java
@@ -22,7 +22,7 @@ package org.apache.inlong.audit.entities;
  */
 public enum AuditCycle {
 
-    MINUTE_5(5), MINUTE_10(10), MINUTE_30(30), HOUR(60), DAY(1440);
+    MINUTE(1), MINUTE_5(5), MINUTE_10(10), MINUTE_30(30), HOUR(60), DAY(1440), UNKNOWN(1000);
 
     private final int cycle;
 
@@ -32,5 +32,20 @@ public enum AuditCycle {
 
     public int getValue() {
         return cycle;
+    }
+
+    /**
+     * Convert int to AuditCycle.
+     *
+     * @param value
+     * @return
+     */
+    public static AuditCycle fromInt(int value) {
+        for (AuditCycle auditCycle : AuditCycle.values()) {
+            if (auditCycle.getValue() == value) {
+                return auditCycle;
+            }
+        }
+        return UNKNOWN;
     }
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/StatData.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/entities/StatData.java
@@ -34,4 +34,5 @@ public class StatData {
     private Long size;
     private Long delay;
     private Timestamp updateTime;
+    private String ip;
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/main/Application.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/main/Application.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.audit.main;
 
 import org.apache.inlong.audit.service.ApiService;
+import org.apache.inlong.audit.service.ConfigService;
 import org.apache.inlong.audit.service.EtlService;
 
 import org.slf4j.Logger;
@@ -31,6 +32,9 @@ public class Application {
 
     public static void main(String[] args) {
         try {
+            // Periodically obtain audit id and audit course configuration from DB
+            ConfigService.getInstance().start();
+
             // Etl service aggregate the data from the data source and store the aggregated data to the target storage
             etlService.start();
 

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
@@ -46,9 +46,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
-import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_CYCLE;
-import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_ID;
-import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_TAG;
 import static org.apache.inlong.audit.config.OpenApiConstants.BIND_PORT;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_BACKLOG_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_DAY_PATH;
@@ -59,11 +56,7 @@ import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_MINUTE
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_REAL_LIMITER_QPS;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_PARAMS_AUDIT_TAG;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_POOL_SIZE;
-import static org.apache.inlong.audit.config.OpenApiConstants.END_TIME;
 import static org.apache.inlong.audit.config.OpenApiConstants.HTTP_RESPOND_CODE;
-import static org.apache.inlong.audit.config.OpenApiConstants.INLONG_GROUP_Id;
-import static org.apache.inlong.audit.config.OpenApiConstants.INLONG_STREAM_Id;
-import static org.apache.inlong.audit.config.OpenApiConstants.IP;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_BACKLOG_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_DAY_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_GET_IDS_PATH;
@@ -76,7 +69,14 @@ import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_BODY_ERR_
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_BODY_ERR_MSG;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_BODY_SUCCESS;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_HEADER_CONTENT_TYPE;
-import static org.apache.inlong.audit.config.OpenApiConstants.START_TIME;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_AUDIT_CYCLE;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_AUDIT_ID;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_AUDIT_TAG;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_END_TIME;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_INLONG_GROUP_Id;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_INLONG_STREAM_Id;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_IP;
+import static org.apache.inlong.audit.config.OpenApiConstants.PARAMS_START_TIME;
 import static org.apache.inlong.audit.config.OpenApiConstants.VALUE_HTTP_HEADER_CONTENT_TYPE;
 import static org.apache.inlong.audit.entities.ApiType.DAY;
 import static org.apache.inlong.audit.entities.ApiType.GET_IDS;
@@ -169,7 +169,7 @@ public class ApiService {
                     }
                 }
             }
-            params.putIfAbsent(AUDIT_TAG, DEFAULT_PARAMS_AUDIT_TAG);
+            params.putIfAbsent(PARAMS_AUDIT_TAG, DEFAULT_PARAMS_AUDIT_TAG);
             return params;
         }
 
@@ -178,23 +178,23 @@ public class ApiService {
                 case HOUR:
                 case DAY:
                 case GET_IPS:
-                    return params.containsKey(START_TIME)
-                            && params.containsKey(END_TIME)
-                            && params.containsKey(AUDIT_ID)
-                            && params.containsKey(INLONG_GROUP_Id)
-                            && params.containsKey(INLONG_STREAM_Id);
+                    return params.containsKey(PARAMS_START_TIME)
+                            && params.containsKey(PARAMS_END_TIME)
+                            && params.containsKey(PARAMS_AUDIT_ID)
+                            && params.containsKey(PARAMS_INLONG_GROUP_Id)
+                            && params.containsKey(PARAMS_INLONG_STREAM_Id);
                 case MINUTES:
-                    return params.containsKey(START_TIME)
-                            && params.containsKey(END_TIME)
-                            && params.containsKey(AUDIT_ID)
-                            && params.containsKey(INLONG_GROUP_Id)
-                            && params.containsKey(INLONG_STREAM_Id)
-                            && params.containsKey(AUDIT_CYCLE);
+                    return params.containsKey(PARAMS_START_TIME)
+                            && params.containsKey(PARAMS_END_TIME)
+                            && params.containsKey(PARAMS_AUDIT_ID)
+                            && params.containsKey(PARAMS_INLONG_GROUP_Id)
+                            && params.containsKey(PARAMS_INLONG_STREAM_Id)
+                            && params.containsKey(PARAMS_AUDIT_CYCLE);
                 case GET_IDS:
-                    return params.containsKey(START_TIME)
-                            && params.containsKey(END_TIME)
-                            && params.containsKey(AUDIT_ID)
-                            && params.containsKey(IP);
+                    return params.containsKey(PARAMS_START_TIME)
+                            && params.containsKey(PARAMS_END_TIME)
+                            && params.containsKey(PARAMS_AUDIT_ID)
+                            && params.containsKey(PARAMS_IP);
                 default:
                     return false;
             }
@@ -214,32 +214,34 @@ public class ApiService {
                     statData = handleMinutesApi(params);
                     break;
                 case HOUR:
-                    String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
-                            params.get(INLONG_STREAM_Id), params.get(AUDIT_ID), params.get(AUDIT_TAG));
+                    String cacheKey =
+                            CacheUtils.buildCacheKey(params.get(PARAMS_START_TIME), params.get(PARAMS_INLONG_GROUP_Id),
+                                    params.get(PARAMS_INLONG_STREAM_Id), params.get(PARAMS_AUDIT_ID),
+                                    params.get(PARAMS_AUDIT_TAG));
                     statData = HourCache.getInstance().getData(cacheKey);
                     break;
                 case DAY:
                     statData = DayCache.getInstance().getData(
-                            params.get(START_TIME),
-                            params.get(END_TIME),
-                            params.get(INLONG_GROUP_Id),
-                            params.get(INLONG_STREAM_Id),
-                            params.get(AUDIT_ID));
+                            params.get(PARAMS_START_TIME),
+                            params.get(PARAMS_END_TIME),
+                            params.get(PARAMS_INLONG_GROUP_Id),
+                            params.get(PARAMS_INLONG_STREAM_Id),
+                            params.get(PARAMS_AUDIT_ID));
                     break;
                 case GET_IDS:
                     statData = RealTimeQuery.getInstance().queryIdsByIp(
-                            params.get(START_TIME),
-                            params.get(END_TIME),
-                            params.get(IP),
-                            params.get(AUDIT_ID));
+                            params.get(PARAMS_START_TIME),
+                            params.get(PARAMS_END_TIME),
+                            params.get(PARAMS_IP),
+                            params.get(PARAMS_AUDIT_ID));
                     break;
                 case GET_IPS:
                     statData = RealTimeQuery.getInstance().queryIpsById(
-                            params.get(START_TIME),
-                            params.get(END_TIME),
-                            params.get(INLONG_GROUP_Id),
-                            params.get(INLONG_STREAM_Id),
-                            params.get(AUDIT_ID));
+                            params.get(PARAMS_START_TIME),
+                            params.get(PARAMS_END_TIME),
+                            params.get(PARAMS_INLONG_GROUP_Id),
+                            params.get(PARAMS_INLONG_STREAM_Id),
+                            params.get(PARAMS_AUDIT_ID));
                     break;
                 default:
                     LOGGER.error("Unsupported interface type! type is {}", apiType);
@@ -255,17 +257,18 @@ public class ApiService {
         }
 
         private List<StatData> handleMinutesApi(Map<String, String> params) {
-            String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
-                    params.get(INLONG_STREAM_Id), params.get(AUDIT_ID), params.get(AUDIT_TAG));
-            int cycle = Integer.parseInt(params.get(AUDIT_CYCLE));
+            String cacheKey = CacheUtils.buildCacheKey(params.get(PARAMS_START_TIME),
+                    params.get(PARAMS_INLONG_GROUP_Id),
+                    params.get(PARAMS_INLONG_STREAM_Id), params.get(PARAMS_AUDIT_ID), params.get(PARAMS_AUDIT_TAG));
+            int cycle = Integer.parseInt(params.get(PARAMS_AUDIT_CYCLE));
             List<StatData> statData = null;
             switch (AuditCycle.fromInt(cycle)) {
                 case MINUTE:
-                    statData = RealTimeQuery.getInstance().queryLogTs(params.get(START_TIME),
-                            params.get(END_TIME),
-                            params.get(INLONG_GROUP_Id),
-                            params.get(INLONG_STREAM_Id),
-                            params.get(AUDIT_ID));
+                    statData = RealTimeQuery.getInstance().queryLogTs(params.get(PARAMS_START_TIME),
+                            params.get(PARAMS_END_TIME),
+                            params.get(PARAMS_INLONG_GROUP_Id),
+                            params.get(PARAMS_INLONG_STREAM_Id),
+                            params.get(PARAMS_AUDIT_ID));
                     break;
                 case MINUTE_10:
                     statData = TenMinutesCache.getInstance().getData(cacheKey);

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
@@ -234,7 +234,7 @@ public class ApiService {
                             params.get(AUDIT_ID));
                     break;
                 case GET_IPS:
-                    statData = RealTimeQuery.getInstance().queryReportIps(
+                    statData = RealTimeQuery.getInstance().queryIpsById(
                             params.get(START_TIME),
                             params.get(END_TIME),
                             params.get(INLONG_GROUP_Id),

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
@@ -57,7 +57,7 @@ import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_GET_IP
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_HOUR_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_MINUTES_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_REAL_LIMITER_QPS;
-import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_AUDIT_TAG;
+import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_PARAMS_AUDIT_TAG;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_POOL_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.END_TIME;
 import static org.apache.inlong.audit.config.OpenApiConstants.HTTP_RESPOND_CODE;
@@ -169,7 +169,7 @@ public class ApiService {
                     }
                 }
             }
-            params.putIfAbsent(AUDIT_TAG, DEFAULT_AUDIT_TAG);
+            params.putIfAbsent(AUDIT_TAG, DEFAULT_PARAMS_AUDIT_TAG);
             return params;
         }
 
@@ -215,7 +215,7 @@ public class ApiService {
                     break;
                 case HOUR:
                     String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
-                            params.get(INLONG_STREAM_Id), params.get(AUDIT_ID));
+                            params.get(INLONG_STREAM_Id), params.get(AUDIT_ID), params.get(AUDIT_TAG));
                     statData = HourCache.getInstance().getData(cacheKey);
                     break;
                 case DAY:
@@ -256,7 +256,7 @@ public class ApiService {
 
         private List<StatData> handleMinutesApi(Map<String, String> params) {
             String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
-                    params.get(INLONG_STREAM_Id), params.get(AUDIT_ID));
+                    params.get(INLONG_STREAM_Id), params.get(AUDIT_ID), params.get(AUDIT_TAG));
             int cycle = Integer.parseInt(params.get(AUDIT_CYCLE));
             List<StatData> statData = null;
             switch (AuditCycle.fromInt(cycle)) {

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ApiService.java
@@ -20,8 +20,10 @@ package org.apache.inlong.audit.service;
 import org.apache.inlong.audit.cache.DayCache;
 import org.apache.inlong.audit.cache.HalfHourCache;
 import org.apache.inlong.audit.cache.HourCache;
+import org.apache.inlong.audit.cache.RealTimeQuery;
 import org.apache.inlong.audit.cache.TenMinutesCache;
 import org.apache.inlong.audit.config.Configuration;
+import org.apache.inlong.audit.entities.ApiType;
 import org.apache.inlong.audit.entities.AuditCycle;
 import org.apache.inlong.audit.entities.StatData;
 import org.apache.inlong.audit.utils.CacheUtils;
@@ -44,14 +46,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 
+import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_CYCLE;
 import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_ID;
 import static org.apache.inlong.audit.config.OpenApiConstants.AUDIT_TAG;
 import static org.apache.inlong.audit.config.OpenApiConstants.BIND_PORT;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_BACKLOG_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_DAY_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_GET_IDS_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_GET_IPS_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_HOUR_PATH;
-import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_MINUTE_10_PATH;
-import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_MINUTE_30_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_MINUTES_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_API_REAL_LIMITER_QPS;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_AUDIT_TAG;
 import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_POOL_SIZE;
@@ -59,11 +63,13 @@ import static org.apache.inlong.audit.config.OpenApiConstants.END_TIME;
 import static org.apache.inlong.audit.config.OpenApiConstants.HTTP_RESPOND_CODE;
 import static org.apache.inlong.audit.config.OpenApiConstants.INLONG_GROUP_Id;
 import static org.apache.inlong.audit.config.OpenApiConstants.INLONG_STREAM_Id;
+import static org.apache.inlong.audit.config.OpenApiConstants.IP;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_BACKLOG_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_DAY_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_GET_IDS_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_GET_IPS_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_HOUR_PATH;
-import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_MINUTE_10_PATH;
-import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_MINUTE_30_PATH;
+import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_MINUTES_PATH;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_POOL_SIZE;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_API_REAL_LIMITER_QPS;
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_BODY_ERR_DATA;
@@ -72,6 +78,11 @@ import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_BODY_SUCC
 import static org.apache.inlong.audit.config.OpenApiConstants.KEY_HTTP_HEADER_CONTENT_TYPE;
 import static org.apache.inlong.audit.config.OpenApiConstants.START_TIME;
 import static org.apache.inlong.audit.config.OpenApiConstants.VALUE_HTTP_HEADER_CONTENT_TYPE;
+import static org.apache.inlong.audit.entities.ApiType.DAY;
+import static org.apache.inlong.audit.entities.ApiType.GET_IDS;
+import static org.apache.inlong.audit.entities.ApiType.GET_IPS;
+import static org.apache.inlong.audit.entities.ApiType.HOUR;
+import static org.apache.inlong.audit.entities.ApiType.MINUTES;
 
 public class ApiService {
 
@@ -92,14 +103,15 @@ public class ApiService {
             server.setExecutor(Executors.newFixedThreadPool(
                     Configuration.getInstance().get(KEY_API_POOL_SIZE, DEFAULT_POOL_SIZE)));
             server.createContext(Configuration.getInstance().get(KEY_API_DAY_PATH, DEFAULT_API_DAY_PATH),
-                    new AuditHandler(AuditCycle.DAY));
+                    new AuditHandler(DAY));
             server.createContext(Configuration.getInstance().get(KEY_API_HOUR_PATH, DEFAULT_API_HOUR_PATH),
-                    new AuditHandler(AuditCycle.HOUR));
-            server.createContext(
-                    Configuration.getInstance().get(KEY_API_MINUTE_10_PATH, DEFAULT_API_MINUTE_10_PATH),
-                    new AuditHandler(AuditCycle.MINUTE_10));
-            server.createContext(Configuration.getInstance().get(KEY_API_MINUTE_30_PATH, DEFAULT_API_MINUTE_30_PATH),
-                    new AuditHandler(AuditCycle.MINUTE_30));
+                    new AuditHandler(HOUR));
+            server.createContext(Configuration.getInstance().get(KEY_API_MINUTES_PATH, DEFAULT_API_MINUTES_PATH),
+                    new AuditHandler(MINUTES));
+            server.createContext(Configuration.getInstance().get(KEY_API_GET_IDS_PATH, DEFAULT_API_GET_IDS_PATH),
+                    new AuditHandler(GET_IDS));
+            server.createContext(Configuration.getInstance().get(KEY_API_GET_IPS_PATH, DEFAULT_API_GET_IPS_PATH),
+                    new AuditHandler(GET_IPS));
             server.start();
         } catch (Exception e) {
             LOGGER.error("Init http server has exception!", e);
@@ -108,10 +120,10 @@ public class ApiService {
 
     static class AuditHandler implements HttpHandler, AutoCloseable {
 
-        private final AuditCycle apiType;
+        private final ApiType apiType;
         private final RateLimiter limiter;
 
-        public AuditHandler(AuditCycle apiType) {
+        public AuditHandler(ApiType apiType) {
             this.apiType = apiType;
             limiter = RateLimiter.create(Configuration.getInstance().get(KEY_API_REAL_LIMITER_QPS,
                     DEFAULT_API_REAL_LIMITER_QPS));
@@ -127,10 +139,10 @@ public class ApiService {
                 JsonObject responseJson = new JsonObject();
 
                 Map<String, String> params = parseRequestURI(exchange.getRequestURI().getQuery());
-                if (!checkParams(params)) {
-                    handleInvalidParams(responseJson, exchange);
-                } else {
+                if (checkNecessaryParams(params)) {
                     handleLegalParams(responseJson, params);
+                } else {
+                    handleInvalidParams(responseJson, exchange);
                 }
 
                 byte[] bytes = responseJson.toString().getBytes(StandardCharsets.UTF_8);
@@ -161,12 +173,31 @@ public class ApiService {
             return params;
         }
 
-        private boolean checkParams(Map<String, String> params) {
-            return params.containsKey(START_TIME)
-                    && params.containsKey(END_TIME)
-                    && params.containsKey(AUDIT_ID)
-                    && params.containsKey(INLONG_GROUP_Id)
-                    && params.containsKey(INLONG_STREAM_Id);
+        private boolean checkNecessaryParams(Map<String, String> params) {
+            switch (apiType) {
+                case HOUR:
+                case DAY:
+                case GET_IPS:
+                    return params.containsKey(START_TIME)
+                            && params.containsKey(END_TIME)
+                            && params.containsKey(AUDIT_ID)
+                            && params.containsKey(INLONG_GROUP_Id)
+                            && params.containsKey(INLONG_STREAM_Id);
+                case MINUTES:
+                    return params.containsKey(START_TIME)
+                            && params.containsKey(END_TIME)
+                            && params.containsKey(AUDIT_ID)
+                            && params.containsKey(INLONG_GROUP_Id)
+                            && params.containsKey(INLONG_STREAM_Id)
+                            && params.containsKey(AUDIT_CYCLE);
+                case GET_IDS:
+                    return params.containsKey(START_TIME)
+                            && params.containsKey(END_TIME)
+                            && params.containsKey(AUDIT_ID)
+                            && params.containsKey(IP);
+                default:
+                    return false;
+            }
         }
 
         private void handleInvalidParams(JsonObject responseJson, HttpExchange exchange) {
@@ -177,18 +208,14 @@ public class ApiService {
         }
 
         private void handleLegalParams(JsonObject responseJson, Map<String, String> params) {
-            String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
-                    params.get(INLONG_STREAM_Id), params.get(AUDIT_ID), params.get(AUDIT_TAG));
-            LOGGER.info("handleLegalParams cacheKey {}", cacheKey);
             List<StatData> statData = null;
             switch (apiType) {
-                case MINUTE_10:
-                    statData = TenMinutesCache.getInstance().getData(cacheKey);
-                    break;
-                case MINUTE_30:
-                    statData = HalfHourCache.getInstance().getData(cacheKey);
+                case MINUTES:
+                    statData = handleMinutesApi(params);
                     break;
                 case HOUR:
+                    String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
+                            params.get(INLONG_STREAM_Id), params.get(AUDIT_ID));
                     statData = HourCache.getInstance().getData(cacheKey);
                     break;
                 case DAY:
@@ -197,12 +224,27 @@ public class ApiService {
                             params.get(END_TIME),
                             params.get(INLONG_GROUP_Id),
                             params.get(INLONG_STREAM_Id),
-                            params.get(AUDIT_ID),
-                            params.get(AUDIT_TAG));
+                            params.get(AUDIT_ID));
+                    break;
+                case GET_IDS:
+                    statData = RealTimeQuery.getInstance().queryIdsByIp(
+                            params.get(START_TIME),
+                            params.get(END_TIME),
+                            params.get(IP),
+                            params.get(AUDIT_ID));
+                    break;
+                case GET_IPS:
+                    statData = RealTimeQuery.getInstance().queryReportIps(
+                            params.get(START_TIME),
+                            params.get(END_TIME),
+                            params.get(INLONG_GROUP_Id),
+                            params.get(INLONG_STREAM_Id),
+                            params.get(AUDIT_ID));
                     break;
                 default:
                     LOGGER.error("Unsupported interface type! type is {}", apiType);
             }
+
             if (null == statData)
                 statData = new LinkedList<>();
 
@@ -210,6 +252,31 @@ public class ApiService {
             responseJson.addProperty(KEY_HTTP_BODY_ERR_MSG, "");
             Gson gson = new Gson();
             responseJson.add(KEY_HTTP_BODY_ERR_DATA, gson.toJsonTree(statData));
+        }
+
+        private List<StatData> handleMinutesApi(Map<String, String> params) {
+            String cacheKey = CacheUtils.buildCacheKey(params.get(START_TIME), params.get(INLONG_GROUP_Id),
+                    params.get(INLONG_STREAM_Id), params.get(AUDIT_ID));
+            int cycle = Integer.parseInt(params.get(AUDIT_CYCLE));
+            List<StatData> statData = null;
+            switch (AuditCycle.fromInt(cycle)) {
+                case MINUTE:
+                    statData = RealTimeQuery.getInstance().queryLogTs(params.get(START_TIME),
+                            params.get(END_TIME),
+                            params.get(INLONG_GROUP_Id),
+                            params.get(INLONG_STREAM_Id),
+                            params.get(AUDIT_ID));
+                    break;
+                case MINUTE_10:
+                    statData = TenMinutesCache.getInstance().getData(cacheKey);
+                    break;
+                case MINUTE_30:
+                    statData = HalfHourCache.getInstance().getData(cacheKey);
+                    break;
+                default:
+                    LOGGER.error("Unsupported cycle type! cycle is {}", cycle);
+            }
+            return statData;
         }
 
         @Override

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
@@ -43,17 +43,17 @@ import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.audit.config.ConfigConstants.CACHE_PREP_STMTS;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CONFIG_UPDATE_INTERVAL_SECONDS;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CONNECTION_TIMEOUT;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_DATASOURCE_POOL_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SQL_LIMIT;
-import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_CONFIG_UPDATE_INTERVAL_SECONDS;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_CONNECTION_TIMEOUT;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_POOL_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SQL_LIMIT;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_UPDATE_CONFIG_INTERVAL_SECONDS;
 import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SQL_LIMIT;
 import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_MYSQL_QUERY_AUDIT_ID_SQL;
@@ -104,8 +104,8 @@ public class ConfigService {
                 updateAuditSource();
             }
         }, 0,
-                Configuration.getInstance().get(KEY_UPDATE_CONFIG_INTERVAL_SECONDS,
-                        DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS),
+                Configuration.getInstance().get(KEY_CONFIG_UPDATE_INTERVAL_SECONDS,
+                        DEFAULT_CONFIG_UPDATE_INTERVAL_SECONDS),
                 TimeUnit.SECONDS);
     }
 

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
@@ -144,14 +144,14 @@ public class ConfigService {
             }
 
             try (ResultSet resultSet = pstat.executeQuery()) {
-                CopyOnWriteArrayList<String> auditIdList = new CopyOnWriteArrayList<>();
+                CopyOnWriteArrayList<String> auditIdsTemp = new CopyOnWriteArrayList<>();
                 while (resultSet.next()) {
                     String auditId = resultSet.getString(1);
                     LOGGER.info("Update audit id {}", auditId);
-                    auditIdList.add(auditId);
+                    auditIdsTemp.add(auditId);
                 }
-                if (!auditIdList.isEmpty()) {
-                    auditIds = auditIdList;
+                if (!auditIdsTemp.isEmpty()) {
+                    auditIds = auditIdsTemp;
                 }
             } catch (SQLException sqlException) {
                 LOGGER.error("Query has SQL exception! ", sqlException);
@@ -172,19 +172,19 @@ public class ConfigService {
                 createDataSource();
             }
             try (ResultSet resultSet = pstat.executeQuery()) {
-                ConcurrentHashMap<String, List<JdbcConfig>> auditSource = new ConcurrentHashMap<>();
+                ConcurrentHashMap<String, List<JdbcConfig>> auditSourcesTemp = new ConcurrentHashMap<>();
                 while (resultSet.next()) {
                     JdbcConfig data = new JdbcConfig(resultSet.getString(1),
                             resultSet.getString(2),
                             resultSet.getString(3),
                             resultSet.getString(4));
                     String serviceId = resultSet.getString(5);
-                    List<JdbcConfig> config = auditSource.computeIfAbsent(serviceId, k -> new LinkedList<>());
+                    List<JdbcConfig> config = auditSourcesTemp.computeIfAbsent(serviceId, k -> new LinkedList<>());
                     config.add(data);
                     LOGGER.info("Update audit source service id = {}, jdbc config = {}", serviceId, data);
                 }
-                if (!auditSource.isEmpty()) {
-                    auditSources = auditSource;
+                if (!auditSourcesTemp.isEmpty()) {
+                    auditSources = auditSourcesTemp;
                 }
             } catch (SQLException sqlException) {
                 LOGGER.error("Query has SQL exception! ", sqlException);

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
@@ -1,0 +1,228 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.service;
+
+import org.apache.inlong.audit.config.Configuration;
+import org.apache.inlong.audit.entities.JdbcConfig;
+import org.apache.inlong.audit.utils.JdbcUtils;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.audit.config.ConfigConstants.CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CONNECTION_TIMEOUT;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_DATASOURCE_POOL_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_CACHE_PREP_STMTS;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_CONNECTION_TIMEOUT;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_POOL_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.ConfigConstants.KEY_UPDATE_CONFIG_INTERVAL_SECONDS;
+import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SIZE;
+import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SQL_LIMIT;
+import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_MYSQL_QUERY_AUDIT_ID_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.DEFAULT_MYSQL_QUERY_AUDIT_SOURCE_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.KEY_MYSQL_QUERY_AUDIT_ID_SQL;
+import static org.apache.inlong.audit.config.SqlConstants.KEY_MYSQL_QUERY_AUDIT_SOURCE_SQL;
+
+/**
+ * ConfigService periodically pull the configuration of audit id and audit source from DB.
+ */
+public class ConfigService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigService.class);
+
+    private static volatile ConfigService configService = null;
+    private CopyOnWriteArrayList<String> auditIds = new CopyOnWriteArrayList<>();
+    protected final ScheduledExecutorService updateTimer = Executors.newSingleThreadScheduledExecutor();
+    private DataSource dataSource;
+    private ConcurrentHashMap<String, List<JdbcConfig>> auditSources = new ConcurrentHashMap<>();
+    private final String queryAuditIdSql;
+    private final String queryAuditSourceSql;
+
+    public static ConfigService getInstance() {
+        if (configService == null) {
+            synchronized (ConfigService.class) {
+                if (configService == null) {
+                    configService = new ConfigService();
+                }
+            }
+        }
+        return configService;
+    }
+
+    private ConfigService() {
+        queryAuditIdSql = Configuration.getInstance().get(KEY_MYSQL_QUERY_AUDIT_ID_SQL,
+                DEFAULT_MYSQL_QUERY_AUDIT_ID_SQL);
+        queryAuditSourceSql = Configuration.getInstance().get(KEY_MYSQL_QUERY_AUDIT_SOURCE_SQL,
+                DEFAULT_MYSQL_QUERY_AUDIT_SOURCE_SQL);
+    }
+
+    public void start() {
+        createDataSource();
+        updateTimer.scheduleWithFixedDelay(new Runnable() {
+
+            @Override
+            public void run() {
+                updateAuditIds();
+                updateAuditSource();
+            }
+        }, 0,
+                Configuration.getInstance().get(KEY_UPDATE_CONFIG_INTERVAL_SECONDS,
+                        DEFAULT_UPDATE_CONFIG_INTERVAL_SECONDS),
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Create data source.
+     */
+    private void createDataSource() {
+        JdbcConfig jdbcConfig = JdbcUtils.buildMysqlConfig();
+        HikariConfig config = new HikariConfig();
+        config.setDriverClassName(jdbcConfig.getDriverClass());
+        config.setJdbcUrl(jdbcConfig.getJdbcUrl());
+        config.setUsername(jdbcConfig.getUserName());
+        config.setPassword(jdbcConfig.getPassword());
+        config.setConnectionTimeout(Configuration.getInstance().get(KEY_DATASOURCE_CONNECTION_TIMEOUT,
+                DEFAULT_CONNECTION_TIMEOUT));
+        config.addDataSourceProperty(CACHE_PREP_STMTS,
+                Configuration.getInstance().get(KEY_CACHE_PREP_STMTS, DEFAULT_CACHE_PREP_STMTS));
+        config.addDataSourceProperty(PREP_STMT_CACHE_SIZE,
+                Configuration.getInstance().get(KEY_PREP_STMT_CACHE_SIZE, DEFAULT_PREP_STMT_CACHE_SIZE));
+        config.addDataSourceProperty(PREP_STMT_CACHE_SQL_LIMIT,
+                Configuration.getInstance().get(KEY_PREP_STMT_CACHE_SQL_LIMIT, DEFAULT_PREP_STMT_CACHE_SQL_LIMIT));
+        config.setMaximumPoolSize(
+                Configuration.getInstance().get(KEY_DATASOURCE_POOL_SIZE,
+                        DEFAULT_DATASOURCE_POOL_SIZE));
+        dataSource = new HikariDataSource(config);
+    }
+
+    /**
+     * Update audit ids.
+     */
+    private void updateAuditIds() {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement pstat = connection.prepareStatement(queryAuditIdSql)) {
+            if (connection.isClosed()) {
+                createDataSource();
+            }
+
+            try (ResultSet resultSet = pstat.executeQuery()) {
+                CopyOnWriteArrayList<String> auditIdList = new CopyOnWriteArrayList<>();
+                while (resultSet.next()) {
+                    String auditId = resultSet.getString(1);
+                    LOGGER.info("Update audit id {}", auditId);
+                    auditIdList.add(auditId);
+                }
+                if (!auditIdList.isEmpty()) {
+                    auditIds = auditIdList;
+                }
+            } catch (SQLException sqlException) {
+                LOGGER.error("Query has SQL exception! ", sqlException);
+            }
+
+        } catch (Exception exception) {
+            LOGGER.error("Query has exception! ", exception);
+        }
+    }
+
+    /**
+     * Update audit source.
+     */
+    private void updateAuditSource() {
+        try (Connection connection = dataSource.getConnection();
+                PreparedStatement pstat = connection.prepareStatement(queryAuditSourceSql)) {
+            if (connection.isClosed()) {
+                createDataSource();
+            }
+            try (ResultSet resultSet = pstat.executeQuery()) {
+                ConcurrentHashMap<String, List<JdbcConfig>> auditSource = new ConcurrentHashMap<>();
+                while (resultSet.next()) {
+                    JdbcConfig data = new JdbcConfig(resultSet.getString(1),
+                            resultSet.getString(2),
+                            resultSet.getString(3),
+                            resultSet.getString(4));
+                    String serviceId = resultSet.getString(5);
+                    List<JdbcConfig> config = auditSource.computeIfAbsent(serviceId, k -> new LinkedList<>());
+                    config.add(data);
+                    LOGGER.info("Update audit source service id = {}, jdbc config = {}", serviceId, data);
+                }
+                if (!auditSource.isEmpty()) {
+                    auditSources = auditSource;
+                }
+            } catch (SQLException sqlException) {
+                LOGGER.error("Query has SQL exception! ", sqlException);
+            }
+        } catch (Exception exception) {
+            LOGGER.error("Query has exception! ", exception);
+        }
+    }
+
+    /**
+     * Get audit ids.
+     *
+     * @return
+     */
+    public List<String> getAuditIds() {
+        return auditIds = auditIds == null ? new CopyOnWriteArrayList<>() : auditIds;
+    }
+
+    /**
+     * Get all audit source.
+     *
+     * @return
+     */
+    public List<JdbcConfig> getAllAuditSource() {
+        List<JdbcConfig> sourceList = new LinkedList<>();
+        for (Map.Entry<String, List<JdbcConfig>> entry : auditSources.entrySet()) {
+            sourceList.addAll(entry.getValue());
+        }
+        return sourceList;
+    }
+
+    /**
+     * Get audit source by service id.
+     *
+     * @param serviceId
+     * @return
+     */
+    public List<JdbcConfig> getAuditSourceByServiceId(String serviceId) {
+        return auditSources.get(serviceId);
+    }
+}

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/EtlService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/EtlService.java
@@ -170,7 +170,7 @@ public class EtlService {
         DataQueue dataQueue = new DataQueue(queueSize);
         List<JdbcConfig> sourceList = ConfigService.getInstance().getAuditSourceByServiceId(serviceId);
         for (JdbcConfig jdbcConfig : sourceList) {
-            JdbcSource jdbcSource= new JdbcSource(dataQueue, buildAuditJdbcSourceConfig(jdbcConfig));
+            JdbcSource jdbcSource = new JdbcSource(dataQueue, buildAuditJdbcSourceConfig(jdbcConfig));
             jdbcSource.start();
             auditJdbcSources.add(jdbcSource);
             LOGGER.info("Audit source to mysql jdbc config:{}", jdbcConfig);

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/sink/CacheSink.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/sink/CacheSink.java
@@ -72,7 +72,7 @@ public class CacheSink {
             StatData data = dataQueue.pull(pullTimeOut, TimeUnit.MILLISECONDS);
             while (data != null) {
                 String cacheKey = CacheUtils.buildCacheKey(data.getLogTs(), data.getInlongGroupId(),
-                        data.getInlongStreamId(), data.getAuditId());
+                        data.getInlongStreamId(), data.getAuditId(), data.getAuditTag());
                 cache.put(cacheKey, data);
                 data = dataQueue.pull(pullTimeOut, TimeUnit.MILLISECONDS);
             }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/sink/CacheSink.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/sink/CacheSink.java
@@ -72,7 +72,7 @@ public class CacheSink {
             StatData data = dataQueue.pull(pullTimeOut, TimeUnit.MILLISECONDS);
             while (data != null) {
                 String cacheKey = CacheUtils.buildCacheKey(data.getLogTs(), data.getInlongGroupId(),
-                        data.getInlongStreamId(), data.getAuditId(), data.getAuditTag());
+                        data.getInlongStreamId(), data.getAuditId());
                 cache.put(cacheKey, data);
                 data = dataQueue.pull(pullTimeOut, TimeUnit.MILLISECONDS);
             }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
@@ -65,7 +65,7 @@ import static org.apache.inlong.audit.config.ConfigConstants.KEY_SOURCE_DB_STAT_
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_STAT_BACK_INITIAL_OFFSET;
 import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SIZE;
 import static org.apache.inlong.audit.config.ConfigConstants.PREP_STMT_CACHE_SQL_LIMIT;
-import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_AUDIT_TAG;
+import static org.apache.inlong.audit.config.OpenApiConstants.DEFAULT_PARAMS_AUDIT_TAG;
 import static org.apache.inlong.audit.entities.AuditCycle.DAY;
 import static org.apache.inlong.audit.entities.AuditCycle.HOUR;
 
@@ -290,7 +290,7 @@ public class JdbcSource {
                         data.setAuditId(resultSet.getString(3));
                         String auditTag = resultSet.getString(4);
                         if (null == auditTag) {
-                            data.setAuditTag(DEFAULT_AUDIT_TAG);
+                            data.setAuditTag(DEFAULT_PARAMS_AUDIT_TAG);
                         } else {
                             data.setAuditTag(auditTag);
                         }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
@@ -22,6 +22,7 @@ import org.apache.inlong.audit.config.Configuration;
 import org.apache.inlong.audit.entities.SourceConfig;
 import org.apache.inlong.audit.entities.StartEndTime;
 import org.apache.inlong.audit.entities.StatData;
+import org.apache.inlong.audit.service.ConfigService;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -37,7 +38,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.LinkedList;
 import java.util.List;
@@ -49,7 +49,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.inlong.audit.config.ConfigConstants.CACHE_PREP_STMTS;
-import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_AUDIT_IDS;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CACHE_PREP_STMTS;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CONNECTION_TIMEOUT;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_DATASOURCE_POOL_SIZE;
@@ -57,7 +56,6 @@ import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_C
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_PREP_STMT_CACHE_SQL_LIMIT;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_SOURCE_DB_STAT_INTERVAL;
 import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_STAT_BACK_INITIAL_OFFSET;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_AUDIT_IDS;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_CACHE_PREP_STMTS;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_CONNECTION_TIMEOUT;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_DATASOURCE_POOL_SIZE;
@@ -80,7 +78,6 @@ public class JdbcSource {
     private static final Logger LOGGER = LoggerFactory.getLogger(JdbcSource.class);
     private final ConcurrentHashMap<Integer, ScheduledExecutorService> statTimers = new ConcurrentHashMap<>();
     private DataQueue dataQueue;
-    private List<String> auditIds;
     private int querySqlTimeout;
     private DataSource dataSource;
     private String querySql;
@@ -92,7 +89,6 @@ public class JdbcSource {
     public JdbcSource(DataQueue dataQueue, SourceConfig sourceConfig) {
         this.dataQueue = dataQueue;
         this.sourceConfig = sourceConfig;
-        auditIds = Arrays.asList(Configuration.getInstance().get(KEY_AUDIT_IDS, DEFAULT_AUDIT_IDS).split(";"));
     }
 
     /**
@@ -235,7 +231,9 @@ public class JdbcSource {
          * Stat by step
          */
         public void statByStep() {
+            List<String> auditIds = ConfigService.getInstance().getAuditIds();
             if (auditIds.isEmpty()) {
+                LOGGER.info("No audit id need to stat!");
                 return;
             }
             List<CompletableFuture<Void>> futures = new ArrayList<>();

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/utils/CacheUtils.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/utils/CacheUtils.java
@@ -23,12 +23,13 @@ package org.apache.inlong.audit.utils;
 public class CacheUtils {
 
     public static String buildCacheKey(String logTs, String inlongGroupId, String inlongStreamId,
-            String auditId) {
+            String auditId, String auditTag) {
         return new StringBuilder()
                 .append(logTs)
                 .append(inlongGroupId)
                 .append(inlongStreamId)
                 .append(auditId)
+                .append(auditTag)
                 .toString();
     }
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/utils/JdbcUtils.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/utils/JdbcUtils.java
@@ -22,11 +22,6 @@ import org.apache.inlong.audit.entities.JdbcConfig;
 
 import java.util.Objects;
 
-import static org.apache.inlong.audit.config.ConfigConstants.DEFAULT_CLICKHOUSE_DRIVER;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_CLICKHOUSE_DRIVER;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_CLICKHOUSE_JDBC_URL;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_CLICKHOUSE_PASSWORD;
-import static org.apache.inlong.audit.config.ConfigConstants.KEY_CLICKHOUSE_USERNAME;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_DEFAULT_MYSQL_DRIVER;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_MYSQL_DRIVER;
 import static org.apache.inlong.audit.config.ConfigConstants.KEY_MYSQL_JDBC_URL;
@@ -47,18 +42,6 @@ public class JdbcUtils {
                 Configuration.getInstance().get(KEY_MYSQL_JDBC_URL),
                 Configuration.getInstance().get(KEY_MYSQL_USERNAME),
                 Configuration.getInstance().get(KEY_MYSQL_PASSWORD));
-    }
-
-    /**
-     * Build clickhouse config
-     * @return
-     */
-    public static JdbcConfig buildClickhouseConfig() {
-        return doBuild(
-                Configuration.getInstance().get(KEY_CLICKHOUSE_DRIVER, DEFAULT_CLICKHOUSE_DRIVER),
-                Configuration.getInstance().get(KEY_CLICKHOUSE_JDBC_URL),
-                Configuration.getInstance().get(KEY_CLICKHOUSE_USERNAME),
-                Configuration.getInstance().get(KEY_CLICKHOUSE_PASSWORD));
     }
 
     /**

--- a/inlong-audit/sql/audit-service/apcache_inlong_audit_aggregate.sql
+++ b/inlong-audit/sql/audit-service/apcache_inlong_audit_aggregate.sql
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS `audit_id_config` (
 -- ----------------------------
 -- Table structure for audit source config
 -- ----------------------------
-CREATE TABLE `audit_source_config` (
+CREATE TABLE IF NOT EXISTS `audit_source_config` (
      `source_name` varchar(32) NOT NULL DEFAULT '' COMMENT 'Source_name',
      `jdbc_url` varchar(256) NOT NULL DEFAULT '' COMMENT 'Jdbc url',
      `jdbc_driver_class` varchar(128) NOT NULL DEFAULT '' COMMENT 'Jdbc driver class',

--- a/inlong-audit/sql/audit-service/apcache_inlong_audit_aggregate.sql
+++ b/inlong-audit/sql/audit-service/apcache_inlong_audit_aggregate.sql
@@ -77,4 +77,29 @@ CREATE TABLE IF NOT EXISTS `leader_selector` (
    PRIMARY KEY (`service_id`)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci COMMENT = 'selector db'
 
+-- ----------------------------
+-- Table structure for audit id config
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `audit_id_config` (
+    `audit_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Audit id',
+    `status` int(11) DEFAULT '1' COMMENT 'Audit source config status. 0:Offline,1:Online',
+    `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+    PRIMARY KEY (`audit_id`)
+) ENGINE = InnoDB DEFAULT CHARSET = UTF8 COMMENT = 'Audit id config'
+
+
+-- ----------------------------
+-- Table structure for audit source config
+-- ----------------------------
+CREATE TABLE `audit_source_config` (
+     `source_name` varchar(32) NOT NULL DEFAULT '' COMMENT 'Source_name',
+     `jdbc_url` varchar(256) NOT NULL DEFAULT '' COMMENT 'Jdbc url',
+     `jdbc_driver_class` varchar(128) NOT NULL DEFAULT '' COMMENT 'Jdbc driver class',
+     `jdbc_user_name` varchar(128) NOT NULL DEFAULT '' COMMENT 'Jdbc url',
+     `jdbc_password` varchar(128) NOT NULL DEFAULT '' COMMENT 'Jdbc password',
+     `service_id` varchar(128) NOT NULL DEFAULT '' COMMENT 'Service id',
+     `status` int(11) DEFAULT '1' COMMENT 'Audit source config status. 0:Offline,1:Online',
+     `update_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Update time',
+     PRIMARY KEY (`source_name`, `jdbc_url`)
+) ENGINE = InnoDB DEFAULT CHARSET = UTF8 COMMENT = 'Audit source config'
 


### PR DESCRIPTION
### Prepare a Pull Request
- Fixes #10003 
### Motivation
![image](https://github.com/apache/inlong/assets/43397300/ff3c964a-a426-4d2f-b121-21edbf37ada9)

- Audit-service support querying multiple clickhouse/starrocks clusters at the same time.

- OpenAPI supports simultaneous real-time query of multiple data source clusters.

- OpenAPI supports minute, hour, day,getIps,getIds interface.

### Modifications

*Dynamically configure audit data source information through DB, and perform statistics and cache on multiple audit data sources simultaneously through configuration.*