### PR TITLE
[INLONG-10126][TubeMQ] Fix maven sleepycat je.version 7.3.7 can not found

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <jsr.version>3.0.2</jsr.version>
         <jcommander.version>1.78</jcommander.version>
-        <je.version>7.3.7</je.version>
+        <je.version>18.1.11</je.version>
         <tencentcloud.cls.version>1.0.9</tencentcloud.cls.version>
         <HikariCP.version>4.0.3</HikariCP.version>
         <caffeine.version>2.9.3</caffeine.version>


### PR DESCRIPTION
Fixes #10126 

### Motivation

`mvn clean compile package` error : com.sleepycat.je version 7.3.7 not found

### Modification

Change *com.sleepycat.je* version to resolve maven compile error.

### Verifying this change
<img width="1226" alt="image" src="https://github.com/apache/inlong/assets/28130163/fe2a2aaf-ad68-4d99-b41f-bd121e8e3a04">

*(Please pick either of the following options)*

- [✅] This change is a trivial rework/code cleanup without any test coverage.
