### PR TITLE
[INLONG-10487][Manager] Fix the error of not return success ListenerResult

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/listener/StartupSortListener.java
@@ -95,7 +95,7 @@ public class StartupSortListener implements SortOperateListener {
         List<ListenerResult> failedStreams = listenerResults.stream()
                 .filter(t -> !t.isSuccess()).collect(Collectors.toList());
         if (failedStreams.isEmpty()) {
-            ListenerResult.success();
+            return ListenerResult.success();
         }
         return ListenerResult.fail(failedStreams.get(0).getRemark());
     }


### PR DESCRIPTION
### [INLONG-10487][Manager] Fix the error of not return success ListenerResult
Fixes #10487 

### Motivation

Fix the error of not return success ListenerResult due to config display failed.

### Modifications

Add return LIstenerResult.success to display right config information.

