### PR TITLE
[INLONG-10399][Agent] Add global configurations updater

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/FetcherConstants.java
@@ -36,8 +36,9 @@ public class FetcherConstants {
     public static final String DEFAULT_AGENT_MANAGER_VIP_HTTP_PREFIX_PATH = "/inlong/manager/openapi";
 
     public static final String AGENT_MANAGER_TASK_HTTP_PATH = "agent.manager.task.http.path";
-    public static final String DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH = "/agent/reportAndGetTask";
-    public static final String DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH = "/agent/getExistTaskConfig";
+    public static final String DEFAULT_AGENT_MANAGER_EXIST_TASK_HTTP_PATH = "/agent/getExistTaskConfig";
+    public static final String AGENT_MANAGER_CONFIG_HTTP_PATH = "agent.manager.config.http.path";
+    public static final String DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH = "/agent/getConfig";
 
     public static final String INSTALLER_MANAGER_CONFIG_HTTP_PATH = "installer.manager.config.http.path";
     public static final String DEFAULT_INSTALLER_MANAGER_CONFIG_HTTP_PATH = "/installer/getConfig";

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentManager.java
@@ -22,14 +22,17 @@ import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.agent.conf.ProfileFetcher;
 import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.agent.core.task.TaskManager;
+import org.apache.inlong.common.pojo.agent.AgentConfigInfo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 
 /**
  * Agent Manager, the bridge for task manager, task store e.t.c it manages agent level operations and communicates
@@ -43,6 +46,8 @@ public class AgentManager extends AbstractDaemon {
     private final ProfileFetcher fetcher;
     private final AgentConfiguration conf;
     private final ExecutorService agentConfMonitor;
+    public static final int CONFIG_QUEUE_CAPACITY = 2;
+    private static BlockingQueue<AgentConfigInfo> configQueue = new LinkedBlockingQueue<>(CONFIG_QUEUE_CAPACITY);
 
     public AgentManager() {
         conf = AgentConfiguration.getAgentConf();
@@ -50,6 +55,20 @@ public class AgentManager extends AbstractDaemon {
         taskManager = new TaskManager();
         fetcher = initFetcher(this);
         heartbeatManager = HeartbeatManager.getInstance(this);
+    }
+
+    public static AgentConfigInfo getAgentConfigInfo() {
+        return configQueue.peek();
+    }
+
+    public void subNewAgentConfigInfo(AgentConfigInfo info) {
+        if (info == null) {
+            return;
+        }
+        if (configQueue.size() == CONFIG_QUEUE_CAPACITY) {
+            configQueue.poll();
+        }
+        configQueue.add(info);
     }
 
     /**

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -26,8 +26,9 @@ import org.apache.inlong.agent.pojo.FileTask.FileTaskConfig;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.HttpManager;
 import org.apache.inlong.agent.utils.ThreadUtils;
-import org.apache.inlong.common.db.CommandEntity;
 import org.apache.inlong.common.enums.PullJobTypeEnum;
+import org.apache.inlong.common.pojo.agent.AgentConfigInfo;
+import org.apache.inlong.common.pojo.agent.AgentConfigRequest;
 import org.apache.inlong.common.pojo.agent.DataConfig;
 import org.apache.inlong.common.pojo.agent.TaskRequest;
 import org.apache.inlong.common.pojo.agent.TaskResult;
@@ -46,15 +47,17 @@ import java.util.Date;
 import java.util.List;
 
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_UNIQ_ID;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AGENT_UNIQ_ID;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_FETCHER_INTERVAL;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_ADDR;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_CONFIG_HTTP_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_RETURN_PARAM_DATA;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_TASK_HTTP_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_FETCHER_INTERVAL;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH;
-import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH;
+import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_EXIST_TASK_HTTP_PATH;
 import static org.apache.inlong.agent.plugin.fetcher.ManagerResultFormatter.getResultData;
 import static org.apache.inlong.agent.utils.AgentUtils.fetchLocalIp;
 import static org.apache.inlong.agent.utils.AgentUtils.fetchLocalUuid;
@@ -69,14 +72,15 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     private static final GsonBuilder gsonBuilder = new GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss");
     private static final Gson GSON = gsonBuilder.create();
     private final String baseManagerUrl;
-    private final String taskConfigUrl;
     private final String staticConfigUrl;
+    private final String agentConfigInfoUrl;
     private final AgentConfiguration conf;
     private final String uniqId;
     private final AgentManager agentManager;
     private final HttpManager httpManager;
     private String localIp;
     private String uuid;
+    private String clusterTag;
     private String clusterName;
 
     public ManagerFetcher(AgentManager agentManager) {
@@ -85,9 +89,10 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         if (requiredKeys(conf)) {
             httpManager = new HttpManager(conf);
             baseManagerUrl = httpManager.getBaseUrl();
-            taskConfigUrl = buildTaskConfigUrl(baseManagerUrl);
             staticConfigUrl = buildStaticConfigUrl(baseManagerUrl);
+            agentConfigInfoUrl = buildAgentConfigInfoUrl(baseManagerUrl);
             uniqId = conf.get(AGENT_UNIQ_ID, DEFAULT_AGENT_UNIQ_ID);
+            clusterTag = conf.get(AGENT_CLUSTER_TAG);
             clusterName = conf.get(AGENT_CLUSTER_NAME);
         } else {
             throw new RuntimeException("init manager error, cannot find required key");
@@ -101,45 +106,27 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     /**
      * Build task config url for manager according to config
      *
-     * example - http://127.0.0.1:8080/inlong/manager/openapi/fileAgent/getTaskConf
-     */
-    private String buildTaskConfigUrl(String baseUrl) {
-        return baseUrl + conf.get(AGENT_MANAGER_TASK_HTTP_PATH, DEFAULT_AGENT_MANAGER_TASK_HTTP_PATH);
-    }
-
-    /**
-     * Build task config url for manager according to config
-     *
-     * example - http://127.0.0.1:8080/inlong/manager/openapi/fileAgent/getTaskConf
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/agent/getTaskConf
      */
     private String buildStaticConfigUrl(String baseUrl) {
-        return baseUrl + conf.get(AGENT_MANAGER_TASK_HTTP_PATH, DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH);
+        return baseUrl + conf.get(AGENT_MANAGER_TASK_HTTP_PATH, DEFAULT_AGENT_MANAGER_EXIST_TASK_HTTP_PATH);
     }
 
     /**
-     * Request manager to get commands, make sure it is not throwing exceptions
+     * Build agent config info url for manager according to config
+     *
+     * example - http://127.0.0.1:8080/inlong/manager/openapi/agent/getConfig
      */
-    public TaskResult fetchTaskConfig() {
-        LOGGER.info("fetchTaskConfig start");
-        String resultStr = httpManager.doSentPost(taskConfigUrl, getFetchRequest(null));
-        JsonObject resultData = getResultData(resultStr);
-        JsonElement element = resultData.get(AGENT_MANAGER_RETURN_PARAM_DATA);
-        LOGGER.info("fetchTaskConfig end");
-        if (element != null) {
-            LOGGER.info("fetchTaskConfig not null {}", resultData);
-            return GSON.fromJson(element.getAsJsonObject(), TaskResult.class);
-        } else {
-            LOGGER.info("fetchTaskConfig nothing to do");
-            return null;
-        }
+    private String buildAgentConfigInfoUrl(String baseUrl) {
+        return baseUrl + conf.get(AGENT_MANAGER_CONFIG_HTTP_PATH, DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH);
     }
 
     /**
-     * Request manager to get commands, make sure it is not throwing exceptions
+     * Request manager to get task config, make sure it is not throwing exceptions
      */
     public TaskResult getStaticConfig() {
         LOGGER.info("Get static config start");
-        String resultStr = httpManager.doSentPost(staticConfigUrl, getFetchRequest(null));
+        String resultStr = httpManager.doSentPost(staticConfigUrl, getTaskRequest());
         LOGGER.info("Url to get static config staticConfigUrl {}", staticConfigUrl);
         JsonObject resultData = getResultData(resultStr);
         JsonElement element = resultData.get(AGENT_MANAGER_RETURN_PARAM_DATA);
@@ -154,15 +141,38 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     }
 
     /**
-     * Form file command fetch request
+     * Request manager to get config, make sure it is not throwing exceptions
      */
-    public TaskRequest getFetchRequest(List<CommandEntity> unackedCommands) {
+    public AgentConfigInfo getAgentConfigInfo() {
+        LOGGER.info("Get agent config info");
+        String resultStr = httpManager.doSentPost(agentConfigInfoUrl, getAgentConfigInfoRequest());
+        LOGGER.info("Url to get agent config agentConfigInfoUrl {}", agentConfigInfoUrl);
+        JsonObject resultData = getResultData(resultStr);
+        JsonElement element = resultData.get(AGENT_MANAGER_RETURN_PARAM_DATA);
+        LOGGER.info("Get agent config end");
+        if (element != null) {
+            LOGGER.info("Get agent config not null {}", resultData);
+            return GSON.fromJson(element.getAsJsonObject(), AgentConfigInfo.class);
+        } else {
+            LOGGER.info("Get agent config nothing to do");
+            return null;
+        }
+    }
+
+    public TaskRequest getTaskRequest() {
         TaskRequest request = new TaskRequest();
         request.setAgentIp(localIp);
         request.setUuid(uuid);
         request.setClusterName(clusterName);
         request.setPullJobType(PullJobTypeEnum.NEW.getType());
-        request.setCommandInfo(unackedCommands);
+        request.setCommandInfo(null);
+        return request;
+    }
+
+    public AgentConfigRequest getAgentConfigInfoRequest() {
+        AgentConfigRequest request = new AgentConfigRequest();
+        request.setClusterTag(clusterTag);
+        request.setClusterName(clusterName);
         return request;
     }
 
@@ -171,7 +181,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
      *
      * @return runnable profile.
      */
-    private Runnable taskConfigFetchThread() {
+    private Runnable configFetchThread() {
         return () -> {
             Thread.currentThread().setName("ManagerFetcher");
             while (isRunnable()) {
@@ -184,6 +194,10 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
                             taskProfiles.add(profile);
                         });
                         agentManager.getTaskManager().submitTaskProfiles(taskProfiles);
+                    }
+                    AgentConfigInfo config = getAgentConfigInfo();
+                    if (config != null) {
+                        agentManager.subNewAgentConfigInfo(config);
                     }
                 } catch (Throwable ex) {
                     LOGGER.warn("exception caught", ex);
@@ -243,7 +257,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         // when agent start, check local ip and fetch manager ip list;
         localIp = fetchLocalIp();
         uuid = fetchLocalUuid();
-        submitWorker(taskConfigFetchThread());
+        submitWorker(configFetchThread());
     }
 
     @Override

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -173,6 +173,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
         AgentConfigRequest request = new AgentConfigRequest();
         request.setClusterTag(clusterTag);
         request.setClusterName(clusterName);
+        request.setIp(localIp);
         return request;
     }
 

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/AgentConfigRequest.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/agent/AgentConfigRequest.java
@@ -33,4 +33,5 @@ public class AgentConfigRequest {
 
     private String clusterName;
 
+    private String ip;
 }


### PR DESCRIPTION
Fixes #10399 

### Motivation

Global configuration is required for agent writing zk and real-time control of sending speed

### Modifications

Increase the ability to periodically pull global configurations from the manager

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
