### PR TITLE
[INLONG-10441][DataProxy] Supports obtaining Audit-Proxy through InLong Manager

### DIFF
--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -39,5 +39,7 @@ online.metric.prometheus.http.port=9081
 
 # whether to enable audit
 audit.enable=true
+## whether enable audit proxy discovery by Manager
+audit.proxys.discovery.manager.enable=false
 # audit proxy address
 audit.proxys=127.0.0.1:10081

--- a/inlong-dataproxy/conf/common.properties
+++ b/inlong-dataproxy/conf/common.properties
@@ -39,7 +39,7 @@ online.metric.prometheus.http.port=9081
 
 # whether to enable audit
 audit.enable=true
-## whether enable audit proxy discovery by Manager
+# whether to enable audit proxy address discovery by the Manager
 audit.proxys.discovery.manager.enable=false
 # audit proxy address
 audit.proxys=127.0.0.1:10081

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -128,6 +128,8 @@ public class CommonConfigHolder {
     // Audit fields
     private static final String KEY_ENABLE_AUDIT = "audit.enable";
     private static final boolean VAL_DEF_ENABLE_AUDIT = true;
+    private static final String KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER = "audit.obtain.proxys.from.manager";
+    private static final boolean VAL_DEF_AUDIT_OBTAIN_PROXYS_FROM_MANAGER = false;
     private static final String KEY_AUDIT_PROXYS = "audit.proxys";
     @Deprecated
     private static final String KEY_AUDIT_FILE_PATH = "audit.filePath";
@@ -209,6 +211,7 @@ public class CommonConfigHolder {
     private long metaConfigSyncInvlMs = VAL_DEF_CONFIG_SYNC_INTERVAL_MS;
     private long metaConfigWastAlarmMs = VAL_DEF_META_CONFIG_SYNC_WAST_ALARM_MS;
     private boolean enableAudit = VAL_DEF_ENABLE_AUDIT;
+    private boolean auditObtainProxysFromManager = VAL_DEF_AUDIT_OBTAIN_PROXYS_FROM_MANAGER;
     private final HashSet<String> auditProxys = new HashSet<>();
     private String auditFilePath = VAL_DEF_AUDIT_FILE_PATH;
     private int auditMaxCacheRows = VAL_DEF_AUDIT_MAX_CACHE_ROWS;
@@ -335,6 +338,10 @@ public class CommonConfigHolder {
 
     public boolean isEnableAudit() {
         return enableAudit;
+    }
+
+    public boolean isAuditObtainProxysFromManager() {
+        return auditObtainProxysFromManager;
     }
 
     public boolean isEnableFileMetric() {
@@ -657,6 +664,11 @@ public class CommonConfigHolder {
         if (StringUtils.isNotEmpty(tmpValue)) {
             this.enableAudit = "TRUE".equalsIgnoreCase(tmpValue.trim());
         }
+        // read whether obtain audit proxys from manager
+        tmpValue = this.props.get(KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER);
+        if (StringUtils.isNotEmpty(tmpValue)) {
+            this.auditObtainProxysFromManager = "TRUE".equalsIgnoreCase(tmpValue.trim());
+        }
         // read audit proxys
         tmpValue = this.props.get(KEY_AUDIT_PROXYS);
         if (StringUtils.isNotBlank(tmpValue)) {
@@ -666,6 +678,15 @@ public class CommonConfigHolder {
                     continue;
                 }
                 this.auditProxys.add(tmpIPPort.trim());
+            }
+        }
+        // check auditProxys configure
+        if (this.enableAudit) {
+            if (!this.auditObtainProxysFromManager && this.auditProxys.isEmpty()) {
+                LOG.error("{}'s {} must be configured when {} is true and {} is false, exist!",
+                        COMMON_CONFIG_FILE_NAME, KEY_AUDIT_PROXYS, KEY_ENABLE_AUDIT,
+                        KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER);
+                System.exit(2);
             }
         }
         // read audit file path
@@ -774,6 +795,7 @@ public class CommonConfigHolder {
                 .append("metaConfigSyncInvlMs", metaConfigSyncInvlMs)
                 .append("metaConfigWastAlarmMs", metaConfigWastAlarmMs)
                 .append("enableAudit", enableAudit)
+                .append("auditObtainProxysFromManager", auditObtainProxysFromManager)
                 .append("auditProxys", auditProxys)
                 .append("auditFilePath", auditFilePath)
                 .append("auditMaxCacheRows", auditMaxCacheRows)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/config/CommonConfigHolder.java
@@ -128,8 +128,8 @@ public class CommonConfigHolder {
     // Audit fields
     private static final String KEY_ENABLE_AUDIT = "audit.enable";
     private static final boolean VAL_DEF_ENABLE_AUDIT = true;
-    private static final String KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER = "audit.obtain.proxys.from.manager";
-    private static final boolean VAL_DEF_AUDIT_OBTAIN_PROXYS_FROM_MANAGER = false;
+    private static final String KEY_AUDIT_PROXYS_DISCOVERY_MANAGER_ENABLE = "audit.proxys.discovery.manager.enable";
+    private static final boolean VAL_DEF_AUDIT_PROXYS_DISCOVERY_MANAGER_ENABLE = false;
     private static final String KEY_AUDIT_PROXYS = "audit.proxys";
     @Deprecated
     private static final String KEY_AUDIT_FILE_PATH = "audit.filePath";
@@ -211,7 +211,7 @@ public class CommonConfigHolder {
     private long metaConfigSyncInvlMs = VAL_DEF_CONFIG_SYNC_INTERVAL_MS;
     private long metaConfigWastAlarmMs = VAL_DEF_META_CONFIG_SYNC_WAST_ALARM_MS;
     private boolean enableAudit = VAL_DEF_ENABLE_AUDIT;
-    private boolean auditObtainProxysFromManager = VAL_DEF_AUDIT_OBTAIN_PROXYS_FROM_MANAGER;
+    private boolean enableAuditProxysDiscoveryFromManager = VAL_DEF_AUDIT_PROXYS_DISCOVERY_MANAGER_ENABLE;
     private final HashSet<String> auditProxys = new HashSet<>();
     private String auditFilePath = VAL_DEF_AUDIT_FILE_PATH;
     private int auditMaxCacheRows = VAL_DEF_AUDIT_MAX_CACHE_ROWS;
@@ -340,8 +340,8 @@ public class CommonConfigHolder {
         return enableAudit;
     }
 
-    public boolean isAuditObtainProxysFromManager() {
-        return auditObtainProxysFromManager;
+    public boolean isEnableAuditProxysDiscoveryFromManager() {
+        return enableAuditProxysDiscoveryFromManager;
     }
 
     public boolean isEnableFileMetric() {
@@ -664,10 +664,10 @@ public class CommonConfigHolder {
         if (StringUtils.isNotEmpty(tmpValue)) {
             this.enableAudit = "TRUE".equalsIgnoreCase(tmpValue.trim());
         }
-        // read whether obtain audit proxys from manager
-        tmpValue = this.props.get(KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER);
+        // read whether discovery audit proxys from manager
+        tmpValue = this.props.get(KEY_AUDIT_PROXYS_DISCOVERY_MANAGER_ENABLE);
         if (StringUtils.isNotEmpty(tmpValue)) {
-            this.auditObtainProxysFromManager = "TRUE".equalsIgnoreCase(tmpValue.trim());
+            this.enableAuditProxysDiscoveryFromManager = "TRUE".equalsIgnoreCase(tmpValue.trim());
         }
         // read audit proxys
         tmpValue = this.props.get(KEY_AUDIT_PROXYS);
@@ -682,10 +682,10 @@ public class CommonConfigHolder {
         }
         // check auditProxys configure
         if (this.enableAudit) {
-            if (!this.auditObtainProxysFromManager && this.auditProxys.isEmpty()) {
+            if (!this.enableAuditProxysDiscoveryFromManager && this.auditProxys.isEmpty()) {
                 LOG.error("{}'s {} must be configured when {} is true and {} is false, exist!",
                         COMMON_CONFIG_FILE_NAME, KEY_AUDIT_PROXYS, KEY_ENABLE_AUDIT,
-                        KEY_AUDIT_OBTAIN_PROXYS_FROM_MANAGER);
+                        KEY_AUDIT_PROXYS_DISCOVERY_MANAGER_ENABLE);
                 System.exit(2);
             }
         }
@@ -795,7 +795,8 @@ public class CommonConfigHolder {
                 .append("metaConfigSyncInvlMs", metaConfigSyncInvlMs)
                 .append("metaConfigWastAlarmMs", metaConfigWastAlarmMs)
                 .append("enableAudit", enableAudit)
-                .append("auditObtainProxysFromManager", auditObtainProxysFromManager)
+                .append("enableAuditProxysDiscoveryFromManager",
+                        enableAuditProxysDiscoveryFromManager)
                 .append("auditProxys", auditProxys)
                 .append("auditFilePath", auditFilePath)
                 .append("auditMaxCacheRows", auditMaxCacheRows)

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
@@ -19,6 +19,7 @@ package org.apache.inlong.dataproxy.metrics.audit;
 
 import org.apache.inlong.audit.AuditIdEnum;
 import org.apache.inlong.audit.AuditOperator;
+import org.apache.inlong.audit.entity.AuditComponent;
 import org.apache.inlong.audit.util.AuditConfig;
 import org.apache.inlong.common.enums.MessageWrapType;
 import org.apache.inlong.common.msg.AttributeConstants;
@@ -49,8 +50,15 @@ public class AuditUtils {
     public static void initAudit() {
         if (CommonConfigHolder.getInstance().isEnableAudit()) {
             // AuditProxy
-            AuditOperator.getInstance().setAuditProxy(
-                    CommonConfigHolder.getInstance().getAuditProxys());
+            if (CommonConfigHolder.getInstance().isAuditObtainProxysFromManager()) {
+                AuditOperator.getInstance().setAuditProxy(AuditComponent.DATAPROXY,
+                        CommonConfigHolder.getInstance().getManagerHosts().get(0),
+                        CommonConfigHolder.getInstance().getManagerAuthSecretId(),
+                        CommonConfigHolder.getInstance().getManagerAuthSecretKey());
+            } else {
+                AuditOperator.getInstance().setAuditProxy(
+                        CommonConfigHolder.getInstance().getAuditProxys());
+            }
             // AuditConfig
             AuditConfig auditConfig = new AuditConfig(
                     CommonConfigHolder.getInstance().getAuditFilePath(),

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/metrics/audit/AuditUtils.java
@@ -50,7 +50,7 @@ public class AuditUtils {
     public static void initAudit() {
         if (CommonConfigHolder.getInstance().isEnableAudit()) {
             // AuditProxy
-            if (CommonConfigHolder.getInstance().isAuditObtainProxysFromManager()) {
+            if (CommonConfigHolder.getInstance().isEnableAuditProxysDiscoveryFromManager()) {
                 AuditOperator.getInstance().setAuditProxy(AuditComponent.DATAPROXY,
                         CommonConfigHolder.getInstance().getManagerHosts().get(0),
                         CommonConfigHolder.getInstance().getManagerAuthSecretId(),

--- a/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
+++ b/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
@@ -34,3 +34,5 @@ id2topic.unconfigured.default.topics= test1 test2 test3
 msg.send.failure.retry.enable = true
 # max retries after sent failure
 msg.max.retries=2
+# enalbe audit proxys discovery by manager
+audit.proxys.discovery.manager.enable=true

--- a/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
+++ b/inlong-dataproxy/dataproxy-source/src/test/resources/common.properties
@@ -34,5 +34,5 @@ id2topic.unconfigured.default.topics= test1 test2 test3
 msg.send.failure.retry.enable = true
 # max retries after sent failure
 msg.max.retries=2
-# enalbe audit proxys discovery by manager
+# whether to enable audit proxy address discovery by the Manager
 audit.proxys.discovery.manager.enable=true


### PR DESCRIPTION

Fixes #10441 

1. add "audit.obtain.proxys.from.manager configure" configuration key for  obtaining Audit-Proxy through InLong Manager
2. Call different setAuditProxy methods according to the "audit.obtain.proxys.from.manager configure" configuration value
