### PR TITLE
[INLONG-10091][Agent] Delete the useless code related to 8008 listen port

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -99,8 +99,6 @@ services:
       - DATAPROXY_IP=dataproxy
       - DATAPROXY_PORT=46801
       - AUDIT_PROXY_URL=audit:10081
-    ports:
-      - "8008:8008"
     volumes:
       - ./collect-data:/data/collect-data
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -39,8 +39,6 @@ public class AgentConstants {
     public static final String AGENT_FETCHER_CLASSNAME = "agent.fetcher.classname";
     public static final String AGENT_CONF_PARENT = "agent.conf.parent";
     public static final String DEFAULT_AGENT_CONF_PARENT = "conf";
-    public static final String AGENT_HTTP_PORT = "agent.http.port";
-    public static final int DEFAULT_AGENT_HTTP_PORT = 8008;
     public static final String CHANNEL_MEMORY_CAPACITY = "channel.memory.capacity";
     public static final int DEFAULT_CHANNEL_MEMORY_CAPACITY = 2000;
     public static final String JOB_NUMBER_LIMIT = "job.number.limit";

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -39,9 +39,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_IN_CHARGES;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
-import static org.apache.inlong.agent.constant.AgentConstants.AGENT_HTTP_PORT;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_NODE_GROUP;
-import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AGENT_HTTP_PORT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_HEARTBEAT_HTTP_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_HEARTBEAT_HTTP_PATH;
 
@@ -148,7 +146,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
      */
     private HeartbeatMsg buildHeartbeatMsg() {
         final String agentIp = AgentUtils.fetchLocalIp();
-        final int agentPort = conf.getInt(AGENT_HTTP_PORT, DEFAULT_AGENT_HTTP_PORT);
         final String clusterName = conf.get(AGENT_CLUSTER_NAME);
         final String clusterTag = conf.get(AGENT_CLUSTER_TAG);
         final String inCharges = conf.get(AGENT_CLUSTER_IN_CHARGES);
@@ -156,7 +153,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
 
         HeartbeatMsg heartbeatMsg = new HeartbeatMsg();
         heartbeatMsg.setIp(agentIp);
-        heartbeatMsg.setPort(String.valueOf(agentPort));
         heartbeatMsg.setComponentType(ComponentTypeEnum.Agent.getType());
         heartbeatMsg.setReportTime(System.currentTimeMillis());
         if (StringUtils.isNotBlank(clusterName)) {
@@ -183,7 +179,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
         heartbeatMsg.setNodeSrvStatus(NodeSrvStatus.SERVICE_UNINSTALL);
         heartbeatMsg.setInCharges(conf.get(AGENT_CLUSTER_IN_CHARGES));
         heartbeatMsg.setIp(AgentUtils.fetchLocalIp());
-        heartbeatMsg.setPort(String.valueOf(conf.getInt(AGENT_HTTP_PORT, DEFAULT_AGENT_HTTP_PORT)));
         heartbeatMsg.setComponentType(ComponentTypeEnum.Agent.getType());
         heartbeatMsg.setClusterName(conf.get(AGENT_CLUSTER_NAME));
         heartbeatMsg.setClusterTag(conf.get(AGENT_CLUSTER_TAG));

--- a/inlong-agent/agent-docker/Dockerfile
+++ b/inlong-agent/agent-docker/Dockerfile
@@ -27,7 +27,6 @@ ADD ${AGENT_TARBALL} /opt/inlong-agent
 RUN cp /usr/share/java/snappy-java.jar lib/snappy-java-*.jar
 # add mysql connector
 RUN wget -P lib/ https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar
-EXPOSE 8008
 ENV MANAGER_OPENAPI_IP=127.0.0.1
 ENV MANAGER_OPENAPI_PORT=8082
 ENV DATAPROXY_IP=127.0.0.1

--- a/inlong-agent/agent-docker/README.md
+++ b/inlong-agent/agent-docker/README.md
@@ -8,7 +8,6 @@ docker pull inlong/agent:latest
 
 ##### Start Container
 ```
-docker run -d --name agent  -p 8008:8008 \
 -e MANAGER_OPENAPI_IP=manager_opeapi_ip -e DATAPROXY_IP=dataproxy_ip \
 -e MANAGER_OPENAPI_AUTH_ID=auth_id -e MANAGER_OPENAPI_AUTH_KEY=auth_key \
 -e MANAGER_OPENAPI_PORT=8082 -e DATAPROXY_PORT=46801 inlong/agent

--- a/inlong-agent/agent-docker/README.md
+++ b/inlong-agent/agent-docker/README.md
@@ -8,6 +8,7 @@ docker pull inlong/agent:latest
 
 ##### Start Container
 ```
+docker run -d --name agent \
 -e MANAGER_OPENAPI_IP=manager_opeapi_ip -e DATAPROXY_IP=dataproxy_ip \
 -e MANAGER_OPENAPI_AUTH_ID=auth_id -e MANAGER_OPENAPI_AUTH_KEY=auth_key \
 -e MANAGER_OPENAPI_PORT=8082 -e DATAPROXY_PORT=46801 inlong/agent

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -24,8 +24,6 @@
 agent.localStore.readonly=false
 # whether enable http service
 agent.http.enable=true
-# http default port
-agent.http.port=8008
 
 ######################
 #  fetch center

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -22,8 +22,6 @@
 ########################
 # bdb data readonly
 agent.localStore.readonly=false
-# whether enable http service
-agent.http.enable=true
 
 ######################
 #  fetch center


### PR DESCRIPTION
Fixes #10091

### Motivation
The agent does not listen to the port, and the relevant code is useless
### Modifications

Delete useless code

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
