### PR TITLE
[INLONG-10064][Feature][Tool] Support multi-version flinks in inlong-dev-toolkit

### DIFF
--- a/inlong-tools/dev/inlong-dev-toolkit.sh
+++ b/inlong-tools/dev/inlong-dev-toolkit.sh
@@ -78,6 +78,15 @@ function manager() {
     exec:exec)
 
   echo 'current_version: '"$project_version"
+
+  sort_flink_version=$(mvn -q \
+    -Dexec.executable=echo \
+    -Dexec.args='${sort.flink.version}' \
+    --non-recursive \
+    exec:exec)
+
+  echo 'sort_filnk_version: '"${sort_flink_version}"
+
   #
   echo 'associate plugins directory: inlong-manager/manager-plugins/target/plugins'
   # plugins -> manager-plugins/target/plugins
@@ -100,7 +109,7 @@ function manager() {
   rm -rf $sort_connector_dir
   mkdir "$sort_connector_dir"
   cd "$sort_connector_dir"
-  connector_names=$(grep '<module>' "$base_dir"/inlong-sort/sort-connectors/pom.xml | sed 's/<module>//g' | sed 's/<\/module>//g' | grep -v base)
+  connector_names=$(grep '<module>' "$base_dir"/inlong-sort/sort-flink/sort-flink-"${sort_flink_version}"/sort-connectors/pom.xml | sed 's/<module>//g' | sed 's/<\/module>//g' | grep -v base)
 
   echo 'All connector names: '
   echo $connector_names | tr -d '\n'


### PR DESCRIPTION
fixes #10064 

fix sort-connectors path with multi  sort flink version in inlong-dev-toolkit

default sort.flink.version=v1.15
<img width="1405" alt="image" src="https://github.com/apache/inlong/assets/95902504/7247c305-21bc-47da-b5b6-156fcddb5f5e">

set sort.flink.version=v1.13
<img width="1662" alt="image" src="https://github.com/apache/inlong/assets/95902504/6b8ffde6-9b43-4f6b-b625-a6f8c1173244">

