### PR TITLE
[INLONG-10010][Agent] Adjust source encapsulation, keep public initialization in the base class init, and place specific source related initialization in the subclass's initSource

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/DatabaseSqlSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/DatabaseSqlSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.file.Reader;
@@ -91,6 +92,11 @@ public class DatabaseSqlSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
@@ -69,11 +69,9 @@ public class KafkaSource extends AbstractSource {
     }
 
     @Override
-    public void init(InstanceProfile profile) {
+    protected void initSource(InstanceProfile profile) {
         try {
             LOGGER.info("KafkaSource init: {}", profile.toJsonStr());
-            this.profile = profile;
-            super.init(profile);
             topic = profile.getInstanceId();
             props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, profile.get(TASK_KAFKA_BOOTSTRAP_SERVERS));
             props.put(ConsumerConfig.GROUP_ID_CONFIG, taskId);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -65,10 +65,9 @@ public class LogFileSource extends AbstractSource {
     }
 
     @Override
-    public void init(InstanceProfile profile) {
+    protected void initSource(InstanceProfile profile) {
         try {
             LOGGER.info("LogFileSource init: {}", profile.toJsonStr());
-            super.init(profile);
             fileName = profile.getInstanceId();
             bufferToReadFile = new byte[SIZE_OF_BUFFER_TO_READ_FILE];
             isIncrement = isIncrement(profile);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MongoDBSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MongoDBSource.java
@@ -66,11 +66,9 @@ public class MongoDBSource extends AbstractSource {
     }
 
     @Override
-    public void init(InstanceProfile profile) {
+    protected void initSource(InstanceProfile profile) {
         try {
             LOGGER.info("MongoDBSource init: {}", profile.toJsonStr());
-            this.profile = profile;
-            super.init(profile);
             debeziumQueue = new LinkedBlockingQueue<>(DEBEZIUM_QUEUE_SIZE);
             database = profile.get(TaskConstants.TASK_MONGO_DATABASE_INCLUDE_LIST);
             collection = profile.get(TaskConstants.TASK_MONGO_COLLECTION_INCLUDE_LIST);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MqttSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MqttSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.constant.CommonConstants;
 import org.apache.inlong.agent.plugin.Message;
@@ -82,6 +83,11 @@ public class MqttSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/OracleSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/OracleSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.file.Reader;
@@ -51,6 +52,11 @@ public class OracleSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PostgreSQLSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PostgreSQLSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.file.Reader;
@@ -52,6 +53,11 @@ public class PostgreSQLSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -63,10 +63,9 @@ public class PulsarSource extends AbstractSource {
     }
 
     @Override
-    public void init(InstanceProfile profile) {
+    protected void initSource(InstanceProfile profile) {
         try {
             LOGGER.info("PulsarSource init: {}", profile.toJsonStr());
-            super.init(profile);
             topic = profile.getInstanceId();
             serviceUrl = profile.get(TASK_PULSAR_SERVICE_URL);
             subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, PULSAR_SUBSCRIPTION_PREFIX + inlongStreamId);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/RedisSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/RedisSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.file.Reader;
@@ -52,6 +53,11 @@ public class RedisSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/SQLServerSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/SQLServerSource.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.agent.plugin.sources;
 
+import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.file.Reader;
@@ -51,6 +52,11 @@ public class SQLServerSource extends AbstractSource {
     @Override
     protected String getThreadName() {
         return null;
+    }
+
+    @Override
+    protected void initSource(InstanceProfile profile) {
+
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
@@ -20,6 +20,7 @@ package org.apache.inlong.agent.plugin.sources.file;
 import org.apache.inlong.agent.common.AgentThreadFactory;
 import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.OffsetProfile;
+import org.apache.inlong.agent.conf.TaskProfile;
 import org.apache.inlong.agent.constant.CycleUnitType;
 import org.apache.inlong.agent.constant.TaskConstants;
 import org.apache.inlong.agent.core.task.MemoryManager;
@@ -29,6 +30,7 @@ import org.apache.inlong.agent.metrics.AgentMetricItem;
 import org.apache.inlong.agent.metrics.AgentMetricItemSet;
 import org.apache.inlong.agent.metrics.audit.AuditUtils;
 import org.apache.inlong.agent.plugin.Message;
+import org.apache.inlong.agent.plugin.file.Reader;
 import org.apache.inlong.agent.plugin.file.Source;
 import org.apache.inlong.agent.plugin.sources.file.extend.ExtendedHandler;
 import org.apache.inlong.agent.utils.AgentUtils;
@@ -128,7 +130,10 @@ public abstract class AbstractSource implements Source {
         initOffset();
         registerMetric();
         initExtendHandler();
+        initSource(profile);
     }
+
+    protected abstract void initSource(InstanceProfile profile);
 
     protected void initOffset() {
         offsetProfile = OffsetManager.getInstance().getOffset(taskId, instanceId);
@@ -395,5 +400,10 @@ public abstract class AbstractSource implements Source {
             return false;
         }
         return emptyCount > EMPTY_CHECK_COUNT_AT_LEAST;
+    }
+
+    @Override
+    public List<Reader> split(TaskProfile conf) {
+        return null;
     }
 }


### PR DESCRIPTION
[INLONG-10010][Agent] Adjust source encapsulation, keep public initialization in the base class init, and place specific source related initialization in the subclass's initSource
- Fixes #10010

### Motivation

Adjust source encapsulation, keep public initialization in the base class init, and place specific source related initialization in the subclass's initSource

### Modifications
Keep public initialization in the base class init, and place specific source related initialization in the subclass's initSource

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
