### PR TITLE
[INLONG-10201][Audit] Renamed configuration variables for clarity

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/file/ConfigManager.java
@@ -247,7 +247,7 @@ public class ConfigManager {
             try {
                 String managerHosts = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES).get("manager.hosts");
                 String proxyClusterTag = configManager.getProperties(DEFAULT_CONFIG_PROPERTIES)
-                        .get("proxy.cluster.tag");
+                        .get("default.mq.cluster.tag");
                 LOG.info("manager url: {}", managerHosts);
                 String[] hostList = StringUtils.split(managerHosts, ",");
                 for (String host : hostList) {

--- a/inlong-audit/audit-docker/audit-docker.sh
+++ b/inlong-audit/audit-docker/audit-docker.sh
@@ -32,7 +32,7 @@ service_conf_file=${file_path}/conf/audit-service.properties
 
 # replace the configuration for audit-proxy
 sed -i "s/manager.hosts=.*$/manager.hosts=${MANAGER_OPENAPI_IP}:${MANAGER_OPENAPI_PORT}/g" "${store_conf_file}"
-sed -i "s/proxy.cluster.tag=.*$/proxy.cluster.tag=${CLUSTER_TAG}/g" "${store_conf_file}"
+sed -i "s/default.mq.cluster.tag=.*$/default.mq.cluster.tag=${CLUSTER_TAG}/g" "${store_conf_file}"
 if [ "${MQ_TYPE}" = "pulsar" ]; then
   sed -i "s/audit.config.proxy.type=.*$/audit.config.proxy.type=pulsar"/g "${store_conf_file}"
   sed -i "s/audit.pulsar.topic = .*$/audit.pulsar.topic = ${PULSAR_AUDIT_TOPIC}/g" "${store_conf_file}"

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/service/AuditMsgConsumerServer.java
@@ -121,7 +121,7 @@ public class AuditMsgConsumerServer implements InitializingBean {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(DEFAULT_CONFIG_PROPERTIES)) {
             properties.load(inputStream);
             String managerHosts = properties.getProperty("manager.hosts");
-            String clusterTag = properties.getProperty("proxy.cluster.tag");
+            String clusterTag = properties.getProperty("default.mq.cluster.tag");
             String[] hostList = StringUtils.split(managerHosts, ",");
             for (String host : hostList) {
                 while (true) {

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -25,7 +25,7 @@ audit.config.store.mode=jdbc
 # manger config
 manager.hosts=127.0.0.1:8083
 
-# Get Kafka or Pulsar address with this cluster tag from manager.
+# Kafka or Pulsar cluster tag
 default.mq.cluster.tag=default_cluster
 
 # pulsar config

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-# proxy.type: pulsar / tube / kafka
+# the MQ type for audit proxy: pulsar / kafka
 audit.config.proxy.type=pulsar
 
 # Supports common JDBC protocol
@@ -24,7 +24,9 @@ audit.config.store.mode=jdbc
 
 # manger config
 manager.hosts=127.0.0.1:8083
-proxy.cluster.tag=default_cluster
+
+# Get Kafka or Pulsar address from the cluster tag.
+default.mq.cluster.tag=default_cluster
 
 # pulsar config
 audit.pulsar.topic=persistent://public/default/inlong-audit

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -25,7 +25,7 @@ audit.config.store.mode=jdbc
 # manger config
 manager.hosts=127.0.0.1:8083
 
-# Get Kafka or Pulsar address from the cluster tag.
+# Get Kafka or Pulsar address with this cluster tag from manager.
 default.mq.cluster.tag=default_cluster
 
 # pulsar config


### PR DESCRIPTION
Fixes #10201 

### Motivation

Renamed configuration variables for clarity

### Modifications

- Rename configuration variables
- Rename audit docker variables

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.
