### PR TITLE
[Inlong-10144][Sort] Redis connectors support audit ID

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
@@ -37,7 +37,11 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Map;
 
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.*;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
+
+//import static org.apache.flink.table.types.logical.LogicalTypeRoot.*;
 
 /**
  * Redis dynamic table source
@@ -52,9 +56,9 @@ public class RedisDynamicTableSource implements LookupTableSource {
     private final RedisLookupOptions redisLookupOptions;
     private final Map<String, String> properties;
 
-    private String inlongMetric;
-    private String auditHostAndPorts;
-    private String auditKeys;
+    private final String inlongMetric;
+    private final String auditHostAndPorts;
+    private final String auditKeys;
 
     public RedisDynamicTableSource(Map<String, String> properties, ResolvedSchema tableSchema,
             ReadableConfig config, RedisLookupOptions redisLookupOptions, String inlongMetric, String auditHostAndPorts,

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
@@ -52,8 +52,13 @@ public class RedisDynamicTableSource implements LookupTableSource {
     private final RedisLookupOptions redisLookupOptions;
     private final Map<String, String> properties;
 
+    private String inlongMetric;
+    private String auditHostAndPorts;
+    private String auditKeys;
+
     public RedisDynamicTableSource(Map<String, String> properties, ResolvedSchema tableSchema,
-            ReadableConfig config, RedisLookupOptions redisLookupOptions) {
+            ReadableConfig config, RedisLookupOptions redisLookupOptions, String inlongMetric, String auditHostAndPorts,
+                                   String auditKeys) {
         this.properties = properties;
         Preconditions.checkNotNull(properties, "properties should not be null");
         this.tableSchema = tableSchema;
@@ -73,11 +78,15 @@ public class RedisDynamicTableSource implements LookupTableSource {
         flinkJedisConfigBase = RedisHandlerServices
                 .findRedisHandler(InlongJedisConfigHandler.class, properties).createFlinkJedisConfig(config);
         this.redisLookupOptions = redisLookupOptions;
+        this.inlongMetric = inlongMetric;
+        this.auditHostAndPorts = auditHostAndPorts;
+        this.auditKeys = auditKeys;
     }
 
     @Override
     public DynamicTableSource copy() {
-        return new RedisDynamicTableSource(properties, tableSchema, config, redisLookupOptions);
+        return new RedisDynamicTableSource(properties, tableSchema, config, redisLookupOptions, inlongMetric,
+                auditHostAndPorts, auditKeys);
     }
 
     @Override
@@ -88,6 +97,7 @@ public class RedisDynamicTableSource implements LookupTableSource {
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
         return TableFunctionProvider.of(new RedisRowDataLookupFunction(
-                redisMapper.getCommandDescription(), flinkJedisConfigBase, this.redisLookupOptions));
+                redisMapper.getCommandDescription(), flinkJedisConfigBase, this.redisLookupOptions, inlongMetric,
+                auditHostAndPorts, auditKeys));
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisDynamicTableSource.java
@@ -37,9 +37,9 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Map;
 
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.DOUBLE;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.VARCHAR;
-import static org.apache.flink.table.types.logical.LogicalTypeRoot.BIGINT;
 
 //import static org.apache.flink.table.types.logical.LogicalTypeRoot.*;
 
@@ -62,7 +62,7 @@ public class RedisDynamicTableSource implements LookupTableSource {
 
     public RedisDynamicTableSource(Map<String, String> properties, ResolvedSchema tableSchema,
             ReadableConfig config, RedisLookupOptions redisLookupOptions, String inlongMetric, String auditHostAndPorts,
-                                   String auditKeys) {
+            String auditKeys) {
         this.properties = properties;
         Preconditions.checkNotNull(properties, "properties should not be null");
         this.tableSchema = tableSchema;

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
@@ -39,8 +39,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.inlong.sort.base.util.CalculateObjectSizeUtils.getDataSize;
-
 /**
  * Redis RowData lookup function
  */
@@ -75,7 +73,9 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
                 .withAuditAddress(auditHostAndPorts)
                 .withAuditKeys(auditKeys)
                 .build();
-        this.sourceMetricData = new SourceMetricData(metricOption);
+        if (metricOption != null) {
+            sourceMetricData = new SourceMetricData(metricOption);
+        }
     }
 
     /**
@@ -120,7 +120,9 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
                         throw new UnsupportedOperationException(
                                 String.format("Unsupported for redisCommand: %s", redisCommand));
                 }
-                sourceMetricData.outputMetricsWithEstimate(rowData, System.currentTimeMillis());
+                if(sourceMetricData != null){
+                    sourceMetricData.outputMetricsWithEstimate(rowData, System.currentTimeMillis());
+                }
                 LOG.info("Report audit: {} and time : {}", rowData, System.currentTimeMillis());
                 if (cache == null) {
                     collect(rowData);

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.redis.source;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.SourceMetricData;
 import org.apache.inlong.sort.redis.common.config.RedisLookupOptions;
 import org.apache.inlong.sort.redis.common.container.InlongRedisCommandsContainer;
 import org.apache.inlong.sort.redis.common.container.RedisCommandsContainerBuilder;
@@ -37,6 +39,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.inlong.sort.base.util.CalculateObjectSizeUtils.getDataSize;
+
 /**
  * Redis RowData lookup function
  */
@@ -55,14 +59,23 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
     private transient Cache<RowData, RowData> cache;
     private InlongRedisCommandsContainer redisCommandsContainer;
 
+    private SourceMetricData sourceMetricData;
+
     RedisRowDataLookupFunction(RedisCommandDescription redisCommandDescription,
-            FlinkJedisConfigBase flinkJedisConfigBase, RedisLookupOptions redisLookupOptions) {
+            FlinkJedisConfigBase flinkJedisConfigBase, RedisLookupOptions redisLookupOptions, String inlongMetric,
+                               String auditHostAndPorts, String auditKeys) {
         this.flinkJedisConfigBase = flinkJedisConfigBase;
         this.redisCommand = redisCommandDescription.getCommand();
         this.additionalKey = redisCommandDescription.getAdditionalKey();
         this.cacheMaxSize = redisLookupOptions.getCacheMaxSize();
         this.cacheExpireMs = redisLookupOptions.getCacheExpireMs();
         this.maxRetryTimes = redisLookupOptions.getMaxRetryTimes();
+        MetricOption metricOption = MetricOption.builder()
+                .withInlongLabels(inlongMetric)
+                .withAuditAddress(auditHostAndPorts)
+                .withAuditKeys(auditKeys)
+                .build();
+        this.sourceMetricData = new SourceMetricData(metricOption);
     }
 
     /**
@@ -107,6 +120,8 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
                         throw new UnsupportedOperationException(
                                 String.format("Unsupported for redisCommand: %s", redisCommand));
                 }
+                sourceMetricData.outputMetricsWithEstimate(rowData, System.currentTimeMillis());
+                LOG.info("Report audit: {} and time : {}", rowData, System.currentTimeMillis());
                 if (cache == null) {
                     collect(rowData);
                 } else {

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/source/RedisRowDataLookupFunction.java
@@ -61,7 +61,7 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
 
     RedisRowDataLookupFunction(RedisCommandDescription redisCommandDescription,
             FlinkJedisConfigBase flinkJedisConfigBase, RedisLookupOptions redisLookupOptions, String inlongMetric,
-                               String auditHostAndPorts, String auditKeys) {
+            String auditHostAndPorts, String auditKeys) {
         this.flinkJedisConfigBase = flinkJedisConfigBase;
         this.redisCommand = redisCommandDescription.getCommand();
         this.additionalKey = redisCommandDescription.getAdditionalKey();
@@ -120,7 +120,7 @@ public class RedisRowDataLookupFunction extends TableFunction<RowData> {
                         throw new UnsupportedOperationException(
                                 String.format("Unsupported for redisCommand: %s", redisCommand));
                 }
-                if(sourceMetricData != null){
+                if (sourceMetricData != null) {
                     sourceMetricData.outputMetricsWithEstimate(rowData, System.currentTimeMillis());
                 }
                 LOG.info("Report audit: {} and time : {}", rowData, System.currentTimeMillis());

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/table/RedisDynamicTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/src/main/java/org/apache/inlong/sort/redis/table/RedisDynamicTableFactory.java
@@ -95,10 +95,15 @@ public class RedisDynamicTableFactory implements DynamicTableSourceFactory, Dyna
     public DynamicTableSource createDynamicTableSource(Context context) {
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
         ReadableConfig config = helper.getOptions();
+
         helper.validate();
         validateConfigOptions(config, SUPPORT_SOURCE_COMMANDS);
+        String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
+        String auditHostAndPorts = config.get(INLONG_AUDIT);
+        String auditKeys = config.get(AUDIT_KEYS);
         return new RedisDynamicTableSource(context.getCatalogTable().getOptions(),
-                context.getCatalogTable().getResolvedSchema(), config, getJdbcLookupOptions(config));
+                context.getCatalogTable().getResolvedSchema(), config, getJdbcLookupOptions(config), inlongMetric,
+                auditHostAndPorts, auditKeys);
     }
 
     @Override


### PR DESCRIPTION
### Prepare a Pull Request

- [INLONG-10144][Sort] Redis connectors support audit ID

- Fixes #10144 

### Motivation

Redis connector not support audit function. So this pr will make it support audit function.

### Modifications

Modify redis connector source.when source receive data, it will send audit information at same time.

