### PR TITLE
[INLONG-10082][Dashboard] Fixed missing pulsar tenant field when updating group info

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Info/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Info/index.tsx
@@ -70,6 +70,9 @@ const Comp = ({ inlongGroupId, readonly, isCreate }: Props, ref) => {
 
     if (isUpdate) {
       submitData.inlongGroupId = inlongGroupId;
+      if (mqType == 'PULSAR') {
+        submitData.pulsarTenat = form.getFieldValue('pulsarTenant');
+      }
     }
 
     const result = await request({

--- a/inlong-dashboard/src/ui/pages/SynchronizeDetail/Info/index.tsx
+++ b/inlong-dashboard/src/ui/pages/SynchronizeDetail/Info/index.tsx
@@ -119,6 +119,9 @@ const Comp = ({ inlongGroupId, inlongStreamId, readonly, isCreate }: Props, ref)
     if (isUpdate) {
       submitData.inlongGroupId = inlongGroupId;
       submitData.inlongStreamId = inlongStreamId;
+      if (mqType == 'PULSAR') {
+        submitData.pulsarTenat = form.getFieldValue('pulsarTenant');
+      }
     }
 
     const result = await request({


### PR DESCRIPTION
Fixes #10082 

### Motivation

The pulsar tenant field is missing when updating group info

### Modifications

Add `pulsarTenant` when updating group info and mqType is `PULSAR`

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
