### PR TITLE
[INLONG-8791][TubeMQ] Add log level and log path configuration API to Tubemq-client-go

### DIFF
--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -144,8 +144,13 @@ type Config struct {
 		// AfterFail is the heartbeat timeout after a heartbeat failure.
 		AfterFail time.Duration
 	}
+
+	// Log is the namespace for configuration related to log messages,
+	// used by the logger
 	Log struct {
-		LogPath  string
+		// LogPath represents the path where the log save in
+		LogPath string
+		// LogLevel represents the level of log
 		LogLevel string
 	}
 }
@@ -642,6 +647,11 @@ func WithConsumePosition(consumePosition int) Option {
 // WithLogLevel set log level
 func WithLogLevel(level string) Option {
 	return func(c *Config) {
+		err := log.SetLogLevel(level)
+		if err != nil {
+			log.Errorf("[Log]log level setting error: %s", err.Error())
+			return
+		}
 		c.Log.LogLevel = level
 	}
 }
@@ -649,6 +659,11 @@ func WithLogLevel(level string) Option {
 // WithLogPath set log path
 func WithLogPath(path string) Option {
 	return func(c *Config) {
+		err := log.SetLogPath(path)
+		if err != nil {
+			log.Errorf("[Log]log path setting error %s", err.Error())
+			return
+		}
 		c.Log.LogPath = path
 	}
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -475,8 +475,14 @@ func getConfigFromToken(config *Config, values []string) error {
 		config.Net.Auth.Password = values[1]
 	case "logPath":
 		err = log.SetLogPath(values[1])
+		if err == nil {
+			config.Log.LogPath = values[1]
+		}
 	case "logLevel":
 		err = log.SetLogLevel(values[1])
+		if err == nil {
+			config.Log.LogLevel = values[1]
+		}
 	default:
 		return fmt.Errorf("address format invalid, unknown keys: %v", values[0])
 	}

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/config/config.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"github.com/apache/inlong/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -180,6 +179,7 @@ func NewDefaultConfig() *Config {
 	c.Heartbeat.Interval = 10000 * time.Millisecond
 	c.Heartbeat.MaxRetryTimes = 5
 	c.Heartbeat.AfterFail = 60000 * time.Millisecond
+
 	c.Log.LogLevel = "warn"
 	c.Log.LogPath = "../log/tubemq.log"
 
@@ -474,9 +474,9 @@ func getConfigFromToken(config *Config, values []string) error {
 	case "authPassword":
 		config.Net.Auth.Password = values[1]
 	case "logPath":
-		config.Log.LogPath, err = parseLogPath(values[1])
+		err = log.SetLogPath(values[1])
 	case "logLevel":
-		config.Log.LogLevel, err = parseLogLevel(values[1])
+		err = log.SetLogLevel(values[1])
 	default:
 		return fmt.Errorf("address format invalid, unknown keys: %v", values[0])
 	}
@@ -492,31 +492,6 @@ func parseDuration(val string) (time.Duration, error) {
 		return 0, err
 	}
 	return time.Duration(maxWait) * time.Millisecond, err
-}
-func parseLogPath(path string) (string, error) {
-	// Check if file already exists
-	if _, err := os.Stat(path); err == nil {
-		return path, nil
-	}
-	// Attempt to create it
-	var d []byte
-	err := os.WriteFile(path, d, 0644)
-	if err == nil {
-		removeErr := os.Remove(path)
-		if removeErr != nil {
-			return "", removeErr
-		} // And delete it
-		return path, nil
-	}
-	return "", err
-}
-
-func parseLogLevel(level string) (string, error) {
-	if _, exist := log.LevelNames[level]; !exist {
-		return "",
-			errors.New("the supported log levels are: trace, debug, info, warn, error, fatal. Please check your log level")
-	}
-	return level, nil
 }
 
 type Option func(*Config)

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -17,6 +17,11 @@
 
 package log
 
+import (
+	"errors"
+	"os"
+)
+
 // OutputConfig defines the output config which can be reconfigured by user.
 type OutputConfig struct {
 	// LogPath is the path for the log.
@@ -38,4 +43,41 @@ var defaultConfig = &OutputConfig{
 	MaxBackups: 5,
 	MaxAge:     3,
 	Level:      "warn",
+}
+
+// SetLogLevel set log level
+func SetLogLevel(level string) error {
+	if _, exist := LevelNames[level]; !exist {
+		return errors.New("the supported log levels are: trace, debug, info, warn, error, fatal. Please check your log level")
+	}
+	defaultConfig.Level = level
+	return nil
+}
+
+// SetLogPath set log path
+func SetLogPath(path string) error {
+	err := isValidLogPath(path)
+	if err != nil {
+		return err
+	}
+	defaultConfig.LogPath = path
+	return nil
+}
+func isValidLogPath(path string) error {
+	// Check if file already exists
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	}
+
+	// Attempt to create it
+	var d []byte
+	err := os.WriteFile(path, d, 0644)
+	if err == nil {
+		removeErr := os.Remove(path)
+		if removeErr != nil {
+			return removeErr
+		} // And delete it
+		return nil
+	}
+	return err
 }

--- a/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
+++ b/inlong-tubemq/tubemq-client-twins/tubemq-client-go/log/config.go
@@ -56,14 +56,15 @@ func SetLogLevel(level string) error {
 
 // SetLogPath set log path
 func SetLogPath(path string) error {
-	err := isValidLogPath(path)
+	err := verifyLogPath(path)
 	if err != nil {
 		return err
 	}
 	defaultConfig.LogPath = path
 	return nil
 }
-func isValidLogPath(path string) error {
+
+func verifyLogPath(path string) error {
 	// Check if file already exists
 	if _, err := os.Stat(path); err == nil {
 		return nil


### PR DESCRIPTION
### Prepare a Pull Request

- Title Example: [INLONG-8791][TubeMQ] Add log level and log path configuration API to Tubemq-client-go

- Fixes #8791 

### Motivation

The PR #8793 has a little problem, I solve it.

### Modifications

- Add validation to SetLogPath and SetLogLeve.

- Add log level and log path configuration API.

