### PR TITLE
[INLONG-10184][SDK] The header in ProxyEvent need contain both 'rtms' and 'auditVersion'.

### DIFF
--- a/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/protocol/ProxyEvent.java
+++ b/inlong-sdk/sdk-common/src/main/java/org/apache/inlong/sdk/commons/protocol/ProxyEvent.java
@@ -17,10 +17,12 @@
 
 package org.apache.inlong.sdk.commons.protocol;
 
+import org.apache.inlong.common.msg.AttributeConstants;
 import org.apache.inlong.sdk.commons.protocol.ProxySdk.MessageObj;
 
 import org.apache.commons.lang3.math.NumberUtils;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -83,6 +85,16 @@ public class ProxyEvent extends SdkEvent {
         headers.put(EventConstants.INLONG_STREAM_ID, inlongStreamId);
         headers.put(EventConstants.HEADER_KEY_MSG_TIME, String.valueOf(msgTime));
         headers.put(EventConstants.HEADER_KEY_SOURCE_IP, sourceIp);
+        if (obj != null && obj.getParamsList() != null) {
+            List<ProxySdk.MapFieldEntry> list = obj.getParamsList();
+            for (ProxySdk.MapFieldEntry entry : list) {
+                if (AttributeConstants.MSG_RPT_TIME.equalsIgnoreCase(entry.getKey())) {
+                    headers.put(AttributeConstants.MSG_RPT_TIME, entry.getValue());
+                } else if (AttributeConstants.AUDIT_VERSION.equalsIgnoreCase(entry.getKey())) {
+                    headers.put(AttributeConstants.AUDIT_VERSION, entry.getValue());
+                }
+            }
+        }
 
         this.sourceTime = System.currentTimeMillis();
         this.getHeaders().put(EventConstants.HEADER_KEY_SOURCE_TIME, String.valueOf(sourceTime));


### PR DESCRIPTION
Fixes #10184

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
