### PR TITLE
[INLONG-10152][Sort] Refactor MetricOption code structure.

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -57,7 +57,7 @@ public class MetricOption implements Serializable {
     private List<Integer> inlongAuditKeys;
 
     private MetricOption(
-            String inlongLabels,
+            Map<String, String> labels,
             @Nullable String inlongAudit,
             RegisteredMetric registeredMetric,
             long initRecords,
@@ -65,46 +65,18 @@ public class MetricOption implements Serializable {
             Long initDirtyRecords,
             Long initDirtyBytes,
             Long readPhase,
-            String inlongAuditKeys) {
-        Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(inlongLabels),
-                "Inlong labels must be set for register metric.");
-
+            List<Integer> inlongAuditKeys,
+            HashSet<String> ipPortList) {
         this.initRecords = initRecords;
         this.initBytes = initBytes;
         this.initDirtyRecords = initDirtyRecords;
         this.initDirtyBytes = initDirtyBytes;
         this.readPhase = readPhase;
-        this.labels = new LinkedHashMap<>();
-        String[] inLongLabelArray = inlongLabels.split(DELIMITER);
-        Preconditions.checkArgument(Stream.of(inLongLabelArray).allMatch(label -> label.contains("=")),
-                "InLong metric label format must be xxx=xxx");
-        Stream.of(inLongLabelArray).forEach(label -> {
-            String key = label.substring(0, label.indexOf('='));
-            String value = label.substring(label.indexOf('=') + 1);
-            labels.put(key, value);
-        });
-
+        this.labels = labels;
         this.ipPorts = inlongAudit;
-
-        if (ipPorts != null) {
-
-            Preconditions.checkArgument(labels.containsKey(GROUP_ID) && labels.containsKey(STREAM_ID),
-                    "groupId and streamId must be set when enable inlong audit collect.");
-
-            if (inlongAuditKeys == null) {
-                LOG.warn("should set inlongAuditKeys when enable inlong audit collect, "
-                        + "fallback to use id {} as audit key", AUDIT_SORT_INPUT);
-                inlongAuditKeys = AUDIT_SORT_INPUT;
-            }
-
-            this.inlongAuditKeys = AuditUtils.extractAuditKeys(inlongAuditKeys);
-            this.ipPortList = AuditUtils.extractAuditIpPorts(ipPorts);
-
-        }
-
-        if (registeredMetric != null) {
-            this.registeredMetric = registeredMetric;
-        }
+        this.inlongAuditKeys = inlongAuditKeys;
+        this.ipPortList = ipPortList;
+        this.registeredMetric = registeredMetric;
     }
 
     public Map<String, String> getLabels() {
@@ -238,11 +210,43 @@ public class MetricOption implements Serializable {
         }
 
         public MetricOption build() {
-            if (inlongLabels == null && inlongAudit == null) {
+            if (inlongAudit == null) {
+                LOG.warn("The property 'metrics.audit.proxy.hosts' has not been set," +
+                        " the program will not open audit function");
                 return null;
             }
-            return new MetricOption(inlongLabels, inlongAudit, registeredMetric, initRecords, initBytes,
-                    initDirtyRecords, initDirtyBytes, initReadPhase, inlongAuditKeys);
+
+            Preconditions.checkArgument(!StringUtils.isNullOrWhitespaceOnly(inlongLabels),
+                    "Inlong labels must be set for register metric.");
+            String[] inLongLabelArray = inlongLabels.split(DELIMITER);
+            Preconditions.checkArgument(Stream.of(inLongLabelArray).allMatch(label -> label.contains("=")),
+                    "InLong metric label format must be xxx=xxx");
+            Map<String, String> labels = new LinkedHashMap<>();
+            Stream.of(inLongLabelArray).forEach(label -> {
+                String key = label.substring(0, label.indexOf('='));
+                String value = label.substring(label.indexOf('=') + 1);
+                labels.put(key, value);
+            });
+
+            List<Integer> inlongAuditKeysList = null;
+            HashSet<String> ipPortList = null;
+
+            if (inlongAudit != null) {
+                Preconditions.checkArgument(labels.containsKey(GROUP_ID) && labels.containsKey(STREAM_ID),
+                        "The groupId and streamId must be set when enable inlong audit collect.");
+
+                if (inlongAuditKeys == null) {
+                    LOG.warn("The inlongAuditKeys should be set when enable inlong audit collect, "
+                            + "fallback to use id {} as audit key", AUDIT_SORT_INPUT);
+                    inlongAuditKeys = AUDIT_SORT_INPUT;
+                }
+
+                inlongAuditKeysList = AuditUtils.extractAuditKeys(inlongAuditKeys);
+                ipPortList = AuditUtils.extractAuditIpPorts(inlongAudit);
+            }
+
+            return new MetricOption(labels, inlongAudit, registeredMetric, initRecords, initBytes,
+                    initDirtyRecords, initDirtyBytes, initReadPhase, inlongAuditKeysList, ipPortList);
         }
     }
 }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -83,7 +83,7 @@ public class MetricOption implements Serializable {
     public Map<String, String> getLabels() {
         return labels;
     }
-    
+
     public HashSet<String> getIpPortSet() {
         return new HashSet<>(ipPortSet);
     }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class MetricOption implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Map<String, String> labels;
-    private HashSet<String> ipPortList;
+    private Set<String> ipPortSet;
     private String ipPorts;
     private RegisteredMetric registeredMetric;
     private long initRecords;
@@ -66,7 +67,7 @@ public class MetricOption implements Serializable {
             Long initDirtyBytes,
             Long readPhase,
             List<Integer> inlongAuditKeys,
-            HashSet<String> ipPortList) {
+            Set<String> ipPortSet) {
         this.initRecords = initRecords;
         this.initBytes = initBytes;
         this.initDirtyRecords = initDirtyRecords;
@@ -75,7 +76,7 @@ public class MetricOption implements Serializable {
         this.labels = labels;
         this.ipPorts = inlongAudit;
         this.inlongAuditKeys = inlongAuditKeys;
-        this.ipPortList = ipPortList;
+        this.ipPortSet = ipPortSet;
         this.registeredMetric = registeredMetric;
     }
 
@@ -83,8 +84,12 @@ public class MetricOption implements Serializable {
         return labels;
     }
 
-    public HashSet<String> getIpPortList() {
-        return ipPortList;
+    public Set<String> getIpPortSet() {
+        return ipPortSet;
+    }
+
+    public HashSet<String> getIpPortSetAsHashSet() {
+        return new HashSet<>(ipPortSet);
     }
 
     public Optional<String> getIpPorts() {
@@ -229,7 +234,7 @@ public class MetricOption implements Serializable {
             });
 
             List<Integer> inlongAuditKeysList = null;
-            HashSet<String> ipPortList = null;
+            Set<String> ipPortSet = null;
 
             if (inlongAudit != null) {
                 Preconditions.checkArgument(labels.containsKey(GROUP_ID) && labels.containsKey(STREAM_ID),
@@ -242,11 +247,11 @@ public class MetricOption implements Serializable {
                 }
 
                 inlongAuditKeysList = AuditUtils.extractAuditKeys(inlongAuditKeys);
-                ipPortList = AuditUtils.extractAuditIpPorts(inlongAudit);
+                ipPortSet = AuditUtils.extractAuditIpPorts(inlongAudit);
             }
 
             return new MetricOption(labels, inlongAudit, registeredMetric, initRecords, initBytes,
-                    initDirtyRecords, initDirtyBytes, initReadPhase, inlongAuditKeysList, ipPortList);
+                    initDirtyRecords, initDirtyBytes, initReadPhase, inlongAuditKeysList, ipPortSet);
         }
     }
 }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -28,11 +28,11 @@ import javax.annotation.Nullable;
 
 import java.io.Serializable;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.apache.inlong.sort.base.Constants.AUDIT_SORT_INPUT;

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -83,12 +83,8 @@ public class MetricOption implements Serializable {
     public Map<String, String> getLabels() {
         return labels;
     }
-
-    public Set<String> getIpPortSet() {
-        return ipPortSet;
-    }
-
-    public HashSet<String> getIpPortSetAsHashSet() {
+    
+    public HashSet<String> getIpPortSet() {
         return new HashSet<>(ipPortSet);
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricOption.java
@@ -215,8 +215,8 @@ public class MetricOption implements Serializable {
         }
 
         public MetricOption build() {
-            if (inlongAudit == null) {
-                LOG.warn("The property 'metrics.audit.proxy.hosts' has not been set," +
+            if (inlongAudit == null && inlongLabels == null) {
+                LOG.warn("The property 'metrics.audit.proxy.hosts and inlong.metric.labels' has not been set," +
                         " the program will not open audit function");
                 return null;
             }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -101,7 +101,7 @@ public class SinkMetricData implements MetricData, Serializable {
         }
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SinkMetricData.java
@@ -101,7 +101,7 @@ public class SinkMetricData implements MetricData, Serializable {
         }
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortList());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -104,7 +104,7 @@ public class SourceMetricData implements MetricData, Serializable {
         }
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }
@@ -114,7 +114,7 @@ public class SourceMetricData implements MetricData, Serializable {
         this.labels = option.getLabels();
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -104,7 +104,7 @@ public class SourceMetricData implements MetricData, Serializable {
         }
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortList());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }
@@ -114,7 +114,7 @@ public class SourceMetricData implements MetricData, Serializable {
         this.labels = option.getLabels();
 
         if (option.getIpPorts().isPresent()) {
-            AuditOperator.getInstance().setAuditProxy(option.getIpPortList());
+            AuditOperator.getInstance().setAuditProxy(option.getIpPortSetAsHashSet());
             this.auditOperator = AuditOperator.getInstance();
             this.auditKeys = option.getInlongAuditKeys();
         }


### PR DESCRIPTION
Prepare a Pull Request

- [INLONG-10152][Sort] Refactor MetricOption code structure.

- Fixes #10152 

### Motivation

The MetricOption constructor Does not conform to the single responsibility design pattern，check arguments not exist in constructor will make code clearly.

### Modifications

Adjust constructor and move check arguments code statement.

