### PR TITLE
[INLONG-8962][Agent] Fix the bug: before state and after state are the same in StateCallback.call

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/AbstractStateWrapper.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/state/AbstractStateWrapper.java
@@ -57,9 +57,10 @@ public abstract class AbstractStateWrapper implements Runnable {
         Pair<State, State> statePair = new ImmutablePair<>(currentState, nextState);
         StateCallback callback = callBacks.get(statePair);
         // change state before callback.
+        State lastState = currentState;
         currentState = nextState;
         if (callback != null) {
-            callback.call(currentState, nextState);
+            callback.call(lastState, nextState);
         }
     }
 


### PR DESCRIPTION
[INLONG-8962][Agent] Fix the bug: before state and after state are the same in StateCallback.call
- Fixes #8962 

### Motivation
Fix the bug: before state and after state are the same in StateCallback.call
### Modifications
Store the before state as the param of  StateCallback.call

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
