### PR TITLE
[INLONG-10332][Sort] Relocate the google.protobuf in Iceberg Connector 

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
@@ -160,8 +160,8 @@
                                     <shadedPattern>org.apache.inlong.sort.iceberg.shaded.org.apache.inlong.sort.base</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>org.apache.inlong.sort.iceberg.shaded.com.google</shadedPattern>
+                                    <pattern>com.google.protobuf</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.iceberg.shaded.com.google.protobuf</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
@@ -124,7 +124,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.apache.inlong:*</include>
-                                    <include>com.google.protobuf:protobuf-java</include>
+                                    <include>com.google.protobuf:*</include>
                                     <include>org.apache.kafka:*</include>
                                     <include>com.fasterxml.*:*</include>
                                     <include>org.apache.iceberg:*</include>
@@ -158,6 +158,10 @@
                                 <relocation>
                                     <pattern>org.apache.inlong.sort.base</pattern>
                                     <shadedPattern>org.apache.inlong.sort.iceberg.shaded.org.apache.inlong.sort.base</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.iceberg.shaded.com.google</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
[INLONG-10332][Sort] Relocation the google.protobuf

Fixes #10332 

### Motivation

com.google.protobuf not packge in iceberg.jar

### Modifications

pom.xml add relocation statement

### Verifying this change

<img width="457" alt="image" src="https://github.com/apache/inlong/assets/58425449/da5f577c-4085-4a69-bb2a-2ccb6af5da94">

