### PR TITLE
[INLONG-10360][Manager] Combine schedule state transition with group operations

### DIFF
--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -127,6 +127,7 @@ public enum ErrorCodeEnum {
 
     SCHEDULE_NOT_FOUND(1700, "Schedule info not found"),
     SCHEDULE_DUPLICATE(1701, "Schedule info already exist"),
+    SCHEDULE_STATUS_TRANSITION_NOT_ALLOWED(1702, "Schedule status transition is not allowed"),
 
     WORKFLOW_EXE_FAILED(4000, "Workflow execution exception"),
     WORKFLOW_APPROVER_NOT_FOUND(4001, "Workflow approver does not exist/no operation authority"),

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -127,7 +127,8 @@ public enum ErrorCodeEnum {
 
     SCHEDULE_NOT_FOUND(1700, "Schedule info not found"),
     SCHEDULE_DUPLICATE(1701, "Schedule info already exist"),
-    SCHEDULE_STATUS_TRANSITION_NOT_ALLOWED(1702, "Schedule status transition is not allowed"),
+    SCHEDULE_ENGINE_NOT_SUPPORTED(1702, "Schedule engine type not supported"),
+    SCHEDULE_STATUS_TRANSITION_NOT_ALLOWED(1703, "Schedule status transition is not allowed"),
 
     WORKFLOW_EXE_FAILED(4000, "Workflow execution exception"),
     WORKFLOW_APPROVER_NOT_FOUND(4001, "Workflow approver does not exist/no operation authority"),

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
@@ -34,10 +34,10 @@ import lombok.Getter;
 public enum ScheduleStatus {
 
     NEW(100, "new"),
-    APPROVED(103, "approved"),
-    REGISTERED(130, "registered"),
-    UPDATED(151, "updated"),
-    DELETED(40, "deleted");
+    APPROVED(101, "approved"),
+    REGISTERED(102, "registered"),
+    UPDATED(103, "updated"),
+    DELETED(99, "deleted");
 
     private final Integer code;
     private final String description;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
@@ -23,7 +23,10 @@ import lombok.Getter;
 public enum ScheduleStatus {
 
     NEW(100, "new"),
-    DELETED(40, "deleted");
+    APPROVED(101, "approved"),
+    REGISTERED(200, "registered"),
+    UPDATED(300, "updated"),
+    DELETED(400, "deleted");
 
     private final Integer code;
     private final String description;

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ScheduleStatus.java
@@ -19,14 +19,25 @@ package org.apache.inlong.manager.common.enums;
 
 import lombok.Getter;
 
+/**
+ * Status for schedule info.
+ * This is the transient status of the schedule info.
+ * With specified operations, the status will change to corresponding value.
+ *  Status                Operations
+ *  NEW                   inlong group created with schedule info
+ *  APPROVED              the new inlong group approved by admin
+ *  REGISTERED            schedule info registered to schedule engine
+ *  UPDATED               update schedule info for a group
+ *  DELETED               delete a group
+ * */
 @Getter
 public enum ScheduleStatus {
 
     NEW(100, "new"),
-    APPROVED(101, "approved"),
-    REGISTERED(200, "registered"),
-    UPDATED(300, "updated"),
-    DELETED(400, "deleted");
+    APPROVED(103, "approved"),
+    REGISTERED(130, "registered"),
+    UPDATED(151, "updated"),
+    DELETED(40, "deleted");
 
     private final Integer code;
     private final String description;

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.group;
 
-import java.sql.Timestamp;
 import org.apache.inlong.manager.common.auth.Authentication;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
 
@@ -31,6 +30,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.pojo.group;
 
+import java.sql.Timestamp;
 import org.apache.inlong.manager.common.auth.Authentication;
 import org.apache.inlong.manager.pojo.sort.BaseSortConf;
 
@@ -136,6 +137,36 @@ public abstract class InlongGroupInfo extends BaseInlongGroup {
 
     @ApiModelProperty(value = "Inlong tenant")
     private String tenant;
+
+    // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
+    @ApiModelProperty("Schedule type")
+    private Integer scheduleType;
+
+    // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]
+    // Y=year, M=month, W=week, D=day, H=hour, I=minute, O=oneway
+    @ApiModelProperty("TimeUnit for schedule interval")
+    private String scheduleUnit;
+
+    @ApiModelProperty("Schedule interval")
+    private Integer scheduleInterval;
+
+    @ApiModelProperty("Start time")
+    private Timestamp startTime;
+
+    @ApiModelProperty("End time")
+    private Timestamp endTime;
+
+    @ApiModelProperty("Delay time")
+    private Integer delayTime;
+
+    @ApiModelProperty("Self depend")
+    private Integer selfDepend;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer taskParallelism;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer crontabExpression;
 
     public abstract InlongGroupRequest genRequest();
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupRequest.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.pojo.group;
 
+import java.sql.Timestamp;
 import org.apache.inlong.manager.common.validation.SaveValidation;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
 
@@ -129,5 +130,35 @@ public abstract class InlongGroupRequest extends BaseInlongGroup {
     @ApiModelProperty(value = "Version number")
     @NotNull(groups = UpdateValidation.class, message = "version cannot be null")
     private Integer version;
+
+    // schedule type, support [normal, crontab], 0 for normal and 1 for crontab
+    @ApiModelProperty("Schedule type")
+    private Integer scheduleType;
+
+    // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneway]
+    // Y=year, M=month, W=week, D=day, H=hour, I=minute, O=oneway
+    @ApiModelProperty("TimeUnit for schedule interval")
+    private String scheduleUnit;
+
+    @ApiModelProperty("Schedule interval")
+    private Integer scheduleInterval;
+
+    @ApiModelProperty("Start time")
+    private Timestamp startTime;
+
+    @ApiModelProperty("End time")
+    private Timestamp endTime;
+
+    @ApiModelProperty("Delay time")
+    private Integer delayTime;
+
+    @ApiModelProperty("Self depend")
+    private Integer selfDepend;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer taskParallelism;
+
+    @ApiModelProperty("Schedule task parallelism")
+    private Integer crontabExpression;
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupRequest.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.manager.pojo.group;
 
-import java.sql.Timestamp;
 import org.apache.inlong.manager.common.validation.SaveValidation;
 import org.apache.inlong.manager.common.validation.UpdateValidation;
 
@@ -35,6 +34,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
+import java.sql.Timestamp;
 import java.util.List;
 
 /**

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
@@ -29,6 +29,7 @@ import lombok.NoArgsConstructor;
 import javax.validation.constraints.NotNull;
 
 import java.sql.Timestamp;
+import java.util.Objects;
 
 @Data
 @Builder
@@ -78,5 +79,33 @@ public class ScheduleInfo {
     @ApiModelProperty(value = "Version number")
     @NotNull(groups = UpdateValidation.class, message = "version cannot be null")
     private Integer version;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScheduleInfo that = (ScheduleInfo) o;
+        return Objects.equals(id, that.id) && Objects.equals(inlongGroupId, that.inlongGroupId)
+                && Objects.equals(scheduleType, that.scheduleType) && Objects.equals(scheduleUnit,
+                        that.scheduleUnit)
+                && Objects.equals(scheduleInterval, that.scheduleInterval)
+                && Objects.equals(startTime, that.startTime) && Objects.equals(endTime, that.endTime)
+                && Objects.equals(delayTime, that.delayTime) && Objects.equals(selfDepend,
+                        that.selfDepend)
+                && Objects.equals(taskParallelism, that.taskParallelism)
+                && Objects.equals(crontabExpression, that.crontabExpression) && Objects.equals(version,
+                        that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, inlongGroupId, scheduleType, scheduleUnit, scheduleInterval, startTime, endTime,
+                delayTime,
+                selfDepend, taskParallelism, crontabExpression, version);
+    }
 
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
@@ -26,6 +26,7 @@ import lombok.Data;
 import javax.validation.constraints.NotNull;
 
 import java.sql.Timestamp;
+import java.util.Objects;
 
 @Data
 @ApiModel("Schedule request")
@@ -73,4 +74,31 @@ public class ScheduleInfoRequest {
     @NotNull(groups = UpdateValidation.class, message = "version cannot be null")
     private Integer version;
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ScheduleInfoRequest that = (ScheduleInfoRequest) o;
+        return Objects.equals(id, that.id) && Objects.equals(inlongGroupId, that.inlongGroupId)
+                && Objects.equals(scheduleType, that.scheduleType) && Objects.equals(scheduleUnit,
+                        that.scheduleUnit)
+                && Objects.equals(scheduleInterval, that.scheduleInterval)
+                && Objects.equals(startTime, that.startTime) && Objects.equals(endTime, that.endTime)
+                && Objects.equals(delayTime, that.delayTime) && Objects.equals(selfDepend,
+                        that.selfDepend)
+                && Objects.equals(taskParallelism, that.taskParallelism)
+                && Objects.equals(crontabExpression, that.crontabExpression) && Objects.equals(version,
+                        that.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, inlongGroupId, scheduleType, scheduleUnit, scheduleInterval, startTime, endTime,
+                delayTime,
+                selfDepend, taskParallelism, crontabExpression, version);
+    }
 }

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.manager.schedule;
 
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+
 import org.springframework.stereotype.Service;
 
 @Service

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
@@ -15,42 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.schedule.quartz;
+package org.apache.inlong.manager.schedule;
 
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
-import org.apache.inlong.manager.schedule.ScheduleEngineClient;
-import org.apache.inlong.manager.schedule.ScheduleEngineType;
 
-/**
- * Built-in implementation of schedule engine client corresponding with {@link QuartzScheduleEngine}.
- * QuartzScheduleClient simply invokes the {@link QuartzScheduleEngine} to register/unregister/update
- * schedule info instead of calling a remote schedule service.
- * */
-public class QuartzScheduleClient implements ScheduleEngineClient {
-
-    private final QuartzScheduleEngine scheduleEngine;
-
-    public QuartzScheduleClient(QuartzScheduleEngine scheduleEngine) {
-        this.scheduleEngine = scheduleEngine;
-    }
+public class NoopScheduleClient implements ScheduleEngineClient {
 
     @Override
     public boolean accept(String engineType) {
-        return ScheduleEngineType.QUARTZ.getType().equalsIgnoreCase(engineType);
+        return ScheduleEngineType.NONE.getType().equals(engineType);
     }
 
     @Override
     public boolean register(ScheduleInfo scheduleInfo) {
-        return scheduleEngine.handleRegister(scheduleInfo);
+        return true;
     }
 
     @Override
     public boolean unregister(String groupId) {
-        return scheduleEngine.handleUnregister(groupId);
+        return true;
     }
 
     @Override
     public boolean update(ScheduleInfo scheduleInfo) {
-        return scheduleEngine.handleUpdate(scheduleInfo);
+        return true;
     }
 }

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
@@ -18,7 +18,9 @@
 package org.apache.inlong.manager.schedule;
 
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.springframework.stereotype.Service;
 
+@Service
 public class NoopScheduleClient implements ScheduleEngineClient {
 
     @Override

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.schedule;
 
 import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.schedule;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ScheduleClientFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduleClientFactory.class);
+
+    @Value("${inlong.schedule.engine:none}")
+    private String scheduleEngineName;
+
+    @Autowired
+    List<ScheduleEngineClient> scheduleEngineClients;
+
+    public ScheduleEngineClient getInstance() {
+        Optional<ScheduleEngineClient> optScheduleClient =
+                scheduleEngineClients.stream().filter(t -> t.accept(scheduleEngineName)).findFirst();
+        if (!optScheduleClient.isPresent()) {
+            LOGGER.warn("Schedule engine client not found for {} ", scheduleEngineName);
+            return null;
+        }
+        LOGGER.info("Get schedule engine client success for {}", scheduleEngineName);
+        return optScheduleClient.get();
+    }
+
+}

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleClientFactory.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.manager.schedule;
 
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,7 +44,8 @@ public class ScheduleClientFactory {
                 scheduleEngineClients.stream().filter(t -> t.accept(scheduleEngineName)).findFirst();
         if (!optScheduleClient.isPresent()) {
             LOGGER.warn("Schedule engine client not found for {} ", scheduleEngineName);
-            return null;
+            throw new BusinessException(ErrorCodeEnum.SCHEDULE_ENGINE_NOT_SUPPORTED,
+                    String.format(ErrorCodeEnum.SCHEDULE_ENGINE_NOT_SUPPORTED.getMessage(), scheduleEngineName));
         }
         LOGGER.info("Get schedule engine client success for {}", scheduleEngineName);
         return optScheduleClient.get();

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngine.java
@@ -37,9 +37,9 @@ public interface ScheduleEngine {
 
     /**
      * Handle schedule unregister.
-     * @param scheduleInfo schedule info to unregister
+     * @param groupId group to un-register schedule info
      * */
-    boolean handleUnregister(ScheduleInfo scheduleInfo);
+    boolean handleUnregister(String groupId);
 
     /**
      * Handle schedule update.

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngineType.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngineType.java
@@ -17,35 +17,26 @@
 
 package org.apache.inlong.manager.schedule;
 
-import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import lombok.Getter;
 
-/**
- * Interface for schedule engine client which responses for communicating with schedule engine.
- * */
-public interface ScheduleEngineClient {
+@Getter
+public enum ScheduleEngineType {
 
-    /**
-     * Check whether scheduleEngine type is matched.
-     * */
-    boolean accept(String engineType);
+    NONE("None"),
+    QUARTZ("Quartz");
 
-    /**
-     * Register schedule to schedule engine.
-     * @param scheduleInfo schedule info to register
-     * */
-    boolean register(ScheduleInfo scheduleInfo);
+    private final String type;
 
-    /**
-     * Un-register schedule from schedule engine.
-     *
-     * @param groupId schedule info to unregister
-     */
-    boolean unregister(String groupId);
+    ScheduleEngineType(String type) {
+        this.type = type;
+    }
 
-    /**
-     * Update schedule from schedule engine.
-     * @param scheduleInfo schedule info to update
-     * */
-    boolean update(ScheduleInfo scheduleInfo);
-
+    public static ScheduleEngineType fromCode(String type) {
+        for (ScheduleEngineType scheduleEngineType : ScheduleEngineType.values()) {
+            if (scheduleEngineType.type.equalsIgnoreCase(type)) {
+                return scheduleEngineType;
+            }
+        }
+        return null;
+    }
 }

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngineType.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/ScheduleEngineType.java
@@ -30,13 +30,4 @@ public enum ScheduleEngineType {
     ScheduleEngineType(String type) {
         this.type = type;
     }
-
-    public static ScheduleEngineType fromCode(String type) {
-        for (ScheduleEngineType scheduleEngineType : ScheduleEngineType.values()) {
-            if (scheduleEngineType.type.equalsIgnoreCase(type)) {
-                return scheduleEngineType;
-            }
-        }
-        return null;
-    }
 }

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleClient.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.schedule.quartz;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.schedule.ScheduleEngineClient;
 import org.apache.inlong.manager.schedule.ScheduleEngineType;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleClient.java
@@ -20,19 +20,19 @@ package org.apache.inlong.manager.schedule.quartz;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.schedule.ScheduleEngineClient;
 import org.apache.inlong.manager.schedule.ScheduleEngineType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
 /**
  * Built-in implementation of schedule engine client corresponding with {@link QuartzScheduleEngine}.
  * QuartzScheduleClient simply invokes the {@link QuartzScheduleEngine} to register/unregister/update
  * schedule info instead of calling a remote schedule service.
  * */
+@Service
 public class QuartzScheduleClient implements ScheduleEngineClient {
 
-    private final QuartzScheduleEngine scheduleEngine;
-
-    public QuartzScheduleClient(QuartzScheduleEngine scheduleEngine) {
-        this.scheduleEngine = scheduleEngine;
-    }
+    @Autowired
+    public QuartzScheduleEngine scheduleEngine;
 
     @Override
     public boolean accept(String engineType) {

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.springframework.stereotype.Service;
 
 import static org.apache.inlong.manager.schedule.util.ScheduleUtils.genQuartzJobDetail;
 import static org.apache.inlong.manager.schedule.util.ScheduleUtils.genQuartzTrigger;
@@ -44,6 +45,7 @@ import static org.apache.inlong.manager.schedule.util.ScheduleUtils.genQuartzTri
  * the register/unregister/update requests from {@link QuartzScheduleClient}
  * */
 @Getter
+@Service
 public class QuartzScheduleEngine implements ScheduleEngine {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QuartzScheduleEngine.class);

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
@@ -32,10 +32,10 @@ import org.quartz.Trigger;
 import org.quartz.impl.StdSchedulerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.springframework.stereotype.Service;
 
 import static org.apache.inlong.manager.schedule.util.ScheduleUtils.genQuartzJobDetail;
 import static org.apache.inlong.manager.schedule.util.ScheduleUtils.genQuartzTrigger;

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngine.java
@@ -23,6 +23,7 @@ import org.apache.inlong.manager.schedule.exception.QuartzScheduleException;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
+import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.Scheduler;
@@ -90,7 +91,7 @@ public class QuartzScheduleEngine implements ScheduleEngine {
     }
 
     @VisibleForTesting
-    public boolean handleRegister(ScheduleInfo scheduleInfo, Class<? extends QuartzOfflineSyncJob> clz) {
+    public boolean handleRegister(ScheduleInfo scheduleInfo, Class<? extends Job> clz) {
         if (scheduledJobSet.contains(scheduleInfo.getInlongGroupId())) {
             throw new QuartzScheduleException("Group " + scheduleInfo.getInlongGroupId() + " is already registered");
         }
@@ -108,19 +109,19 @@ public class QuartzScheduleEngine implements ScheduleEngine {
 
     /**
      * Handle schedule unregister.
-     * @param scheduleInfo schedule info to unregister
+     * @param groupId group to un-register schedule info
      * */
     @Override
-    public boolean handleUnregister(ScheduleInfo scheduleInfo) {
-        if (scheduledJobSet.contains(scheduleInfo.getInlongGroupId())) {
+    public boolean handleUnregister(String groupId) {
+        if (scheduledJobSet.contains(groupId)) {
             try {
-                scheduler.deleteJob(new JobKey(scheduleInfo.getInlongGroupId()));
+                scheduler.deleteJob(new JobKey(groupId));
             } catch (SchedulerException e) {
                 throw new QuartzScheduleException(e.getMessage());
             }
         }
-        scheduledJobSet.remove(scheduleInfo.getInlongGroupId());
-        LOGGER.info("Un-registered schedule info for {}", scheduleInfo.getInlongGroupId());
+        scheduledJobSet.remove(groupId);
+        LOGGER.info("Un-registered schedule info for {}", groupId);
         return true;
     }
 
@@ -134,8 +135,8 @@ public class QuartzScheduleEngine implements ScheduleEngine {
     }
 
     @VisibleForTesting
-    public boolean handleUpdate(ScheduleInfo scheduleInfo, Class<? extends QuartzOfflineSyncJob> clz) {
-        handleUnregister(scheduleInfo);
+    public boolean handleUpdate(ScheduleInfo scheduleInfo, Class<? extends Job> clz) {
+        handleUnregister(scheduleInfo.getInlongGroupId());
         handleRegister(scheduleInfo, clz);
         LOGGER.info("Updated schedule info for {}", scheduleInfo.getInlongGroupId());
         return false;

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/util/ScheduleUtils.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/util/ScheduleUtils.java
@@ -21,11 +21,11 @@ import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.schedule.ScheduleType;
 import org.apache.inlong.manager.schedule.ScheduleUnit;
 import org.apache.inlong.manager.schedule.exception.QuartzScheduleException;
-import org.apache.inlong.manager.schedule.quartz.QuartzOfflineSyncJob;
 
 import org.apache.commons.lang3.StringUtils;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
+import org.quartz.Job;
 import org.quartz.JobBuilder;
 import org.quartz.JobDetail;
 import org.quartz.ScheduleBuilder;
@@ -42,7 +42,7 @@ import java.util.Date;
  * */
 public class ScheduleUtils {
 
-    public static JobDetail genQuartzJobDetail(ScheduleInfo scheduleInfo, Class<? extends QuartzOfflineSyncJob> clz) {
+    public static JobDetail genQuartzJobDetail(ScheduleInfo scheduleInfo, Class<? extends Job> clz) {
         return JobBuilder.newJob(clz)
                 .withIdentity(scheduleInfo.getInlongGroupId())
                 .build();

--- a/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/quartz/MockJob.java
+++ b/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/quartz/MockJob.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.schedule.quartz;
 
+import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
@@ -25,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class MockJob extends QuartzOfflineSyncJob {
+public class MockJob implements Job {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MockJob.class);
 

--- a/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngineTest.java
+++ b/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/quartz/QuartzScheduleEngineTest.java
@@ -103,7 +103,7 @@ public class QuartzScheduleEngineTest extends BaseScheduleTest {
         MockJob.countDownLatch.await();
 
         // un-register before trigger finalized
-        scheduleEngine.handleUnregister(scheduleInfo);
+        scheduleEngine.handleUnregister(scheduleInfo.getInlongGroupId());
         // not job exist after un-register
         assertEquals(0, scheduleEngine.getScheduledJobSet().size());
         exist = scheduleEngine.getScheduler().checkExists(jobKey);

--- a/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/util/ScheduleUtilsTest.java
+++ b/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/util/ScheduleUtilsTest.java
@@ -20,7 +20,7 @@ package org.apache.inlong.manager.schedule.util;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.schedule.BaseScheduleTest;
 import org.apache.inlong.manager.schedule.exception.QuartzScheduleException;
-import org.apache.inlong.manager.schedule.quartz.QuartzOfflineSyncJob;
+import org.apache.inlong.manager.schedule.quartz.MockJob;
 
 import org.junit.jupiter.api.Test;
 import org.quartz.CronScheduleBuilder;
@@ -102,7 +102,7 @@ public class ScheduleUtilsTest extends BaseScheduleTest {
     @Test
     public void testGenJobDetail() {
         ScheduleInfo scheduleInfo = genDefaultScheduleInfo();
-        JobDetail jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, QuartzOfflineSyncJob.class);
+        JobDetail jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, MockJob.class);
         assertNotNull(jobDetail);
 
         JobKey jobKey = jobDetail.getKey();
@@ -116,7 +116,7 @@ public class ScheduleUtilsTest extends BaseScheduleTest {
     public void testGenCronTrigger() {
         // normal
         ScheduleInfo scheduleInfo = genDefaultScheduleInfo();
-        JobDetail jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, QuartzOfflineSyncJob.class);
+        JobDetail jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, MockJob.class);
 
         Trigger trigger = ScheduleUtils.genQuartzTrigger(jobDetail, scheduleInfo);
         assertNotNull(trigger);
@@ -139,7 +139,7 @@ public class ScheduleUtilsTest extends BaseScheduleTest {
 
         // cron
         scheduleInfo = genDefaultCronScheduleInfo();
-        jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, QuartzOfflineSyncJob.class);
+        jobDetail = ScheduleUtils.genQuartzJobDetail(scheduleInfo, MockJob.class);
 
         trigger = ScheduleUtils.genQuartzTrigger(jobDetail, scheduleInfo);
         assertNotNull(trigger);

--- a/inlong-manager/manager-service/pom.xml
+++ b/inlong-manager/manager-service/pom.xml
@@ -54,6 +54,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
+            <artifactId>manager-schedule</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
             <artifactId>manager-test</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
@@ -87,15 +87,6 @@ public interface InlongGroupService {
     String getTenant(String groupId, String operator);
 
     /**
-     * Get inlong group info based on inlong group id
-     *
-     * @param groupId inlong group id
-     * @param opInfo userinfo of operator
-     * @return detail of inlong group
-     */
-    InlongGroupInfo get(String groupId, UserInfo opInfo);
-
-    /**
      * Query the group information of each status of the current user
      *
      * @param operator name of operator

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -495,7 +495,8 @@ public class InlongGroupServiceImpl implements InlongGroupService {
 
         // save schedule info for offline group
         if (DATASYNC_OFFLINE_MODE.equals(request.getInlongGroupMode())) {
-            scheduleOperator.updateOpt(CommonBeanUtils.copyProperties(request, ScheduleInfoRequest::new), operator);
+            scheduleOperator.updateAndRegister(CommonBeanUtils.copyProperties(request, ScheduleInfoRequest::new),
+                    operator);
         }
 
         LOGGER.info("success to update inlong group for groupId={} by user={}", groupId, operator);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -281,8 +281,10 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         List<InlongStreamExtEntity> streamExtEntities = streamExtMapper.selectByRelatedId(groupId, null);
         BaseSortConf sortConf = buildSortConfig(streamExtEntities);
         groupInfo.setSortConf(sortConf);
-        // get schedule info and set into group info
-        addScheduleInfo(entity, groupInfo);
+        if (DATASYNC_OFFLINE_MODE.equals(entity.getInlongGroupMode())) {
+            // get schedule info and set into group info
+            addScheduleInfo(entity, groupInfo);
+        }
         LOGGER.debug("success to get inlong group for groupId={}", groupId);
         return groupInfo;
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/GroupScheduleResourceListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/schedule/GroupScheduleResourceListener.java
@@ -24,11 +24,13 @@ import org.apache.inlong.manager.pojo.group.InlongGroupExtInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupInfo;
 import org.apache.inlong.manager.pojo.workflow.form.process.GroupResourceProcessForm;
 import org.apache.inlong.manager.pojo.workflow.form.process.ProcessForm;
+import org.apache.inlong.manager.service.schedule.ScheduleOperator;
 import org.apache.inlong.manager.workflow.WorkflowContext;
 import org.apache.inlong.manager.workflow.event.ListenerResult;
 import org.apache.inlong.manager.workflow.event.task.ScheduleOperateListener;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -36,6 +38,9 @@ import java.util.List;
 @Service
 @Slf4j
 public class GroupScheduleResourceListener implements ScheduleOperateListener {
+
+    @Autowired
+    private ScheduleOperator scheduleOperator;
 
     @Override
     public TaskEvent event() {
@@ -68,7 +73,8 @@ public class GroupScheduleResourceListener implements ScheduleOperateListener {
         final String groupId = groupInfo.getInlongGroupId();
         log.info("begin to register schedule info for groupId={}", groupId);
 
-        // todo: register schedule info to schedule service
+        // handle schedule info after group approved
+        scheduleOperator.handleGroupApprove(groupId);
 
         // after register schedule info successfully, add ext property to group ext info
         saveInfo(groupInfo, InlongConstants.REGISTER_SCHEDULE_STATUS,

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
@@ -66,6 +66,14 @@ public interface ScheduleOperator {
     Boolean updateOpt(ScheduleInfoRequest request, String operator);
 
     /**
+     * Register schedule information
+     * @param request schedule request that needs to be modified
+     * @param operator name of operator
+     * @return whether succeed
+     */
+    Boolean updateAndRegister(ScheduleInfoRequest request, String operator);
+
+    /**
      * Delete schedule info for groupId.
      * There are two places may delete schedule info:
      * - 1. delete an inlong group

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
@@ -31,7 +31,8 @@ public interface ScheduleOperator {
      * Save schedule info.
      * There are two places may save schedule info:
      * - 1. create new inlong group with schedule info
-     * - 2. create new schedule info directly(inlong group has been already exist)
+     * - 2. create new schedule info directly(inlong group has been already exist), in this situation, we should
+     *      register schedule info to schedule engine if group has been approved.
      * @param request schedule request need to save
      * @param operator name of operator
      * @return schedule info id in backend storage

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
@@ -17,32 +17,34 @@
 
 package org.apache.inlong.manager.service.schedule;
 
-import org.apache.inlong.manager.common.enums.ScheduleStatus;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
 
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
-public interface ScheduleService {
+/**
+ * Operator for schedule. Including:
+ * 1. schedule info management
+ * 2. schedule operations like resister, un-register etc.
+ * */
+public interface ScheduleOperator {
 
     /**
      * Save schedule info.
-     *
+     * There are two places may save schedule info:
+     * - 1. create new inlong group with schedule info
+     * - 2. create new schedule info directly(inlong group has been already exist)
      * @param request schedule request need to save
      * @param operator name of operator
      * @return schedule info id in backend storage
      */
-    int save(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest request,
-            String operator);
+    int saveOpt(ScheduleInfoRequest request, String operator);
 
     /**
-     * Query whether schedule info exists for specified inlong group
+     * Check whether schedule info exists for specified inlong group
      *
      * @param groupId the group id to be queried
      * @return does it exist
      */
-    Boolean exist(String groupId);
+    Boolean scheduleInfoExist(String groupId);
 
     /**
      * Get schedule info based on inlong group id
@@ -50,33 +52,35 @@ public interface ScheduleService {
      * @param groupId inlong group id
      * @return detail of inlong group
      */
-    ScheduleInfo get(String groupId);
+    ScheduleInfo getScheduleInfo(String groupId);
 
     /**
      * Modify schedule information
-     *
+     * There are two places may update schedule info:
+     * - 1. update inlong group with new schedule info
+     * - 2. update schedule info directly(inlong group has been already exist)
      * @param request schedule request that needs to be modified
      * @param operator name of operator
      * @return whether succeed
      */
-    Boolean update(@Valid @NotNull(message = "schedule request cannot be null") ScheduleInfoRequest request,
-            String operator);
+    Boolean updateOpt(ScheduleInfoRequest request, String operator);
 
     /**
-     * Update status of schedule info.
-     *
-     * @param groupId group to update schedule status
-     * @param newStatus status to update
-     * @param operator name of operator
-     * @return whether succeed
-     */
-    Boolean updateStatus(String groupId, ScheduleStatus newStatus, String operator);
-
-    /**
-     * Delete schedule info for gropuId.
+     * Delete schedule info for groupId.
+     * There are two places may delete schedule info:
+     * - 1. delete an inlong group
+     * - 2. delete schedule info directly, left inlong group alone without schedule info, which means the group of
+     * offline sync job will never be triggered
      * @param groupId groupId to find a schedule info to delete
      * @param operator  name of operator
      * @Return whether succeed
      * */
-    Boolean deleteByGroupId(String groupId, String operator);
+    Boolean deleteByGroupIdOpt(String groupId, String operator);
+
+    /**
+     * Handle inlong group approve, check schedule info and try to register it to schedule engine.
+     * @param groupId groupId to find a schedule info to delete
+     * @Return whether succeed
+     * */
+    Boolean handleGroupApprove(String groupId);
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -58,11 +58,11 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     @Override
     public int saveOpt(ScheduleInfoRequest request, String operator) {
         // save schedule info first
-        int res = scheduleService.save(request, operator);
+        int scheduleInfoId = scheduleService.save(request, operator);
         LOGGER.info("Save schedule info success for group {}", request.getInlongGroupId());
         // process new schedule info for approved inlong group
         registerScheduleInfoForApprovedGroup(CommonBeanUtils.copyProperties(request, ScheduleInfo::new), operator);
-        return res;
+        return scheduleInfoId;
     }
 
     /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -115,10 +115,10 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
         }
         // update schedule info
         scheduleService.update(request, operator);
-        LOGGER.info("Update schedule info success for group {}", request.getInlongGroupId());
         // update register to schedule engine
-        boolean res = getScheduleEngineClient().update(scheduleInfo);
         scheduleService.updateStatus(request.getInlongGroupId(), UPDATED, operator);
+        boolean res = getScheduleEngineClient().update(scheduleInfo);
+        scheduleService.updateStatus(request.getInlongGroupId(), REGISTERED, operator);
         LOGGER.info("Update schedule info success for group {}", request.getInlongGroupId());
         return res;
     }
@@ -128,7 +128,7 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
             return false;
         }
         ScheduleInfo existedSchedule = getScheduleInfo(scheduleInfo.getInlongGroupId());
-        return scheduleInfo.equals(existedSchedule);
+        return !scheduleInfo.equals(existedSchedule);
     }
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.apache.inlong.manager.common.enums.ScheduleStatus.APPROVED;
 import static org.apache.inlong.manager.common.enums.ScheduleStatus.REGISTERED;
@@ -56,6 +57,7 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     private ScheduleEngineClient scheduleEngineClient;
 
     @Override
+    @Transactional(rollbackFor = Throwable.class)
     public int saveOpt(ScheduleInfoRequest request, String operator) {
         // save schedule info first
         int scheduleInfoId = scheduleService.save(request, operator);
@@ -101,6 +103,7 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     }
 
     @Override
+    @Transactional(rollbackFor = Throwable.class)
     public Boolean updateOpt(ScheduleInfoRequest request, String operator) {
         // if the inlong group exist without schedule info
         // then, save the new schedule info when updating inlong group

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.schedule;
+
+import org.apache.inlong.manager.common.consts.InlongConstants;
+import org.apache.inlong.manager.common.util.CommonBeanUtils;
+import org.apache.inlong.manager.dao.entity.InlongGroupExtEntity;
+import org.apache.inlong.manager.dao.mapper.InlongGroupExtEntityMapper;
+import org.apache.inlong.manager.dao.mapper.ScheduleEntityMapper;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
+import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
+import org.apache.inlong.manager.schedule.ScheduleClientFactory;
+import org.apache.inlong.manager.schedule.ScheduleEngineClient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.APPROVED;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.REGISTERED;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.UPDATED;
+
+@Service
+public class ScheduleOperatorImpl implements ScheduleOperator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduleOperatorImpl.class);
+
+    @Autowired
+    private ScheduleService scheduleService;
+
+    @Autowired
+    private InlongGroupExtEntityMapper groupExtMapper;
+
+    @Autowired
+    private ScheduleEntityMapper scheduleMapper;
+
+    @Autowired
+    private ScheduleClientFactory scheduleClientFactory;
+
+    private ScheduleEngineClient scheduleEngineClient;
+
+    @Override
+    public int saveOpt(ScheduleInfoRequest request, String operator) {
+        // save schedule info first
+        int res = scheduleService.save(request, operator);
+        LOGGER.info("Save schedule info success for group {}", request.getInlongGroupId());
+        // process new schedule info for approved inlong group
+        registerScheduleInfoForApprovedGroup(CommonBeanUtils.copyProperties(request, ScheduleInfo::new), operator);
+        return res;
+    }
+
+    /**
+     * If an inlong group in DATASYNC_OFFLINE_MODE created first without schedule info and has been approved, it should
+     * be registered to schedule engine once the schedule info for this group is added.
+     * */
+    private void registerScheduleInfoForApprovedGroup(ScheduleInfo scheduleInfo, String operator) {
+        String groupId = scheduleInfo.getInlongGroupId();
+        InlongGroupExtEntity scheduleStatusExt =
+                groupExtMapper.selectByUniqueKey(groupId, InlongConstants.REGISTER_SCHEDULE_STATUS);
+        if (InlongConstants.REGISTERED.equalsIgnoreCase(scheduleStatusExt.getKeyValue())) {
+            // change schedule state to approved
+            scheduleService.updateStatus(scheduleInfo.getInlongGroupId(), APPROVED, operator);
+            getScheduleEngineClient().register(scheduleInfo);
+            // change schedule state to registered
+            scheduleService.updateStatus(scheduleInfo.getInlongGroupId(), REGISTERED, operator);
+            LOGGER.info("Register schedule info success for group {}", groupId);
+        }
+    }
+
+    private ScheduleEngineClient getScheduleEngineClient() {
+        if (scheduleEngineClient == null) {
+            scheduleEngineClient = scheduleClientFactory.getInstance();
+        }
+        return scheduleEngineClient;
+    }
+
+    @Override
+    public Boolean scheduleInfoExist(String groupId) {
+        return scheduleService.exist(groupId);
+    }
+
+    @Override
+    public ScheduleInfo getScheduleInfo(String groupId) {
+        return scheduleService.get(groupId);
+    }
+
+    @Override
+    public Boolean updateOpt(ScheduleInfoRequest request, String operator) {
+        // if the inlong group exist without schedule info
+        // then, save the new schedule info when updating inlong group
+        if (!scheduleInfoExist(request.getInlongGroupId())) {
+            saveOpt(request, operator);
+            return true;
+        }
+        ScheduleInfo scheduleInfo = CommonBeanUtils.copyProperties(request, ScheduleInfo::new);
+        if (!needUpdate(scheduleInfo)) {
+            LOGGER.info("schedule info not changed for group {}", request.getInlongGroupId());
+            return false;
+        }
+        // update schedule info
+        scheduleService.update(request, operator);
+        LOGGER.info("Update schedule info success for group {}", request.getInlongGroupId());
+        // update register to schedule engine
+        boolean res = getScheduleEngineClient().update(scheduleInfo);
+        scheduleService.updateStatus(request.getInlongGroupId(), UPDATED, operator);
+        LOGGER.info("Update schedule info success for group {}", request.getInlongGroupId());
+        return res;
+    }
+
+    private boolean needUpdate(ScheduleInfo scheduleInfo) {
+        if (scheduleInfo == null) {
+            return false;
+        }
+        ScheduleInfo existedSchedule = getScheduleInfo(scheduleInfo.getInlongGroupId());
+        return scheduleInfo.equals(existedSchedule);
+    }
+
+    @Override
+    public Boolean deleteByGroupIdOpt(String groupId, String operator) {
+        return scheduleService.deleteByGroupId(groupId, operator);
+    }
+
+    @Override
+    public Boolean handleGroupApprove(String groupId) {
+        // if the inlong group exist without schedule info
+        // then, save the new schedule info when updating inlong group
+        if (!scheduleInfoExist(groupId)) {
+            LOGGER.warn("schedule info not exist for group {}", groupId);
+            return false;
+        }
+        ScheduleInfo scheduleInfo = getScheduleInfo(groupId);
+        // change schedule state to approved
+        scheduleService.updateStatus(groupId, APPROVED, null);
+        getScheduleEngineClient().register(scheduleInfo);
+        // change schedule state to registered
+        scheduleService.updateStatus(groupId, REGISTERED, null);
+        return true;
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -139,7 +139,7 @@ public class ScheduleServiceImpl implements ScheduleService {
         }
         fsm = new HashMap<>();
         fsm.put(NEW, new HashSet<>(Arrays.asList(APPROVED, DELETED)));
-        fsm.put(APPROVED, new HashSet<>(Arrays.asList(REGISTERED, UPDATED, DELETED)));
+        fsm.put(APPROVED, new HashSet<>(Arrays.asList(REGISTERED, DELETED)));
         fsm.put(REGISTERED, new HashSet<>(Arrays.asList(UPDATED, DELETED)));
         fsm.put(UPDATED, new HashSet<>(Arrays.asList(REGISTERED, DELETED)));
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -35,7 +35,18 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.APPROVED;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.DELETED;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.NEW;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.REGISTERED;
+import static org.apache.inlong.manager.common.enums.ScheduleStatus.UPDATED;
 
 @Service
 public class ScheduleServiceImpl implements ScheduleService {
@@ -46,6 +57,9 @@ public class ScheduleServiceImpl implements ScheduleService {
     private InlongGroupEntityMapper groupMapper;
     @Autowired
     private ScheduleEntityMapper scheduleEntityMapper;
+
+    // finite state machine
+    private Map<ScheduleStatus, Set<ScheduleStatus>> fsm;
 
     @Override
     public int save(ScheduleInfoRequest request, String operator) {
@@ -95,6 +109,43 @@ public class ScheduleServiceImpl implements ScheduleService {
         updateScheduleInfo(entity, errMsg);
         LOGGER.info("success to update schedule info for groupId={}", groupId);
         return true;
+    }
+
+    @Override
+    public Boolean updateStatus(String groupId, ScheduleStatus newStatus, String operator) {
+        LOGGER.debug("begin to update schedule status for groupId={}", groupId);
+        ScheduleEntity entity = getScheduleEntity(groupId);
+        ScheduleStatus preStatus = ScheduleStatus.forCode(entity.getStatus());
+        if (!isAllowedTransition(preStatus, newStatus)) {
+            String errorMsg = String.format("Schedule status transition is not allowed from %s to %s for group %s",
+                    preStatus, newStatus, groupId);
+            LOGGER.error(errorMsg);
+            throw new BusinessException(ErrorCodeEnum.SCHEDULE_STATUS_TRANSITION_NOT_ALLOWED);
+        }
+        entity.setStatus(newStatus.getCode());
+        entity.setModifier(operator);
+        updateScheduleInfo(entity,
+                String.format("update schedule status from %s to %s failed for groupId=%s",
+                        preStatus.getCode(), newStatus.getCode(), entity.getInlongGroupId()));
+        LOGGER.info("success to update schedule status from {} to {} for groupId={}",
+                preStatus.getCode(), newStatus.getCode(), groupId);
+        return true;
+    }
+
+    private void initFSMIfNeed() {
+        if (fsm != null) {
+            return;
+        }
+        fsm = new HashMap<>();
+        fsm.put(NEW, new HashSet<>(Arrays.asList(APPROVED, DELETED)));
+        fsm.put(APPROVED, new HashSet<>(Arrays.asList(REGISTERED, UPDATED, DELETED)));
+        fsm.put(REGISTERED, new HashSet<>(Arrays.asList(UPDATED, DELETED)));
+        fsm.put(UPDATED, new HashSet<>(Arrays.asList(REGISTERED, DELETED)));
+    }
+
+    private boolean isAllowedTransition(ScheduleStatus preStatus, ScheduleStatus newStatus) {
+        initFSMIfNeed();
+        return fsm.get(preStatus).contains(newStatus);
     }
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleServiceImpl.java
@@ -76,7 +76,8 @@ public class ScheduleServiceImpl implements ScheduleService {
         scheduleEntity.setStatus(ScheduleStatus.NEW.getCode());
         scheduleEntity.setCreator(operator);
         scheduleEntity.setModifier(operator);
-        return scheduleEntityMapper.insert(scheduleEntity);
+        scheduleEntityMapper.insert(scheduleEntity);
+        return scheduleEntity.getId();
     }
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
@@ -51,8 +51,8 @@ public class InLongSchedulerController {
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SCHEDULE)
     @ApiOperation(value = "Save schedule info")
     public Response<Integer> save(@RequestBody ScheduleInfoRequest request) {
-        int result = scheduleOperator.saveOpt(request, LoginUserUtils.getLoginUser().getName());
-        return Response.success(result);
+        int scheduleInfoId = scheduleOperator.saveOpt(request, LoginUserUtils.getLoginUser().getName());
+        return Response.success(scheduleInfoId);
     }
 
     @RequestMapping(value = "/schedule/exist/{groupId}", method = RequestMethod.GET)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
@@ -76,6 +76,14 @@ public class InLongSchedulerController {
         return Response.success(scheduleOperator.updateOpt(request, LoginUserUtils.getLoginUser().getName()));
     }
 
+    @RequestMapping(value = "/schedule/updateAndRegister", method = RequestMethod.POST)
+    @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SCHEDULE)
+    @ApiOperation(value = "Update schedule info and register to schedule engine")
+    public Response<Boolean> updateAndRegister(
+            @Validated(UpdateValidation.class) @RequestBody ScheduleInfoRequest request) {
+        return Response.success(scheduleOperator.updateAndRegister(request, LoginUserUtils.getLoginUser().getName()));
+    }
+
     @RequestMapping(value = "/schedule/delete/{groupId}", method = RequestMethod.DELETE)
     @ApiOperation(value = "Delete schedule info")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.SCHEDULE)

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InLongSchedulerController.java
@@ -25,7 +25,7 @@ import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
 import org.apache.inlong.manager.service.operationlog.OperationLog;
-import org.apache.inlong.manager.service.schedule.ScheduleService;
+import org.apache.inlong.manager.service.schedule.ScheduleOperator;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -45,13 +45,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class InLongSchedulerController {
 
     @Autowired
-    private ScheduleService scheduleService;
+    private ScheduleOperator scheduleOperator;
 
     @RequestMapping(value = "/schedule/save", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.SCHEDULE)
     @ApiOperation(value = "Save schedule info")
     public Response<Integer> save(@RequestBody ScheduleInfoRequest request) {
-        int result = scheduleService.save(request, LoginUserUtils.getLoginUser().getName());
+        int result = scheduleOperator.saveOpt(request, LoginUserUtils.getLoginUser().getName());
         return Response.success(result);
     }
 
@@ -59,21 +59,21 @@ public class InLongSchedulerController {
     @ApiOperation(value = "Is the schedule info exists for inlong group")
     @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
     public Response<Boolean> exist(@PathVariable String groupId) {
-        return Response.success(scheduleService.exist(groupId));
+        return Response.success(scheduleOperator.scheduleInfoExist(groupId));
     }
 
     @RequestMapping(value = "/schedule/get", method = RequestMethod.GET)
     @ApiOperation(value = "Get schedule info for inlong group")
     @ApiImplicitParam(name = "groupId", dataTypeClass = String.class, required = true)
     public Response<ScheduleInfo> get(@RequestParam String groupId) {
-        return Response.success(scheduleService.get(groupId));
+        return Response.success(scheduleOperator.getScheduleInfo(groupId));
     }
 
     @RequestMapping(value = "/schedule/update", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.SCHEDULE)
     @ApiOperation(value = "Update schedule info")
     public Response<Boolean> update(@Validated(UpdateValidation.class) @RequestBody ScheduleInfoRequest request) {
-        return Response.success(scheduleService.update(request, LoginUserUtils.getLoginUser().getName()));
+        return Response.success(scheduleOperator.updateOpt(request, LoginUserUtils.getLoginUser().getName()));
     }
 
     @RequestMapping(value = "/schedule/delete/{groupId}", method = RequestMethod.DELETE)
@@ -82,7 +82,7 @@ public class InLongSchedulerController {
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class, required = true)
     public Response<Boolean> delete(@PathVariable String groupId) {
         String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(scheduleService.deleteByGroupId(groupId, operator));
+        return Response.success(scheduleOperator.deleteByGroupIdOpt(groupId, operator));
     }
 
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongGroupController.java
@@ -69,7 +69,7 @@ public class OpenInLongGroupController {
     public Response<InlongGroupInfo> get(@PathVariable String groupId) {
         Preconditions.expectNotBlank(groupId, ErrorCodeEnum.INVALID_PARAMETER, "groupId cannot be blank");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
-        return Response.success(groupService.get(groupId, LoginUserUtils.getLoginUser()));
+        return Response.success(groupService.get(groupId));
     }
 
     @PostMapping(value = "/group/list")

--- a/inlong-manager/manager-web/src/main/resources/application-dev.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-dev.properties
@@ -104,3 +104,7 @@ cls.manager.endpoint=127.0.0.1
 
 manager.url=127.0.0.1:8083
 agent.install.path=
+
+# schedule engine type
+# support none(no scheduler) and quartz(quartz scheduler), default is none
+inlong.schedule.engine=none

--- a/inlong-manager/manager-web/src/main/resources/application-prod.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-prod.properties
@@ -100,3 +100,6 @@ metrics.audit.proxy.hosts=127.0.0.1:10081
 # Tencent cloud log service endpoint, The Operator cls resource by it
 cls.manager.endpoint=127.0.0.1
 
+# schedule engine type
+# support none(no scheduler) and quartz(quartz scheduler), default is none
+inlong.schedule.engine=none

--- a/inlong-manager/manager-web/src/main/resources/application-test.properties
+++ b/inlong-manager/manager-web/src/main/resources/application-test.properties
@@ -101,3 +101,6 @@ metrics.audit.proxy.hosts=127.0.0.1:10081
 # Tencent cloud log service endpoint, The Operator cls resource by it
 cls.manager.endpoint=127.0.0.1
 
+# schedule engine type
+# support none(no scheduler) and quartz(quartz scheduler), default is none
+inlong.schedule.engine=none

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -66,3 +66,7 @@ audit.user.ids=3,4,5,6
 
 # tencent cloud log service endpoint, The Operator cls resource by it
 cls.manager.endpoint=127.0.0.1
+
+# schedule engine type
+# support none(no scheduler) and quartz(quartz scheduler), default is none
+inlong.schedule.engine=none


### PR DESCRIPTION
Fixes #10360 

### Motivation

Combine schedule state transition with group operations. details see description in #10360
The finite state machine for schedule :
![image](https://github.com/apache/inlong/assets/48062889/dbfbd67b-a8f0-4b8f-ab88-f2313f2ba7d8)


This is the transient status of the schedule info.
With specified operations, the status will change to corresponding value.

|Status|Operation|
|---------------|-------------------------------------------|
|NEW                 | inlong group created with schedule info|
|APPROVED      |  the new inlong group approved by admin|
|REGISTERED   | schedule info registered to schedule engine|
|UPDATED         |update schedule info for a group|
|DELETED         |delete a group|
### Modifications

1. add schedule info in `InlongGroupRequest`
2. add configuration `inlong.schedule.engine` to indicate the schedule engine type
3. replace the implementation `QuartzOfflineSyncJob` with  the interface `Job` when building quartz job
4. add `ScheduleOperator` to process all the schedule related operations
5. register schedule info to schedule engine after group approved
6. save schedule info when group created
7. update schedule info to schedule engine when group updated
8. delete schedule info when group deleted

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)

