### PR TITLE
[INLONG-10138][CI] Bump actions/checkout@v3, actions/setup-java@v3, actions/cache@v3 to v4

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Release space size
       - name: Remove unnecessary packages
@@ -73,13 +73,13 @@ jobs:
           df -h
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/ci_chart_test.yml
+++ b/.github/workflows/ci_chart_test.yml
@@ -51,7 +51,7 @@ jobs:
           - 'kindest/node:v1.23.4'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/ci_check_format.yml
+++ b/.github/workflows/ci_check_format.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt

--- a/.github/workflows/ci_check_license.yml
+++ b/.github/workflows/ci_check_license.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check license header
         uses: apache/skywalking-eyes@v0.3.0

--- a/.github/workflows/ci_check_pr_title.yml
+++ b/.github/workflows/ci_check_pr_title.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # The correct title should start with [WIP] or [INLONG-xxx],
       # where xxx is the issue number, e.g. [INLONG-123].

--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Release space size
       - name: Remove unnecessary packages
@@ -67,7 +67,7 @@ jobs:
           df -h
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
@@ -85,7 +85,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -58,16 +58,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository

--- a/.github/workflows/ci_ut_flink13.yml
+++ b/.github/workflows/ci_ut_flink13.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Release space size
       - name: Remove unnecessary packages
@@ -52,13 +52,13 @@ jobs:
           df -h
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/ci_ut_flink15.yml
+++ b/.github/workflows/ci_ut_flink15.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Release space size
       - name: Remove unnecessary packages
@@ -52,13 +52,13 @@ jobs:
           df -h
 
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
 
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/*/*/*

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Release space size
       - name: Remove unnecessary packages
@@ -51,7 +51,7 @@ jobs:
 
       # Set up jdk
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
           distribution: adopt
@@ -64,7 +64,7 @@ jobs:
 
       # Build project
       - name: Cache Maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.m2/repository/*/*/*


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10138

### Motivation

Node.js 16 actions are deprecated, bump actions/checkout@v3, actions/setup-java@v3, actions/cache@v3 to v4

### Modifications

Node.js 16 actions are deprecated, bump actions/checkout@v3, actions/setup-java@v3, actions/cache@v3 to v4