### PR TITLE
[INLONG-10147][Audit] Less usage costs when the Audit uses the MySQL as storage

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/ConfigService.java
@@ -248,7 +248,6 @@ public class ConfigService {
         for (Map.Entry<String, List<JdbcConfig>> entry : auditSources.entrySet()) {
             sourceList.addAll(entry.getValue());
         }
-        sourceList.add(JdbcUtils.buildMysqlConfig());
         return sourceList;
     }
 


### PR DESCRIPTION
- Fixes #10147 

### Motivation

When the audit system uses MySQL as the storage, the audit service can use the same MySQL configuration as the storage system, making it more convenient to use.

### Modifications
If the audit data source is not configured in the service configuration table audit_source_config, use the same MySQL configuration as the service.


