### PR TITLE
[INLONG-10302][Agent] Add an interface for limiting the number of instances obtained

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
@@ -19,7 +19,6 @@ package org.apache.inlong.agent.plugin.task;
 
 import org.apache.inlong.agent.conf.InstanceProfile;
 import org.apache.inlong.agent.conf.TaskProfile;
-import org.apache.inlong.agent.constant.TaskConstants;
 import org.apache.inlong.agent.core.instance.ActionType;
 import org.apache.inlong.agent.core.instance.InstanceAction;
 import org.apache.inlong.agent.core.instance.InstanceManager;
@@ -58,7 +57,7 @@ public abstract class AbstractTask extends Task {
         this.taskProfile = taskProfile;
         this.basicDb = basicDb;
         auditVersion = Long.parseLong(taskProfile.get(TASK_AUDIT_VERSION));
-        instanceManager = new InstanceManager(taskProfile.getTaskId(), taskProfile.getInt(TaskConstants.FILE_MAX_NUM),
+        instanceManager = new InstanceManager(taskProfile.getTaskId(), getInstanceLimit(),
                 basicDb, taskManager.getTaskDb());
         try {
             instanceManager.start();
@@ -68,6 +67,8 @@ public abstract class AbstractTask extends Task {
         initTask();
         initOK = true;
     }
+
+    protected abstract int getInstanceLimit();
 
     protected abstract void initTask();
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/KafkaTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/KafkaTask.java
@@ -36,9 +36,15 @@ public class KafkaTask extends AbstractTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaTask.class);
     public static final String DEFAULT_KAFKA_INSTANCE = "org.apache.inlong.agent.plugin.instance.KafkaInstance";
+    public static final int DEFAULT_INSTANCE_LIMIT = 1;
     private boolean isAdded = false;
     private String topic;
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+    @Override
+    protected int getInstanceLimit() {
+        return DEFAULT_INSTANCE_LIMIT;
+    }
 
     @Override
     protected void initTask() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/MongoDBTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/MongoDBTask.java
@@ -35,9 +35,15 @@ public class MongoDBTask extends AbstractTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoDBTask.class);
     public static final String DEFAULT_MONGODB_INSTANCE = "org.apache.inlong.agent.plugin.instance.MongoDBInstance";
+    public static final int DEFAULT_INSTANCE_LIMIT = 1;
     private boolean isAdded = false;
     private String collection;
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+    @Override
+    protected int getInstanceLimit() {
+        return DEFAULT_INSTANCE_LIMIT;
+    }
 
     @Override
     protected void initTask() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/PulsarTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/PulsarTask.java
@@ -38,12 +38,18 @@ public class PulsarTask extends AbstractTask {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PulsarTask.class);
     public static final String DEFAULT_PULSAR_INSTANCE = "org.apache.inlong.agent.plugin.instance.PulsarInstance";
+    public static final int DEFAULT_INSTANCE_LIMIT = 1;
     private boolean isAdded = false;
     private String tenant;
     private String namespace;
     private String topic;
     private String instanceId;
     private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+
+    @Override
+    protected int getInstanceLimit() {
+        return DEFAULT_INSTANCE_LIMIT;
+    }
 
     @Override
     protected void initTask() {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -88,6 +88,11 @@ public class LogFileTask extends AbstractTask {
     private BlockingQueue<InstanceProfile> instanceQueue;
 
     @Override
+    protected int getInstanceLimit() {
+        return taskProfile.getInt(TaskConstants.FILE_MAX_NUM);
+    }
+
+    @Override
     protected void initTask() {
         instanceQueue = new LinkedBlockingQueue<>(INSTANCE_QUEUE_CAPACITY);
         retry = taskProfile.getBoolean(TaskConstants.TASK_RETRY, false);


### PR DESCRIPTION
Fixes #10302 

### Motivation

The Task base class needs to add an interface that limits the number of instances obtained

### Modifications

 Add an interface for limiting the number of instances obtained

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
