### PR TITLE
[INLONG-10395][Manager] Add interface for schedule client and engine

### DIFF
--- a/inlong-manager/manager-schedule/pom.xml
+++ b/inlong-manager/manager-schedule/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.inlong</groupId>
+        <artifactId>inlong-manager</artifactId>
+        <version>1.13.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>manager-schedule</artifactId>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>manager-pojo</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngine.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.schedule;
+
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+
+/**
+ * Build-in schedule engine, provides basic schedule capabilities.
+ * */
+public interface ScheduleEngine {
+
+    /**
+     * Start schedule engine.
+     * */
+    void start();
+
+    /**
+     * handle schedule register.
+     * @param scheduleInfo schedule info to register
+     * */
+    boolean handleRegister(ScheduleInfo scheduleInfo);
+
+    /**
+     * handle schedule unregister.
+     * @param scheduleInfo schedule info to unregister
+     * */
+    boolean handleUnregister(ScheduleInfo scheduleInfo);
+
+    /**
+     * handle schedule update.
+     * @param scheduleInfo schedule info to update
+     * */
+    boolean handleUpdate(ScheduleInfo scheduleInfo);
+
+    /**
+     * Stop schedule engine.
+     * */
+    void stop();
+}

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngine.java
@@ -30,19 +30,19 @@ public interface ScheduleEngine {
     void start();
 
     /**
-     * handle schedule register.
+     * Handle schedule register.
      * @param scheduleInfo schedule info to register
      * */
     boolean handleRegister(ScheduleInfo scheduleInfo);
 
     /**
-     * handle schedule unregister.
+     * Handle schedule unregister.
      * @param scheduleInfo schedule info to unregister
      * */
     boolean handleUnregister(ScheduleInfo scheduleInfo);
 
     /**
-     * handle schedule update.
+     * Handle schedule update.
      * @param scheduleInfo schedule info to update
      * */
     boolean handleUpdate(ScheduleInfo scheduleInfo);

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngineClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngineClient.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.schedule;
+
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+
+/**
+ * Interface for schedule engine client which responses for communicating with schedule engine.
+ * */
+public interface ScheduleEngineClient {
+
+    /**
+     * register schedule to schedule engine.
+     * @param scheduleInfo schedule info to register
+     * */
+    boolean register(ScheduleInfo scheduleInfo);
+
+    /**
+     * unregister schedule from schedule engine.
+     * @param scheduleInfo schedule info to unregister
+     * */
+    boolean unregister(ScheduleInfo scheduleInfo);
+
+    /**
+     * update schedule from schedule engine.
+     * @param scheduleInfo schedule info to update
+     * */
+    boolean update(ScheduleInfo scheduleInfo);
+
+}

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngineClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/schedule/ScheduleEngineClient.java
@@ -25,19 +25,19 @@ import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 public interface ScheduleEngineClient {
 
     /**
-     * register schedule to schedule engine.
+     * Register schedule to schedule engine.
      * @param scheduleInfo schedule info to register
      * */
     boolean register(ScheduleInfo scheduleInfo);
 
     /**
-     * unregister schedule from schedule engine.
+     * Un-register schedule from schedule engine.
      * @param scheduleInfo schedule info to unregister
      * */
     boolean unregister(ScheduleInfo scheduleInfo);
 
     /**
-     * update schedule from schedule engine.
+     * Update schedule from schedule engine.
      * @param scheduleInfo schedule info to update
      * */
     boolean update(ScheduleInfo scheduleInfo);

--- a/inlong-manager/pom.xml
+++ b/inlong-manager/pom.xml
@@ -41,6 +41,7 @@
         <module>manager-workflow</module>
         <module>manager-web</module>
         <module>manager-docker</module>
+        <module>manager-schedule</module>
     </modules>
 
     <properties>


### PR DESCRIPTION

Fixes #10395 

### Motivation

The first part of support schedule client and engine, define the interfaces for schedule client and engine

### Modifications

1. create a new module `manager-schedule` in manager 
2. add interfaces for scheduler client and engine

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.



### Documentation

  - Does this pull request introduce a new feature? (no)

