### PR TITLE
[INLONG-10427][SDK] The Go SDK supports authentication for Manager access

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
@@ -119,7 +119,7 @@ func (c *client) initAll() error {
 }
 
 func (c *client) initDiscoverer() error {
-	dis, err := NewDiscoverer(c.options.URL, c.options.GroupID, c.options.UpdateInterval, c.options.Logger)
+	dis, err := NewDiscoverer(c.options.URL, c.options.GroupID, c.options.UpdateInterval, c.options.Logger, c.options.Auth)
 	if err != nil {
 		return err
 	}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
@@ -77,6 +77,7 @@ type Options struct {
 	BlockIfQueueIsFull      bool                  // whether Send and SendAsync block if producer's message queue is full, default: false
 	AddColumns              map[string]string     // addition columns to add to the message, for example: __addcol1__worldid=xxx&__addcol2__ip=yyy, all the message will be added 2 more columns with worldid=xxx and ip=yyy
 	addColumnStr            string                // the string format of the AddColumns, just a cache, used internal
+	Auth                    Auth                  // dataproxy authentication interface
 }
 
 // ValidateAndSetDefault validates an options and set up the default values

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_basic.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_basic.go
@@ -172,3 +172,13 @@ func WithMetricsRegistry(reg prometheus.Registerer) Option {
 		o.MetricsRegistry = reg
 	}
 }
+
+// WithAtuh sets Atuh
+func WithAtuh(auth Auth) Option {
+	return func(o *Options) {
+		if auth == nil {
+			return
+		}
+		o.Auth = auth
+	}
+}


### PR DESCRIPTION
Fixes #10427

### Motivation

The Go SDK supports authentication for Manager access

### Modifications

1. Add authentication interface definition
2. Add authentication interface instance configuration
3. Add authentication processing logic

### Verifying this change

When the manager enables authentication, it can be accessed through authentication.

