### PR TITLE
[INLONG-10468][Dashboard] Audit data showing totals and variances

### DIFF
--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -655,6 +655,8 @@
   "pages.GroupDetail.Audit.Hour": "小时",
   "pages.GroupDetail.Audit.Day": "天",
   "pages.GroupDetail.Audit.Sink": "数据目标",
+  "pages.GroupDetail.Audit.Total": "总计",
+  "pages.GroupDetail.Audit.DatepickerRule": "超出可选范围",
   "pages.GroupDetail.Delay.QueryDate": "查询日期",
   "pages.GroupDetail.Delay.AverageTitle": "平均传输时延 (ms)",
   "pages.GroupDetail.Delay.RealTimeTitle": "传输时延 (ms)",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -655,6 +655,8 @@
   "pages.GroupDetail.Audit.Day": "Day",
   "pages.GroupDetail.Audit.Sink": "Sink",
   "pages.GroupDetail.Audit.Item": "Audit item",
+  "pages.GroupDetail.Audit.Total": "Total",
+  "pages.GroupDetail.Audit.DatepickerRule": "Out of selectable time range",
   "pages.GroupDetail.Delay.QueryDate": "Query date",
   "pages.GroupDetail.Delay.AverageTitle": "Average transmission delay (ms)",
   "pages.GroupDetail.Delay.RealTimeTitle": "Transmission delay (ms)",

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -99,7 +99,8 @@ export const toTableData = (source, sourceDataMap) => {
       ...sourceDataMap[logTs],
       logTs,
     }));
-  return getSourceDataWithPercent(source, map);
+  let sourceData = getSourceDataWithPercent(source, map);
+  return getSourceDataWithCommas(sourceData);
 };
 
 export const getSourceDataWithPercent = (sourceKeys, sourceMap) => {
@@ -133,9 +134,25 @@ export const getDiff = (first, current) => {
     return '0%';
   }
   let result;
-  const diff = parseFloat(((current / first - 1) * 100).toFixed(0));
+  const diff = Math.ceil((current / first - 1) * 100);
   result = diff > 0 ? '+' + diff + '%' : diff + '%';
   return result;
+};
+
+export const getSourceDataWithCommas = sourceData => {
+  sourceData.map(source => {
+    for (const key in source) {
+      if (key !== 'logTs') {
+        let parts = source[key].split(' ');
+        let numberPart = parts[0];
+        let percentPart = parts[1] || '';
+        let number = parseInt(numberPart, 10);
+        let formattedNumber = number.toLocaleString();
+        source[key] = formattedNumber + ' ' + percentPart;
+      }
+    }
+  });
+  return sourceData;
 };
 
 let endTimeVisible = true;

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -133,7 +133,7 @@ export const getDiff = (first, current) => {
     return '0%';
   }
   let result;
-  const diff = parseFloat(((current / first - 1) * 100).toFixed(3));
+  const diff = parseFloat(((current / first - 1) * 100).toFixed(0));
   result = diff > 0 ? '+' + diff + '%' : diff + '%';
   return result;
 };
@@ -306,7 +306,7 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
   },
 ];
 
-export const getTableColumns = source => {
+export const getTableColumns = (source, dim) => {
   const data = source.map(item => ({
     title: item.auditName,
     dataIndex: item.auditId,
@@ -324,6 +324,9 @@ export const getTableColumns = source => {
     {
       title: i18n.t('pages.GroupDetail.Audit.Time'),
       dataIndex: 'logTs',
+      render: text => {
+        return dim === 'MINUTE' ? dayjs(text).format('HH:mm:ss') : text;
+      },
     },
   ].concat(data);
 };

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -235,7 +235,7 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
               return Promise.resolve();
             }
           }
-          return Promise.reject(new Error('Out of selectable time range'));
+          return Promise.reject(new Error(i18n.t('pages.GroupDetail.Audit.DatepickerRule')));
         },
       }),
     ],

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -325,7 +325,7 @@ export const getTableColumns = (source, dim) => {
       title: i18n.t('pages.GroupDetail.Audit.Time'),
       dataIndex: 'logTs',
       render: text => {
-        return dim === 'MINUTE' ? dayjs(text).format('HH:mm:ss') : text;
+        return dim === 'MINUTE' ? dayjs(text).format('HH:mm') : text;
       },
     },
   ].concat(data);

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -31,6 +31,7 @@ import {
   getTableColumns,
   timeStaticsDimList,
 } from './config';
+import { Table } from 'antd';
 
 type Props = CommonInterface;
 
@@ -92,7 +93,10 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
   }, [sourceData, query.timeStaticsDim]);
 
   const onSearch = async () => {
-    await form.validateFields();
+    let values = await form.validateFields();
+    if (values.timeStaticsDim == 'MINUTE') {
+      setQuery(prev => ({ ...prev, endDate: prev.startDate }));
+    }
     run();
   };
 
@@ -129,6 +133,18 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
           columns: getTableColumns(sourceData),
           dataSource: toTableData(sourceData, sourceDataMap),
           rowKey: 'logTs',
+          summary: () => (
+            <Table.Summary fixed>
+              <Table.Summary.Row>
+                <Table.Summary.Cell index={0}>总计</Table.Summary.Cell>
+                {sourceData.map((row, index) => (
+                  <Table.Summary.Cell index={index + 1}>
+                    {row.auditSet.reduce((total, item) => total + item.count, 0)}
+                  </Table.Summary.Cell>
+                ))}
+              </Table.Summary.Row>
+            </Table.Summary>
+          ),
         }}
       />
     </>

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -32,6 +32,7 @@ import {
   timeStaticsDimList,
 } from './config';
 import { Table } from 'antd';
+import i18n from '@/i18n';
 
 type Props = CommonInterface;
 
@@ -136,7 +137,9 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
           summary: () => (
             <Table.Summary fixed>
               <Table.Summary.Row>
-                <Table.Summary.Cell index={0}>总计</Table.Summary.Cell>
+                <Table.Summary.Cell index={0}>
+                  {i18n.t('pages.GroupDetail.Audit.Min')}
+                </Table.Summary.Cell>
                 {sourceData.map((row, index) => (
                   <Table.Summary.Cell index={index + 1}>
                     {row.auditSet.reduce((total, item) => total + item.count, 0)}

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -142,7 +142,7 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
                 </Table.Summary.Cell>
                 {sourceData.map((row, index) => (
                   <Table.Summary.Cell index={index + 1}>
-                    {row.auditSet.reduce((total, item) => total + item.count, 0)}
+                    {row.auditSet.reduce((total, item) => total + item.count, 0).toLocaleString()}
                   </Table.Summary.Cell>
                 ))}
               </Table.Summary.Row>

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -131,7 +131,7 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
 
       <HighTable
         table={{
-          columns: getTableColumns(sourceData),
+          columns: getTableColumns(sourceData, query.timeStaticsDim),
           dataSource: toTableData(sourceData, sourceDataMap),
           rowKey: 'logTs',
           summary: () => (

--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/index.tsx
@@ -138,7 +138,7 @@ const Comp: React.FC<Props> = ({ inlongGroupId }) => {
             <Table.Summary fixed>
               <Table.Summary.Row>
                 <Table.Summary.Cell index={0}>
-                  {i18n.t('pages.GroupDetail.Audit.Min')}
+                  {i18n.t('pages.GroupDetail.Audit.Total')}
                 </Table.Summary.Cell>
                 {sourceData.map((row, index) => (
                   <Table.Summary.Cell index={index + 1}>


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10468 

### Motivation

Audit data showing totals and variances.

### Modifications

- Calculate the difference ratio between each column and the first column.
- Calculate the sum of each column, including all pages.
- Limit the date selection range based on time units.
`MINUTE` - 1 day
`HOUR` - 3 days
`DAY` - 7 days
- Add commas to audit data for easier reading.

### Verifying this change

Before:
![image](https://github.com/apache/inlong/assets/58519431/96abffbe-34be-403b-97db-ae3135c4417f)

After:
![image](https://github.com/apache/inlong/assets/58519431/c5b7dd22-e1f0-402d-8a4d-768c4ca8cda5)

Minute Audit
![image](https://github.com/apache/inlong/assets/58519431/1277d3d4-47c5-43a9-b1c4-425feed32b01)
Hourly Audit
![image](https://github.com/apache/inlong/assets/58519431/a0f60549-fa3b-4ee5-a700-bcba49e8b8f1)
Audit by day
![image](https://github.com/apache/inlong/assets/58519431/594623d8-fae9-4ae2-a78d-738ead33c725)


