### PR TITLE
[INLONG-10501][Dashboard] Modify component type to be more intuitive

### DIFF
--- a/inlong-dashboard/src/plugins/streams/common/StreamDefaultInfo.ts
+++ b/inlong-dashboard/src/plugins/streams/common/StreamDefaultInfo.ts
@@ -173,11 +173,10 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
   dataEncoding: string;
 
   @FieldDecorator({
-    type: 'select',
-    initialValue: '124',
+    type: 'radio',
     props: values => ({
       disabled: [110].includes(values?.status),
-      dropdownMatchSelectWidth: false,
+      initialValue: '124',
       options: [
         {
           label: i18n.t('meta.Stream.DataSeparator.Space'),
@@ -204,11 +203,6 @@ export class StreamDefaultInfo implements DataWithBackend, RenderRow, RenderList
           value: '34',
         },
       ],
-      useInput: true,
-      useInputProps: {
-        placeholder: 'ASCII',
-      },
-      style: { width: 100 },
     }),
     rules: [
       {


### PR DESCRIPTION


Fixes #10501 

### Motivation

Modify component type to be more intuitive

### Modifications

Change the separator component type from select box to radio button

### Verifying this change

Before：
![image](https://github.com/apache/inlong/assets/58519431/c2e7d069-f0fb-46a3-a183-fa74b8bdc3e3)

After：
![image](https://github.com/apache/inlong/assets/58519431/f1820513-e5f4-4db5-b3f3-77970e62cc81)

