### PR TITLE
[INLONG-10210][Agent] Add a script for environment initialization

### DIFF
--- a/inlong-agent/agent-installer/assembly.xml
+++ b/inlong-agent/agent-installer/assembly.xml
@@ -30,6 +30,16 @@
     <fileSets>
         <!-- for bin -->
         <fileSet>
+            <directory>environment</directory>
+            <includes>
+                <include>*.*</include>
+            </includes>
+            <fileMode>0755</fileMode>
+            <outputDirectory>environment</outputDirectory>
+            <lineEnding>unix</lineEnding>
+        </fileSet>
+
+        <fileSet>
             <directory>bin</directory>
             <includes>
                 <include>*.*</include>

--- a/inlong-agent/agent-installer/environment/init.sh
+++ b/inlong-agent/agent-installer/environment/init.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+echo "Start doing some environment initialization work"

--- a/inlong-agent/agent-installer/environment/init.sh
+++ b/inlong-agent/agent-installer/environment/init.sh
@@ -16,4 +16,5 @@
 # limitations under the License.
 #
 
+# This script is used for environment initialization and can be modified according to different environments
 echo "Begin initializing the environment"

--- a/inlong-agent/agent-installer/environment/init.sh
+++ b/inlong-agent/agent-installer/environment/init.sh
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-echo "Start doing some environment initialization work"
+echo "Begin initializing the environment"


### PR DESCRIPTION
Fixes #10210

### Motivation

The installer needs to add a script for environment initialization

### Modifications

Add a script for environment initialization

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
