### PR TITLE
[INLONG-10059][Agent] Fix the exception of installation package comparison

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -54,6 +54,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -461,7 +462,7 @@ public class ModuleManager extends AbstractDaemon {
     private boolean isPackageDownloaded(ModuleConfig module) {
         String path = module.getPackageConfig().getStoragePath() + "/" + module.getPackageConfig().getFileName();
         String fileMd5 = calcFileMd5(path);
-        if (fileMd5.equals(module.getPackageConfig().getMd5())) {
+        if (Objects.equals(fileMd5, module.getPackageConfig().getMd5())) {
             return true;
         } else {
             LOGGER.error("md5 not match! fileMd5 {} moduleMd5 {}", fileMd5, module.getPackageConfig().getMd5());

--- a/inlong-agent/agent-installer/src/test/java/installer/TestModuleManager.java
+++ b/inlong-agent/agent-installer/src/test/java/installer/TestModuleManager.java
@@ -174,11 +174,11 @@ public class TestModuleManager {
         configs.add(getModuleConfig(1, "inlong-agent", "inlong-agent-md5-185454", "1.0", 1,
                 "cd ~/inlong-agent/bin;sh agent.sh start", "cd ~/inlong-agent/bin;sh agent.sh stop",
                 "ps aux | grep core.AgentMain | grep java | grep -v grep | awk '{print $2}'",
-                "cd ~/inlong-agent/bin;sh agent.sh stop;rm -rf ~/inlong-agent/;mkdir ~/inlong-agent;cd /tmp;tar -xzvf agent-release-1.12.0-SNAPSHOT-bin.tar.gz -C ~/inlong-agent;cd ~/inlong-agent/bin;sh agent.sh start",
-                "echo empty uninstall cmd", "agent-release-1.12.0-SNAPSHOT-bin.tar.gz",
-                "http://11.151.252.111:8083/inlong/manager/openapi/agent/download/agent-release-1.12.0-SNAPSHOT-bin.tar.gz",
+                "cd ~/inlong-agent/bin;sh agent.sh stop;rm -rf ~/inlong-agent/;mkdir ~/inlong-agent;cd /tmp;tar -xzvf agent-release-1.13.0-SNAPSHOT-bin.tar.gz -C ~/inlong-agent;cd ~/inlong-agent/bin;sh agent.sh start",
+                "echo empty uninstall cmd", "agent-release-1.13.0-SNAPSHOT-bin.tar.gz",
+                "http://11.151.252.111:8083/inlong/manager/openapi/agent/download/agent-release-1.13.0-SNAPSHOT-bin.tar.gz",
                 NEW_MD5));
-        return ConfigResult.builder().moduleList(configs).moduleNum(1).md5("config-result-md5-193603").build();
+        return ConfigResult.builder().moduleList(configs).md5("config-result-md5-193603").build();
     }
 
     private ModuleConfig getModuleConfig(int id, String name, String md5, String version, Integer procNum,

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/installer/ConfigResult.java
@@ -42,10 +42,7 @@ public class ConfigResult {
      * The md5 of the config result
      */
     private String md5;
-    /**
-     * Number of module
-     */
-    private Integer moduleNum;
+
     /**
      * The list of module config list
      */

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -844,8 +844,7 @@ public class AgentServiceImpl implements AgentService {
         String jsonStr = GSON.toJson(configs);
         String configMd5 = DigestUtils.md5Hex(jsonStr);
 
-        ConfigResult configResult = ConfigResult.builder().moduleList(configs).moduleNum(configs.size())
-                .md5(configMd5)
+        ConfigResult configResult = ConfigResult.builder().moduleList(configs).md5(configMd5)
                 .code(InstallerCode.SUCCESS)
                 .build();
         LOGGER.info("success load module config, size = {}", configResult.getModuleList().size());


### PR DESCRIPTION
Fixes #10059

### Motivation
There are an bug in the comparison of installation package md5, an exception will occur when md5 is null
### Modifications

Use Objects.equals instead of equals to handle null md5

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation
No doc needed 
