### PR TITLE
[INLONG-10311][Sort] Implement TubeMQ Source report audit information exactly once And fix consuming TubeMQ data twice

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
@@ -31,7 +31,7 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     private long timestampMillis;
 
-    SourceMetricsReporter metricsReporter;
+    private final SourceMetricsReporter metricsReporter;
     public MetricsCollector(Collector<T> collector,
             SourceMetricsReporter sourceMetricData) {
         this.metricsReporter = sourceMetricData;

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
@@ -31,10 +31,10 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     private long timestampMillis;
 
-    private final SourceMetricsReporter metricsReporter;
+    private final SourceMetricsReporter sourceMetricsReporter;
     public MetricsCollector(Collector<T> collector,
             SourceMetricsReporter sourceMetricData) {
-        this.metricsReporter = sourceMetricData;
+        this.sourceMetricsReporter = sourceMetricData;
         this.collector = collector;
     }
 
@@ -44,8 +44,8 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     @Override
     public void collect(T record) {
-        if (metricsReporter != null) {
-            metricsReporter.outputMetricsWithEstimate(record, timestampMillis);
+        if (sourceMetricsReporter != null) {
+            sourceMetricsReporter.outputMetricsWithEstimate(record, timestampMillis);
         }
         collector.collect(record);
     }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
@@ -31,11 +31,10 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     private long timestampMillis;
 
-    SourceMetricData metricData;
-
+    SourceMetricsReporter metricsReporter;
     public MetricsCollector(Collector<T> collector,
-            SourceMetricData sourceMetricData) {
-        this.metricData = sourceMetricData;
+            SourceMetricsReporter sourceMetricData) {
+        this.metricsReporter = sourceMetricData;
         this.collector = collector;
     }
 
@@ -45,8 +44,8 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     @Override
     public void collect(T record) {
-        if (metricData != null) {
-            metricData.outputMetricsWithEstimate(record, timestampMillis);
+        if (metricsReporter != null) {
+            metricsReporter.outputMetricsWithEstimate(record, timestampMillis);
         }
         collector.collect(record);
     }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/MetricsCollector.java
@@ -33,8 +33,8 @@ public class MetricsCollector<T> implements TimestampedCollector<T> {
 
     private final SourceMetricsReporter sourceMetricsReporter;
     public MetricsCollector(Collector<T> collector,
-            SourceMetricsReporter sourceMetricData) {
-        this.sourceMetricsReporter = sourceMetricData;
+            SourceMetricsReporter sourceMetricsReporter) {
+        this.sourceMetricsReporter = sourceMetricsReporter;
         this.collector = collector;
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -54,7 +54,8 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
     private Meter numBytesInPerSecond;
     private AuditReporterImpl auditReporter;
     private List<Integer> auditKeys;
-    private Long nowCheckpointId = 1L;
+    private Long currentCheckpointId = 0L;
+    private Long lastCheckpointId = 0L;
 
     /**
      * currentFetchEventTimeLag = FetchTime - messageTimestamp, where the FetchTime is the time the
@@ -258,7 +259,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         if (auditReporter != null) {
             for (Integer key : auditKeys) {
                 auditReporter.add(
-                        this.nowCheckpointId,
+                        this.currentCheckpointId,
                         key,
                         DEFAULT_AUDIT_TAG,
                         getGroupId(),
@@ -297,14 +298,21 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
      * flush audit data
      * usually call this method in close method or when checkpointing
      */
-    public void flushAuditById(long checkpointId) {
+    public void flushAudit() {
         if (auditReporter != null) {
-            auditReporter.flush(checkpointId);
+            auditReporter.flush(lastCheckpointId);
         }
     }
 
-    public void setNowCheckpointId(Long nowCheckpointId) {
-        this.nowCheckpointId = nowCheckpointId;
+    public void updateLastCheckpointId(Long checkpointId){
+        lastCheckpointId = checkpointId;
+    }
+    public void setCurrentCheckpointId(Long currentCheckpointId) {
+        this.currentCheckpointId = currentCheckpointId;
+    }
+
+    public Long getLastCheckpointId() {
+        return lastCheckpointId;
     }
 
     @Override

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -307,7 +307,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
     public void updateLastCheckpointId(Long checkpointId) {
         lastCheckpointId = checkpointId;
     }
-    public void setCurrentCheckpointId(Long currentCheckpointId) {
+    public void updateCurrentCheckpointId(Long currentCheckpointId) {
         this.currentCheckpointId = currentCheckpointId;
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -311,10 +311,6 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         this.currentCheckpointId = currentCheckpointId;
     }
 
-    public Long getLastCheckpointId() {
-        return lastCheckpointId;
-    }
-
     @Override
     public String toString() {
         return "SourceMetricData{"

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -304,7 +304,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         }
     }
 
-    public void updateLastCheckpointId(Long checkpointId){
+    public void updateLastCheckpointId(Long checkpointId) {
         lastCheckpointId = checkpointId;
     }
     public void setCurrentCheckpointId(Long currentCheckpointId) {

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -120,73 +120,45 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
     }
 
     /**
-     * Default counter is {@link SimpleCounter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
+     * Users can custom counter that extends from {@link SimpleCounter}
+     * groupId and streamId and nodeId are label values,
+     * user can use it to filter metric data when using metric reporter Prometheus
+     * The following method is similar
      */
     public void registerMetricsForNumRecordsInForMeter() {
         registerMetricsForNumRecordsInForMeter(new SimpleCounter());
     }
 
     /**
-     * User can use custom counter that extends from {@link Counter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
+     * Users can custom counter that extends from {@link Counter}
+     * groupId and streamId and nodeId are label values,
+     * user can use it to filter metric data when using metric reporter Prometheus
+     * The following method is similar
      */
     public void registerMetricsForNumRecordsInForMeter(Counter counter) {
         numRecordsInForMeter = registerCounter(NUM_RECORDS_IN_FOR_METER, counter);
     }
 
-    /**
-     * Default counter is {@link SimpleCounter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumBytesInForMeter() {
         registerMetricsForNumBytesInForMeter(new SimpleCounter());
     }
 
-    /**
-     * User can use custom counter that extends from {@link Counter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumBytesInForMeter(Counter counter) {
         numBytesInForMeter = registerCounter(NUM_BYTES_IN_FOR_METER, counter);
     }
 
-    /**
-     * Default counter is {@link SimpleCounter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumRecordsIn() {
         registerMetricsForNumRecordsIn(new SimpleCounter());
     }
 
-    /**
-     * User can use custom counter that extends from {@link Counter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumRecordsIn(Counter counter) {
         numRecordsIn = registerCounter(NUM_RECORDS_IN, counter);
     }
 
-    /**
-     * Default counter is {@link SimpleCounter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumBytesIn() {
         registerMetricsForNumBytesIn(new SimpleCounter());
     }
 
-    /**
-     * User can use custom counter that extends from {@link Counter}
-     * groupId and streamId and nodeId are label value, user can use it filter metric data when use metric reporter
-     * prometheus
-     */
     public void registerMetricsForNumBytesIn(Counter counter) {
         numBytesIn = registerCounter(NUM_BYTES_IN, counter);
     }
@@ -270,10 +242,6 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
                         DEFAULT_AUDIT_VERSION);
             }
         }
-    }
-
-    private long getCurrentOrProvidedTime(long dataTime) {
-        return dataTime == 0 ? System.currentTimeMillis() : dataTime;
     }
 
     private void outputDefaultMetrics(long rowCountSize, long rowDataSize) {

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -307,8 +307,8 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
     public void updateLastCheckpointId(Long checkpointId) {
         lastCheckpointId = checkpointId;
     }
-    public void updateCurrentCheckpointId(Long currentCheckpointId) {
-        this.currentCheckpointId = currentCheckpointId;
+    public void updateCurrentCheckpointId(Long checkpointId) {
+        currentCheckpointId = checkpointId;
     }
 
     @Override

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricData.java
@@ -42,6 +42,7 @@ import static org.apache.inlong.sort.base.util.CalculateObjectSizeUtils.getDataS
 /**
  * A collection class for handling metrics
  */
+@Deprecated
 public class SourceMetricData implements MetricData, Serializable, SourceMetricsReporter {
 
     private static final long serialVersionUID = 1L;

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricsReporter.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceMetricsReporter.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.base.metric;
+
+public interface SourceMetricsReporter {
+
+    void outputMetricsWithEstimate(Object data, long dataTime);
+
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.tubemq;
 import org.apache.inlong.sort.tubemq.table.DynamicTubeMQDeserializationSchema;
 import org.apache.inlong.sort.tubemq.table.TubeMQOptions;
 import org.apache.inlong.tubemq.client.config.ConsumerConfig;
+import org.apache.inlong.tubemq.client.consumer.ConsumeOffsetInfo;
 import org.apache.inlong.tubemq.client.consumer.ConsumePosition;
 import org.apache.inlong.tubemq.client.consumer.ConsumerResult;
 import org.apache.inlong.tubemq.client.consumer.PullMessageConsumer;
@@ -28,6 +29,7 @@ import org.apache.inlong.tubemq.corebase.Message;
 import org.apache.inlong.tubemq.corebase.TErrCodeConstants;
 
 import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.state.OperatorStateStore;
@@ -64,7 +66,8 @@ import static org.apache.flink.util.TimeUtils.parseDuration;
  */
 public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
         implements
-            CheckpointedFunction {
+            CheckpointedFunction,
+            CheckpointListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(FlinkTubeMQConsumer.class);
     private static final String TUBE_OFFSET_STATE = "tube-offset-state";
@@ -257,18 +260,24 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
             lastConsumeInstant = Instant.now();
 
             List<T> records = new ArrayList<>();
-            lastConsumeInstant = getRecords(lastConsumeInstant, messageList, records);
 
             synchronized (ctx.getCheckpointLock()) {
-
+                lastConsumeInstant = getRecords(lastConsumeInstant, messageList, records);
                 for (T record : records) {
                     ctx.collect(record);
                 }
-                currentOffsets.put(
-                        consumeResult.getPartitionKey(),
-                        consumeResult.getCurrOffset());
+                ConsumerResult confirmResult = confirmOffset(consumeResult);
+                if (confirmResult != null && confirmResult.isSuccess()) {
+                    currentOffsets.put(confirmResult.getPartitionKey(), confirmResult.getCurrOffset());
+                } else {
+                    LOG.warn("Confirm offset failed, fallback to use offset in consume result.");
+                    currentOffsets.put(consumeResult.getPartitionKey(), consumeResult.getCurrOffset());
+                }
             }
-
+        }
+    }
+    private ConsumerResult confirmOffset(ConsumerResult consumeResult) {
+        try {
             ConsumerResult confirmResult = messagePullConsumer
                     .confirmConsume(consumeResult.getConfirmContext(), true);
             if (!confirmResult.isSuccess()) {
@@ -283,9 +292,12 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
                             confirmResult.getErrMsg());
                 }
             }
+            return confirmResult;
+        } catch (Exception e) {
+            LOG.error("Confirm tube offset exception.", e);
         }
+        return null;
     }
-
     private Instant getRecords(Instant lastConsumeInstant, List<Message> messageList, List<T> records)
             throws Exception {
         if (messageList != null) {
@@ -311,13 +323,20 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
-
+        deserializationSchema.setNowCheckpointId(context.getCheckpointId());
+        // Make sure snapshot all tube partitions' offset to avoid inconsistency. See BUG-124774267 for details.
+        Map<String, ConsumeOffsetInfo> curConsumedPartitions = messagePullConsumer.getCurConsumedPartitions();
+        for (Map.Entry<String, ConsumeOffsetInfo> consumedPartition : curConsumedPartitions.entrySet()) {
+            ConsumeOffsetInfo consumeOffsetInfo = consumedPartition.getValue();
+            if (!currentOffsets.containsKey(consumeOffsetInfo.getPartitionKey())) {
+                LOG.info("snapshot assigned but not consume partition: {}", consumedPartition.getValue());
+                currentOffsets.put(consumeOffsetInfo.getPartitionKey(), consumedPartition.getValue().getCurrOffset());
+            }
+        }
         offsetsState.clear();
         for (Map.Entry<String, Long> entry : currentOffsets.entrySet()) {
             offsetsState.add(new Tuple2<>(entry.getKey(), entry.getValue()));
         }
-
-        deserializationSchema.flushAudit();
 
         LOG.info("Successfully save the offsets in checkpoint {}: {}.",
                 context.getCheckpointId(), currentOffsets);
@@ -352,5 +371,15 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
         super.close();
 
         LOG.info("Closed the tubemq source.");
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        deserializationSchema.flushAuditById(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        CheckpointListener.super.notifyCheckpointAborted(checkpointId);
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
@@ -325,7 +325,7 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         deserializationSchema.setCurrentCheckpointId(context.getCheckpointId());
-        // Make sure snapshot all tube partitions' offset to avoid inconsistency. See BUG-124774267 for details.
+        // Make sure snapshot all tube partitions' offset to avoid inconsistency.
         Map<String, ConsumeOffsetInfo> curConsumedPartitions = messagePullConsumer.getCurConsumedPartitions();
         for (Map.Entry<String, ConsumeOffsetInfo> consumedPartition : curConsumedPartitions.entrySet()) {
             ConsumeOffsetInfo consumeOffsetInfo = consumedPartition.getValue();

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
@@ -59,5 +59,7 @@ public interface DynamicTubeMQDeserializationSchema<T> extends Serializable, Res
         }
     }
 
-    void flushAudit();
+    void setNowCheckpointId(long checkpointId);
+
+    void flushAuditById(long checkpointId);
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQDeserializationSchema.java
@@ -29,7 +29,7 @@ import java.io.Serializable;
 public interface DynamicTubeMQDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
 
     @PublicEvolving
-    default void open() throws Exception {
+    default void open() {
     }
 
     /**
@@ -59,7 +59,9 @@ public interface DynamicTubeMQDeserializationSchema<T> extends Serializable, Res
         }
     }
 
-    void setNowCheckpointId(long checkpointId);
+    void setCurrentCheckpointId(long checkpointId);
 
-    void flushAuditById(long checkpointId);
+    void updateLastCheckpointId(Long checkpointId);
+
+    void flushAudit();
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
@@ -19,7 +19,7 @@ package org.apache.inlong.sort.tubemq.table;
 
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricsCollector;
-import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
 import org.apache.inlong.tubemq.corebase.Message;
 
 import com.google.common.base.Objects;
@@ -61,9 +61,9 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
 
     private final boolean innerFormat;
 
-    private SourceMetricData sourceMetricData;
+    private SourceExactlyMetric sourceMetricData;
 
-    private MetricOption metricOption;
+    private final MetricOption metricOption;
 
     public DynamicTubeMQTableDeserializationSchema(
             DeserializationSchema<RowData> schema,
@@ -83,7 +83,7 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
     @Override
     public void open() {
         if (metricOption != null) {
-            sourceMetricData = new SourceMetricData(metricOption);
+            sourceMetricData = new SourceExactlyMetric(metricOption);
         }
     }
 
@@ -110,9 +110,15 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
     }
 
     @Override
-    public void flushAudit() {
+    public void flushAuditById(long checkpointId) {
         if (sourceMetricData != null) {
-            sourceMetricData.flushAuditData();
+            sourceMetricData.flushAuditById(checkpointId);
+        }
+    }
+    @Override
+    public void setNowCheckpointId(long checkpointId) {
+        if (sourceMetricData != null) {
+            sourceMetricData.setNowCheckpointId(checkpointId + 1);
         }
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
@@ -61,7 +61,7 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
 
     private final boolean innerFormat;
 
-    private SourceExactlyMetric sourceMetricData;
+    private SourceExactlyMetric sourceExactlyMetric;
 
     private final MetricOption metricOption;
 
@@ -83,7 +83,7 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
     @Override
     public void open() {
         if (metricOption != null) {
-            sourceMetricData = new SourceExactlyMetric(metricOption);
+            sourceExactlyMetric = new SourceExactlyMetric(metricOption);
         }
     }
 
@@ -97,7 +97,7 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
         List<RowData> rows = new ArrayList<>();
 
         MetricsCollector<RowData> metricsCollector =
-                new MetricsCollector<>(new ListCollector<>(rows), sourceMetricData);
+                new MetricsCollector<>(new ListCollector<>(rows), sourceExactlyMetric);
 
         // reset time stamp if the deserialize schema has not inner format
         if (!innerFormat) {
@@ -111,21 +111,21 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
 
     @Override
     public void flushAudit() {
-        if (sourceMetricData != null) {
-            sourceMetricData.flushAudit();
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.flushAudit();
         }
     }
     @Override
     public void setCurrentCheckpointId(long checkpointId) {
-        if (sourceMetricData != null) {
-            sourceMetricData.updateCurrentCheckpointId(checkpointId);
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateCurrentCheckpointId(checkpointId);
         }
     }
 
     @Override
     public void updateLastCheckpointId(Long checkpointId) {
-        if (sourceMetricData != null) {
-            sourceMetricData.updateLastCheckpointId(checkpointId);
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateLastCheckpointId(checkpointId);
         }
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
@@ -118,7 +118,7 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
     @Override
     public void setCurrentCheckpointId(long checkpointId) {
         if (sourceMetricData != null) {
-            sourceMetricData.setCurrentCheckpointId(checkpointId);
+            sourceMetricData.updateCurrentCheckpointId(checkpointId);
         }
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/table/DynamicTubeMQTableDeserializationSchema.java
@@ -110,15 +110,22 @@ public class DynamicTubeMQTableDeserializationSchema implements DynamicTubeMQDes
     }
 
     @Override
-    public void flushAuditById(long checkpointId) {
+    public void flushAudit() {
         if (sourceMetricData != null) {
-            sourceMetricData.flushAuditById(checkpointId);
+            sourceMetricData.flushAudit();
         }
     }
     @Override
-    public void setNowCheckpointId(long checkpointId) {
+    public void setCurrentCheckpointId(long checkpointId) {
         if (sourceMetricData != null) {
-            sourceMetricData.setNowCheckpointId(checkpointId + 1);
+            sourceMetricData.setCurrentCheckpointId(checkpointId);
+        }
+    }
+
+    @Override
+    public void updateLastCheckpointId(Long checkpointId) {
+        if (sourceMetricData != null) {
+            sourceMetricData.updateLastCheckpointId(checkpointId);
         }
     }
 


### PR DESCRIPTION
### [INLONG-10311][Sort] Implement TubeMQ Source report audit information exactly once

Fixes #10311 

### Motivation

Now，every connectors report audit information only support at least once. So，This pr base it to implements report audit information exactly once. The audit information will not be wrong in much exception situation.

### Modifications
1. Using the checkpoint principle in Flink to modify the process, the modified flow chart is shown in Figure 1 and Figure 2. In Figure 1, the callback method of notifyCompleteCheckpoint is used to upload audit information instead of scheduled upload.

Each Source/Sink will save the checkpointId of the currently ongoing checkpoint, which is nowCheckpointId in the figure. When the audit information is written to the Buffer, nowCheckpointId will be attached, indicating that the audit information
is written during this ongoing checkpoint. The audit information and checkpointId are in a many-to-one relationship.

![image](https://github.com/apache/inlong/assets/58425449/2f09c6c6-e9c2-4383-bca7-965333ccab65)
When a snapshot request is received, the current operator's nowCheckpointId is updated to (snapshot) checkpointId + 1. When all operators in a task complete the snapshot, the notifyCompleteCheckpoint method is called back.

At this time, AuditBuffer uploads audit information less than or equal to checkpointId (parameters in the notifyCompleteCheckpoint method).

![image](https://github.com/apache/inlong/assets/58425449/33d2de48-df21-49ce-96c7-d044d25f37b0)

2. The getCurConsumedPartitions method gets the partitions assigned to the client by the tube server, including the partitions where the client has consumed data and t the client has not consumed data. According to the previous logic, the offsets of the partitions that have not been consumed are not recorded. Here, the offsets of the partitions that have not been consumed are added.