### PR TITLE
[INLONG-10263][Audit] Solve the conflict between the jdbc.url parameter of Audit Store and the container environment variable

### DIFF
--- a/inlong-audit/audit-docker/audit-docker.sh
+++ b/inlong-audit/audit-docker/audit-docker.sh
@@ -54,8 +54,8 @@ sed -i "s/apache_inlong_audit/${AUDIT_DBNAME}/g" "${sql_mysql_file}"
 
 # replace the configuration for audit-store
 sed -i "s/127.0.0.1:3306\/apache_inlong_audit/${AUDIT_JDBC_URL}\/${AUDIT_DBNAME}/g" "${store_conf_file}"
-sed -i "s/jdbc.username=.*$/jdbc.username=${AUDIT_JDBC_USERNAME}/g" "${store_conf_file}"
-sed -i "s/jdbc.password=.*$/jdbc.password=${AUDIT_JDBC_PASSWORD}/g" "${store_conf_file}"
+sed -i "s/audit.store.jdbc.username=.*$/audit.store.jdbc.username=${AUDIT_JDBC_USERNAME}/g" "${store_conf_file}"
+sed -i "s/audit.store.jdbc.password=.*$/audit.store.jdbc.password=${AUDIT_JDBC_PASSWORD}/g" "${store_conf_file}"
 
 # replace the configuration for audit-service
 sed -i "s/mysql.jdbc.url=.*$/mysql.jdbc.url=jdbc:mysql:\/\/${AUDIT_JDBC_URL}\/${AUDIT_DBNAME}/g" "${service_conf_file}"

--- a/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/JdbcConfig.java
+++ b/inlong-audit/audit-store/src/main/java/org/apache/inlong/audit/config/JdbcConfig.java
@@ -25,20 +25,20 @@ import org.springframework.context.annotation.Configuration;
 @Data
 public class JdbcConfig {
 
-    @Value("${jdbc.driver:com.mysql.cj.jdbc.Driver}")
+    @Value("${audit.store.jdbc.driver:com.mysql.cj.jdbc.Driver}")
     private String driver;
-    @Value("${jdbc.url}")
+    @Value("${audit.store.jdbc.url}")
     private String url;
-    @Value("${jdbc.username}")
+    @Value("${audit.store.jdbc.username}")
     private String userName;
-    @Value("${jdbc.password}")
+    @Value("${audit.store.jdbc.password}")
     private String password;
-    @Value("${jdbc.batchIntervalMs:1000}")
+    @Value("${audit.store.jdbc.batchIntervalMs:1000}")
     private int batchIntervalMs;
-    @Value("${jdbc.batchThreshold:500}")
+    @Value("${audit.store.jdbc.batchThreshold:500}")
     private int batchThreshold;
-    @Value("${jdbc.processIntervalMs:100}")
+    @Value("${audit.store.jdbc.processIntervalMs:100}")
     private int processIntervalMs;
-    @Value("${data.queue.size:1000000}")
+    @Value("${audit.store.data.queue.size:1000000}")
     private int dataQueueSize;
 }

--- a/inlong-audit/conf/application.properties
+++ b/inlong-audit/conf/application.properties
@@ -47,7 +47,7 @@ audit.kafka.consumer.name=inlong-audit-consumer
 audit.kafka.group.id=audit-consumer-group
 
 # Generic jdbc storage
-jdbc.driver=com.mysql.cj.jdbc.Driver
-jdbc.url=jdbc:mysql://127.0.0.1:3306/apache_inlong_audit?characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2b8&rewriteBatchedStatements=true&allowMultiQueries=true&zeroDateTimeBehavior=CONVERT_TO_NULL
-jdbc.username=root
-jdbc.password=inlong
+audit.store.jdbc.driver=com.mysql.cj.jdbc.Driver
+audit.store.jdbc.url=jdbc:mysql://127.0.0.1:3306/apache_inlong_audit?characterEncoding=utf8&useSSL=false&serverTimezone=GMT%2b8&rewriteBatchedStatements=true&allowMultiQueries=true&zeroDateTimeBehavior=CONVERT_TO_NULL
+audit.store.jdbc.username=root
+audit.store.jdbc.password=inlong


### PR DESCRIPTION
- Fixes #10263

### Motivation

Solve the conflict between the jdbc.url parameter of Audit Store and the container environment variable.
![image](https://github.com/apache/inlong/assets/43397300/6a4c3812-dafa-4419-b86f-e93aabaea919)
![image](https://github.com/apache/inlong/assets/43397300/89afbad7-ee05-4741-b962-82a9469493de)


### Modifications

Audit Store replacement parameter name of jdbc.url to audit.store.jdbc.url.

