### PR TITLE
[INLONG-10401][Sort] Add audit time metadata for Mysql connector and relocate debezium dependencies

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/MySqlExtractNode.java
@@ -311,6 +311,9 @@ public class MySqlExtractNode extends ExtractNode implements Metadata, InlongMet
             case UPDATE_BEFORE:
                 metadataKey = "meta.update_before";
                 break;
+            case AUDIT_DATA_TIME:
+                metadataKey = "meta.ts";
+                break;
             default:
                 throw new UnsupportedOperationException(String.format("Unsupport meta field for %s: %s",
                         this.getClass().getSimpleName(), metaField));
@@ -329,6 +332,7 @@ public class MySqlExtractNode extends ExtractNode implements Metadata, InlongMet
                 MetaField.DATABASE_NAME, MetaField.OP_TYPE, MetaField.OP_TS, MetaField.IS_DDL,
                 MetaField.TS, MetaField.SQL_TYPE, MetaField.MYSQL_TYPE, MetaField.PK_NAMES,
                 MetaField.BATCH_ID, MetaField.UPDATE_BEFORE, MetaField.DATA_BYTES_DEBEZIUM,
-                MetaField.DATA_DEBEZIUM, MetaField.DATA_BYTES_CANAL, MetaField.DATA, MetaField.DATA_BYTES);
+                MetaField.DATA_DEBEZIUM, MetaField.DATA_BYTES_CANAL, MetaField.DATA, MetaField.DATA_BYTES,
+                MetaField.AUDIT_DATA_TIME);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/pom.xml
@@ -169,6 +169,10 @@
                                     <pattern>com.zaxxer</pattern>
                                     <shadedPattern>com.ververica.cdc.connectors.shaded.com.zaxxer</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>io.debezium</pattern>
+                                    <shadedPattern>com.ververica.cdc.connectors.shaded.io.debezium</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/MySqlTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/MySqlTableSource.java
@@ -21,7 +21,6 @@ import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.mysql.source.MySqlSource;
 
 import com.ververica.cdc.connectors.mysql.table.MySqlDeserializationConverterFactory;
-import com.ververica.cdc.connectors.mysql.table.MySqlReadableMetadata;
 import com.ververica.cdc.connectors.mysql.table.StartupOptions;
 import com.ververica.cdc.debezium.DebeziumDeserializationSchema;
 import com.ververica.cdc.debezium.DebeziumSourceFunction;
@@ -51,6 +50,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.inlong.sort.mysql.table.MySqlReadableMetadata;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/RowDataDebeziumDeserializeSchema.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sort.mysql;
 
+import io.debezium.data.Envelope.FieldName;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricsCollector;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
@@ -145,7 +146,7 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
             validator.validate(insert, RowKind.INSERT);
             insert.setRowKind(RowKind.INSERT);
             if (sourceMetricData != null) {
-                out = new MetricsCollector<>(out, sourceMetricData);
+                out = createMetricsCollector(record, out);
             }
             emit(record, insert, out);
         } else if (op == Envelope.Operation.DELETE) {
@@ -153,7 +154,7 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
             validator.validate(delete, RowKind.DELETE);
             delete.setRowKind(RowKind.DELETE);
             if (sourceMetricData != null) {
-                out = new MetricsCollector<>(out, sourceMetricData);
+                out = createMetricsCollector(record, out);
             }
             emit(record, delete, out);
         } else {
@@ -168,11 +169,25 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
             validator.validate(after, RowKind.UPDATE_AFTER);
             after.setRowKind(RowKind.UPDATE_AFTER);
             if (sourceMetricData != null) {
-                out = new MetricsCollector<>(out, sourceMetricData);
+                out = createMetricsCollector(record, out);
             }
             emit(record, after, out);
         }
     }
+
+
+    /**
+     * Create a metrics collector to collect metrics data and reset timestamp from source record
+     * @param record source record
+     * @param out output collector
+     * @return metrics collector
+     */
+    private Collector<RowData> createMetricsCollector(SourceRecord record, Collector<RowData> out) {
+        MetricsCollector<RowData> collector = new MetricsCollector<>(out, sourceMetricData);
+        collector.resetTimestamp((Long) ((Struct) record.value()).get(FieldName.TIMESTAMP));
+        return collector;
+    }
+
 
     /**
      * Initialize the source metric data.

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/table/MySqlReadableMetadata.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/table/MySqlReadableMetadata.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.apache.inlong.sort.mysql.table;
+
+import com.ververica.cdc.debezium.table.MetadataConverter;
+import io.debezium.connector.AbstractSourceInfo;
+import io.debezium.data.Envelope;
+import io.debezium.data.Envelope.FieldName;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.source.SourceRecord;
+
+
+/**
+ * Metadata that can be read from a MySQL source.
+ * Copied from com.ververica:flink-connector-mysql-cdc-2.3.0
+ */
+public enum MySqlReadableMetadata {
+    /** Name of the table that contain the row. */
+    TABLE_NAME(
+        "table_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
+                return StringData.fromString(
+                    sourceStruct.getString(AbstractSourceInfo.TABLE_NAME_KEY));
+            }
+        }),
+
+    /** Name of the database that contain the row. */
+    DATABASE_NAME(
+        "database_name",
+        DataTypes.STRING().notNull(),
+        new MetadataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
+                return StringData.fromString(
+                    sourceStruct.getString(AbstractSourceInfo.DATABASE_NAME_KEY));
+            }
+        }),
+
+    /**
+     * It indicates the time that the change was made in the database. If the record is read from
+     * snapshot of the table instead of the binlog, the value is always 0.
+     */
+    OP_TS(
+        "op_ts",
+        DataTypes.TIMESTAMP_LTZ(3).notNull(),
+        new MetadataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object read(SourceRecord record) {
+                Struct messageStruct = (Struct) record.value();
+                Struct sourceStruct = messageStruct.getStruct(Envelope.FieldName.SOURCE);
+                return TimestampData.fromEpochMillis(
+                    (Long) sourceStruct.get(AbstractSourceInfo.TIMESTAMP_KEY));
+            }
+        }),
+
+    TS(
+            "meta.ts",
+        DataTypes.BIGINT(),
+            new MetadataConverter() {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public Object read(SourceRecord record) {
+            Struct messageStruct = (Struct) record.value();
+            return messageStruct.get(FieldName.TIMESTAMP);
+        }
+    });
+
+    private final String key;
+
+    private final DataType dataType;
+
+    private final MetadataConverter converter;
+
+    MySqlReadableMetadata(String key, DataType dataType, MetadataConverter converter) {
+        this.key = key;
+        this.dataType = dataType;
+        this.converter = converter;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public MetadataConverter getConverter() {
+        return converter;
+    }
+}

--- a/licenses/inlong-sort-connectors/LICENSE
+++ b/licenses/inlong-sort-connectors/LICENSE
@@ -898,6 +898,7 @@ License : https://github.com/ververica/flink-cdc-connectors/blob/master/LICENSE
        inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/RowDataDebeziumDeserializeSchema.java
        inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/source/MySqlSourceBuilder.java
        inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/source/MySqlSource.java
+       inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/src/main/java/org/apache/inlong/sort/mysql/table/MySqlReadableMetadata.java
 Source  : com.ververica:flink-connector-mysql-cdc:2.3.0 (Please note that the software have been modified.)
 License : https://github.com/ververica/flink-cdc-connectors/blob/master/LICENSE
 


### PR DESCRIPTION
Fixes #10401 

### Motivation

Add audit time metadata for Mysql connector and relocate debezium dependencies

### Modifications

Add audit time metadata for Mysql connector and relocate debezium dependencies

### Verifying this change

Tested on mysql -> Starrocks 

### Documentation

  - Does this pull request introduce a new feature? (no)