### PR TITLE
[INLONG-10313][DataProxy] Replace audit ID macro with audit API

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.dataproxy.metrics.audit;
 
+import org.apache.inlong.audit.AuditIdEnum;
 import org.apache.inlong.audit.AuditOperator;
 import org.apache.inlong.audit.util.AuditConfig;
 import org.apache.inlong.common.enums.MessageWrapType;
@@ -39,9 +40,6 @@ import static org.apache.inlong.audit.consts.ConfigConstants.DEFAULT_AUDIT_TAG;
  */
 public class AuditUtils {
 
-    public static final int AUDIT_ID_DATAPROXY_READ_SUCCESS = 5;
-    public static final int AUDIT_ID_DATAPROXY_SEND_SUCCESS = 6;
-
     /**
      * Init audit
      */
@@ -59,12 +57,32 @@ public class AuditUtils {
     }
 
     /**
-     * Add audit data
+     * Add input audit data
+     *
+     * @param event    event to be counted
      */
-    public static void add(int auditID, Event event) {
-        if (!CommonConfigHolder.getInstance().isEnableAudit() || event == null) {
+    public static void addInputSuccess(Event event) {
+        if (event == null || !CommonConfigHolder.getInstance().isEnableAudit()) {
             return;
         }
+        addAuditData(event,
+                AuditOperator.getInstance().buildSuccessfulAuditId(AuditIdEnum.DATA_PROXY_INPUT));
+    }
+
+    /**
+     * Add output audit data
+     *
+     * @param event    event to be counted
+     */
+    public static void addOutputSuccess(Event event) {
+        if (event == null || !CommonConfigHolder.getInstance().isEnableAudit()) {
+            return;
+        }
+        addAuditData(event,
+                AuditOperator.getInstance().buildFailedAuditId(AuditIdEnum.DATA_PROXY_OUTPUT));
+    }
+
+    private static void addAuditData(Event event, int auditID) {
         Map<String, String> headers = event.getHeaders();
         String pkgVersion = headers.get(ConfigConstants.MSG_ENCODE_VER);
         if (MessageWrapType.INLONG_MSG_V1.getStrId().equalsIgnoreCase(pkgVersion)) {

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/sink/mq/MessageQueueZoneSinkContext.java
@@ -134,8 +134,7 @@ public class MessageQueueZoneSinkContext extends SinkContext {
             long sendTime) {
         if (currentRecord instanceof SimplePackProfile) {
             if (result) {
-                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_SEND_SUCCESS,
-                        ((SimplePackProfile) currentRecord).getEvent());
+                AuditUtils.addOutputSuccess(((SimplePackProfile) currentRecord).getEvent());
             }
             return;
         }
@@ -166,7 +165,7 @@ public class MessageQueueZoneSinkContext extends SinkContext {
                     metricItem.nodeDuration.addAndGet(nodeDuration);
                     metricItem.wholeDuration.addAndGet(wholeDuration);
                 }
-                AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_SEND_SUCCESS, event);
+                AuditUtils.addOutputSuccess(event);
             } else {
                 metricItem.sendFailCount.addAndGet(1);
                 metricItem.sendFailSize.addAndGet(event.getBody().length);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/BaseSource.java
@@ -485,7 +485,7 @@ public abstract class BaseSource
         if (result) {
             metricItem.readSuccessCount.incrementAndGet();
             metricItem.readSuccessSize.addAndGet(size);
-            AuditUtils.add(AuditUtils.AUDIT_ID_DATAPROXY_READ_SUCCESS, event);
+            AuditUtils.addInputSuccess(event);
         } else {
             metricItem.readFailCount.incrementAndGet();
             metricItem.readFailSize.addAndGet(size);


### PR DESCRIPTION

Fixes #10313

Replace

public static final int AUDIT_ID_DATAPROXY_READ_SUCCESS = 5;
public static final int AUDIT_ID_DATAPROXY_SEND_SUCCESS = 6;

with:

buildSuccessfulAuditId()
buildFailedAuditId()