### PR TITLE
[INLONG-10221][SDK] DataProxy SDK of cpp supports automatic installation of log4cplus components

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
@@ -62,5 +62,5 @@ add_library(dataproxy_sdk STATIC ${UTILS} ${CONFIGS} ${CORE} ${MANAGER} ${GROUP}
 
 set_target_properties(dataproxy_sdk PROPERTIES OUTPUT_NAME "dataproxy_sdk" PREFIX "")
 
-target_link_libraries(dataproxy_sdk liblog4cplus.a libsnappy.a libcurl.a)
+target_link_libraries(dataproxy_sdk liblog4cplusS.a libsnappy.a libcurl.a)
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/build.sh
@@ -19,9 +19,17 @@
 
 #!/bin/bash
 
+
+# Install third-party components
+cd ./third_party
+cmake .
+make
+
+cd ../
 rm -r build
 mkdir build
-# mkdir release
+
+# Compile project code
 cd build
 cmake ../
 make

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
@@ -26,6 +26,14 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 include(ExternalProject)
 
 ExternalProject_Add(
+        log4cplus
+        PREFIX ${LOG4CPLUS_BINARY_DIR}
+        GIT_REPOSITORY https://github.com/log4cplus/log4cplus.git
+        GIT_TAG REL_2_0_8
+        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR} -DBUILD_SHARED_LIBS=OFF
+)
+
+ExternalProject_Add(
         snappy_proj
         URL https://github.com/google/snappy/archive/1.1.8.tar.gz
         CMAKE_ARGS

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/third_party/CMakeLists.txt
@@ -27,7 +27,6 @@ include(ExternalProject)
 
 ExternalProject_Add(
         log4cplus
-        PREFIX ${LOG4CPLUS_BINARY_DIR}
         GIT_REPOSITORY https://github.com/log4cplus/log4cplus.git
         GIT_TAG REL_2_0_8
         CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_SOURCE_DIR} -DBUILD_SHARED_LIBS=OFF


### PR DESCRIPTION
- Fixes #10221

### Motivation
DataProxy SDK of cpp supports automatic installation of log4cplus components.

### Modifications
In the CMake file CMakeLists.txt, add the automatic installation of log4cplus.