### PR TITLE
[INLONG-10474][Manager] Restrict sortTaskName and sortConsumeName the same with datanodeName when migrate Inlong Group

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
@@ -272,6 +272,8 @@ public class InlongTenantServiceImpl implements InlongTenantService {
 
         String newName = copyDataNode(dataNodeName, type, from, to);
         sink.setDataNodeName(newName);
+        sink.setSortConsumerGroup(newName);
+        sink.setSortTaskName(newName);
         return sinkMapper.updateByIdSelective(sink) == InlongConstants.AFFECTED_ONE_ROW;
 
     }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/tenant/InlongTenantServiceImpl.java
@@ -272,8 +272,9 @@ public class InlongTenantServiceImpl implements InlongTenantService {
 
         String newName = copyDataNode(dataNodeName, type, from, to);
         sink.setDataNodeName(newName);
-        sink.setSortConsumerGroup(newName);
-        sink.setSortTaskName(newName);
+        if (StringUtils.isNotBlank(sink.getSortTaskName())) {
+            sink.setSortTaskName(newName);
+        }
         return sinkMapper.updateByIdSelective(sink) == InlongConstants.AFFECTED_ONE_ROW;
 
     }


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10474 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
