### PR TITLE
[INLONG-10379][Audit] Add HDFS Audit items in the Audit SDK

### DIFF
--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditIdEnum.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditIdEnum.java
@@ -31,6 +31,7 @@ import static org.apache.inlong.audit.entity.AuditType.DATAPROXY;
 import static org.apache.inlong.audit.entity.AuditType.DORIS;
 import static org.apache.inlong.audit.entity.AuditType.ELASTICSEARCH;
 import static org.apache.inlong.audit.entity.AuditType.HBASE;
+import static org.apache.inlong.audit.entity.AuditType.HDFS;
 import static org.apache.inlong.audit.entity.AuditType.HIVE;
 import static org.apache.inlong.audit.entity.AuditType.HUDI;
 import static org.apache.inlong.audit.entity.AuditType.ICEBERG;
@@ -94,7 +95,10 @@ public enum AuditIdEnum {
     SORT_TUBE_OUTPUT(34, OUTPUT, TUBE, "Sent Audit Metrics for Sort Tube"),
 
     SORT_MYSQL_INPUT(35, INPUT, MYSQL, "Received Audit Metrics for Sort MySQL"),
-    SORT_MYSQL_OUTPUT(36, OUTPUT, MYSQL, "Sent Audit Metrics for Sort MySQL");
+    SORT_MYSQL_OUTPUT(36, OUTPUT, MYSQL, "Sent Audit Metrics for Sort MySQL"),
+
+    SORT_HDFS_INPUT(37, INPUT, HDFS, "Received Audit Metrics for Sort HDFS"),
+    SORT_HDFS_OUTPUT(38, OUTPUT, HDFS, "Sent Audit Metrics for Sort HDFS");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditIdEnum.class);
     private final int auditId;

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/entity/AuditType.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/entity/AuditType.java
@@ -34,7 +34,8 @@ public enum AuditType {
     POSTGRES("Postgres"),
     BINLOG("Binlog"),
     TUBE("Tube"),
-    MYSQL("MySQL");
+    MYSQL("MySQL"),
+    HDFS("HDFS");
 
     private final String auditType;
 

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.audit.util;
 
 import org.apache.inlong.audit.AuditIdEnum;
+import org.apache.inlong.audit.MetricIdEnum;
 import org.apache.inlong.audit.entity.AuditInformation;
 import org.apache.inlong.audit.entity.FlowType;
 
@@ -134,6 +135,10 @@ public class AuditManagerUtils {
         for (AuditIdEnum auditIdEnum : AuditIdEnum.values()) {
             auditInformationList.addAll(combineAuditInformation(auditIdEnum.getAuditType().value(),
                     auditIdEnum.getFlowType()));
+        }
+        for (MetricIdEnum metricIdEnum : MetricIdEnum.values()) {
+            auditInformationList.add(new AuditInformation(metricIdEnum.getValue(), metricIdEnum.getEnglishDescription(),
+                    metricIdEnum.getChineseDescription()));
         }
         return auditInformationList;
     }


### PR DESCRIPTION
- Fixes #10379

### Motivation

Add HDFS Audit items in the Audit SDK
<img width="796" alt="image" src="https://github.com/apache/inlong/assets/43397300/34f14625-92fa-4aab-9d2c-254e57db270e">


### Modifications

Add HDFS Audit items in the Audit SDK
