### PR TITLE
[INLONG-10459][Manager] Support schedule instance callback to submit Flink batch job

### DIFF
--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/offline/FlinkOfflineJobOperator.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/offline/FlinkOfflineJobOperator.java
@@ -20,13 +20,13 @@ package org.apache.inlong.manager.plugin.offline;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 import org.apache.inlong.manager.workflow.processor.OfflineJobOperator;
 
-import org.springframework.stereotype.Component;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 import static org.apache.inlong.manager.plugin.util.FlinkUtils.submitFlinkJobs;
 
-@Component
+@NoArgsConstructor
 public class FlinkOfflineJobOperator implements OfflineJobOperator {
 
     @Override

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/offline/FlinkOfflineJobOperator.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/offline/FlinkOfflineJobOperator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.plugin.offline;
+
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+import org.apache.inlong.manager.workflow.processor.OfflineJobOperator;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static org.apache.inlong.manager.plugin.util.FlinkUtils.submitFlinkJobs;
+
+@Component
+public class FlinkOfflineJobOperator implements OfflineJobOperator {
+
+    @Override
+    public void submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList) throws Exception {
+        submitFlinkJobs(groupId, streamInfoList);
+    }
+}

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
@@ -218,6 +218,33 @@ public class FlinkUtils {
         return flinkConfig;
     }
 
+    public static ListenerResult submitFlinkJobs(String groupId, List<InlongStreamInfo> streamInfoList)
+            throws Exception {
+        int sinkCount = streamInfoList.stream()
+                .map(s -> s.getSinkList() == null ? 0 : s.getSinkList().size())
+                .reduce(0, Integer::sum);
+        if (sinkCount == 0) {
+            log.warn("not any sink configured for group {} and stream list {}, skip launching sort job", groupId,
+                    streamInfoList.stream()
+                            .map(s -> s.getInlongGroupId() + ":" + s.getName()).collect(Collectors.toList()));
+            return ListenerResult.success();
+        }
+
+        List<ListenerResult> listenerResults = new ArrayList<>();
+        for (InlongStreamInfo streamInfo : streamInfoList) {
+            listenerResults.add(FlinkUtils.submitFlinkJob(streamInfo, FlinkUtils.genFlinkJobName(streamInfo)));
+        }
+
+        // only one stream in group for now
+        // we can return the list of ListenerResult if support multi-stream in the future
+        List<ListenerResult> failedStreams = listenerResults.stream()
+                .filter(t -> !t.isSuccess()).collect(Collectors.toList());
+        if (failedStreams.isEmpty()) {
+            ListenerResult.success();
+        }
+        return ListenerResult.fail(failedStreams.get(0).getRemark());
+    }
+
     public static ListenerResult submitFlinkJob(InlongStreamInfo streamInfo, String jobName) throws Exception {
         List<StreamSink> sinkList = streamInfo.getSinkList();
         List<String> sinkTypes = sinkList.stream().map(StreamSink::getSinkType).collect(Collectors.toList());
@@ -293,6 +320,11 @@ public class FlinkUtils {
 
     public static String genFlinkJobName(ProcessForm processForm, InlongStreamInfo streamInfo) {
         return Constants.SORT_JOB_NAME_GENERATOR.apply(processForm) + InlongConstants.HYPHEN
+                + streamInfo.getInlongStreamId();
+    }
+
+    public static String genFlinkJobName(InlongStreamInfo streamInfo) {
+        return String.format(Constants.SORT_JOB_NAME_TEMPLATE, streamInfo.getInlongGroupId()) + InlongConstants.HYPHEN
                 + streamInfo.getInlongStreamId();
     }
 }

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
@@ -240,7 +240,7 @@ public class FlinkUtils {
         List<ListenerResult> failedStreams = listenerResults.stream()
                 .filter(t -> !t.isSuccess()).collect(Collectors.toList());
         if (failedStreams.isEmpty()) {
-            ListenerResult.success();
+            return ListenerResult.success();
         }
         return ListenerResult.fail(failedStreams.get(0).getRemark());
     }

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/util/FlinkUtils.java
@@ -224,7 +224,7 @@ public class FlinkUtils {
                 .map(s -> s.getSinkList() == null ? 0 : s.getSinkList().size())
                 .reduce(0, Integer::sum);
         if (sinkCount == 0) {
-            log.warn("not any sink configured for group {} and stream list {}, skip launching sort job", groupId,
+            log.warn("Not any sink configured for group {} and stream list {}, skip launching sort job", groupId,
                     streamInfoList.stream()
                             .map(s -> s.getInlongGroupId() + ":" + s.getName()).collect(Collectors.toList()));
             return ListenerResult.success();

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfo.java
@@ -89,16 +89,16 @@ public class ScheduleInfo {
             return false;
         }
         ScheduleInfo that = (ScheduleInfo) o;
-        return Objects.equals(id, that.id) && Objects.equals(inlongGroupId, that.inlongGroupId)
-                && Objects.equals(scheduleType, that.scheduleType) && Objects.equals(scheduleUnit,
-                        that.scheduleUnit)
+        return Objects.equals(inlongGroupId, that.inlongGroupId)
+                && Objects.equals(scheduleType, that.scheduleType)
+                && Objects.equals(scheduleUnit, that.scheduleUnit)
                 && Objects.equals(scheduleInterval, that.scheduleInterval)
-                && Objects.equals(startTime, that.startTime) && Objects.equals(endTime, that.endTime)
-                && Objects.equals(delayTime, that.delayTime) && Objects.equals(selfDepend,
-                        that.selfDepend)
+                && Objects.equals(startTime, that.startTime)
+                && Objects.equals(endTime, that.endTime)
+                && Objects.equals(delayTime, that.delayTime)
+                && Objects.equals(selfDepend, that.selfDepend)
                 && Objects.equals(taskParallelism, that.taskParallelism)
-                && Objects.equals(crontabExpression, that.crontabExpression) && Objects.equals(version,
-                        that.version);
+                && Objects.equals(crontabExpression, that.crontabExpression);
     }
 
     @Override

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/ScheduleInfoRequest.java
@@ -83,16 +83,16 @@ public class ScheduleInfoRequest {
             return false;
         }
         ScheduleInfoRequest that = (ScheduleInfoRequest) o;
-        return Objects.equals(id, that.id) && Objects.equals(inlongGroupId, that.inlongGroupId)
-                && Objects.equals(scheduleType, that.scheduleType) && Objects.equals(scheduleUnit,
-                        that.scheduleUnit)
+        return Objects.equals(inlongGroupId, that.inlongGroupId)
+                && Objects.equals(scheduleType, that.scheduleType)
+                && Objects.equals(scheduleUnit, that.scheduleUnit)
                 && Objects.equals(scheduleInterval, that.scheduleInterval)
-                && Objects.equals(startTime, that.startTime) && Objects.equals(endTime, that.endTime)
-                && Objects.equals(delayTime, that.delayTime) && Objects.equals(selfDepend,
-                        that.selfDepend)
+                && Objects.equals(startTime, that.startTime)
+                && Objects.equals(endTime, that.endTime)
+                && Objects.equals(delayTime, that.delayTime)
+                && Objects.equals(selfDepend, that.selfDepend)
                 && Objects.equals(taskParallelism, that.taskParallelism)
-                && Objects.equals(crontabExpression, that.crontabExpression) && Objects.equals(version,
-                        that.version);
+                && Objects.equals(crontabExpression, that.crontabExpression);
     }
 
     @Override

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/NoopScheduleClient.java
@@ -26,7 +26,7 @@ public class NoopScheduleClient implements ScheduleEngineClient {
 
     @Override
     public boolean accept(String engineType) {
-        return ScheduleEngineType.NONE.getType().equals(engineType);
+        return ScheduleEngineType.NONE.getType().equalsIgnoreCase(engineType);
     }
 
     @Override

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
@@ -218,4 +218,11 @@ public interface InlongGroupService {
      */
     List<GroupFullInfo> getGroupByBackUpClusterTag(String clusterTag);
 
+    /**
+     * Submitting offline job for the given group.
+     * @param groupId the inlong group to submit offline job
+     *
+     * */
+    Boolean submitOfflineJob(String groupId);
+
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -931,4 +931,22 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         return groupInfoList;
     }
 
+    @Override
+    public Boolean submitOfflineJob(String groupId) {
+        // 1. get stream info list
+        InlongGroupInfo groupInfo = get(groupId);
+        if (groupInfo == null) {
+            String msg = String.format("InLong group not found for groupId=%s", groupId);
+            LOGGER.error(msg);
+            throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
+        }
+
+        List<InlongStreamInfo> streamInfoList = streamService.list(groupId);
+        if (CollectionUtils.isEmpty(streamInfoList)) {
+            LOGGER.warn("No stream info found for group {}, skip submit offline job", groupId);
+            return false;
+        }
+        return scheduleOperator.submitOfflineJob(groupId, streamInfoList);
+    }
+
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -936,7 +936,7 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         // 1. get stream info list
         InlongGroupInfo groupInfo = get(groupId);
         if (groupInfo == null) {
-            String msg = String.format("InLong group not found for groupId=%s", groupId);
+            String msg = String.format("InLong group not found for group=%s", groupId);
             LOGGER.error(msg);
             throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND);
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -137,7 +137,7 @@ public class SortConfigListener implements SortOperateListener {
                 }
             }
         } catch (Exception e) {
-            String msg = String.format("failed to build sort config for groupId=%s, ", groupId);
+            String msg = String.format("Failed to build sort config for group=%s, ", groupId);
             LOGGER.error("{} streamInfos={}", msg, streamInfos, e);
             throw new WorkflowListenerException(msg + e.getMessage());
         }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/sort/SortConfigListener.java
@@ -125,12 +125,6 @@ public class SortConfigListener implements SortOperateListener {
 
         try {
             for (InlongStreamInfo streamInfo : streamInfos) {
-                // do not build sort config if the group mode is offline
-                if (InlongConstants.DATASYNC_OFFLINE_MODE.equals(groupInfo.getInlongGroupMode())) {
-                    LOGGER.info("no need to build sort config for groupId={} streamId={} as the mode is offline",
-                            groupId, streamInfo.getInlongStreamId());
-                    continue;
-                }
                 List<StreamSink> sinkList = streamInfo.getSinkList();
                 if (CollectionUtils.isEmpty(sinkList)) {
                     continue;
@@ -144,7 +138,7 @@ public class SortConfigListener implements SortOperateListener {
             }
         } catch (Exception e) {
             String msg = String.format("failed to build sort config for groupId=%s, ", groupId);
-            LOGGER.error(msg + "streamInfos=" + streamInfos, e);
+            LOGGER.error("{} streamInfos={}", msg, streamInfos, e);
             throw new WorkflowListenerException(msg + e.getMessage());
         }
 

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/OfflineJobOperatorFactory.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/OfflineJobOperatorFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.schedule;
+
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+import org.apache.inlong.manager.workflow.processor.OfflineJobOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OfflineJobOperatorFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(OfflineJobOperatorFactory.class);
+    public static final String DEFAULT_OPERATOR_CLASS_NAME =
+            "org.apache.inlong.manager.plugin.offline.FlinkOfflineJobOperator";
+
+    public static OfflineJobOperator getOfflineJobOperator() {
+        return getOfflineJobOperator(DEFAULT_OPERATOR_CLASS_NAME);
+    }
+
+    public static OfflineJobOperator getOfflineJobOperator(String operatorClassName) {
+        return getOfflineJobOperator(operatorClassName, Thread.currentThread().getContextClassLoader());
+    }
+
+    public static OfflineJobOperator getOfflineJobOperator(String operatorClassName, ClassLoader classLoader) {
+        try {
+            Class<?> operatorClass = classLoader.loadClass(operatorClassName);
+            Object operator = operatorClass.getDeclaredConstructor().newInstance();
+            return (OfflineJobOperator) operator;
+        } catch (Throwable e) {
+            log.error("Failed to get offline job operator: ", e);
+            throw new BusinessException("Failed to get offline job operator: " + e.getMessage());
+        }
+    }
+
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
@@ -19,6 +19,9 @@ package org.apache.inlong.manager.service.schedule;
 
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+
+import java.util.List;
 
 /**
  * Operator for schedule. Including:
@@ -92,4 +95,12 @@ public interface ScheduleOperator {
      * @Return whether succeed
      * */
     Boolean handleGroupApprove(String groupId);
+
+    /**
+     * Start offline sync job when the schedule instance callback.
+     * @param groupId groupId to start offline job
+     * @param streamInfoList stream list to start offline job
+     * @Return whether succeed
+     * */
+    Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList);
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -80,7 +80,7 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
         String groupId = scheduleInfo.getInlongGroupId();
         InlongGroupExtEntity scheduleStatusExt =
                 groupExtMapper.selectByUniqueKey(groupId, InlongConstants.REGISTER_SCHEDULE_STATUS);
-        if (InlongConstants.REGISTERED.equalsIgnoreCase(scheduleStatusExt.getKeyValue())) {
+        if (scheduleStatusExt != null && InlongConstants.REGISTERED.equalsIgnoreCase(scheduleStatusExt.getKeyValue())) {
             // change schedule state to approved
             scheduleService.updateStatus(scheduleInfo.getInlongGroupId(), APPROVED, operator);
             registerToScheduleEngine(scheduleInfo, operator, false);
@@ -129,8 +129,10 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     @Override
     @Transactional(rollbackFor = Throwable.class)
     public Boolean updateAndRegister(ScheduleInfoRequest request, String operator) {
-        updateOpt(request, operator);
-        return registerToScheduleEngine(CommonBeanUtils.copyProperties(request, ScheduleInfo::new), operator, true);
+        if (updateOpt(request, operator)) {
+            return registerToScheduleEngine(CommonBeanUtils.copyProperties(request, ScheduleInfo::new), operator, true);
+        }
+        return false;
     }
 
     /**

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -56,7 +56,6 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     @Autowired
     private ScheduleClientFactory scheduleClientFactory;
 
-    @Autowired
     private OfflineJobOperator offlineJobOperator;
 
     private ScheduleEngineClient scheduleEngineClient;
@@ -181,6 +180,9 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
 
     @Override
     public Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList) {
+        if (offlineJobOperator == null) {
+            offlineJobOperator = OfflineJobOperatorFactory.getOfflineJobOperator();
+        }
         try {
             offlineJobOperator.submitOfflineJob(groupId, streamInfoList);
             LOGGER.info("Submit offline job for group {} and stream list {} success.", groupId,

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -255,8 +255,7 @@ public class InlongGroupController {
     @RequestMapping(value = "/group/submitOfflineJob/{groupId}", method = RequestMethod.POST)
     @ApiOperation(value = "Submitting inlong offline job process")
     @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    public Response<WorkflowResult> submitOfflineJob(@PathVariable String groupId) {
-        String operator = LoginUserUtils.getLoginUser().getName();
-        return Response.success(groupProcessOperation.restartProcess(groupId, operator));
+    public Response<Boolean> submitOfflineJob(@PathVariable String groupId) {
+        return Response.success(groupService.submitOfflineJob(groupId));
     }
 }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -252,4 +252,11 @@ public class InlongGroupController {
         return Response.success(groupService.finishTagSwitch(groupId));
     }
 
+    @RequestMapping(value = "/group/submitOfflineJob/{groupId}", method = RequestMethod.POST)
+    @ApiOperation(value = "Submitting inlong offline job process")
+    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
+    public Response<WorkflowResult> submitOfflineJob(@PathVariable String groupId) {
+        String operator = LoginUserUtils.getLoginUser().getName();
+        return Response.success(groupProcessOperation.restartProcess(groupId, operator));
+    }
 }

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -66,7 +66,3 @@ audit.user.ids=3,4,5,6
 
 # tencent cloud log service endpoint, The Operator cls resource by it
 cls.manager.endpoint=127.0.0.1
-
-# schedule engine type
-# support none(no scheduler) and quartz(quartz scheduler), default is none
-inlong.schedule.engine=none

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/processor/OfflineJobOperator.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/processor/OfflineJobOperator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.workflow.processor;
+
+import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
+
+import java.util.List;
+
+public interface OfflineJobOperator {
+
+    void submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList) throws Exception;
+}


### PR DESCRIPTION
Fixes #10459 

### Motivation

Support submitting Flink batch job when the scheduling instance callback.

Details see descriptions in #10459 

### Modifications

1. make sure `StartupSortListener` only take effect in real time sync workflow 
2. add `OfflineOperator` interface and `FlinkOfflineOperator`  to handle the submitting of flink batch job
3. add interface to `InLongGroupController` to receive the callback of schedule instance
4. improve update logic for schedule info
5. other tiny improvements in `NoopScheduleClient` and `application.properties`

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)

