### PR TITLE
[INLONG-10047][Agent] Fix the bug in the logic for judging the completion status of the supplementary recording task

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -236,7 +236,7 @@ public class LogFileTask extends AbstractTask {
             runAtLeastOneTime = true;
         }
         dealWithEventMap();
-        if (allInstanceFinished()) {
+        if (instanceQueue.isEmpty() && allInstanceFinished()) {
             LOGGER.info("retry task finished, send action to task manager, taskId {}", getTaskId());
             TaskAction action = new TaskAction(org.apache.inlong.agent.core.task.ActionType.FINISH, taskProfile);
             taskManager.submitAction(action);


### PR DESCRIPTION
[INLONG-10047][Agent] Fix the bug in the logic for judging the completion status of the supplementary recording task
- Fixes #10047

### Motivation

Fix the bug in the logic for judging the completion status of the supplementary recording task

### Modifications

Need to simultaneously check if the local instance queue is empty

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
