### PR TITLE
[INLONG-10100][Dashboard] Add authentication information for the agent cluster

### DIFF
--- a/inlong-dashboard/src/plugins/clusters/defaults/Agent.ts
+++ b/inlong-dashboard/src/plugins/clusters/defaults/Agent.ts
@@ -22,6 +22,22 @@ import { RenderRow } from '@/plugins/RenderRow';
 import { RenderList } from '@/plugins/RenderList';
 import { ClusterInfo } from '../common/ClusterInfo';
 
+const { I18n } = DataWithBackend;
+const { FieldDecorator } = RenderRow;
+
 export default class AgentCluster
   extends ClusterInfo
-  implements DataWithBackend, RenderRow, RenderList {}
+  implements DataWithBackend, RenderRow, RenderList
+{
+  @FieldDecorator({
+    type: 'input',
+  })
+  @I18n('pages.Clusters.Agent.AuthUsername')
+  authUsername: string;
+
+  @FieldDecorator({
+    type: 'input',
+  })
+  @I18n('pages.Clusters.Agent.AuthCmk')
+  authCmk: string;
+}

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -773,6 +773,8 @@
   "pages.Clusters.Pulsar.AdminUrlHelper": "用于管理（如：创建、修改）租户、命名空间、Topic 和订阅组",
   "pages.Clusters.Tube.MasterRpcUrlHelper": "Master RPC 地址，用于生产和消费数据",
   "pages.Clusters.Tube.MasterWebUrlHelper": "Master Web 地址，用于管理（如：创建、修改）Topic 和消费组",
+  "pages.Clusters.Agent.AuthUsername": "认证用户",
+  "pages.Clusters.Agent.AuthCmk": "认证 Cmk",
   "pages.ClusterTags.Name": "集群标签",
   "pages.ClusterTags.InCharges": "负责人",
   "pages.ClusterTags.Description": "标签描述",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -773,6 +773,8 @@
   "pages.Clusters.Pulsar.AdminUrlHelper": "Used to manage (e.g. create, modify) tenants, namespaces, topics and subscription groups",
   "pages.Clusters.Tube.MasterRpcUrlHelper": "Master RPC URL, used to produce and consume data",
   "pages.Clusters.Tube.MasterWebUrlHelper": "Master Web URL, used to manage (e.g. create, modify) topics and consumer groups",
+  "pages.Clusters.Agent.AuthUsername": "Auth Username",
+  "pages.Clusters.Agent.AuthCmk": "Auth Cmk",
   "pages.ClusterTags.Name": "Cluster tag",
   "pages.ClusterTags.InCharges": "Owners",
   "pages.ClusterTags.Description": "Description",


### PR DESCRIPTION

Fixes #10100

### Motivation

Add authentication information for the agent cluster

### Modifications

Add `authUsername` and `authCmk` for the agent cluster

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/39764cf4-e747-4d20-befc-60f54abc0c96)

