### PR TITLE
[INLONG-10115][Agent] Change the offset save format from long to string

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/OffsetProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/OffsetProfile.java
@@ -42,7 +42,7 @@ public class OffsetProfile extends AbstractConfiguration {
     public OffsetProfile() {
     }
 
-    public OffsetProfile(String taskId, String instanceId, long offset, String inodeInfo) {
+    public OffsetProfile(String taskId, String instanceId, String offset, String inodeInfo) {
         setTaskId(taskId);
         setInstanceId(instanceId);
         setOffset(offset);
@@ -77,12 +77,12 @@ public class OffsetProfile extends AbstractConfiguration {
         setLong(TaskConstants.LAST_UPDATE_TIME, lastUpdateTime);
     }
 
-    public Long getOffset() {
-        return getLong(TaskConstants.OFFSET, TaskConstants.DEFAULT_OFFSET);
+    public String getOffset() {
+        return get(TaskConstants.OFFSET, TaskConstants.DEFAULT_OFFSET);
     }
 
-    public void setOffset(Long offset) {
-        setLong(TaskConstants.OFFSET, offset);
+    public void setOffset(String offset) {
+        set(TaskConstants.OFFSET, offset);
     }
 
     public String getInodeInfo() {

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -68,7 +68,7 @@ public class TaskConstants extends CommonConstants {
     public static final String PREDEFINE_FIELDS = "task.predefinedFields";
     public static final String FILE_SOURCE_EXTEND_CLASS = "task.fileTask.extendedClass";
     public static final String DEFAULT_FILE_SOURCE_EXTEND_CLASS =
-            "org.apache.inlong.agent.plugin.sources.file.extend.MixSourceHandler";
+            "org.apache.inlong.agent.plugin.sources.file.extend.ExtendedHandler";
 
     // Kafka task
     public static final String TASK_KAFKA_TOPIC = "task.kafkaTask.topic";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -48,7 +48,7 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_MQ_CLUSTERS = "task.mqClusters";
     public static final String TASK_MQ_TOPIC = "task.topicInfo";
     public static final String OFFSET = "offset";
-    public static final Long DEFAULT_OFFSET = -1L;
+    public static final String DEFAULT_OFFSET = "-1L";
     public static final String INODE_INFO = "inodeInfo";
 
     // File task
@@ -68,7 +68,7 @@ public class TaskConstants extends CommonConstants {
     public static final String PREDEFINE_FIELDS = "task.predefinedFields";
     public static final String FILE_SOURCE_EXTEND_CLASS = "task.fileTask.extendedClass";
     public static final String DEFAULT_FILE_SOURCE_EXTEND_CLASS =
-            "org.apache.inlong.agent.plugin.sources.file.extend.ExtendedHandler";
+            "org.apache.inlong.agent.plugin.sources.file.extend.MixSourceHandler";
 
     // Kafka task
     public static final String TASK_KAFKA_TOPIC = "task.kafkaTask.topic";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/OffsetAckInfo.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/OffsetAckInfo.java
@@ -24,7 +24,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class OffsetAckInfo {
 
-    private Long offset;
+    private String offset;
     private int len;
     private Boolean hasAck;
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessage.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessage.java
@@ -50,8 +50,7 @@ public class ProxyMessage implements Message {
         this.dataKey = header.getOrDefault(PROXY_KEY_DATA, "");
         // use the batch key of user and inlongStreamId to determine one batch
         this.batchKey = dataKey + inlongStreamId;
-        Long offset = Long.parseLong(header.get(TaskConstants.OFFSET));
-        ackInfo = new OffsetAckInfo(offset, body.length, false);
+        ackInfo = new OffsetAckInfo(header.get(TaskConstants.OFFSET), body.length, false);
     }
 
     public ProxyMessage(Message message) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/KafkaSource.java
@@ -112,7 +112,7 @@ public class KafkaSource extends AbstractSource {
         List<SourceData> dataList = new ArrayList<>();
         ConsumerRecords<String, byte[]> records = kafkaConsumer.poll(Duration.ofMillis(1000));
         for (ConsumerRecord<String, byte[]> record : records) {
-            SourceData sourceData = new SourceData(record.value(), record.offset());
+            SourceData sourceData = new SourceData(record.value(), Long.toString(record.offset()));
             dataList.add(sourceData);
             offset = record.offset();
         }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -130,7 +130,7 @@ public class LogFileSource extends AbstractSource {
         bytePosition = readLines(randomAccessFile, pos, lines, BATCH_READ_LINE_COUNT, BATCH_READ_LINE_TOTAL_LEN, false);
         for (int i = 0; i < lines.size(); i++) {
             linePosition++;
-            dataList.add(new SourceData(lines.get(i), linePosition));
+            dataList.add(new SourceData(lines.get(i), Long.toString(linePosition)));
         }
         return dataList;
     }
@@ -148,7 +148,7 @@ public class LogFileSource extends AbstractSource {
     private long getInitLineOffset(boolean isIncrement, String taskId, String instanceId, String inodeInfo) {
         long offset = 0;
         if (offsetProfile != null && offsetProfile.getInodeInfo().compareTo(inodeInfo) == 0) {
-            offset = offsetProfile.getOffset();
+            offset = Long.parseLong(offsetProfile.getOffset());
             int fileLineCount = getRealLineCount(instanceId);
             if (fileLineCount < offset) {
                 LOGGER.info("getInitLineOffset inode no change taskId {} file rotate, offset set to 0, file {}", taskId,

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MongoDBSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/MongoDBSource.java
@@ -121,7 +121,7 @@ public class MongoDBSource extends AbstractSource {
             RecordCommitter<ChangeEvent<String, String>> committer) throws InterruptedException {
         boolean offerSuc = false;
         for (ChangeEvent<String, String> record : records) {
-            SourceData sourceData = new SourceData(record.value().getBytes(StandardCharsets.UTF_8), 0L);
+            SourceData sourceData = new SourceData(record.value().getBytes(StandardCharsets.UTF_8), "0L");
             while (isRunnable() && !offerSuc) {
                 offerSuc = debeziumQueue.offer(sourceData, 1, TimeUnit.SECONDS);
             }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -33,6 +33,7 @@ import org.apache.pulsar.client.api.SubscriptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -103,7 +104,8 @@ public class PulsarSource extends AbstractSource {
             LOGGER.error("read from pulsar error", e);
         }
         if (!ObjectUtils.isEmpty(message)) {
-            dataList.add(new SourceData(message.getValue(), 0L));
+            dataList.add(new SourceData(message.getValue(), new String(message.getMessageId().toByteArray(),
+                    StandardCharsets.UTF_8)));
         }
         try {
             consumer.acknowledge(message);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
@@ -77,7 +77,7 @@ public abstract class AbstractSource implements Source {
     protected class SourceData {
 
         private byte[] data;
-        private Long offset;
+        private String offset;
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSource.class);
@@ -323,7 +323,7 @@ public abstract class AbstractSource implements Source {
         String proxyPartitionKey = profile.get(PROXY_SEND_PARTITION_KEY, DigestUtils.md5Hex(inlongGroupId));
         Map<String, String> header = new HashMap<>();
         header.put(PROXY_KEY_DATA, proxyPartitionKey);
-        header.put(OFFSET, sourceData.getOffset().toString());
+        header.put(OFFSET, sourceData.getOffset());
         header.put(PROXY_KEY_STREAM_ID, inlongStreamId);
         if (extendedHandler != null) {
             extendedHandler.dealWithHeader(header, sourceData.getData());

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
@@ -104,7 +104,7 @@ public class TestSenderManager {
                 List<OffsetAckInfo> ackInfoList = new ArrayList<>();
                 bodyList.add("123456789".getBytes(StandardCharsets.UTF_8));
                 for (int j = 0; j < bodyList.size(); j++) {
-                    OffsetAckInfo ackInfo = new OffsetAckInfo(offset++, bodyList.get(j).length, false);
+                    OffsetAckInfo ackInfo = new OffsetAckInfo(Long.toString(offset++), bodyList.get(j).length, false);
                     ackInfoList.add(ackInfo);
                     ackInfoListTotal.add(ackInfo);
                 }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
@@ -92,7 +92,7 @@ public class TestLogFileSource {
             if (offset > 0) {
                 OffsetProfile offsetProfile = new OffsetProfile(instanceProfile.getTaskId(),
                         instanceProfile.getInstanceId(),
-                        offset, instanceProfile.get(INODE_INFO));
+                        Long.toString(offset), instanceProfile.get(INODE_INFO));
                 OffsetManager.getInstance().setOffset(offsetProfile);
             }
             source.init(instanceProfile);


### PR DESCRIPTION
Fixes #10115

### Motivation

Offset needs to be changed to save in string format because some data sources have non integer positions
### Modifications

Change the offset save format from long to string
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
