### PR TITLE
[INLONG-10314][DashBoard] Add an operation time to the operation log table

### DIFF
--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -669,6 +669,7 @@
   "pages.GroupDetail.OperationLog.Table.OperationType": "操作类型",
   "pages.GroupDetail.OperationLog.Table.OperationTarget": "操作目标",
   "pages.GroupDetail.OperationLog.Table.Log": "日志",
+  "pages.GroupDetail.OperationLog.Table.OperationTime": "操作时间",
   "pages.ApprovalDetail.GroupConfig.DataStorages": "数据存储",
   "pages.ApprovalDetail.GroupConfig.ApprovalInformation": "审批信息",
   "pages.ApprovalDetail.GroupConfig.DataFlowInformation": "数据流信息",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -669,6 +669,7 @@
   "pages.GroupDetail.OperationLog.Table.OperationType": "Operation type",
   "pages.GroupDetail.OperationLog.Table.OperationTarget": "Operation target",
   "pages.GroupDetail.OperationLog.Table.Log": "Log",
+  "pages.GroupDetail.OperationLog.Table.OperationTime": "Operation time",
   "pages.ApprovalDetail.GroupConfig.DataStorages": "Data storages",
   "pages.ApprovalDetail.GroupConfig.ApprovalInformation": "Approval information",
   "pages.ApprovalDetail.GroupConfig.DataFlowInformation": "Data stream information",

--- a/inlong-dashboard/src/ui/pages/GroupDetail/OperationLog/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/OperationLog/config.tsx
@@ -20,6 +20,7 @@
 import i18n from '@/i18n';
 import { Tooltip } from 'antd';
 import React from 'react';
+import { dateFormat } from '@/core/utils';
 
 const targetList = [
   {
@@ -140,5 +141,10 @@ export const getTableColumns = [
         {body}
       </Tooltip>
     ),
+  },
+  {
+    title: i18n.t('pages.GroupDetail.OperationLog.Table.OperationTime'),
+    dataIndex: 'requestTime',
+    render: text => dateFormat(new Date(text)),
   },
 ];


### PR DESCRIPTION


Fixes #10314 

### Motivation

 Add an operation time to the operation log table

### Modifications
Added an operation time column to the operation log table


### Verifying this change
![image](https://github.com/apache/inlong/assets/165994047/840ae444-f9d3-4c31-aa2c-545a01cf518e)

![image](https://github.com/apache/inlong/assets/165994047/1fe2b8d3-7560-4f7b-bb2c-d92216ff5d6c)
