### PR TITLE
[INLONG-10482][Dashboard]The front-end parameters on the approval pag…

### DIFF
--- a/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
+++ b/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
@@ -43,9 +43,10 @@ export const getFilterFormContent = defaultValues => [
   {
     type: 'select',
     label: i18n.t('basic.Status'),
-    name: 'status',
+    name: 'statusSet',
     initialValue: defaultValues.status,
     props: {
+      mode: 'multiple',
       dropdownMatchSelectWidth: false,
       options: statusList,
       allowClear: true,


### PR DESCRIPTION
…e are incorrect, and the page cannot be filtered based on the approval status

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10482 

### Motivation

The front-end parameters on the approval page are incorrect, and the page cannot be filtered based on the approval status

### Modifications

Let the approval page be filtered based on the approval status

### Verifying this change
before 
![image](https://github.com/apache/inlong/assets/165994047/a1f2dbb7-8ed3-41f5-a0a8-ea721c48e000)

 update
![image](https://github.com/apache/inlong/assets/165994047/8f5c4f8f-3ddd-4756-b03e-9c1bde581111)


