### PR TITLE
[INLONG-9613][TubeMQ] Adjust FATAL type error return content, without carrying class name

### DIFF
--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/utils/MixUtils.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corerpc/utils/MixUtils.java
@@ -75,7 +75,7 @@ public class MixUtils {
             if (strExceptionMsgSet.length > 0) {
                 if (!TStringUtils.isBlank(strExceptionMsgSet[0])) {
                     Class clazz = Class.forName(strExceptionMsgSet[0]);
-                    if (clazz != null) {
+                    if (clazz != null && Throwable.class.isAssignableFrom(clazz)) {
                         Constructor<?> ctor = clazz.getConstructor(String.class);
                         if (ctor != null) {
                             if (strExceptionMsgSet.length == 1) {


### PR DESCRIPTION

Fixes #9613 

In the unwrapException function, check whether clazz belongs to Throwable class or its subclass to avoid Remote Code Execution (RCE) issues.