### PR TITLE
[INLONG-10179][DashBoard] Remove the All types In cluster management

### DIFF
--- a/inlong-dashboard/src/plugins/clusters/common/ClusterDefaultInfo.ts
+++ b/inlong-dashboard/src/plugins/clusters/common/ClusterDefaultInfo.ts
@@ -52,7 +52,7 @@ export class ClusterDefaultInfo implements DataWithBackend, RenderRow, RenderLis
     props: values => ({
       disabled: Boolean(values.id),
       options: clusters
-        .filter(item => item.value !== 'DATAPROXY')
+        .filter(item => item.value !== 'DATAPROXY' && item.value !== '')
         .map(item => ({
           label: item.label,
           value: item.value,


### PR DESCRIPTION
Fixes #10179 

### Motivation

The drop-down box in the Create Cluster modal does not need to be of type All

### Modifications

Remove the All-type in the Create Cluster modal

### Verifying this change
![image](https://github.com/apache/inlong/assets/165994047/3ae79f93-3497-40af-9749-b4903f4347da)
![image](https://github.com/apache/inlong/assets/165994047/31553ba2-4fcd-44f4-8397-a66dc7300c73)




