### PR TITLE
[INLONG-10274][Audit] The OpenAPI of Audit Service returns the average transmission time

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/cache/RealTimeQuery.java
@@ -216,9 +216,10 @@ public class RealTimeQuery {
                     data.setInlongStreamId(resultSet.getString(3));
                     data.setAuditId(resultSet.getString(4));
                     data.setAuditTag(resultSet.getString(5));
-                    data.setCount(resultSet.getLong(6));
+                    long count = resultSet.getLong(6);
+                    data.setCount(count);
                     data.setSize(resultSet.getLong(7));
-                    data.setDelay(resultSet.getLong(8));
+                    data.setDelay(CacheUtils.calculateAverageDelay(count, resultSet.getLong(8)));
                     data.setAuditVersion(resultSet.getLong(9));
                     result.add(data);
                 }
@@ -281,9 +282,10 @@ public class RealTimeQuery {
                     data.setInlongStreamId(resultSet.getString(2));
                     data.setAuditId(resultSet.getString(3));
                     data.setAuditTag(resultSet.getString(4));
-                    data.setCount(resultSet.getLong(5));
+                    long count = resultSet.getLong(5);
+                    data.setCount(count);
                     data.setSize(resultSet.getLong(6));
-                    data.setDelay(resultSet.getLong(7));
+                    data.setDelay(CacheUtils.calculateAverageDelay(count, resultSet.getLong(7)));
                     result.add(data);
                 }
             } catch (SQLException sqlException) {
@@ -345,9 +347,10 @@ public class RealTimeQuery {
                 while (resultSet.next()) {
                     StatData data = new StatData();
                     data.setIp(resultSet.getString(1));
-                    data.setCount(resultSet.getLong(2));
+                    long count = resultSet.getLong(2);
+                    data.setCount(count);
                     data.setSize(resultSet.getLong(3));
-                    data.setDelay(resultSet.getLong(4));
+                    data.setDelay(CacheUtils.calculateAverageDelay(count, resultSet.getLong(4)));
                     result.add(data);
                 }
             } catch (SQLException sqlException) {

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/source/JdbcSource.java
@@ -23,6 +23,7 @@ import org.apache.inlong.audit.entities.SourceConfig;
 import org.apache.inlong.audit.entities.StartEndTime;
 import org.apache.inlong.audit.entities.StatData;
 import org.apache.inlong.audit.service.ConfigService;
+import org.apache.inlong.audit.utils.CacheUtils;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -304,9 +305,10 @@ public class JdbcSource {
                         } else {
                             data.setAuditTag(auditTag);
                         }
-                        data.setCount(resultSet.getLong(5));
+                        long count = resultSet.getLong(5);
+                        data.setCount(count);
                         data.setSize(resultSet.getLong(6));
-                        data.setDelay(resultSet.getLong(7));
+                        data.setDelay(CacheUtils.calculateAverageDelay(count, resultSet.getLong(7)));
                         dataQueue.push(data);
                     }
                 } catch (SQLException sqlException) {

--- a/inlong-audit/audit-service/src/test/java/utils/CacheUtilsTest.java
+++ b/inlong-audit/audit-service/src/test/java/utils/CacheUtilsTest.java
@@ -15,25 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.audit.utils;
+package utils;
 
-/**
- * Cache utils
- */
-public class CacheUtils {
+import org.apache.inlong.audit.utils.CacheUtils;
 
-    public static String buildCacheKey(String logTs, String inlongGroupId, String inlongStreamId,
-            String auditId, String auditTag) {
-        return new StringBuilder()
-                .append(logTs)
-                .append(inlongGroupId)
-                .append(inlongStreamId)
-                .append(auditId)
-                .append(auditTag)
-                .toString();
-    }
+import org.junit.Test;
 
-    public static long calculateAverageDelay(long totalCount, long totalDelay) {
-        return totalCount == 0 ? 0 : (totalDelay / Math.abs(totalCount));
+import static org.junit.Assert.assertEquals;
+
+public class CacheUtilsTest {
+
+    @Test
+    public void calculateAverageDelay() {
+        long averageDelay = CacheUtils.calculateAverageDelay(10, 100);
+        assertEquals(10, averageDelay);
+
+        averageDelay = CacheUtils.calculateAverageDelay(-10, 100);
+        assertEquals(10, averageDelay);
+
+        averageDelay = CacheUtils.calculateAverageDelay(0, 100);
+        assertEquals(0, averageDelay);
     }
 }


### PR DESCRIPTION
- Fixes #10274

### Motivation

The OpenAPI of Audit Service returns the average transmission time.

### Modifications

The OpenAPI of Audit Service returns the average transmission time instead of the total transmission time.