### PR TITLE
[INLONG-10381][Sort] Kafka source connector report audit attach input time

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNode.java
@@ -27,6 +27,7 @@ import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.node.format.AvroFormat;
 import org.apache.inlong.sort.protocol.node.format.CsvFormat;
 import org.apache.inlong.sort.protocol.node.format.Format;
+import org.apache.inlong.sort.protocol.node.format.InLongMsgFormat;
 import org.apache.inlong.sort.protocol.node.format.JsonFormat;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
 
@@ -262,6 +263,13 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
             case TIMESTAMP:
                 metadataKey = "timestamp";
                 break;
+            case AUDIT_DATA_TIME:
+                if (format instanceof InLongMsgFormat) {
+                    metadataKey = INLONG_MSG_AUDIT_TIME;
+                } else {
+                    metadataKey = CONSUME_AUDIT_TIME;
+                }
+                break;
             default:
                 throw new UnsupportedOperationException(String.format("Unsupport meta field for %s: %s",
                         this.getClass().getSimpleName(), metaField));
@@ -279,6 +287,7 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
             case PARTITION:
             case OFFSET:
             case TIMESTAMP:
+            case AUDIT_DATA_TIME:
                 return true;
             default:
                 return false;
@@ -291,6 +300,6 @@ public class KafkaExtractNode extends ExtractNode implements InlongMetric, Metad
                 MetaField.SQL_TYPE, MetaField.PK_NAMES, MetaField.TS, MetaField.OP_TS, MetaField.IS_DDL,
                 MetaField.MYSQL_TYPE, MetaField.BATCH_ID, MetaField.UPDATE_BEFORE,
                 MetaField.KEY, MetaField.VALUE, MetaField.PARTITION, MetaField.HEADERS,
-                MetaField.HEADERS_TO_JSON_STR, MetaField.OFFSET, MetaField.TIMESTAMP);
+                MetaField.HEADERS_TO_JSON_STR, MetaField.OFFSET, MetaField.TIMESTAMP, MetaField.AUDIT_DATA_TIME);
     }
 }

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/KafkaExtractNodeTest.java
@@ -112,6 +112,7 @@ public class KafkaExtractNodeTest extends SerializeBaseTest<KafkaExtractNode> {
         formatMap.put(MetaField.OFFSET, "BIGINT METADATA FROM 'offset' VIRTUAL");
         formatMap.put(MetaField.PARTITION, "BIGINT METADATA FROM 'partition' VIRTUAL");
         formatMap.put(MetaField.TIMESTAMP, "TIMESTAMP_LTZ(3) METADATA FROM 'timestamp' VIRTUAL");
+        formatMap.put(MetaField.AUDIT_DATA_TIME, "BIGINT METADATA FROM 'consume_time' VIRTUAL");
 
         KafkaExtractNode node = getTestObject();
         boolean formatEquals = true;

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/pom.xml
@@ -54,8 +54,12 @@
             <artifactId>audit-sdk</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
@@ -145,8 +145,7 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
         outputCollector.physicalKeyRows = keyCollector.buffer;
         if (sourceMetricData != null) {
             MetricsCollector<RowData> metricsCollector = new MetricsCollector<>(collector, sourceMetricData);
-            metricsCollector.resetTimestamp(
-                    getRecordTime(consumeTimeIndex, outputCollector.metadataConverters, record));
+            metricsCollector.resetTimestamp(getRecordTime(outputCollector.metadataConverters, record));
             outputCollector.outputCollector = metricsCollector;
         } else {
             outputCollector.outputCollector = collector;
@@ -160,7 +159,7 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
         keyCollector.buffer.clear();
     }
 
-    private Long getRecordTime(int consumeTimeIndex, MetadataConverter[] metadataConverters,
+    private Long getRecordTime(MetadataConverter[] metadataConverters,
             ConsumerRecord<byte[], byte[]> record) {
         if (consumeTimeIndex == -1) {
             return System.currentTimeMillis();

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/DynamicKafkaDeserializationSchema.java
@@ -64,7 +64,7 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
 
     private SourceMetricData sourceMetricData;
 
-    private int consumeTimeIndex;
+    private int consumeTimeIndex = -1;
 
     DynamicKafkaDeserializationSchema(
             int physicalArity,
@@ -145,7 +145,12 @@ class DynamicKafkaDeserializationSchema implements KafkaDeserializationSchema<Ro
         outputCollector.physicalKeyRows = keyCollector.buffer;
         if (sourceMetricData != null) {
             MetricsCollector<RowData> metricsCollector = new MetricsCollector<>(collector, sourceMetricData);
-            metricsCollector.resetTimestamp((Long) outputCollector.metadataConverters[consumeTimeIndex].read(record));
+            if (consumeTimeIndex != -1) {
+                metricsCollector
+                        .resetTimestamp((Long) outputCollector.metadataConverters[consumeTimeIndex].read(record));
+            } else {
+                metricsCollector.resetTimestamp(System.currentTimeMillis());
+            }
             outputCollector.outputCollector = metricsCollector;
         } else {
             outputCollector.outputCollector = collector;

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicSource.java
@@ -17,9 +17,6 @@
 
 package org.apache.inlong.sort.kafka.table;
 
-import org.apache.inlong.sort.base.metric.MetricOption;
-import org.apache.inlong.sort.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
-
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -52,6 +49,9 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -59,17 +59,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 
 import javax.annotation.Nullable;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -619,6 +609,18 @@ public class KafkaDynamicSource
                     @Override
                     public Object read(ConsumerRecord<?, ?> record) {
                         return StringData.fromString(record.timestampType().toString());
+                    }
+                }),
+        CONSUME_TIME(
+                ExtractNode.CONSUME_AUDIT_TIME,
+                DataTypes.BIGINT().notNull(),
+                new MetadataConverter() {
+
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object read(ConsumerRecord<?, ?> record) {
+                        return System.currentTimeMillis();
                     }
                 });
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/src/main/java/org/apache/inlong/sort/kafka/table/KafkaDynamicSource.java
@@ -17,6 +17,10 @@
 
 package org.apache.inlong.sort.kafka.table;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
@@ -49,9 +53,6 @@ import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.utils.DataTypeUtils;
 import org.apache.flink.util.Preconditions;
-import org.apache.inlong.sort.base.metric.MetricOption;
-import org.apache.inlong.sort.kafka.table.DynamicKafkaDeserializationSchema.MetadataConverter;
-import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
@@ -59,7 +60,17 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
 
 import javax.annotation.Nullable;
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;


### PR DESCRIPTION
### [INLONG-10381][Sort] Kafka source connector report audit attach input time

Fixes #10381

### Motivation

Kafka source connector not attach input time when send audit. It will due to the report audit time not same with input time

### Modifications

Make DeserializationSchema report audit attach input time when deserialize.
