### PR TITLE
[INLONG-10438][Manager] GetConfig does not throw an exception when obtaining the zk address fails

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AgentServiceImpl.java
@@ -340,10 +340,9 @@ public class AgentServiceImpl implements AgentService {
                 .clusterTagList(clusterTagList)
                 .build();
         List<InlongClusterEntity> agentZkCluster = clusterMapper.selectByCondition(pageRequest);
-        if (CollectionUtils.isEmpty(agentZkCluster)) {
-            throw new BusinessException("zk cluster for ha not found for cluster tag=" + request.getClusterTag());
+        if (CollectionUtils.isNotEmpty(agentZkCluster)) {
+            agentConfigInfo.setZkUrl(agentZkCluster.get(0).getUrl());
         }
-        agentConfigInfo.setZkUrl(agentZkCluster.get(0).getUrl());
 
         AgentClusterInfo clusterInfo = (AgentClusterInfo) clusterService.getOne(
                 null, request.getClusterName(), ClusterType.AGENT);


### PR DESCRIPTION


<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10438 

### Motivation

GetConfig does not throw an exception when obtaining the zk address fails.
When the getconfig interface does not obtain the zk address, the agent will use local configuration.
### Modifications

GetConfig does not throw an exception when obtaining the zk address fails.
