### PR TITLE
[INLONG-10189][Agent] Handling SDK initialization exceptions

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Instance.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/Instance.java
@@ -53,4 +53,6 @@ public abstract class Instance extends AbstractStateWrapper {
      * get instance id
      */
     public abstract String getInstanceId();
+
+    public abstract long getLastHeartbeatTime();
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -242,7 +242,8 @@ public class InstanceManager extends AbstractDaemon {
                 deleteFromMemory(instance.getInstanceId());
             }
             if (AgentUtils.getCurrentTime() - instance.getLastHeartbeatTime() > INSTANCE_KEEP_ALIVE_MS) {
-                LOGGER.error("instance heartbeat timeout, id: {}, will be deleted from memory", instance.getInstanceId());
+                LOGGER.error("instance heartbeat timeout, id: {}, will be deleted from memory",
+                        instance.getInstanceId());
                 deleteFromMemory(instance.getInstanceId());
             }
         });

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -54,7 +54,7 @@ public class InstanceManager extends AbstractDaemon {
     private static final int ACTION_QUEUE_CAPACITY = 100;
     public volatile int CORE_THREAD_SLEEP_TIME_MS = 1000;
     public static final int INSTANCE_PRINT_INTERVAL_MS = 10000;
-    public static final long INSTANCE_MAX_HEARTBEAT_GAP_MS = 5 * 60 * 1000;
+    public static final long INSTANCE_KEEP_ALIVE_MS = 5 * 60 * 1000;
     private long lastPrintTime = 0;
     // instance in db
     private final InstanceDb instanceDb;
@@ -241,7 +241,7 @@ public class InstanceManager extends AbstractDaemon {
             if (stateFromDb != InstanceStateEnum.DEFAULT) {
                 deleteFromMemory(instance.getInstanceId());
             }
-            if (AgentUtils.getCurrentTime() - instance.getLastHeartbeatTime() > INSTANCE_MAX_HEARTBEAT_GAP_MS) {
+            if (AgentUtils.getCurrentTime() - instance.getLastHeartbeatTime() > INSTANCE_KEEP_ALIVE_MS) {
                 LOGGER.error("instance heartbeat timeout {} will delete from memory", instance.getInstanceId());
                 deleteFromMemory(instance.getInstanceId());
             }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -242,7 +242,7 @@ public class InstanceManager extends AbstractDaemon {
                 deleteFromMemory(instance.getInstanceId());
             }
             if (AgentUtils.getCurrentTime() - instance.getLastHeartbeatTime() > INSTANCE_KEEP_ALIVE_MS) {
-                LOGGER.error("instance heartbeat timeout {} will delete from memory", instance.getInstanceId());
+                LOGGER.error("instance heartbeat timeout, id: {}, will be deleted from memory", instance.getInstanceId());
                 deleteFromMemory(instance.getInstanceId());
             }
         });

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -58,7 +58,7 @@ public class TaskManager extends AbstractDaemon {
     public static final int CONFIG_QUEUE_CAPACITY = 1;
     public static final int CORE_THREAD_SLEEP_TIME = 1000;
     public static final int CORE_THREAD_PRINT_TIME = 10000;
-    private static final int ACTION_QUEUE_CAPACITY = 100000;
+    private static final int ACTION_QUEUE_CAPACITY = 1000;
     private long lastPrintTime = 0;
     // task basic db
     private final Db taskBasicDb;

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/instance/MockInstance.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/instance/MockInstance.java
@@ -19,6 +19,7 @@ package org.apache.inlong.agent.core.instance;
 
 import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.plugin.Instance;
+import org.apache.inlong.agent.utils.AgentUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +65,11 @@ public class MockInstance extends Instance {
     @Override
     public String getInstanceId() {
         return profile.getInstanceId();
+    }
+
+    @Override
+    public long getLastHeartbeatTime() {
+        return AgentUtils.getCurrentTime();
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/CommonInstance.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/instance/CommonInstance.java
@@ -57,7 +57,7 @@ public abstract class CommonInstance extends Instance {
     private volatile boolean running = false;
     private volatile boolean inited = false;
     private volatile int checkFinishCount = 0;
-    private int heartbeatcheckCount = 0;
+    private int heartbeatCheckCount = 0;
     private long heartBeatStartTime = AgentUtils.getCurrentTime();
     protected long auditVersion;
 
@@ -72,15 +72,15 @@ public abstract class CommonInstance extends Instance {
                     profile.getInstanceId(), profile.toJsonStr());
             source = (Source) Class.forName(profile.getSourceClass()).newInstance();
             source.init(profile);
-            source.start();
             sink = (Sink) Class.forName(profile.getSinkClass()).newInstance();
             sink.init(profile);
             inited = true;
             return true;
         } catch (Throwable e) {
-            handleSourceDeleted();
+            handleDeleted();
             doChangeState(State.FATAL);
-            LOGGER.error("init instance {} for task {} failed", profile.getInstanceId(), profile.getInstanceId(), e);
+            LOGGER.error("init instance {} for task {} failed", profile.getInstanceId(), profile.getInstanceId(),
+                    e);
             ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);
             return false;
         }
@@ -117,10 +117,17 @@ public abstract class CommonInstance extends Instance {
     }
 
     private void doRun() {
+        source.start();
         while (!isFinished()) {
             if (!source.sourceExist()) {
-                handleSourceDeleted();
-                break;
+                if (handleDeleted()) {
+                    break;
+                } else {
+                    LOGGER.error("instance manager action queue is full: taskId {}",
+                            instanceManager.getTaskId());
+                    AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME);
+                    continue;
+                }
             }
             Message msg = source.read();
             if (msg == null) {
@@ -144,8 +151,8 @@ public abstract class CommonInstance extends Instance {
                         AgentUtils.silenceSleepInMs(WRITE_FAILED_WAIT_TIME_MS);
                     }
                 }
-                heartbeatcheckCount++;
-                if (heartbeatcheckCount > HEARTBEAT_CHECK_GAP) {
+                heartbeatCheckCount++;
+                if (heartbeatCheckCount > HEARTBEAT_CHECK_GAP) {
                     heartbeatStatic();
                 }
             }
@@ -156,7 +163,7 @@ public abstract class CommonInstance extends Instance {
         if (AgentUtils.getCurrentTime() - heartBeatStartTime > TimeUnit.SECONDS.toMillis(1)) {
             AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_INSTANCE_HEARTBEAT, profile.getInlongGroupId(),
                     profile.getInlongStreamId(), AgentUtils.getCurrentTime(), 1, 1, auditVersion);
-            heartbeatcheckCount = 0;
+            heartbeatCheckCount = 0;
             heartBeatStartTime = AgentUtils.getCurrentTime();
         }
     }
@@ -169,16 +176,17 @@ public abstract class CommonInstance extends Instance {
         }
     }
 
-    private void handleSourceDeleted() {
+    private boolean handleDeleted() {
         OffsetManager.getInstance().deleteOffset(getTaskId(), getInstanceId());
         profile.setState(InstanceStateEnum.DELETE);
         profile.setModifyTime(AgentUtils.getCurrentTime());
         InstanceAction action = new InstanceAction(ActionType.DELETE, profile);
-        while (!isFinished() && !instanceManager.submitAction(action)) {
-            LOGGER.error("instance manager action queue is full: taskId {}",
-                    instanceManager.getTaskId());
-            AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME);
-        }
+        return instanceManager.submitAction(action);
+    }
+
+    @Override
+    public long getLastHeartbeatTime() {
+        return heartBeatStartTime;
     }
 
     @Override


### PR DESCRIPTION
Fixes #10189

### Motivation

Handling data proxy SDK initialization exceptions

### Modifications

1 Add instance heartbeat timeout detection
2 Clean up timeout instances and wait for retry
3 Move the source startup operation from the initialization function to the main Instance thread

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
