### PR TITLE
[INLONG-10290][Manager] Prohibit groups that have not been successfully configured from obtaining dataproxy addresses

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -1210,6 +1210,14 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     public DataProxyNodeResponse getDataProxyNodes(String groupId, String protocolType) {
         LOGGER.debug("begin to get data proxy nodes for groupId={}, protocol={}", groupId, protocolType);
 
+        InlongGroupEntity groupEntity = groupMapper.selectByGroupId(groupId);
+        GroupStatus groupStatus = GroupStatus.forCode(groupEntity.getStatus());
+        if (!Objects.equals(groupStatus, GroupStatus.CONFIG_SUCCESSFUL)) {
+            String errMsg =
+                    String.format("current group status=%s was not allowed to get data proxy nodes", groupStatus);
+            LOGGER.warn(errMsg);
+            throw new BusinessException(errMsg);
+        }
         List<InlongClusterNodeEntity> nodeEntities = getClusterNodes(groupId, ClusterType.DATAPROXY, protocolType);
         DataProxyNodeResponse response = new DataProxyNodeResponse();
         if (CollectionUtils.isEmpty(nodeEntities)) {

--- a/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/ServiceBaseTest.java
+++ b/inlong-manager/manager-service/src/test/java/org/apache/inlong/manager/service/ServiceBaseTest.java
@@ -111,6 +111,8 @@ public class ServiceBaseTest extends BaseTest {
         InlongGroupInfo updateGroupInfo = groupService.get(inlongGroupId);
         groupService.updateStatus(inlongGroupId, GroupStatus.TO_BE_APPROVAL.getCode(), GLOBAL_OPERATOR);
         groupService.updateStatus(inlongGroupId, GroupStatus.APPROVE_PASSED.getCode(), GLOBAL_OPERATOR);
+        groupService.updateStatus(inlongGroupId, GroupStatus.CONFIG_ING.getCode(), GLOBAL_OPERATOR);
+        groupService.updateStatus(inlongGroupId, GroupStatus.CONFIG_SUCCESSFUL.getCode(), GLOBAL_OPERATOR);
         groupService.update(updateGroupInfo.genRequest(), GLOBAL_OPERATOR);
 
         return groupInfo;


### PR DESCRIPTION

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

- Fixes #10290 

### Motivation

Prohibit groups that have not been successfully configured from obtaining dataproxy addresses.
Prevent dataproxy from sending data to MQ clusters without creating a topic.
### Modifications

Prohibit groups that have not been successfully configured from obtaining dataproxy addresses.
The manager determines whether to return dataproxy node information based on the group status.

