### PR TITLE
[INLONG-10076][Manager] Doris data node supports test connections

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/DataNodeServiceImpl.java
@@ -288,7 +288,6 @@ public class DataNodeServiceImpl implements DataNodeService {
     @Override
     public Boolean testConnection(DataNodeRequest request) {
         LOGGER.info("begin test connection for: {}", request);
-        String type = request.getType();
 
         // according to the data node type, test connection
         DataNodeOperator dataNodeOperator = operatorFactory.getInstance(request.getType());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/doris/DorisDataNodeOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/node/doris/DorisDataNodeOperator.java
@@ -21,13 +21,16 @@ import org.apache.inlong.manager.common.consts.DataNodeType;
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.dao.entity.DataNodeEntity;
 import org.apache.inlong.manager.pojo.node.DataNodeInfo;
 import org.apache.inlong.manager.pojo.node.DataNodeRequest;
 import org.apache.inlong.manager.pojo.node.doris.DorisDataNodeDTO;
 import org.apache.inlong.manager.pojo.node.doris.DorisDataNodeInfo;
 import org.apache.inlong.manager.pojo.node.doris.DorisDataNodeRequest;
+import org.apache.inlong.manager.pojo.node.mysql.MySQLDataNodeDTO;
 import org.apache.inlong.manager.service.node.AbstractDataNodeOperator;
+import org.apache.inlong.manager.service.resource.sink.mysql.MySQLJdbcUtils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
@@ -35,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.sql.Connection;
 
 @Service
 public class DorisDataNodeOperator extends AbstractDataNodeOperator {
@@ -81,4 +86,21 @@ public class DorisDataNodeOperator extends AbstractDataNodeOperator {
         }
     }
 
+    @Override
+    public Boolean testConnection(DataNodeRequest request) {
+        String jdbcUrl = MySQLDataNodeDTO.convertToJdbcurl(request.getUrl());
+        String username = request.getUsername();
+        String password = request.getToken();
+        Preconditions.expectNotBlank(jdbcUrl, ErrorCodeEnum.INVALID_PARAMETER, "connection jdbcUrl cannot be empty");
+        try (Connection ignored = MySQLJdbcUtils.getConnection(jdbcUrl, username, password)) {
+            LOGGER.info("doris connection not null - connection success for jdbcUrl={}, username={}, password={}",
+                    jdbcUrl, username, password);
+            return true;
+        } catch (Exception e) {
+            String errMsg = String.format("doris connection failed for jdbcUrl=%s, username=%s, password=%s", jdbcUrl,
+                    username, password);
+            LOGGER.error(errMsg, e);
+            throw new BusinessException(errMsg);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #10076 

### Motivation

Doris data node supports test connections.

### Modifications

Add test connections for Doris data node.

### Verifying this change

![image](https://github.com/apache/inlong/assets/58519431/7825365b-1d21-482c-b55f-b5adbcdf11be)
