### PR TITLE
[INLONG-10500][Dashboard] Change the visible range to a drop-down box

### DIFF
--- a/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
+++ b/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
@@ -82,9 +82,7 @@ export class GroupDataTemplateInfo implements DataWithBackend, RenderRow, Render
 
   @FieldDecorator({
     type: 'select',
-    visible: values => {
-      return values.visibleRange === 'TENANT';
-    },
+    hidden: true,
     props: {
       mode: 'multiple',
       filterOption: true,

--- a/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
+++ b/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
@@ -58,6 +58,33 @@ export class GroupDataTemplateInfo implements DataWithBackend, RenderRow, Render
 
   @FieldDecorator({
     type: 'select',
+    initialValue: 'ALL',
+    props: values => ({
+      options: [
+        {
+          label: i18n.t('pages.GroupDataTemplate.VisibleRange.All'),
+          value: 'ALL',
+        },
+        {
+          label: i18n.t('pages.GroupDataTemplate.VisibleRange.InCharger'),
+          value: 'IN_CHARGE',
+        },
+        {
+          label: i18n.t('pages.GroupDataTemplate.VisibleRange.Tenant'),
+          value: 'TENANT',
+        },
+      ],
+    }),
+    rules: [{ required: true }],
+  })
+  @I18n('pages.GroupDataTemplate.VisibleRange')
+  visibleRange: String;
+
+  @FieldDecorator({
+    type: 'select',
+    visible: values => {
+      return values.visibleRange === 'TENANT';
+    },
     props: {
       mode: 'multiple',
       filterOption: true,
@@ -101,14 +128,6 @@ export class GroupDataTemplateInfo implements DataWithBackend, RenderRow, Render
   })
   @I18n('pages.GroupDataTemplate.Version')
   version: number;
-
-  @FieldDecorator({
-    type: 'input',
-    initialValue: '',
-    rules: [{ required: true }],
-  })
-  @I18n('pages.GroupDataTemplate.VisibleRange')
-  visibleRange: String;
 
   @FieldDecorator({
     type: EditableTable,

--- a/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
+++ b/inlong-dashboard/src/plugins/groups/common/GroupDataTemplateInfo.ts
@@ -53,7 +53,7 @@ export class GroupDataTemplateInfo implements DataWithBackend, RenderRow, Render
     },
   })
   @ColumnDecorator()
-  @I18n('pages.GroupDataTemplate.InChargers')
+  @I18n('pages.GroupDataTemplate.InCharges')
   inCharges: string;
 
   @FieldDecorator({
@@ -66,7 +66,7 @@ export class GroupDataTemplateInfo implements DataWithBackend, RenderRow, Render
           value: 'ALL',
         },
         {
-          label: i18n.t('pages.GroupDataTemplate.VisibleRange.InCharger'),
+          label: i18n.t('pages.GroupDataTemplate.VisibleRange.InCharges'),
           value: 'IN_CHARGE',
         },
         {

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -915,7 +915,9 @@
   "pages.GroupDataTemplate.TenantList":"租户",
   "pages.GroupDataTemplate.Version":"版本",
   "pages.GroupDataTemplate.VisibleRange":"可视范围",
-  "pages.GroupDataTemplate.InCharges":"负责人",
+  "pages.GroupDataTemplate.InCharges":"责任人",
+  "pages.GroupDataTemplate.Creator":"创建人",
+  "pages.GroupDataTemplate.Modifier":"修改人",
   "pages.GroupDataTemplate.VisibleRange.All":"全局",
   "pages.GroupDataTemplate.VisibleRange.InCharges":"责任人",
   "pages.GroupDataTemplate.VisibleRange.Tenant":"租户"

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -915,8 +915,8 @@
   "pages.GroupDataTemplate.TenantList":"租户",
   "pages.GroupDataTemplate.Version":"版本",
   "pages.GroupDataTemplate.VisibleRange":"可视范围",
-  "pages.GroupDataTemplate.InChargers":"负责人",
-  "pages.GroupDataTemplate.VisibleRange.All":"全局可见",
-  "pages.GroupDataTemplate.VisibleRange.InCharger":"责任人可见",
-  "pages.GroupDataTemplate.VisibleRange.Tenant":"租户可见"
+  "pages.GroupDataTemplate.InCharges":"负责人",
+  "pages.GroupDataTemplate.VisibleRange.All":"全局",
+  "pages.GroupDataTemplate.VisibleRange.InCharges":"责任人",
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"租户"
 }

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -915,5 +915,8 @@
   "pages.GroupDataTemplate.TenantList":"租户",
   "pages.GroupDataTemplate.Version":"版本",
   "pages.GroupDataTemplate.VisibleRange":"可视范围",
-  "pages.GroupDataTemplate.InChargers":"负责人"
+  "pages.GroupDataTemplate.InChargers":"负责人",
+  "pages.GroupDataTemplate.VisibleRange.All":"全局可见",
+  "pages.GroupDataTemplate.VisibleRange.InCharger":"责任人可见",
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"租户可见"
 }

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -919,6 +919,6 @@
   "pages.GroupDataTemplate.Creator":"创建人",
   "pages.GroupDataTemplate.Modifier":"修改人",
   "pages.GroupDataTemplate.VisibleRange.All":"全局",
-  "pages.GroupDataTemplate.VisibleRange.InCharges":"负责人",
+  "pages.GroupDataTemplate.VisibleRange.InCharges":"责任人",
   "pages.GroupDataTemplate.VisibleRange.Tenant":"租户"
 }

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -915,7 +915,9 @@
   "pages.GroupDataTemplate.TenantList":"Tenant",
   "pages.GroupDataTemplate.Version":"Version",
   "pages.GroupDataTemplate.VisibleRange":"Visible Range",
-  "pages.GroupDataTemplate.InCharges":"In-Charges",
+  "pages.GroupDataTemplate.InCharges":"Owner",
+  "pages.GroupDataTemplate.Creator":"Creator",
+  "pages.GroupDataTemplate.Modifier":"Modifier",
   "pages.GroupDataTemplate.VisibleRange.All":"Global",
   "pages.GroupDataTemplate.VisibleRange.InCharges":"Owner",
   "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenant"

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -915,8 +915,8 @@
   "pages.GroupDataTemplate.TenantList":"Tenant",
   "pages.GroupDataTemplate.Version":"Version",
   "pages.GroupDataTemplate.VisibleRange":"Visible Range",
-  "pages.GroupDataTemplate.InChargers":"InChargers",
-  "pages.GroupDataTemplate.VisibleRange.All":"Globally Visible",
-  "pages.GroupDataTemplate.VisibleRange.InCharger":"InCharger Visible",
-  "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenants Visible"
+  "pages.GroupDataTemplate.InChargers":"In-Charges",
+  "pages.GroupDataTemplate.VisibleRange.All":"Global",
+  "pages.GroupDataTemplate.VisibleRange.InCharges":"Owner",
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenant"
 }

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -915,5 +915,8 @@
   "pages.GroupDataTemplate.TenantList":"Tenant",
   "pages.GroupDataTemplate.Version":"Version",
   "pages.GroupDataTemplate.VisibleRange":"Visible Range",
-  "pages.GroupDataTemplate.InChargers":"InChargers"
+  "pages.GroupDataTemplate.InChargers":"InChargers",
+  "pages.GroupDataTemplate.VisibleRange.All":"Globally Visible",
+  "pages.GroupDataTemplate.VisibleRange.InCharger":"InCharger Visible",
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenants Visible"
 }

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -915,7 +915,7 @@
   "pages.GroupDataTemplate.TenantList":"Tenant",
   "pages.GroupDataTemplate.Version":"Version",
   "pages.GroupDataTemplate.VisibleRange":"Visible Range",
-  "pages.GroupDataTemplate.InChargers":"In-Charges",
+  "pages.GroupDataTemplate.InCharges":"In-Charges",
   "pages.GroupDataTemplate.VisibleRange.All":"Global",
   "pages.GroupDataTemplate.VisibleRange.InCharges":"Owner",
   "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenant"

--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
@@ -132,12 +132,6 @@ const Comp: React.FC = () => {
           </>
         ),
       },
-      {
-        title: i18n.t('pages.GroupDataTemplate.Version'),
-        dataIndex: 'version',
-        key: 'version',
-        width: 200,
-      },
     ];
   }, []);
   const columns = useMemo(() => {

--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
@@ -113,13 +113,13 @@ const Comp: React.FC = () => {
         title: i18n.t('pages.GroupDataTemplate.Name'),
         dataIndex: 'name',
         key: 'name',
-        width: 100,
+        width: 200,
       },
       {
         title: i18n.t('pages.GroupDataTemplate.InCharges'),
         dataIndex: 'inCharges',
         key: 'inCharges',
-        width: 100,
+        width: 200,
       },
       {
         title: i18n.t('pages.GroupDataTemplate.TenantList'),
@@ -132,6 +132,30 @@ const Comp: React.FC = () => {
           </>
         ),
       },
+      {
+        title: i18n.t('pages.GroupDataTemplate.Creator'),
+        dataIndex: 'creator',
+        key: 'creator',
+        width: 200,
+        render: (text, record: any) => (
+          <>
+            <div>{text}</div>
+            <div>{record.createTime && timestampFormat(record.createTime)}</div>
+          </>
+        ),
+      },
+      {
+        title: i18n.t('pages.GroupDataTemplate.Modifier'),
+        dataIndex: 'modifier',
+        key: 'modifier',
+        width: 200,
+        render: (text, record: any) => (
+          <>
+            <div>{text}</div>
+            <div>{record.modifyTime && timestampFormat(record.modifyTime)}</div>
+          </>
+        ),
+      },
     ];
   }, []);
   const columns = useMemo(() => {
@@ -139,7 +163,7 @@ const Comp: React.FC = () => {
       {
         title: i18n.t('basic.Operating'),
         dataIndex: 'action',
-        width: 200,
+        width: 100,
         render: (text, record) => (
           <>
             <Button type="link" onClick={() => onEdit(record)}>

--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
@@ -116,7 +116,7 @@ const Comp: React.FC = () => {
         width: 100,
       },
       {
-        title: i18n.t('pages.GroupDataTemplate.InChargers'),
+        title: i18n.t('pages.GroupDataTemplate.InCharges'),
         dataIndex: 'inCharges',
         key: 'inCharges',
         width: 100,

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/PulsarProvider.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/sort/node/provider/PulsarProvider.java
@@ -30,6 +30,7 @@ import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
 import org.apache.inlong.sort.protocol.node.format.Format;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -67,7 +68,9 @@ public class PulsarProvider implements ExtractNodeProvider {
         final String primaryKey = pulsarSource.getPrimaryKey();
         final String serviceUrl = pulsarSource.getServiceUrl();
         final String adminUrl = pulsarSource.getAdminUrl();
-        final String scanStartupSubStartOffset = null;
+        final String scanStartupSubStartOffset =
+                StringUtils.isNotBlank(pulsarSource.getSubscription()) ? PulsarScanStartupMode.EARLIEST.getValue()
+                        : null;
 
         return new PulsarExtractNode(pulsarSource.getSourceName(),
                 pulsarSource.getSourceName(),


### PR DESCRIPTION
Fixes #10500

### Motivation
When editing the template, select the visual range first, the visual range should be a drop-down selection box, if the visual range is tenant level, the tenant information needs to be filled, otherwise it is hidden


### Modifications
if the visual range is tenant level, the tenant information needs to be filled, otherwise it is hidden, let the visual range be a drop-down selection box

### Verifying this change
before:
![image](https://github.com/apache/inlong/assets/165994047/07968f19-f556-411f-886e-52f9b378fea7)
after:
create 
![image](https://github.com/apache/inlong/assets/165994047/45fd48e0-626d-4d27-b3eb-8a9be196cd9f)
before:
if you select a tenant in the visual range drop-down selection box  show the tenant list
![image](https://github.com/apache/inlong/assets/165994047/f36b9a54-a775-4b67-af91-4c0ce7312aff)

change the list to show
before
![image](https://github.com/apache/inlong/assets/165994047/24bd5925-7b35-4e39-94c5-0591cdefd721)
after
![image](https://github.com/apache/inlong/assets/165994047/b678ffe0-7042-49e5-b794-20650a0d1314)


