### PR TITLE
[INLONG-10226][Dashboard] Fix audit item search failure

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -218,10 +218,9 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
       dropdownMatchSelectWidth: false,
       options: {
         requestAuto: true,
-        requestTrigger: ['onOpen', 'onSearch'],
-        requestService: async keyword => {
-          const res = await request('/audit/getAuditBases');
-          return keyword === undefined ? res : res.filter(audit => audit.name.includes(keyword));
+        requestTrigger: ['onOpen'],
+        requestService: () => {
+          return request('/audit/getAuditBases');
         },
         requestParams: {
           formatResult: result =>
@@ -231,6 +230,7 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
             })) || [],
         },
       },
+      filterOption: (keyword, option) => option.label.includes(keyword),
     },
   },
   {

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
@@ -140,10 +140,9 @@ export const getFormContent = (initialValues, onSearch) => [
       dropdownMatchSelectWidth: false,
       options: {
         requestAuto: true,
-        requestTrigger: ['onOpen', 'onSearch'],
-        requestService: async keyword => {
-          const res = await request('/audit/getAuditBases');
-          return keyword === undefined ? res : res.filter(audit => audit.name.includes(keyword));
+        requestTrigger: ['onOpen'],
+        requestService: () => {
+          return request('/audit/getAuditBases');
         },
         requestParams: {
           formatResult: result =>
@@ -153,6 +152,7 @@ export const getFormContent = (initialValues, onSearch) => [
             })) || [],
         },
       },
+      filterOption: (keyword, option) => option.label.includes(keyword),
     },
   },
   {
@@ -165,10 +165,9 @@ export const getFormContent = (initialValues, onSearch) => [
       dropdownMatchSelectWidth: false,
       options: {
         requestAuto: true,
-        requestTrigger: ['onOpen', 'onSearch'],
-        requestService: async keyword => {
-          const res = await request('/audit/getAuditBases');
-          return keyword === undefined ? res : res.filter(audit => audit.name.includes(keyword));
+        requestTrigger: ['onOpen'],
+        requestService: () => {
+          return request('/audit/getAuditBases');
         },
         requestParams: {
           formatResult: result =>
@@ -178,6 +177,7 @@ export const getFormContent = (initialValues, onSearch) => [
             })) || [],
         },
       },
+      filterOption: (keyword, option) => option.label.includes(keyword),
     },
   },
   {

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
@@ -94,10 +94,9 @@ export const getFormContent = (initialValues, onSearch) => [
       dropdownMatchSelectWidth: false,
       options: {
         requestAuto: true,
-        requestTrigger: ['onOpen', 'onSearch'],
-        requestService: async keyword => {
-          const res = await request('/audit/getAuditBases');
-          return keyword === undefined ? res : res.filter(audit => audit.name.includes(keyword));
+        requestTrigger: ['onOpen'],
+        requestService: () => {
+          return request('/audit/getAuditBases');
         },
         requestParams: {
           formatResult: result =>
@@ -107,6 +106,7 @@ export const getFormContent = (initialValues, onSearch) => [
             })) || [],
         },
       },
+      filterOption: (keyword, option) => option.label.includes(keyword),
     },
   },
   {
@@ -119,10 +119,9 @@ export const getFormContent = (initialValues, onSearch) => [
       dropdownMatchSelectWidth: false,
       options: {
         requestAuto: true,
-        requestTrigger: ['onOpen', 'onSearch'],
-        requestService: async keyword => {
-          const res = await request('/audit/getAuditBases');
-          return keyword === undefined ? res : res.filter(audit => audit.name.includes(keyword));
+        requestTrigger: ['onOpen'],
+        requestService: () => {
+          return request('/audit/getAuditBases');
         },
         requestParams: {
           formatResult: result =>
@@ -132,6 +131,7 @@ export const getFormContent = (initialValues, onSearch) => [
             })) || [],
         },
       },
+      filterOption: (keyword, option) => option.label.includes(keyword),
     },
   },
   {


### PR DESCRIPTION
Fixes #10226

### Motivation

Audit items cannot be searched.
Although filtering is performed, the option is the filtered value, but the page is rendered before filtering, causing it to not be displayed.

### Modifications

Use `Ant Design`'s filter function to perform local searches

### Verifying this change

![Snipaste_2024-05-15_18-23-21](https://github.com/apache/inlong/assets/58519431/9b0d4df3-5b13-4862-baa6-01cf84f91ffd)
