### PR TITLE
[INLONG-10446][Agent] Adjusting audit SDK address settings

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -19,6 +19,7 @@ package org.apache.inlong.agent.metrics.audit;
 
 import org.apache.inlong.agent.conf.AgentConfiguration;
 import org.apache.inlong.audit.AuditOperator;
+import org.apache.inlong.audit.entity.AuditComponent;
 import org.apache.inlong.audit.util.AuditConfig;
 
 import org.apache.commons.lang3.StringUtils;
@@ -30,6 +31,9 @@ import static org.apache.inlong.agent.constant.AgentConstants.AUDIT_ENABLE;
 import static org.apache.inlong.agent.constant.AgentConstants.AUDIT_KEY_PROXYS;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AUDIT_ENABLE;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AUDIT_PROXYS;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_ADDR;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_ID;
+import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_KEY;
 import static org.apache.inlong.audit.consts.ConfigConstants.DEFAULT_AUDIT_TAG;
 import static org.apache.inlong.common.constant.Constants.DEFAULT_AUDIT_VERSION;
 
@@ -75,14 +79,19 @@ public class AuditUtils {
         AgentConfiguration conf = AgentConfiguration.getAgentConf();
         IS_AUDIT = conf.getBoolean(AUDIT_ENABLE, DEFAULT_AUDIT_ENABLE);
         if (IS_AUDIT) {
-            // AuditProxy
-            String strIpPorts = conf.get(AUDIT_KEY_PROXYS, DEFAULT_AUDIT_PROXYS);
-            HashSet<String> proxySet = new HashSet<>();
-            if (!StringUtils.isBlank(strIpPorts)) {
-                String[] ipPorts = strIpPorts.split("\\s+");
-                Collections.addAll(proxySet, ipPorts);
+            if (conf.hasKey(AUDIT_KEY_PROXYS)) {
+                // AuditProxy
+                String strIpPorts = conf.get(AUDIT_KEY_PROXYS, DEFAULT_AUDIT_PROXYS);
+                HashSet<String> proxySet = new HashSet<>();
+                if (!StringUtils.isBlank(strIpPorts)) {
+                    String[] ipPorts = strIpPorts.split("\\s+");
+                    Collections.addAll(proxySet, ipPorts);
+                }
+                AuditOperator.getInstance().setAuditProxy(proxySet);
+            } else {
+                AuditOperator.getInstance().setAuditProxy(AuditComponent.AGENT, conf.get(AGENT_MANAGER_ADDR),
+                        conf.get(AGENT_MANAGER_AUTH_SECRET_ID), conf.get(AGENT_MANAGER_AUTH_SECRET_KEY));
             }
-            AuditOperator.getInstance().setAuditProxy(proxySet);
 
             // AuditConfig
             String filePath = conf.get(AUDIT_KEY_FILE_PATH, AUDIT_DEFAULT_FILE_PATH);

--- a/inlong-agent/agent-installer/conf/installer.properties
+++ b/inlong-agent/agent-installer/conf/installer.properties
@@ -40,4 +40,5 @@ agent.cluster.name=default_agent
 # whether to enable audit
 audit.enable=true
 # audit proxy address
+# If the audit proxy address is configured, use the audit proxy address; otherwise, use the manager address
 audit.proxys=127.0.0.1:10081

--- a/inlong-agent/agent-installer/conf/installer.properties
+++ b/inlong-agent/agent-installer/conf/installer.properties
@@ -40,5 +40,5 @@ agent.cluster.name=default_agent
 # whether to enable audit
 audit.enable=true
 # audit proxy address
-# If the audit proxy address is configured, use the audit proxy address; otherwise, use the manager address
+# Use the audit proxy address if the audit proxy address is configured; otherwise get the proxy address from the manager
 audit.proxys=127.0.0.1:10081

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -25,7 +25,7 @@ clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{pri
 clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
 tdwSecurityUrl=$(cat $installerConfigFile|grep -i 'tdw.security.url'|awk -F = '{print $2}')
 auditFlag=$(cat $installerConfigFile|grep -i 'audit.enable'|awk -F = '{print $2}')
-auditProxy=$(cat $installerConfigFile|grep -i 'audit.proxys'|awk -F = '{print $2}')
+auditProxy=$(cat $installerConfigFile|grep -i 'audit.proxys'|grep -v '#'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
   sed -i "/agent.manager.addr=*/c\agent.manager.addr=$managerAddr" $agentConfigFile
@@ -64,7 +64,8 @@ else
 fi
 
 if [ ${#auditProxy} -gt 0 ]; then
-  sed -i "/audit.proxys.default=*/c\audit.proxys=$auditProxy" $agentConfigFile
+  sed -i "/audit.proxys=*/c\audit.proxys=$auditProxy" $agentConfigFile
 else
+  sed -i "/audit.proxys=*/c\# audit.proxys=$auditProxy" $agentConfigFile
   echo "audit proxy empty"
 fi

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -64,7 +64,7 @@ else
 fi
 
 if [ ${#auditProxy} -gt 0 ]; then
-  sed -i "/audit.proxys=*/c\audit.proxys=$auditProxy" $agentConfigFile
+  sed -i "/audit.proxys.default=*/c\audit.proxys=$auditProxy" $agentConfigFile
 else
   echo "audit proxy empty"
 fi

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -99,4 +99,5 @@ agent.prometheus.exporter.port=9080
 # whether to enable audit
 audit.enable=true
 # audit proxy address
-audit.proxys.default=
+# If the audit proxy address is configured, use the audit proxy address; otherwise, use the manager address
+audit.proxys=127.0.0.1:10081

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -99,5 +99,5 @@ agent.prometheus.exporter.port=9080
 # whether to enable audit
 audit.enable=true
 # audit proxy address
-# If the audit proxy address is configured, use the audit proxy address; otherwise, use the manager address
+# Use the audit proxy address if the audit proxy address is configured; otherwise get the proxy address from the manager
 audit.proxys=127.0.0.1:10081

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -99,4 +99,4 @@ agent.prometheus.exporter.port=9080
 # whether to enable audit
 audit.enable=true
 # audit proxy address
-audit.proxys=127.0.0.1:10081
+audit.proxys.default=


### PR DESCRIPTION
Fixes #10446 

### Motivation

Adjusting audit SDK address settings

### Modifications

If the audit proxy address is configured, use the audit proxy address; otherwise, use the manager address

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation
No doc needed
