### PR TITLE
[INLONG-10041][Sort] Thread unsafety of time format serialization

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
@@ -25,8 +25,12 @@ import javax.annotation.Nonnull;
 
 import java.sql.Date;
 import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_ISO_8601;
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_SQL;
 
 /**
  * The format information for {@link Date}s.
@@ -45,6 +49,13 @@ public class DateFormatInfo implements BasicFormatInfo<Date> {
     public DateFormatInfo(
             @JsonProperty(FIELD_FORMAT) @Nonnull String format) {
         this.format = format;
+        if (!format.equals("SECONDS")
+                && !format.equals("MILLIS")
+                && !format.equals("MICROS")
+                && !DATE_AND_TIME_STANDARD_SQL.equals(format)
+                && !DATE_AND_TIME_STANDARD_ISO_8601.equals(format)) {
+            FastDateFormat.getInstance(format);
+        }
     }
 
     public DateFormatInfo() {

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
@@ -17,21 +17,16 @@
 
 package org.apache.inlong.common.pojo.sort.dataflow.field.format;
 
+import org.apache.commons.lang3.time.FastDateFormat;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import java.sql.Date;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-
-import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_ISO_8601;
-import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_SQL;
 
 /**
  * The format information for {@link Date}s.
@@ -46,28 +41,10 @@ public class DateFormatInfo implements BasicFormatInfo<Date> {
     @Nonnull
     private final String format;
 
-    @JsonIgnore
-    @Nullable
-    private final SimpleDateFormat simpleDateFormat;
-
-    @JsonIgnore
-    @Nullable
-    private final ThreadLocal<SimpleDateFormat> threadLocal;
-
     @JsonCreator
     public DateFormatInfo(
             @JsonProperty(FIELD_FORMAT) @Nonnull String format) {
         this.format = format;
-        this.threadLocal = new ThreadLocal<>();
-        if (!format.equals("SECONDS")
-                && !format.equals("MILLIS")
-                && !format.equals("MICROS")
-                && !DATE_AND_TIME_STANDARD_SQL.equals(format)
-                && !DATE_AND_TIME_STANDARD_ISO_8601.equals(format)) {
-            this.simpleDateFormat = new SimpleDateFormat(format);
-        } else {
-            this.simpleDateFormat = null;
-        }
     }
 
     public DateFormatInfo() {
@@ -82,17 +59,6 @@ public class DateFormatInfo implements BasicFormatInfo<Date> {
     @Override
     public DateTypeInfo getTypeInfo() {
         return DateTypeInfo.INSTANCE;
-    }
-
-    private SimpleDateFormat get() {
-        if (simpleDateFormat == null) {
-            throw new IllegalStateException();
-        }
-        SimpleDateFormat local = threadLocal.get();
-        if (local == null) {
-            threadLocal.set((SimpleDateFormat) simpleDateFormat.clone());
-        }
-        return threadLocal.get();
     }
 
     @Override
@@ -113,7 +79,7 @@ public class DateFormatInfo implements BasicFormatInfo<Date> {
                 return Long.toString(seconds);
             }
             default: {
-                return get().format(date);
+                return FastDateFormat.getInstance(format).format(date.getTime());
             }
         }
     }
@@ -137,8 +103,8 @@ public class DateFormatInfo implements BasicFormatInfo<Date> {
                 return new Date(millis);
             }
             default: {
-                java.util.Date jDate = get().parse(text.trim());
-                return new Date(jDate.getTime());
+                java.util.Date date = FastDateFormat.getInstance(format).parse(text.trim());
+                return new Date(date.getTime());
             }
         }
     }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/DateFormatInfo.java
@@ -25,7 +25,6 @@ import javax.annotation.Nonnull;
 
 import java.sql.Date;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimeFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimeFormatInfo.java
@@ -29,6 +29,9 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_ISO_8601;
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_SQL;
+
 /**
  * The format information for {@link Time}s.
  */
@@ -51,6 +54,13 @@ public class TimeFormatInfo implements BasicFormatInfo<Time> {
             @JsonProperty("precision") int precision) {
         this.format = format;
         this.precision = precision;
+        if (!format.equals("SECONDS")
+                && !format.equals("MILLIS")
+                && !format.equals("MICROS")
+                && !DATE_AND_TIME_STANDARD_SQL.equals(format)
+                && !DATE_AND_TIME_STANDARD_ISO_8601.equals(format)) {
+            FastDateFormat.getInstance(format);
+        }
     }
 
     public TimeFormatInfo(@JsonProperty(FIELD_FORMAT) @Nonnull String format) {

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimestampFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimestampFormatInfo.java
@@ -29,6 +29,9 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_ISO_8601;
+import static org.apache.inlong.common.pojo.sort.dataflow.field.format.Constants.DATE_AND_TIME_STANDARD_SQL;
+
 /**
  * The format information for {@link Timestamp}s.
  */
@@ -53,6 +56,13 @@ public class TimestampFormatInfo implements BasicFormatInfo<Timestamp> {
             @JsonProperty("precision") int precision) {
         this.format = format;
         this.precision = precision;
+        if (!format.equals("SECONDS")
+                && !format.equals("MILLIS")
+                && !format.equals("MICROS")
+                && !DATE_AND_TIME_STANDARD_SQL.equals(format)
+                && !DATE_AND_TIME_STANDARD_ISO_8601.equals(format)) {
+            FastDateFormat.getInstance(format);
+        }
     }
 
     public TimestampFormatInfo(@JsonProperty(FIELD_FORMAT) @Nonnull String format) {

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimestampFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/TimestampFormatInfo.java
@@ -52,7 +52,7 @@ public class TimestampFormatInfo implements BasicFormatInfo<Timestamp> {
     @JsonIgnore
     @Nullable
     private final SimpleDateFormat simpleDateFormat;
-    
+
     @JsonIgnore
     @Nullable
     private final ThreadLocal<SimpleDateFormat> threadLocal;


### PR DESCRIPTION
### Prepare a Pull Request
*(Change the title refer to the following example)*

- Title Example: [INLONG-XYZ][Component] Title of the pull request

*(The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)*

- Fixes #10041 

### Motivation

The serialization and deserialization of the Timestamp, Time, and Date format of Sort will produce unexcepted results because SimpleDateFormatter is thread-unsafe.

### Modifications

*Describe the modifications you've done.*

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
