### PR TITLE
[INLONG-10157][Audit] Use a custom thread pool instead of the system thread pool

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/ConfigConstants.java
@@ -74,6 +74,9 @@ public class ConfigConstants {
     public static final String KEY_STAT_BACK_INITIAL_OFFSET = "stat.back.initial.offset";
     public static final int DEFAULT_STAT_BACK_INITIAL_OFFSET = 0;
 
+    public static final String KEY_STAT_THREAD_POOL_SIZE = "stat.thread.pool.size";
+    public static final int DEFAULT_STAT_THREAD_POOL_SIZE = 3;
+
     // HA selector config
     public static final String KEY_RELEASE_LEADER_INTERVAL = "release.leader.interval";
     public static final int DEFAULT_RELEASE_LEADER_INTERVAL = 40;

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/config/OpenApiConstants.java
@@ -45,7 +45,7 @@ public class OpenApiConstants {
     public static final int DEFAULT_API_CACHE_MAX_SIZE = 50000000;
 
     public static final String KEY_API_CACHE_EXPIRED_HOURS = "api.cache.expired.hours";
-    public static final int DEFAULT_API_CACHE_EXPIRED_HOURS = 18;
+    public static final int DEFAULT_API_CACHE_EXPIRED_HOURS = 12;
 
     // Http config
     public static final String PARAMS_START_TIME = "startTime";


### PR DESCRIPTION
- Fixes #10157

### Motivation

Use a custom thread pool instead of the system thread pool.

### Modifications

Use a custom thread pool instead of the system thread pool.