### PR TITLE
[INLONG-10247][Manager]  Support schedule information management for offline sync

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/ClientFactory.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/ClientFactory.java
@@ -55,6 +55,7 @@ public class ClientFactory {
     private final AuditClient auditClient;
     private final InlongTenantClient inlongTenantClient;
     private final InlongTenantRoleClient inlongTenantRoleClient;
+    private final InLongScheduleClient inLongScheduleClient;
 
     public ClientFactory(ClientConfiguration configuration) {
         groupClient = new InlongGroupClient(configuration);
@@ -74,5 +75,6 @@ public class ClientFactory {
         auditClient = new AuditClient(configuration);
         inlongTenantClient = new InlongTenantClient(configuration);
         inlongTenantRoleClient = new InlongTenantRoleClient(configuration);
+        inLongScheduleClient = new InLongScheduleClient(configuration);
     }
 }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InLongScheduleClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InLongScheduleClient.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.inner.client;
+
+import org.apache.inlong.manager.client.api.ClientConfiguration;
+import org.apache.inlong.manager.client.api.service.InLongScheduleApi;
+import org.apache.inlong.manager.client.api.util.ClientUtils;
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+
+public class InLongScheduleClient {
+
+    private InLongScheduleApi scheduleApi;
+
+    public InLongScheduleClient(ClientConfiguration clientConfiguration) {
+        scheduleApi = ClientUtils.createRetrofit(clientConfiguration).create(InLongScheduleApi.class);
+    }
+
+    public Integer createScheduleInfo(ScheduleInfo scheduleInfo) {
+        Response<Integer> response = ClientUtils.executeHttpCall(scheduleApi.createSchedule(scheduleInfo));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public Boolean scheduleInfoExist(String groupId) {
+        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.exist(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public Boolean scheduleInfoExist(ScheduleInfo scheduleInfo) {
+        String groupId = scheduleInfo.getGroupId();
+        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.exist(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public Boolean updateScheduleInfo(ScheduleInfo scheduleInfo) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.update(scheduleInfo));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public ScheduleInfo getScheduleInfo(String groupId) {
+        Response<ScheduleInfo> response = ClientUtils.executeHttpCall(scheduleApi.get(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public ScheduleInfo getScheduleInfo(ScheduleInfo scheduleInfo) {
+        String groupId = scheduleInfo.getGroupId();
+        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
+        Response<ScheduleInfo> response = ClientUtils.executeHttpCall(scheduleApi.get(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public Boolean deleteScheduleInfo(String groupId) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.delete(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+
+    public Boolean deleteScheduleInfo(ScheduleInfo scheduleInfo) {
+        String groupId = scheduleInfo.getGroupId();
+        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.delete(groupId));
+        ClientUtils.assertRespSuccess(response);
+        return response.getData();
+    }
+}

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InLongScheduleClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InLongScheduleClient.java
@@ -24,6 +24,7 @@ import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.util.Preconditions;
 import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
 
 public class InLongScheduleClient {
 
@@ -33,8 +34,8 @@ public class InLongScheduleClient {
         scheduleApi = ClientUtils.createRetrofit(clientConfiguration).create(InLongScheduleApi.class);
     }
 
-    public Integer createScheduleInfo(ScheduleInfo scheduleInfo) {
-        Response<Integer> response = ClientUtils.executeHttpCall(scheduleApi.createSchedule(scheduleInfo));
+    public Integer createScheduleInfo(ScheduleInfoRequest request) {
+        Response<Integer> response = ClientUtils.executeHttpCall(scheduleApi.createSchedule(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }
@@ -46,16 +47,8 @@ public class InLongScheduleClient {
         return response.getData();
     }
 
-    public Boolean scheduleInfoExist(ScheduleInfo scheduleInfo) {
-        String groupId = scheduleInfo.getGroupId();
-        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
-        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.exist(groupId));
-        ClientUtils.assertRespSuccess(response);
-        return response.getData();
-    }
-
-    public Boolean updateScheduleInfo(ScheduleInfo scheduleInfo) {
-        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.update(scheduleInfo));
+    public Boolean updateScheduleInfo(ScheduleInfoRequest request) {
+        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.update(request));
         ClientUtils.assertRespSuccess(response);
         return response.getData();
     }
@@ -66,23 +59,7 @@ public class InLongScheduleClient {
         return response.getData();
     }
 
-    public ScheduleInfo getScheduleInfo(ScheduleInfo scheduleInfo) {
-        String groupId = scheduleInfo.getGroupId();
-        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
-        Response<ScheduleInfo> response = ClientUtils.executeHttpCall(scheduleApi.get(groupId));
-        ClientUtils.assertRespSuccess(response);
-        return response.getData();
-    }
-
     public Boolean deleteScheduleInfo(String groupId) {
-        Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.delete(groupId));
-        ClientUtils.assertRespSuccess(response);
-        return response.getData();
-    }
-
-    public Boolean deleteScheduleInfo(ScheduleInfo scheduleInfo) {
-        String groupId = scheduleInfo.getGroupId();
-        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
         Response<Boolean> response = ClientUtils.executeHttpCall(scheduleApi.delete(groupId));
         ClientUtils.assertRespSuccess(response);
         return response.getData();

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InLongScheduleApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InLongScheduleApi.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.client.api.service;
 
 import org.apache.inlong.manager.pojo.common.Response;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
 
 import retrofit2.Call;
 import retrofit2.http.Body;
@@ -31,13 +32,13 @@ import retrofit2.http.Query;
 public interface InLongScheduleApi {
 
     @POST("schedule/save")
-    Call<Response<Integer>> createSchedule(@Body ScheduleInfo scheduleInfo);
+    Call<Response<Integer>> createSchedule(@Body ScheduleInfoRequest request);
 
     @GET("schedule/exist/{groupId}")
     Call<Response<Boolean>> exist(@Path("groupId") String groupId);
 
     @POST("schedule/update")
-    Call<Response<Boolean>> update(@Body ScheduleInfo scheduleInfo);
+    Call<Response<Boolean>> update(@Body ScheduleInfoRequest request);
 
     @GET("schedule/get")
     Call<Response<ScheduleInfo>> get(@Query("groupId") String groupId);

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InLongScheduleApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InLongScheduleApi.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.client.api.service;
+
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.DELETE;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+import retrofit2.http.Query;
+
+public interface InLongScheduleApi {
+
+    @POST("schedule/save")
+    Call<Response<Integer>> createSchedule(@Body ScheduleInfo scheduleInfo);
+
+    @GET("schedule/exist/{groupId}")
+    Call<Response<Boolean>> exist(@Path("groupId") String groupId);
+
+    @POST("schedule/update")
+    Call<Response<Boolean>> update(@Body ScheduleInfo scheduleInfo);
+
+    @GET("schedule/get")
+    Call<Response<ScheduleInfo>> get(@Query("groupId") String groupId);
+
+    @DELETE("schedule/delete/{groupId}")
+    Call<Response<Boolean>> delete(@Path("groupId") String groupId);
+
+}

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -125,6 +125,9 @@ public enum ErrorCodeEnum {
     MQ_TYPE_IS_NULL(1600, "MQ type is null"),
     MQ_TYPE_NOT_SUPPORT(1601, "MQ type '%s' not support"),
 
+    SCHEDULE_NOT_FOUND(1700, "Schedule info not found"),
+    SCHEDULE_DUPLICATE(1701, "Schedule info already exist"),
+
     WORKFLOW_EXE_FAILED(4000, "Workflow execution exception"),
     WORKFLOW_APPROVER_NOT_FOUND(4001, "Workflow approver does not exist/no operation authority"),
     WORKFLOW_DELETE_RECORD_FAILED(4002, "Workflow delete record failure"),

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
@@ -17,35 +17,29 @@
 
 package org.apache.inlong.manager.common.enums;
 
-/**
- * Operation target
- */
-public enum OperationTarget {
+import lombok.Getter;
 
-    TENANT,
+@Getter
+public enum ScheduleStatus {
 
-    GROUP,
+    NEW(100, "new"),
+    DELETED(40, "deleted");
 
-    STREAM,
+    private final Integer code;
+    private final String description;
 
-    SOURCE,
+    ScheduleStatus(Integer code, String description) {
+        this.code = code;
+        this.description = description;
+    }
 
-    SINK,
-
-    CONSUME,
-
-    WORKFLOW,
-
-    NODE,
-
-    CLUSTER,
-
-    TRANSFORM,
-
-    INLONG_ROLE,
-
-    TENANT_ROLE,
-
-    SCHEDULE
+    public static ScheduleStatus forCode(int code) {
+        for (ScheduleStatus status : values()) {
+            if (status.getCode() == code) {
+                return status;
+            }
+        }
+        throw new IllegalStateException(String.format("Illegal code=%s for ScheduleStatus", code));
+    }
 
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/ScheduleEntity.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/ScheduleEntity.java
@@ -30,7 +30,7 @@ public class ScheduleEntity implements Serializable {
 
     private Integer id;
     // inLong group id
-    private String groupId;
+    private String inlongGroupId;
     // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
     private Integer scheduleType;
     // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/ScheduleEntity.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/entity/ScheduleEntity.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.dao.entity;
+
+import lombok.Data;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+import java.util.Date;
+
+@Data
+public class ScheduleEntity implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private Integer id;
+    // inLong group id
+    private String groupId;
+    // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
+    private Integer scheduleType;
+    // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]
+    // M=month, W=week, D=day, H=hour, M=minute, O=oneway
+    private String scheduleUnit;
+    private Integer scheduleInterval;
+    // schedule start time, long type timestamp
+    private Timestamp startTime;
+    // schedule end time, long type timestamp
+    private Timestamp endTime;
+    // delay time to start task, in minutes
+    private Integer delayTime;
+    // if task depend on itself
+    private Integer selfDepend;
+    private Integer taskParallelism;
+    // expression of crontab, used when scheduleType is crontab
+    private String crontabExpression;
+
+    private Integer status;
+    private Integer previousStatus;
+    private Integer isDeleted;
+    private String creator;
+    private String modifier;
+    private Date createTime;
+    private Date modifyTime;
+    private Integer version;
+
+}

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityMapper.java
@@ -33,5 +33,5 @@ public interface ScheduleEntityMapper {
 
     int updateByIdSelective(ScheduleEntity scheduleEntity);
 
-    int deleteByGroupId(@Param("groupId") String groupId);
+    int deleteByGroupId(@Param("inlongGroupId") String inlongGroupId);
 }

--- a/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityMapper.java
+++ b/inlong-manager/manager-dao/src/main/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityMapper.java
@@ -15,37 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.common.enums;
+package org.apache.inlong.manager.dao.mapper;
 
-/**
- * Operation target
- */
-public enum OperationTarget {
+import org.apache.inlong.manager.dao.entity.ScheduleEntity;
 
-    TENANT,
+import org.apache.ibatis.annotations.Param;
+import org.springframework.stereotype.Repository;
 
-    GROUP,
+@Repository
+public interface ScheduleEntityMapper {
 
-    STREAM,
+    int insert(ScheduleEntity scheduleEntity);
 
-    SOURCE,
+    ScheduleEntity selectByPrimaryKey(Integer id);
 
-    SINK,
+    ScheduleEntity selectByGroupId(String groupId);
 
-    CONSUME,
+    int updateByIdSelective(ScheduleEntity scheduleEntity);
 
-    WORKFLOW,
-
-    NODE,
-
-    CLUSTER,
-
-    TRANSFORM,
-
-    INLONG_ROLE,
-
-    TENANT_ROLE,
-
-    SCHEDULE
-
+    int deleteByGroupId(@Param("groupId") String groupId);
 }

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
@@ -52,15 +52,15 @@
         insert into schedule_config (id, group_id, schedule_type, schedule_unit,
                                      schedule_interval, start_time, end_time, delay_time,
                                      self_depend, task_parallelism, crontab_expression,
-                                     status, previous_status, is_deleted, creator, modifier)
+                                     status, previous_status, creator, modifier)
         values (#{id, jdbcType=INTEGER}, #{groupId, jdbcType=VARCHAR},
                 #{scheduleType, jdbcType=INTEGER}, #{scheduleUnit, jdbcType=VARCHAR},
                 #{scheduleInterval, jdbcType=INTEGER}, #{startTime, jdbcType=TIMESTAMP},
                 #{endTime, jdbcType=TIMESTAMP}, #{delayTime, jdbcType=INTEGER},
                 #{selfDepend, jdbcType=INTEGER}, #{taskParallelism, jdbcType=INTEGER},
                 #{crontabExpression, jdbcType=VARCHAR}, #{status,jdbcType=INTEGER},
-                #{previousStatus,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
-                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
+                #{previousStatus,jdbcType=INTEGER}, #{creator,jdbcType=VARCHAR},
+                #{modifier,jdbcType=VARCHAR})
     </insert>
 
     <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
@@ -75,6 +75,7 @@
         <include refid="Base_Column_List"/>
         from schedule_config
         where group_id = #{groupId,jdbcType=VARCHAR}
+        and is_deleted = 0
     </select>
 
     <update id="updateByIdSelective" parameterType="org.apache.inlong.manager.dao.entity.ScheduleEntity">
@@ -110,9 +111,26 @@
             <if test="crontabExpression != null">
                 crontab_expression = #{crontabExpression, jdbcType=VARCHAR},
             </if>
+            <if test="status != null">
+                status = #{status, jdbcType=VARCHAR},
+            </if>
+            <if test="previousStatus != null">
+                previous_status = #{previousStatus, jdbcType=VARCHAR},
+            </if>
+            <if test="isDeleted != null">
+                is_deleted = #{isDeleted},
+            </if>
+            <if test="creator != null">
+                creator = #{creator, jdbcType=VARCHAR},
+            </if>
+            <if test="modifier != null">
+                modifier = #{modifier, jdbcType=VARCHAR},
+            </if>
+            version = #{version, jdbcType=INTEGER} + 1
         </set>
         <where>
             id = #{id, jdbcType=INTEGER}
+            and version = #{version,jdbcType=INTEGER}
         </where>
     </update>
 

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
@@ -68,6 +68,7 @@
         <include refid="Base_Column_List"/>
         from schedule_config
         where id = #{id,jdbcType=INTEGER}
+        and is_deleted = 0
     </select>
 
     <select id="selectByGroupId" parameterType="java.lang.String" resultMap="BaseResultMap">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
@@ -20,7 +20,7 @@
 <mapper namespace="org.apache.inlong.manager.dao.mapper.ScheduleEntityMapper">
     <resultMap id="BaseResultMap" type="org.apache.inlong.manager.dao.entity.ScheduleEntity">
         <id column="id" jdbcType="INTEGER" property="id"/>
-        <result column="group_id" jdbcType="VARCHAR" property="groupId"/>
+        <result column="inlong_group_id" jdbcType="VARCHAR" property="inlongGroupId"/>
         <result column="schedule_type" jdbcType="INTEGER" property="scheduleType"/>
         <result column="schedule_unit" jdbcType="VARCHAR" property="scheduleUnit"/>
         <result column="schedule_interval" jdbcType="INTEGER" property="scheduleInterval"/>
@@ -42,18 +42,18 @@
     </resultMap>
 
     <sql id="Base_Column_List">
-        id, group_id, schedule_type, schedule_unit, schedule_interval, start_time,
+        id, inlong_group_id, schedule_type, schedule_unit, schedule_interval, start_time,
           end_time, delay_time, self_depend, task_parallelism, crontab_expression,
            status, previous_status, is_deleted, creator, modifier, create_time, modify_time, version
     </sql>
 
     <insert id="insert" useGeneratedKeys="true" keyProperty="id"
             parameterType="org.apache.inlong.manager.dao.entity.ScheduleEntity">
-        insert into schedule_config (id, group_id, schedule_type, schedule_unit,
+        insert into schedule_config (id, inlong_group_id, schedule_type, schedule_unit,
                                      schedule_interval, start_time, end_time, delay_time,
                                      self_depend, task_parallelism, crontab_expression,
                                      status, previous_status, creator, modifier)
-        values (#{id, jdbcType=INTEGER}, #{groupId, jdbcType=VARCHAR},
+        values (#{id, jdbcType=INTEGER}, #{inlongGroupId, jdbcType=VARCHAR},
                 #{scheduleType, jdbcType=INTEGER}, #{scheduleUnit, jdbcType=VARCHAR},
                 #{scheduleInterval, jdbcType=INTEGER}, #{startTime, jdbcType=TIMESTAMP},
                 #{endTime, jdbcType=TIMESTAMP}, #{delayTime, jdbcType=INTEGER},
@@ -82,7 +82,7 @@
         update schedule_config
         <set>
             <if test="groupId != null">
-                group_id = #{groupId, jdbcType=VARCHAR},
+                inlong_group_id = #{inlongGroupId, jdbcType=VARCHAR},
             </if>
             <if test="scheduleType != null">
                 schedule_type = #{scheduleType, jdbcType=INTEGER},
@@ -137,7 +137,7 @@
     <delete id="deleteByGroupId">
         delete
         from schedule_config
-        where group_id = #{groupId, jdbcType=VARCHAR}
+        where inlong_group_id = #{inlongGroupId, jdbcType=VARCHAR}
     </delete>
 
 </mapper>

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
@@ -74,14 +74,14 @@
         select
         <include refid="Base_Column_List"/>
         from schedule_config
-        where group_id = #{groupId,jdbcType=VARCHAR}
+        where inlong_group_id = #{inlongGroupId,jdbcType=VARCHAR}
         and is_deleted = 0
     </select>
 
     <update id="updateByIdSelective" parameterType="org.apache.inlong.manager.dao.entity.ScheduleEntity">
         update schedule_config
         <set>
-            <if test="groupId != null">
+            <if test="inlongGroupId != null">
                 inlong_group_id = #{inlongGroupId, jdbcType=VARCHAR},
             </if>
             <if test="scheduleType != null">

--- a/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
+++ b/inlong-manager/manager-dao/src/main/resources/mappers/ScheduleEntityMapper.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.inlong.manager.dao.mapper.ScheduleEntityMapper">
+    <resultMap id="BaseResultMap" type="org.apache.inlong.manager.dao.entity.ScheduleEntity">
+        <id column="id" jdbcType="INTEGER" property="id"/>
+        <result column="group_id" jdbcType="VARCHAR" property="groupId"/>
+        <result column="schedule_type" jdbcType="INTEGER" property="scheduleType"/>
+        <result column="schedule_unit" jdbcType="VARCHAR" property="scheduleUnit"/>
+        <result column="schedule_interval" jdbcType="INTEGER" property="scheduleInterval"/>
+        <result column="start_time" jdbcType="TIMESTAMP" property="startTime"/>
+        <result column="end_time" jdbcType="TIMESTAMP" property="endTime"/>
+        <result column="delay_time" jdbcType="INTEGER" property="delayTime"/>
+        <result column="self_depend" jdbcType="INTEGER" property="selfDepend"/>
+        <result column="task_parallelism" jdbcType="INTEGER" property="taskParallelism"/>
+        <result column="crontab_expression" jdbcType="VARCHAR" property="crontabExpression"/>
+
+        <result column="status" jdbcType="INTEGER" property="status"/>
+        <result column="previous_status" jdbcType="INTEGER" property="previousStatus"/>
+        <result column="is_deleted" jdbcType="INTEGER" property="isDeleted"/>
+        <result column="creator" jdbcType="VARCHAR" property="creator"/>
+        <result column="modifier" jdbcType="VARCHAR" property="modifier"/>
+        <result column="create_time" jdbcType="TIMESTAMP" property="createTime"/>
+        <result column="modify_time" jdbcType="TIMESTAMP" property="modifyTime"/>
+        <result column="version" jdbcType="INTEGER" property="version"/>
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id, group_id, schedule_type, schedule_unit, schedule_interval, start_time,
+          end_time, delay_time, self_depend, task_parallelism, crontab_expression,
+           status, previous_status, is_deleted, creator, modifier, create_time, modify_time, version
+    </sql>
+
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id"
+            parameterType="org.apache.inlong.manager.dao.entity.ScheduleEntity">
+        insert into schedule_config (id, group_id, schedule_type, schedule_unit,
+                                     schedule_interval, start_time, end_time, delay_time,
+                                     self_depend, task_parallelism, crontab_expression,
+                                     status, previous_status, is_deleted, creator, modifier)
+        values (#{id, jdbcType=INTEGER}, #{groupId, jdbcType=VARCHAR},
+                #{scheduleType, jdbcType=INTEGER}, #{scheduleUnit, jdbcType=VARCHAR},
+                #{scheduleInterval, jdbcType=INTEGER}, #{startTime, jdbcType=TIMESTAMP},
+                #{endTime, jdbcType=TIMESTAMP}, #{delayTime, jdbcType=INTEGER},
+                #{selfDepend, jdbcType=INTEGER}, #{taskParallelism, jdbcType=INTEGER},
+                #{crontabExpression, jdbcType=VARCHAR}, #{status,jdbcType=INTEGER},
+                #{previousStatus,jdbcType=INTEGER}, #{isDeleted,jdbcType=INTEGER},
+                #{creator,jdbcType=VARCHAR}, #{modifier,jdbcType=VARCHAR})
+    </insert>
+
+    <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from schedule_config
+        where id = #{id,jdbcType=INTEGER}
+    </select>
+
+    <select id="selectByGroupId" parameterType="java.lang.String" resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from schedule_config
+        where group_id = #{groupId,jdbcType=VARCHAR}
+    </select>
+
+    <update id="updateByIdSelective" parameterType="org.apache.inlong.manager.dao.entity.ScheduleEntity">
+        update schedule_config
+        <set>
+            <if test="groupId != null">
+                group_id = #{groupId, jdbcType=VARCHAR},
+            </if>
+            <if test="scheduleType != null">
+                schedule_type = #{scheduleType, jdbcType=INTEGER},
+            </if>
+            <if test="scheduleUnit !=null">
+                schedule_unit = #{scheduleUnit, jdbcType=VARCHAR},
+            </if>
+            <if test="scheduleInterval != null">
+                schedule_interval = #{scheduleInterval, jdbcType=INTEGER},
+            </if>
+            <if test="startTime != null">
+                start_time = #{startTime, jdbcType=TIMESTAMP},
+            </if>
+            <if test="endTime != null">
+                end_time = #{endTime, jdbcType=TIMESTAMP},
+            </if>
+            <if test="delayTime != null">
+                delay_time = #{delayTime, jdbcType=INTEGER},
+            </if>
+            <if test="selfDepend != null">
+                self_depend = #{selfDepend, jdbcType=INTEGER},
+            </if>
+            <if test="taskParallelism != null">
+                task_parallelism = #{taskParallelism, jdbcType=INTEGER},
+            </if>
+            <if test="crontabExpression != null">
+                crontab_expression = #{crontabExpression, jdbcType=VARCHAR},
+            </if>
+        </set>
+        <where>
+            id = #{id, jdbcType=INTEGER}
+        </where>
+    </update>
+
+    <delete id="deleteByGroupId">
+        delete
+        from schedule_config
+        where group_id = #{groupId, jdbcType=VARCHAR}
+    </delete>
+
+</mapper>

--- a/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
+++ b/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
@@ -69,10 +69,10 @@ public class ScheduleEntityTest extends DaoBaseTest {
         Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
         Assertions.assertEquals(USER, entityQueried.getCreator());
 
-        scheduleEntity.setScheduleType(SCHEDULE_TYPE_NEW);
-        scheduleEntity.setScheduleUnit(SCHEDULE_UNIT_NEW);
-        scheduleEntity.setScheduleInterval(SCHEDULE_INTERVAL_NEW);
-        scheduleEntityMapper.updateByIdSelective(scheduleEntity);
+        entityQueried.setScheduleType(SCHEDULE_TYPE_NEW);
+        entityQueried.setScheduleUnit(SCHEDULE_UNIT_NEW);
+        entityQueried.setScheduleInterval(SCHEDULE_INTERVAL_NEW);
+        scheduleEntityMapper.updateByIdSelective(entityQueried);
         entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
         Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
         Assertions.assertEquals(SCHEDULE_TYPE_NEW, entityQueried.getScheduleType());
@@ -112,7 +112,7 @@ public class ScheduleEntityTest extends DaoBaseTest {
         entity.setCreator(USER);
         entity.setCreateTime(new Date());
         entity.setModifyTime(new Date());
-        entity.setVersion(1);
+        entity.setIsDeleted(0);
         return entity;
     }
 }

--- a/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
+++ b/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.dao.mapper;
+
+import org.apache.inlong.manager.dao.DaoBaseTest;
+import org.apache.inlong.manager.dao.entity.ScheduleEntity;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+public class ScheduleEntityTest extends DaoBaseTest {
+
+    public static final String GROUP_ID_PREFIX = "test_group_";
+    public static final String USER = "admin";
+    public static final int SCHEDULE_TYPE = 0;
+    public static final int SCHEDULE_TYPE_NEW = 1;
+    public static final String SCHEDULE_UNIT = "H";
+    public static final String SCHEDULE_UNIT_NEW = "D";
+    public static final int SCHEDULE_INTERVAL = 1;
+    public static final int SCHEDULE_INTERVAL_NEW = 1;
+    public static final Timestamp DEFAULT_TIME = new Timestamp(System.currentTimeMillis());
+
+    @Autowired
+    ScheduleEntityMapper scheduleEntityMapper;
+
+    @Test
+    public void testSelectByGroupId() throws Exception {
+        ScheduleEntity scheduleEntity = genEntity();
+        scheduleEntityMapper.insert(scheduleEntity);
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
+        Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
+        Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getStartTime());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
+        Assertions.assertEquals(USER, entityQueried.getCreator());
+    }
+
+    @Test
+    public void testUpdate() throws Exception {
+        ScheduleEntity scheduleEntity = genEntity();
+        scheduleEntityMapper.insert(scheduleEntity);
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
+        Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
+        Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getStartTime());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
+        Assertions.assertEquals(USER, entityQueried.getCreator());
+
+        scheduleEntity.setScheduleType(SCHEDULE_TYPE_NEW);
+        scheduleEntity.setScheduleUnit(SCHEDULE_UNIT_NEW);
+        scheduleEntity.setScheduleInterval(SCHEDULE_INTERVAL_NEW);
+        scheduleEntityMapper.updateByIdSelective(scheduleEntity);
+        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        Assertions.assertEquals(SCHEDULE_TYPE_NEW, entityQueried.getScheduleType());
+        Assertions.assertEquals(SCHEDULE_UNIT_NEW, entityQueried.getScheduleUnit());
+        Assertions.assertEquals(SCHEDULE_INTERVAL_NEW, entityQueried.getScheduleInterval());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getStartTime());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
+        Assertions.assertEquals(USER, entityQueried.getCreator());
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        ScheduleEntity scheduleEntity = genEntity();
+        scheduleEntityMapper.insert(scheduleEntity);
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
+        Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
+        Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getStartTime());
+        Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
+        Assertions.assertEquals(USER, entityQueried.getCreator());
+
+        scheduleEntityMapper.deleteByGroupId(scheduleEntity.getGroupId());
+        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        Assertions.assertNull(entityQueried);
+    }
+
+    private ScheduleEntity genEntity() {
+        ScheduleEntity entity = new ScheduleEntity();
+        entity.setGroupId(GROUP_ID_PREFIX + System.currentTimeMillis());
+        entity.setScheduleType(SCHEDULE_TYPE);
+        entity.setScheduleUnit(SCHEDULE_UNIT);
+        entity.setScheduleInterval(SCHEDULE_INTERVAL);
+        entity.setStartTime(DEFAULT_TIME);
+        entity.setEndTime(DEFAULT_TIME);
+        entity.setCreator(USER);
+        entity.setCreateTime(new Date());
+        entity.setModifyTime(new Date());
+        entity.setVersion(1);
+        return entity;
+    }
+}

--- a/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
+++ b/inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java
@@ -46,8 +46,8 @@ public class ScheduleEntityTest extends DaoBaseTest {
     public void testSelectByGroupId() throws Exception {
         ScheduleEntity scheduleEntity = genEntity();
         scheduleEntityMapper.insert(scheduleEntity);
-        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
-        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getInlongGroupId());
+        Assertions.assertEquals(scheduleEntity.getInlongGroupId(), entityQueried.getInlongGroupId());
         Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
         Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
         Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
@@ -60,8 +60,8 @@ public class ScheduleEntityTest extends DaoBaseTest {
     public void testUpdate() throws Exception {
         ScheduleEntity scheduleEntity = genEntity();
         scheduleEntityMapper.insert(scheduleEntity);
-        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
-        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getInlongGroupId());
+        Assertions.assertEquals(scheduleEntity.getInlongGroupId(), entityQueried.getInlongGroupId());
         Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
         Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
         Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
@@ -73,8 +73,8 @@ public class ScheduleEntityTest extends DaoBaseTest {
         entityQueried.setScheduleUnit(SCHEDULE_UNIT_NEW);
         entityQueried.setScheduleInterval(SCHEDULE_INTERVAL_NEW);
         scheduleEntityMapper.updateByIdSelective(entityQueried);
-        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
-        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getInlongGroupId());
+        Assertions.assertEquals(scheduleEntity.getInlongGroupId(), entityQueried.getInlongGroupId());
         Assertions.assertEquals(SCHEDULE_TYPE_NEW, entityQueried.getScheduleType());
         Assertions.assertEquals(SCHEDULE_UNIT_NEW, entityQueried.getScheduleUnit());
         Assertions.assertEquals(SCHEDULE_INTERVAL_NEW, entityQueried.getScheduleInterval());
@@ -87,8 +87,8 @@ public class ScheduleEntityTest extends DaoBaseTest {
     public void testDelete() throws Exception {
         ScheduleEntity scheduleEntity = genEntity();
         scheduleEntityMapper.insert(scheduleEntity);
-        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
-        Assertions.assertEquals(scheduleEntity.getGroupId(), entityQueried.getGroupId());
+        ScheduleEntity entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getInlongGroupId());
+        Assertions.assertEquals(scheduleEntity.getInlongGroupId(), entityQueried.getInlongGroupId());
         Assertions.assertEquals(SCHEDULE_TYPE, entityQueried.getScheduleType());
         Assertions.assertEquals(SCHEDULE_UNIT, entityQueried.getScheduleUnit());
         Assertions.assertEquals(SCHEDULE_INTERVAL, entityQueried.getScheduleInterval());
@@ -96,14 +96,14 @@ public class ScheduleEntityTest extends DaoBaseTest {
         Assertions.assertEquals(DEFAULT_TIME, entityQueried.getEndTime());
         Assertions.assertEquals(USER, entityQueried.getCreator());
 
-        scheduleEntityMapper.deleteByGroupId(scheduleEntity.getGroupId());
-        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getGroupId());
+        scheduleEntityMapper.deleteByGroupId(scheduleEntity.getInlongGroupId());
+        entityQueried = scheduleEntityMapper.selectByGroupId(scheduleEntity.getInlongGroupId());
         Assertions.assertNull(entityQueried);
     }
 
     private ScheduleEntity genEntity() {
         ScheduleEntity entity = new ScheduleEntity();
-        entity.setGroupId(GROUP_ID_PREFIX + System.currentTimeMillis());
+        entity.setInlongGroupId(GROUP_ID_PREFIX + System.currentTimeMillis());
         entity.setScheduleType(SCHEDULE_TYPE);
         entity.setScheduleUnit(SCHEDULE_UNIT);
         entity.setScheduleInterval(SCHEDULE_INTERVAL);

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.schedule;
+
+import org.apache.inlong.manager.common.validation.UpdateValidation;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Schedule response")
+public class ScheduleInfo {
+
+    @ApiModelProperty(value = "Primary key")
+    @NotNull(groups = UpdateValidation.class)
+    private Integer id;
+
+    @ApiModelProperty("Inlong Group ID")
+    @NotNull
+    private String groupId;
+
+    // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
+    @ApiModelProperty("Schedule type")
+    private Integer scheduleType;
+
+    // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]
+    // M=month, W=week, D=day, H=hour, M=minute, O=oneway
+    @ApiModelProperty("TimeUnit for schedule interval")
+    private String scheduleUnit;
+
+    @ApiModelProperty("Schedule interval")
+    private Integer scheduleInterval;
+
+    @ApiModelProperty("Start time")
+    private Timestamp startTime;
+
+    @ApiModelProperty("End time")
+    private Timestamp endTime;
+
+    @ApiModelProperty("Delay time")
+    private Integer delayTime;
+
+    @ApiModelProperty("Self depend")
+    private Integer selfDepend;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer taskParallelism;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer crontabExpression;
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
@@ -75,4 +75,8 @@ public class ScheduleInfo {
     @ApiModelProperty("Schedule task parallelism")
     private Integer crontabExpression;
 
+    @ApiModelProperty(value = "Version number")
+    @NotNull(groups = UpdateValidation.class, message = "version cannot be null")
+    private Integer version;
+
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
@@ -43,7 +43,7 @@ public class ScheduleInfo {
 
     @ApiModelProperty("Inlong Group ID")
     @NotNull
-    private String groupId;
+    private String inlongGroupId;
 
     // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
     @ApiModelProperty("Schedule type")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
@@ -37,7 +37,7 @@ public class ScheduleInfoRequest {
 
     @ApiModelProperty("Inlong Group ID")
     @NotNull
-    private String groupId;
+    private String inlongGroupId;
 
     // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
     @ApiModelProperty("Schedule type")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.schedule;
+
+import org.apache.inlong.manager.common.validation.UpdateValidation;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+
+import java.sql.Timestamp;
+
+@Data
+@ApiModel("Schedule request")
+public class ScheduleInfoRequest {
+
+    @ApiModelProperty(value = "Primary key")
+    @NotNull(groups = UpdateValidation.class)
+    private Integer id;
+
+    @ApiModelProperty("Inlong Group ID")
+    @NotNull
+    private String groupId;
+
+    // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
+    @ApiModelProperty("Schedule type")
+    private Integer scheduleType;
+
+    // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]
+    // M=month, W=week, D=day, H=hour, M=minute, O=oneway
+    @ApiModelProperty("TimeUnit for schedule interval")
+    private String scheduleUnit;
+
+    @ApiModelProperty("Schedule interval")
+    private Integer scheduleInterval;
+
+    @ApiModelProperty("Start time")
+    private Timestamp startTime;
+
+    @ApiModelProperty("End time")
+    private Timestamp endTime;
+
+    @ApiModelProperty("Delay time")
+    private Integer delayTime;
+
+    @ApiModelProperty("Self depend")
+    private Integer selfDepend;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer taskParallelism;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer crontabExpression;
+
+}

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
@@ -69,4 +69,8 @@ public class ScheduleInfoRequest {
     @ApiModelProperty("Schedule task parallelism")
     private Integer crontabExpression;
 
+    @ApiModelProperty(value = "Version number")
+    @NotNull(groups = UpdateValidation.class, message = "version cannot be null")
+    private Integer version;
+
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleService.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.schedule;
+
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
+public interface ScheduleService {
+
+    /**
+     * Save schedule info.
+     *
+     * @param scheduleInfo schedule request need to save
+     * @param operator name of operator
+     * @return schedule info id in backend storage
+     */
+    int save(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest scheduleInfo,
+            String operator);
+
+    /**
+     * Query whether schedule info exists for specified inlong group
+     *
+     * @param groupId the group id to be queried
+     * @return does it exist
+     */
+    Boolean exist(String groupId);
+
+    /**
+     * Get schedule info based on inlong group id
+     *
+     * @param groupId inlong group id
+     * @return detail of inlong group
+     */
+    ScheduleInfo get(String groupId);
+
+    /**
+     * Modify schedule information
+     *
+     * @param scheduleInfo schedule request that needs to be modified
+     * @param operator name of operator
+     * @return whether succeed
+     */
+    Boolean update(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest scheduleInfo,
+            String operator);
+
+    /**
+     * Delete schedule info for gropuId.
+     * @param groupId groupId to find a schedule info to delete
+     * @param operator  name of operator
+     * @Return whether succeed
+     * */
+    Boolean deleteByGroupId(String groupId, String operator);
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleService.java
@@ -28,11 +28,11 @@ public interface ScheduleService {
     /**
      * Save schedule info.
      *
-     * @param scheduleInfo schedule request need to save
+     * @param request schedule request need to save
      * @param operator name of operator
      * @return schedule info id in backend storage
      */
-    int save(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest scheduleInfo,
+    int save(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest request,
             String operator);
 
     /**
@@ -54,11 +54,11 @@ public interface ScheduleService {
     /**
      * Modify schedule information
      *
-     * @param scheduleInfo schedule request that needs to be modified
+     * @param request schedule request that needs to be modified
      * @param operator name of operator
      * @return whether succeed
      */
-    Boolean update(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest scheduleInfo,
+    Boolean update(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest request,
             String operator);
 
     /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -85,7 +85,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         ScheduleEntity entity = getScheduleEntity(groupId);
         String errMsg =
                 String.format("schedule info has already been updated with groupId=%s, curVersion=%s, expectVersion=%s",
-                        entity.getGroupId(), request.getVersion(), entity.getVersion());
+                        entity.getInlongGroupId(), request.getVersion(), entity.getVersion());
         if (!Objects.equals(entity.getVersion(), request.getVersion())) {
             LOGGER.error(errMsg);
             throw new BusinessException(ErrorCodeEnum.CONFIG_EXPIRED);
@@ -112,7 +112,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         entity.setIsDeleted(entity.getId());
         updateScheduleInfo(entity,
                 String.format("schedule info has already been updated with groupId=%s, curVersion=%s",
-                        entity.getGroupId(), entity.getVersion()));
+                        entity.getInlongGroupId(), entity.getVersion()));
         LOGGER.info("success to delete schedule info for groupId={}", groupId);
         return true;
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -50,7 +50,6 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public int save(ScheduleInfoRequest request, String operator) {
         LOGGER.debug("begin to save schedule info, scheduleInfo: {}, operator: {}", request, operator);
-        Preconditions.expectNotNull(request, "schedule info request can't be null");
 
         String groupId = request.getGroupId();
         checkGroupExist(groupId);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -49,12 +49,12 @@ public class ScheduleServiceImpl implements ScheduleService {
 
     @Override
     public int save(ScheduleInfoRequest request, String operator) {
-        LOGGER.debug("begin to save schedule info, scheduleInfo: {}, operator: {}", request, operator);
+        LOGGER.debug("begin to save schedule info, scheduleInfo={}, operator={}", request, operator);
 
         String groupId = request.getInlongGroupId();
         checkGroupExist(groupId);
         if (scheduleEntityMapper.selectByGroupId(groupId) != null) {
-            LOGGER.error("schedule info for group : {} already exists", groupId);
+            LOGGER.error("schedule info for group={} already exists", groupId);
             throw new BusinessException(ErrorCodeEnum.SCHEDULE_DUPLICATE);
         }
 
@@ -103,7 +103,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         checkGroupExist(groupId);
         ScheduleEntity entity = scheduleEntityMapper.selectByGroupId(groupId);
         if (entity == null) {
-            LOGGER.error("schedule info for groupId {} does not exist", groupId);
+            LOGGER.error("schedule info for groupId={} does not exist", groupId);
             return false;
         }
         entity.setPreviousStatus(entity.getStatus());
@@ -133,7 +133,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         checkGroupExist(groupId);
         ScheduleEntity entity = scheduleEntityMapper.selectByGroupId(groupId);
         if (entity == null) {
-            LOGGER.error("schedule info for group : {} not found", groupId);
+            LOGGER.error("schedule info for group={} not found", groupId);
             throw new BusinessException(ErrorCodeEnum.SCHEDULE_NOT_FOUND);
         }
         return entity;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -51,7 +51,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     public int save(ScheduleInfoRequest request, String operator) {
         LOGGER.debug("begin to save schedule info, scheduleInfo: {}, operator: {}", request, operator);
 
-        String groupId = request.getGroupId();
+        String groupId = request.getInlongGroupId();
         checkGroupExist(groupId);
         if (scheduleEntityMapper.selectByGroupId(groupId) != null) {
             LOGGER.error("schedule info for group : {} already exists", groupId);
@@ -81,7 +81,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     @Override
     public Boolean update(ScheduleInfoRequest request, String operator) {
         LOGGER.debug("begin to update schedule info={}", request);
-        String groupId = request.getGroupId();
+        String groupId = request.getInlongGroupId();
         ScheduleEntity entity = getScheduleEntity(groupId);
         String errMsg =
                 String.format("schedule info has already been updated with groupId=%s, curVersion=%s, expectVersion=%s",

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.schedule;
+
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.enums.ScheduleStatus;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.common.util.Preconditions;
+import org.apache.inlong.manager.dao.entity.InlongGroupEntity;
+import org.apache.inlong.manager.dao.entity.ScheduleEntity;
+import org.apache.inlong.manager.dao.mapper.InlongGroupEntityMapper;
+import org.apache.inlong.manager.dao.mapper.ScheduleEntityMapper;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScheduleServiceImpl implements ScheduleService {
+
+    private static Logger LOGGER = LoggerFactory.getLogger(ScheduleServiceImpl.class);
+
+    @Autowired
+    private InlongGroupEntityMapper groupMapper;
+    @Autowired
+    private ScheduleEntityMapper scheduleEntityMapper;
+
+    @Override
+    public int save(ScheduleInfoRequest scheduleInfo, String operator) {
+        LOGGER.debug("begin to save schedule info, scheduleInfo: {}, operator: {}", scheduleInfo, operator);
+        Preconditions.expectNotNull(scheduleInfo, "schedule info request can't be null");
+
+        String groupId = scheduleInfo.getGroupId();
+        checkGroupExist(groupId);
+        if (scheduleEntityMapper.selectByGroupId(groupId) != null) {
+            LOGGER.error("schedule info for group : {} already exists", groupId);
+            throw new BusinessException(ErrorCodeEnum.SCHEDULE_DUPLICATE);
+        }
+
+        ScheduleEntity scheduleEntity = CommonBeanUtils.copyProperties(scheduleInfo, ScheduleEntity::new);
+        scheduleEntity.setStatus(ScheduleStatus.NEW.getCode());
+        scheduleEntity.setCreator(operator);
+        scheduleEntity.setModifier(operator);
+        return scheduleEntityMapper.insert(scheduleEntity);
+    }
+
+    @Override
+    public Boolean exist(String groupId) {
+        checkGroupExist(groupId);
+        return scheduleEntityMapper.selectByGroupId(groupId) != null;
+    }
+
+    @Override
+    public ScheduleInfo get(String groupId) {
+        LOGGER.debug("begin to get schedule info by groupId={}", groupId);
+        ScheduleEntity entity = getScheduleEntity(groupId);
+        return CommonBeanUtils.copyProperties(entity, ScheduleInfo::new);
+    }
+
+    @Override
+    public Boolean update(ScheduleInfoRequest request, String operator) {
+        LOGGER.debug("begin to update schedule info={}", request);
+        String groupId = request.getGroupId();
+        ScheduleEntity entity = getScheduleEntity(groupId);
+        CommonBeanUtils.copyProperties(request, entity, true);
+        entity.setModifier(operator);
+        scheduleEntityMapper.updateByIdSelective(entity);
+        LOGGER.info("success to update schedule info for groupId={}", groupId);
+        return true;
+    }
+
+    @Override
+    public Boolean deleteByGroupId(String groupId, String operator) {
+        LOGGER.debug("begin to delete schedule info for groupId={}", groupId);
+        checkGroupExist(groupId);
+        ScheduleEntity entity = scheduleEntityMapper.selectByGroupId(groupId);
+        if (entity == null) {
+            LOGGER.error("schedule info for groupId {} does not exist", groupId);
+            return false;
+        }
+        int res = scheduleEntityMapper.deleteByGroupId(groupId);
+        LOGGER.info("success to delete schedule info for groupId={}", groupId);
+        return res > 0;
+    }
+
+    /**
+     * Check whether InLongGroup exists, throw BusinessException with ErrorCodeEnum.GROUP_NOT_FOUND if check failed.
+     * */
+    private void checkGroupExist(String groupId) {
+        Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
+        InlongGroupEntity entity = groupMapper.selectByGroupId(groupId);
+        if (entity == null) {
+            LOGGER.error("inlong group not found by groupId={}", groupId);
+            throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
+        }
+    }
+
+    private ScheduleEntity getScheduleEntity(String groupId) {
+        checkGroupExist(groupId);
+        ScheduleEntity entity = scheduleEntityMapper.selectByGroupId(groupId);
+        if (entity == null) {
+            LOGGER.error("schedule info for group : {} not found", groupId);
+            throw new BusinessException(ErrorCodeEnum.SCHEDULE_NOT_FOUND);
+        }
+        return entity;
+    }
+}

--- a/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
@@ -963,7 +963,7 @@ CREATE TABLE IF NOT EXISTS `cluster_config`
 CREATE TABLE IF NOT EXISTS `schedule_config`
 (
     `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
-    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `inlong_group_id`        varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
     `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
     `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
     `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',

--- a/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
@@ -982,7 +982,7 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
+    UNIQUE KEY `unique_group_schedule_config` (`inlong_group_id`, `is_deleted`)
     ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
@@ -957,4 +957,34 @@ CREATE TABLE IF NOT EXISTS `cluster_config`
 
 -- ----------------------------
 
+-- ----------------------------
+-- Table structure for schedule_config
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `schedule_config`
+(
+    `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
+    `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
+    `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',
+    `start_time`             timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Start time for schedule',
+    `end_time`               timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'End time for schedule',
+    `delay_time`             int(11)      DEFAULT '0' COMMENT 'Delay time in minutes to schedule',
+    `self_depend`            int(11)      DEFAULT NULL COMMENT 'Self depend info',
+    `task_parallelism`       int(11)      DEFAULT NULL COMMENT 'Task parallelism',
+    `crontab_expression`     varchar(256) DEFAULT NULL COMMENT 'Crontab expression if schedule type is crontab',
+    `status`                 int(4)       DEFAULT '100' COMMENT 'Schedule status',
+    `previous_status`        int(4)       DEFAULT '100' COMMENT 'Previous schedule status',
+    `is_deleted`             int(11)      DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
+    `creator`                varchar(64)  NOT NULL COMMENT 'Creator name',
+    `modifier`               varchar(64)  DEFAULT NULL COMMENT 'Modifier name',
+    `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
+    `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
+    PRIMARY KEY (`id`)
+    ) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
+-- ----------------------------
+
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
+++ b/inlong-manager/manager-test/src/main/resources/h2/apache_inlong_manager.sql
@@ -981,7 +981,8 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
     ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1046,7 +1046,7 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
+    UNIQUE KEY `unique_group_schedule_config` (`inlong_group_id`, `is_deleted`)
 ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1045,7 +1045,8 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
 ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1021,4 +1021,33 @@ CREATE TABLE IF NOT EXISTS `cluster_config`
     DEFAULT CHARSET = utf8mb4 COMMENT = 'cluster_config';
 -- ----------------------------
 
+-- ----------------------------
+-- Table structure for schedule_config
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `schedule_config`
+(
+    `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
+    `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
+    `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',
+    `start_time`             timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Start time for schedule',
+    `end_time`               timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'End time for schedule',
+    `delay_time`             int(11)      DEFAULT '0' COMMENT 'Delay time in minutes to schedule',
+    `self_depend`            int(11)      DEFAULT NULL COMMENT 'Self depend info',
+    `task_parallelism`       int(11)      DEFAULT NULL COMMENT 'Task parallelism',
+    `crontab_expression`     varchar(256) DEFAULT NULL COMMENT 'Crontab expression if schedule type is crontab',
+    `status`                 int(4)       DEFAULT '100' COMMENT 'Schedule status',
+    `previous_status`        int(4)       DEFAULT '100' COMMENT 'Previous schedule status',
+    `is_deleted`             int(11)      DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
+    `creator`                varchar(64)  NOT NULL COMMENT 'Creator name',
+    `modifier`               varchar(64)  DEFAULT NULL COMMENT 'Modifier name',
+    `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
+    `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
+-- ----------------------------
+
 SET FOREIGN_KEY_CHECKS = 1;

--- a/inlong-manager/manager-web/sql/apache_inlong_manager.sql
+++ b/inlong-manager/manager-web/sql/apache_inlong_manager.sql
@@ -1027,7 +1027,7 @@ CREATE TABLE IF NOT EXISTS `cluster_config`
 CREATE TABLE IF NOT EXISTS `schedule_config`
 (
     `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
-    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `inlong_group_id`        varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
     `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
     `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
     `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',

--- a/inlong-manager/manager-web/sql/changes-1.13.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.13.0.sql
@@ -33,7 +33,7 @@ ALTER TABLE `inlong_cluster_node` ADD COLUMN  `ssh_port` int(11) DEFAULT NULL CO
 CREATE TABLE IF NOT EXISTS `schedule_config`
 (
     `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
-    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `inlong_group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
     `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
     `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
     `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',
@@ -52,7 +52,7 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
     PRIMARY KEY (`id`),
-    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
+    UNIQUE KEY `unique_group_schedule_config` (`inlong_group_id`, `is_deleted`)
     ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-web/sql/changes-1.13.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.13.0.sql
@@ -26,3 +26,32 @@ USE `apache_inlong_manager`;
 ALTER TABLE `inlong_cluster_node` ADD COLUMN  `username` varchar(256) DEFAULT NULL COMMENT 'username for ssh';
 ALTER TABLE `inlong_cluster_node` ADD COLUMN  `password` varchar(256) DEFAULT NULL COMMENT 'password for ssh';
 ALTER TABLE `inlong_cluster_node` ADD COLUMN  `ssh_port` int(11) DEFAULT NULL COMMENT 'ssh port';
+
+-- ----------------------------
+-- Table structure for schedule_config
+-- ----------------------------
+CREATE TABLE IF NOT EXISTS `schedule_config`
+(
+    `id`                     int(11)      NOT NULL AUTO_INCREMENT COMMENT 'Incremental primary key',
+    `group_id`               varchar(256) NOT NULL COMMENT 'Inlong group id, undeleted ones cannot be repeated',
+    `schedule_type`          int(4)       NOT NULL DEFAULT '0' COMMENT 'Schedule type, 0 for normal, 1 for crontab',
+    `schedule_unit`          varchar(64)  NOT NULL COMMENT 'Schedule unit,M=month, W=week, D=day, H=hour, M=minute, O=oneway',
+    `schedule_interval`      int(11)      DEFAULT '1' COMMENT 'Schedule interval',
+    `start_time`             timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Start time for schedule',
+    `end_time`               timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'End time for schedule',
+    `delay_time`             int(11)      DEFAULT '0' COMMENT 'Delay time in minutes to schedule',
+    `self_depend`            int(11)      DEFAULT NULL COMMENT 'Self depend info',
+    `task_parallelism`       int(11)      DEFAULT NULL COMMENT 'Task parallelism',
+    `crontab_expression`     varchar(256) DEFAULT NULL COMMENT 'Crontab expression if schedule type is crontab',
+    `status`                 int(4)       DEFAULT '100' COMMENT 'Schedule status',
+    `previous_status`        int(4)       DEFAULT '100' COMMENT 'Previous schedule status',
+    `is_deleted`             int(11)      DEFAULT '0' COMMENT 'Whether to delete, 0: not deleted, > 0: deleted',
+    `creator`                varchar(64)  NOT NULL COMMENT 'Creator name',
+    `modifier`               varchar(64)  DEFAULT NULL COMMENT 'Modifier name',
+    `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
+    `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
+    `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
+    PRIMARY KEY (`id`)
+    ) ENGINE = InnoDB
+    DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
+-- ----------------------------

--- a/inlong-manager/manager-web/sql/changes-1.13.0.sql
+++ b/inlong-manager/manager-web/sql/changes-1.13.0.sql
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS `schedule_config`
     `create_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Create time',
     `modify_time`            timestamp    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'Modify time',
     `version`                int(11)      NOT NULL DEFAULT '1' COMMENT 'Version number, which will be incremented by 1 after modification',
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `unique_group_schedule_config` (`group_id`, `is_deleted`)
     ) ENGINE = InnoDB
     DEFAULT CHARSET = utf8mb4 COMMENT = 'schedule_config';
 -- ----------------------------

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
@@ -29,7 +29,6 @@ import org.apache.inlong.manager.service.schedule.ScheduleService;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
-import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
@@ -58,18 +57,14 @@ public class InLongSchedulerController {
 
     @RequestMapping(value = "/schedule/exist/{groupId}", method = RequestMethod.GET)
     @ApiOperation(value = "Is the schedule info exists for inlong group")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
-    })
+    @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
     public Response<Boolean> exist(@PathVariable String groupId) {
         return Response.success(scheduleService.exist(groupId));
     }
 
     @RequestMapping(value = "/schedule/get", method = RequestMethod.GET)
     @ApiOperation(value = "Get schedule info for inlong group")
-    @ApiImplicitParams({
-            @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
-    })
+    @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
     public Response<ScheduleInfo> get(@RequestParam String groupId) {
         return Response.success(scheduleService.get(groupId));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.web.controller;
+
+import org.apache.inlong.manager.common.enums.OperationTarget;
+import org.apache.inlong.manager.common.enums.OperationType;
+import org.apache.inlong.manager.common.validation.UpdateValidation;
+import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
+import org.apache.inlong.manager.pojo.user.LoginUserUtils;
+import org.apache.inlong.manager.service.operationlog.OperationLog;
+import org.apache.inlong.manager.service.schedule.ScheduleService;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiImplicitParams;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@Api(tags = "Inlong-Schedule-API")
+public class InLongSchedulerController {
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @RequestMapping(value = "/schedule/save", method = RequestMethod.POST)
+    @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SCHEDULE)
+    @ApiOperation(value = "Save schedule info")
+    public Response<Integer> save(@RequestBody ScheduleInfoRequest request) {
+        int result = scheduleService.save(request, LoginUserUtils.getLoginUser().getName());
+        return Response.success(result);
+    }
+
+    @RequestMapping(value = "/schedule/exist/{groupId}", method = RequestMethod.GET)
+    @ApiOperation(value = "Is the schedule info exists for inlong group")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
+    })
+    public Response<Boolean> exist(@PathVariable String groupId) {
+        return Response.success(scheduleService.exist(groupId));
+    }
+
+    @RequestMapping(value = "/schedule/get", method = RequestMethod.GET)
+    @ApiOperation(value = "Get schedule info for inlong group")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
+    })
+    public Response<ScheduleInfo> get(@RequestParam String groupId) {
+        return Response.success(scheduleService.get(groupId));
+    }
+
+    @RequestMapping(value = "/schedule/update", method = RequestMethod.POST)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SCHEDULE)
+    @ApiOperation(value = "Update schedule info")
+    public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody ScheduleInfoRequest request) {
+        return Response.success(scheduleService.update(request, LoginUserUtils.getLoginUser().getName()));
+    }
+
+    @RequestMapping(value = "/schedule/delete/{groupId}", method = RequestMethod.DELETE)
+    @ApiOperation(value = "Delete schedule info")
+    @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SCHEDULE)
+    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
+    public Response<Boolean> delete(@PathVariable String groupId) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(scheduleService.deleteByGroupId(groupId, operator));
+    }
+
+}


### PR DESCRIPTION
Fixes #10247 

### Motivation

Add metadata management of schedule information for offline sync.

### Modifications

1. define key properties of  schedule info
2. support  CURD for schedule information 
3. support managing of schedule info using manager client

### Verifying this change

- [ ] This change added tests and can be verified as follows:

 - inlong-manager/manager-dao/src/test/java/org/apache/inlong/manager/dao/mapper/ScheduleEntityTest.java

### Documentation

  - Does this pull request introduce a new feature? (no)

