### PR TITLE
[INLONG-10261][Manager] Support installing agents by SSH key-based authentication

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -403,9 +403,9 @@ public interface InlongClusterService {
     /**
      * Obtain the SSH public key from the manager to install the agent.
      *
-     * @return ssh public key
+     * @return the SSH public key
      */
-    String getManagerSshPublicKey();
+    String getManagerSSHPublicKey();
 
     /**
      * Query data proxy nodes by the given inlong group id and protocol type

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -401,9 +401,15 @@ public interface InlongClusterService {
     Boolean deleteNode(Integer id, UserInfo opInfo);
 
     /**
-     * Obtain the SSH public key from the manager to install the agent.
+     * Retrieves the SSH public key from the manager node for agent installation.
      *
-     * @return the SSH public key
+     * <p>To enable SSH key-based authentication, the manager node's public key must be added to the agent node.
+     * This method either generates a new public key or retrieves an existing one.</p>
+     *
+     * <p>After obtaining the SSH public key, add it to the <code>~/.ssh/authorized_keys</code> file on the agent node.
+     * This allows the manager node to execute remote commands on the agent node via SSH.</p>
+     *
+     * @return the SSH public key as a String
      */
     String getManagerSSHPublicKey();
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterService.java
@@ -401,6 +401,13 @@ public interface InlongClusterService {
     Boolean deleteNode(Integer id, UserInfo opInfo);
 
     /**
+     * Obtain the SSH public key from the manager to install the agent.
+     *
+     * @return ssh public key
+     */
+    String getManagerSshPublicKey();
+
+    /**
      * Query data proxy nodes by the given inlong group id and protocol type
      *
      * @param inlongGroupId inlong group id

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -77,6 +77,7 @@ import org.apache.inlong.manager.service.cluster.node.InlongClusterNodeInstallOp
 import org.apache.inlong.manager.service.cluster.node.InlongClusterNodeInstallOperatorFactory;
 import org.apache.inlong.manager.service.cluster.node.InlongClusterNodeOperator;
 import org.apache.inlong.manager.service.cluster.node.InlongClusterNodeOperatorFactory;
+import org.apache.inlong.manager.service.cmd.CommandExecutor;
 import org.apache.inlong.manager.service.repository.DataProxyConfigRepository;
 import org.apache.inlong.manager.service.repository.DataProxyConfigRepositoryV2;
 import org.apache.inlong.manager.service.tenant.InlongTenantService;
@@ -99,6 +100,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -146,6 +150,8 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     private TenantRoleService tenantRoleService;
     @Autowired
     private InlongClusterNodeInstallOperatorFactory clusterNodeInstallOperatorFactory;
+    @Autowired
+    private CommandExecutor commandExecutor;
 
     @Lazy
     @Autowired
@@ -1204,6 +1210,22 @@ public class InlongClusterServiceImpl implements InlongClusterService {
                             entity.getProtocolType()));
         }
         return true;
+    }
+
+    @Override
+    public String getManagerSshPublicKey() {
+        String homeDirectory = System.getProperty("user.home");
+        String publicKeyPath = homeDirectory + "/.ssh/inlong_rsa.pub";
+        try {
+            Path path = Paths.get(publicKeyPath);
+            if (!Files.exists(path)) {
+                commandExecutor.execSshKeyGenerator();
+            }
+            return StringUtils.strip(new String(Files.readAllBytes(path)), "\n");
+        } catch (Exception e) {
+            LOGGER.error("get manager ssh public key error", e);
+            throw new RuntimeException("get manager ssh public key error", e);
+        }
     }
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -1213,13 +1213,13 @@ public class InlongClusterServiceImpl implements InlongClusterService {
     }
 
     @Override
-    public String getManagerSshPublicKey() {
+    public String getManagerSSHPublicKey() {
         String homeDirectory = System.getProperty("user.home");
         String publicKeyPath = homeDirectory + "/.ssh/inlong_rsa.pub";
         try {
             Path path = Paths.get(publicKeyPath);
             if (!Files.exists(path)) {
-                commandExecutor.execSshKeyGenerator();
+                commandExecutor.execSSHKeyGeneration();
             }
             return StringUtils.strip(new String(Files.readAllBytes(path)), "\n");
         } catch (Exception e) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutor.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutor.java
@@ -25,6 +25,8 @@ public interface CommandExecutor {
 
     CommandResult exec(String cmd) throws Exception;
 
+    CommandResult execSshKeyGenerator() throws Exception;
+
     CommandResult execRemote(AgentClusterNodeRequest clusterNodeRequest, String cmd) throws Exception;
 
     CommandResult modifyConfig(AgentClusterNodeRequest clusterNodeRequest, Map<String, String> configMap,

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutor.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutor.java
@@ -25,7 +25,7 @@ public interface CommandExecutor {
 
     CommandResult exec(String cmd) throws Exception;
 
-    CommandResult execSshKeyGenerator() throws Exception;
+    CommandResult execSSHKeyGeneration() throws Exception;
 
     CommandResult execRemote(AgentClusterNodeRequest clusterNodeRequest, String cmd) throws Exception;
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
@@ -92,7 +92,7 @@ public class CommandExecutorImpl implements CommandExecutor {
 
         ShellTracker shellTracker = new ShellTracker();
         ShellExecutorImpl shellExecutor = new ShellExecutorImpl(shellTracker);
-        shellExecutor.syncExec(cmdShell, true, ip, user, password, remoteCommandTimeout, cmd, port);
+        shellExecutor.syncExec(cmdShell, ip, user, password, remoteCommandTimeout, cmd, port);
 
         CommandResult commandResult = new CommandResult();
         commandResult.setCode(shellTracker.getCode());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
@@ -55,6 +55,25 @@ public class CommandExecutorImpl implements CommandExecutor {
     }
 
     @Override
+    public CommandResult execSshKeyGenerator() throws Exception {
+        String cmdShell = "./conf/ssh_key_cmd.exp";
+        ShellTracker shellTracker = new ShellTracker();
+        ShellExecutorImpl shellExecutor = new ShellExecutorImpl(shellTracker);
+        shellExecutor.syncExec(cmdShell);
+
+        CommandResult commandResult = new CommandResult();
+        commandResult.setCode(shellTracker.getCode());
+        commandResult.setResult(String.join(InlongConstants.BLANK, shellTracker.getResult()));
+        LOG.debug(commandResult.getResult());
+        if (commandResult.getCode() != 0) {
+            throw new Exception("generate ssh key exec failed, code = " +
+                    commandResult.getCode() + ", output = " + commandResult.getResult());
+        }
+        LOG.debug(commandResult.getResult());
+        return commandResult;
+    }
+
+    @Override
     public CommandResult execRemote(AgentClusterNodeRequest clusterNodeRequest, String cmd) throws Exception {
         String cmdShell = "./conf/exec_cmd.exp";
         String ip = clusterNodeRequest.getIp();
@@ -62,7 +81,10 @@ public class CommandExecutorImpl implements CommandExecutor {
         String user = clusterNodeRequest.getUsername();
         String password = clusterNodeRequest.getPassword();
         String remoteCommandTimeout = "20000";
-
+        // If the password is null, set the password to an empty string, and then use the public key for identification.
+        if (StringUtils.isBlank(password)) {
+            password = "";
+        }
         cmd = "sh -c \"" + cmd + "\"";
         String cmdMsg =
                 String.join(InlongConstants.BLANK, cmdShell, ip, user, password, remoteCommandTimeout, cmd, port);
@@ -70,7 +92,7 @@ public class CommandExecutorImpl implements CommandExecutor {
 
         ShellTracker shellTracker = new ShellTracker();
         ShellExecutorImpl shellExecutor = new ShellExecutorImpl(shellTracker);
-        shellExecutor.syncExec(cmdShell, ip, user, password, remoteCommandTimeout, cmd, port);
+        shellExecutor.syncExec(cmdShell, true, ip, user, password, remoteCommandTimeout, cmd, port);
 
         CommandResult commandResult = new CommandResult();
         commandResult.setCode(shellTracker.getCode());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/CommandExecutorImpl.java
@@ -55,7 +55,7 @@ public class CommandExecutorImpl implements CommandExecutor {
     }
 
     @Override
-    public CommandResult execSshKeyGenerator() throws Exception {
+    public CommandResult execSSHKeyGeneration() throws Exception {
         String cmdShell = "./conf/ssh_key_cmd.exp";
         ShellTracker shellTracker = new ShellTracker();
         ShellExecutorImpl shellExecutor = new ShellExecutorImpl(shellTracker);
@@ -66,7 +66,7 @@ public class CommandExecutorImpl implements CommandExecutor {
         commandResult.setResult(String.join(InlongConstants.BLANK, shellTracker.getResult()));
         LOG.debug(commandResult.getResult());
         if (commandResult.getCode() != 0) {
-            throw new Exception("generate ssh key exec failed, code = " +
+            throw new Exception("SSH key generation failed, code = " +
                     commandResult.getCode() + ", output = " + commandResult.getResult());
         }
         LOG.debug(commandResult.getResult());

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
@@ -93,26 +93,26 @@ public class ShellExecutorImpl implements ShellExecutor {
         return false;
     }
 
-    public void syncExec(String shellPath, boolean keepEmptyParams, String... params) {
-        if (keepEmptyParams) {
+    public void syncExec(String shellPath, boolean includeEmptyParams, String... params) {
+        if (includeEmptyParams) {
             List<String> cmdPath = new ArrayList<>();
             cmdPath.add(shellPath);
             cmdPath.addAll(Arrays.asList(params));
-            syncExecWithCmd(cmdPath.toArray(new String[0]));
+            syncExec(cmdPath.toArray(new String[0]));
         } else {
             syncExec(shellPath, params);
         }
     }
 
     public void syncExec(String shellPath, String... params) {
-        String[] cmds = merge(shellPath, params);
-        syncExecWithCmd(cmds);
+        String[] commands = merge(shellPath, params);
+        syncExec(commands);
     }
 
-    private void syncExecWithCmd(String[] cmds) {
+    private void syncExec(String[] commands) {
         List<String> result = new ArrayList<String>();
         try {
-            Process ps = Runtime.getRuntime().exec(cmds);
+            Process ps = Runtime.getRuntime().exec(commands);
             long pid = getPid(ps);
             tracker.setProcessId(pid);
             BufferedReader br = new BufferedReader(new InputStreamReader(ps.getInputStream()));

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
@@ -20,7 +20,6 @@ package org.apache.inlong.manager.service.cmd.shell;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
@@ -26,6 +26,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -92,9 +93,24 @@ public class ShellExecutorImpl implements ShellExecutor {
         return false;
     }
 
+    public void syncExec(String shellPath, boolean keepEmptyParams, String... params) {
+        if (keepEmptyParams) {
+            List<String> cmdPath = new ArrayList<>();
+            cmdPath.add(shellPath);
+            cmdPath.addAll(Arrays.asList(params));
+            syncExecWithCmd(cmdPath.toArray(new String[0]));
+        } else {
+            syncExec(shellPath, params);
+        }
+    }
+
     public void syncExec(String shellPath, String... params) {
-        List<String> result = new ArrayList<String>();
         String[] cmds = merge(shellPath, params);
+        syncExecWithCmd(cmds);
+    }
+
+    private void syncExecWithCmd(String[] cmds) {
+        List<String> result = new ArrayList<String>();
         try {
             Process ps = Runtime.getRuntime().exec(cmds);
             long pid = getPid(ps);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cmd/shell/ShellExecutorImpl.java
@@ -57,15 +57,8 @@ public class ShellExecutorImpl implements ShellExecutor {
     private static String[] merge(String shellPath, String[] paths) {
         List<String> cmds = new ArrayList<String>();
         cmds.add(shellPath);
-        for (String path : paths) {
-            if (StringUtils.isBlank(path)) {
-                continue;
-            }
-            cmds.add(path);
-        }
-        String[] strings = new String[cmds.size()];
-        cmds.toArray(strings);
-        return strings;
+        cmds.addAll(Arrays.asList(paths));
+        return cmds.toArray(new String[0]);
     }
 
     private static String arrayToString(Object[] array, String split) {
@@ -93,26 +86,11 @@ public class ShellExecutorImpl implements ShellExecutor {
         return false;
     }
 
-    public void syncExec(String shellPath, boolean includeEmptyParams, String... params) {
-        if (includeEmptyParams) {
-            List<String> cmdPath = new ArrayList<>();
-            cmdPath.add(shellPath);
-            cmdPath.addAll(Arrays.asList(params));
-            syncExec(cmdPath.toArray(new String[0]));
-        } else {
-            syncExec(shellPath, params);
-        }
-    }
-
     public void syncExec(String shellPath, String... params) {
-        String[] commands = merge(shellPath, params);
-        syncExec(commands);
-    }
-
-    private void syncExec(String[] commands) {
         List<String> result = new ArrayList<String>();
+        String[] cmds = merge(shellPath, params);
         try {
-            Process ps = Runtime.getRuntime().exec(commands);
+            Process ps = Runtime.getRuntime().exec(cmds);
             long pid = getPid(ps);
             tracker.setProcessId(pid);
             BufferedReader br = new BufferedReader(new InputStreamReader(ps.getInputStream()));

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -299,7 +299,6 @@ public class InlongClusterController {
 
     @RequestMapping(value = "/cluster/node/getManagerSSHPublicKey", method = RequestMethod.GET)
     @ApiOperation(value = "Obtain the SSH public key from the manager to install the agent.")
-    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.CLUSTER)
     public Response<String> getManagerSSHPublicKey() {
         return Response.success(clusterService.getManagerSSHPublicKey());
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -297,11 +297,11 @@ public class InlongClusterController {
         return Response.success(clusterService.unloadNode(id, LoginUserUtils.getLoginUser().getName()));
     }
 
-    @RequestMapping(value = "/cluster/node/getSshPublicKey", method = RequestMethod.GET)
+    @RequestMapping(value = "/cluster/node/getManagerSSHPublicKey", method = RequestMethod.GET)
     @ApiOperation(value = "Obtain the SSH public key from the manager to install the agent.")
     @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.CLUSTER)
-    public Response<String> getManagerSshPublicKey() {
-        return Response.success(clusterService.getManagerSshPublicKey());
+    public Response<String> getManagerSSHPublicKey() {
+        return Response.success(clusterService.getManagerSSHPublicKey());
     }
 
     @PostMapping("/cluster/testConnection")

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -297,6 +297,13 @@ public class InlongClusterController {
         return Response.success(clusterService.unloadNode(id, LoginUserUtils.getLoginUser().getName()));
     }
 
+    @RequestMapping(value = "/cluster/node/getSshPublicKey", method = RequestMethod.GET)
+    @ApiOperation(value = "Obtain the SSH public key from the manager to install the agent.")
+    @OperationLog(operation = OperationType.GET, operationTarget = OperationTarget.CLUSTER)
+    public Response<String> getManagerSshPublicKey() {
+        return Response.success(clusterService.getManagerSshPublicKey());
+    }
+
     @PostMapping("/cluster/testConnection")
     @ApiOperation(value = "Test connection for inlong cluster")
     public Response<Boolean> testConnection(@Validated @RequestBody ClusterRequest request) {

--- a/inlong-manager/manager-web/src/main/resources/exec_cmd.exp
+++ b/inlong-manager/manager-web/src/main/resources/exec_cmd.exp
@@ -24,7 +24,7 @@ set cmdTimeout [lindex $argv 3]
 set runCommand [lindex $argv 4]
 set remotePort [lindex $argv 5]
 
-#use public key identify
+# use the public key to identify
 if { $password == "" } {
     spawn ssh -p ${remotePort} -i ~/.ssh/inlong_rsa ${remoteHost} -l ${remoteUser} "${runCommand} && echo \\#SUCCESS\\# || echo \\#fail\\#"
 } else {

--- a/inlong-manager/manager-web/src/main/resources/exec_cmd.exp
+++ b/inlong-manager/manager-web/src/main/resources/exec_cmd.exp
@@ -24,8 +24,12 @@ set cmdTimeout [lindex $argv 3]
 set runCommand [lindex $argv 4]
 set remotePort [lindex $argv 5]
 
-spawn ssh -p ${remotePort} ${remoteHost} -l ${remoteUser} "${runCommand} && echo \\#SUCCESS\\# || echo \\#fail\\#"
-
+#use public key identify
+if { $password == "" } {
+    spawn ssh -p ${remotePort} -i ~/.ssh/inlong_rsa ${remoteHost} -l ${remoteUser} "${runCommand} && echo \\#SUCCESS\\# || echo \\#fail\\#"
+} else {
+    spawn ssh -p ${remotePort} ${remoteHost} -l ${remoteUser} "${runCommand} && echo \\#SUCCESS\\# || echo \\#fail\\#"
+}
 set timeout ${cmdTimeout}
 expect {
     "*yes/no)?" {send "yes\n"; exp_continue}

--- a/inlong-manager/manager-web/src/main/resources/ssh_key_cmd.exp
+++ b/inlong-manager/manager-web/src/main/resources/ssh_key_cmd.exp
@@ -1,0 +1,35 @@
+#!/usr/bin/expect
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+spawn /bin/sh -c "echo ~"
+expect {
+    -re "(.*)\r\n" {
+        set home_dir $expect_out(1,string)
+    }
+}
+expect eof
+
+spawn ssh-keygen -t rsa -b 4096 -f ${home_dir}/.ssh/inlong_rsa
+expect {
+    "*Enter file in which to save the key" {send "\r"; exp_continue}
+    "Overwrite (y/n)?" { send "n\r"; exp_continue }
+    "Enter passphrase (empty for no passphrase):" { send "\r"; exp_continue }
+    "Enter same passphrase again:" { send "\r"; exp_continue }
+    eof
+}


### PR DESCRIPTION
Fixes #10261 

### Motivation
Implement SSH key-based authentication when installing the agent via SSH.

The implementation plan is as follows:
 1. On the dashboard node, add an option to distinguish between username/password and SSH key authentication when selecting the SSH method. For SSH key authentication, the user also needs to input the username, port, and IP information.
 2. When the user selects SSH key authentication, the dashboard actively calls the SSH key retrieval interface.
 3. If the manager node does not have an SSH key pair, it calls ssh-keygen to generate one. If a key pair already exists, it is returned directly.
 4.  When executing the installation command, if no user password is provided, the installation defaults to using SSH key authentication.

### Modifications
* Added an SSH key generation interface.
* Modified the remote command execution method to support SSH key authentication.
* When the user authenticates via SSH key, the password is empty, so the remote command execution method was modified to support nullable parameters.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.
- [x] This change is already covered by existing tests, such as:
 * Tested SSH key generation; the key was generated successfully.
<img width="1845" alt="image" src="https://github.com/apache/inlong/assets/4103971/86f54fe6-86bf-408a-8ca5-324abf6948ec">

* Tested command execution via SSH key; the execution was successful.

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? (not documented)
