### PR TITLE
[INLONG-10045][Dashboard] Supports one approval order containing multiple inlongGroups

### DIFF
--- a/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
+++ b/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
@@ -76,13 +76,21 @@ export const getColumns = activedName => [
   {
     title: i18n.t('pages.Approvals.GroupId'),
     dataIndex: 'inlongGroupId',
-    render: (text, record) => record.showInList?.inlongGroupId,
+    render: (text, record) =>
+      record.showInList
+      ?.filter(item => item.inlongGroupId)
+      ?.map(item => item.inlongGroupId)
+      .join(';'),
   },
   {
     title: i18n.t('pages.Approvals.ConsumeName'),
     dataIndex: 'consumerGroup',
     width: 200,
-    render: (text, record) => record.showInList?.consumerGroup,
+    render: (text, record) =>
+      record.showInList
+      ?.filter(item => item.consumeName)
+      ?.map(item => item.consumeName)
+      .join(';'),
   },
   {
     title: i18n.t('pages.Approvals.GroupMode'),

--- a/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
+++ b/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
@@ -78,9 +78,9 @@ export const getColumns = activedName => [
     dataIndex: 'inlongGroupId',
     render: (text, record) =>
       record.showInList
-      ?.filter(item => item.inlongGroupId)
-      ?.map(item => item.inlongGroupId)
-      .join(';'),
+        ?.filter(item => item.inlongGroupId)
+        ?.map(item => item.inlongGroupId)
+        .join(';'),
   },
   {
     title: i18n.t('pages.Approvals.ConsumeName'),
@@ -88,9 +88,9 @@ export const getColumns = activedName => [
     width: 200,
     render: (text, record) =>
       record.showInList
-      ?.filter(item => item.consumeName)
-      ?.map(item => item.consumeName)
-      .join(';'),
+        ?.filter(item => item.consumeName)
+        ?.map(item => item.consumeName)
+        .join(';'),
   },
   {
     title: i18n.t('pages.Approvals.GroupMode'),


### PR DESCRIPTION
### Prepare a Pull Request

- Fixes #10045 

### Motivation

Supports one approval order containing multiple inlongGroups

### Modifications

Concatenate multiple `inlongGroupId` / `consumerGroup `with `;`

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/9402d32f-9c3d-4fee-858d-1759f1c26845)


