### PR TITLE
[INLONG-10281][Agent] Real time file collection takes the current time as the data time

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/InstanceProfile.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/conf/InstanceProfile.java
@@ -80,6 +80,10 @@ public class InstanceProfile extends AbstractConfiguration implements Comparable
         return get(TaskConstants.INSTANCE_ID);
     }
 
+    public String getCycleUnit() {
+        return get(TaskConstants.TASK_CYCLE_UNIT);
+    }
+
     public String getSourceClass() {
         return get(TaskConstants.TASK_SOURCE);
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessageCache.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessageCache.java
@@ -83,7 +83,7 @@ public class ProxyMessageCache {
         extraMap.putAll(AgentUtils.parseAddAttrToMap(instanceProfile.getPredefineFields()));
         extraMap.put(AUDIT_VERSION, instanceProfile.get(TASK_AUDIT_VERSION));
         String cycleUnit = instanceProfile.get(TASK_CYCLE_UNIT);
-        if (cycleUnit.compareToIgnoreCase(CycleUnitType.REAL_TIME) == 0) {
+        if (cycleUnit.equalsIgnoreCase(CycleUnitType.REAL_TIME)) {
             isRealTime = true;
         }
     }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessageCache.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/message/file/ProxyMessageCache.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.agent.message.file;
 
 import org.apache.inlong.agent.conf.InstanceProfile;
+import org.apache.inlong.agent.constant.CycleUnitType;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.common.msg.AttributeConstants;
 
@@ -40,6 +41,7 @@ import static org.apache.inlong.agent.constant.CommonConstants.PROXY_INLONG_STRE
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_PACKAGE_MAX_SIZE;
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_PACKAGE_MAX_TIMEOUT_MS;
 import static org.apache.inlong.agent.constant.TaskConstants.TASK_AUDIT_VERSION;
+import static org.apache.inlong.agent.constant.TaskConstants.TASK_CYCLE_UNIT;
 import static org.apache.inlong.common.msg.AttributeConstants.AUDIT_VERSION;
 
 /**
@@ -62,7 +64,6 @@ public class ProxyMessageCache {
     private long lastPrintTime = 0;
     private long dataTime;
     private boolean isRealTime = false;
-    protected long auditVersion;
     /**
      * extra map used when sending to dataproxy
      */
@@ -81,6 +82,10 @@ public class ProxyMessageCache {
         extraMap.put(AttributeConstants.MESSAGE_SYNC_SEND, "false");
         extraMap.putAll(AgentUtils.parseAddAttrToMap(instanceProfile.getPredefineFields()));
         extraMap.put(AUDIT_VERSION, instanceProfile.get(TASK_AUDIT_VERSION));
+        String cycleUnit = instanceProfile.get(TASK_CYCLE_UNIT);
+        if (cycleUnit.compareToIgnoreCase(CycleUnitType.REAL_TIME) == 0) {
+            isRealTime = true;
+        }
     }
 
     public void generateExtraMap(String dataKey) {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/OffsetManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/OffsetManager.java
@@ -162,7 +162,8 @@ public class OffsetManager extends AbstractDaemon {
                     }
                 }
             }
-            long expireTime = DateTransUtils.calcOffset(DB_INSTANCE_EXPIRE_CYCLE_COUNT + taskFromDb.getCycleUnit());
+            long expireTime = DateTransUtils.calcOffset(
+                    DB_INSTANCE_EXPIRE_CYCLE_COUNT + instanceFromDb.getCycleUnit());
             if (AgentUtils.getCurrentTime() - instanceFromDb.getModifyTime() > expireTime) {
                 cleanCount.getAndIncrement();
                 LOGGER.info("instance has expired, delete from db dataTime {} taskId {} instanceId {}",
@@ -170,7 +171,7 @@ public class OffsetManager extends AbstractDaemon {
                 instanceDb.deleteInstance(taskId, instanceId);
                 AuditUtils.add(AuditUtils.AUDIT_ID_AGENT_DEL_INSTANCE_DB, instanceFromDb.getInlongGroupId(),
                         instanceFromDb.getInlongStreamId(), instanceFromDb.getSinkDataTime(), 1, 1,
-                        Long.parseLong(taskFromDb.get(TASK_AUDIT_VERSION)));
+                        Long.parseLong(instanceFromDb.get(TASK_AUDIT_VERSION)));
                 iterator.remove();
             }
         }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -290,7 +290,7 @@ public class LogFileSource extends AbstractSource {
             try {
                 return FileDataUtils.getInodeInfo(fileName).compareTo(inodeInfo) != 0;
             } catch (IOException e) {
-                LOGGER.error("check inode change file {} error {}", fileName, e.getMessage());
+                LOGGER.error("check inode change file {} error", fileName, e);
                 return true;
             }
         }
@@ -299,7 +299,7 @@ public class LogFileSource extends AbstractSource {
 
     @Override
     protected boolean isRunnable() {
-        return runnable && fileExist && !isInodeChanged();
+        return runnable && fileExist;
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
@@ -399,9 +399,6 @@ public abstract class AbstractSource implements Source {
 
     @Override
     public boolean sourceFinish() {
-        if (isRealTime) {
-            return false;
-        }
         return emptyCount > EMPTY_CHECK_COUNT_AT_LEAST;
     }
 


### PR DESCRIPTION
Fixes #10281 

### Motivation

Real time file collection need to take the current time as the data time

### Modifications

Real time file collection uses the current time as the audit time and data, and transmits it downstream
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
