### PR TITLE
[INLONG-10516][Manager] Add flink 1.15 jdbc connectors to manager image

### DIFF
--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -47,10 +47,19 @@ RUN wget -P lib/ ${default_jdbc_connector_url}
 # add sort resource
 ADD target/sort-dist-${VERSION}.jar /opt/inlong-sort/
 RUN wget -P /opt/inlong-sort/connectors/ ${default_jdbc_connector_url}
-ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-kafka-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-mysql-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-hbase-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-hudi-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-iceberg-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-jdbc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-kafka-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-mongodb-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-mysql-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-postgres-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-redis-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-sqlserver-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+
+
 # audit
 ENV AUDIT_QUERY_URL=127.0.0.1:10080
 ADD manager-docker.sh bin/

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -59,6 +59,7 @@ ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connector
 ADD target/sort-connector-redis-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-sqlserver-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-starrocks-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-tubemq-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 
 
 # audit

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -58,6 +58,7 @@ ADD target/sort-connector-postgres-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/con
 ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-redis-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-sqlserver-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-starrocks-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 
 
 # audit

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -50,6 +50,7 @@ RUN wget -P /opt/inlong-sort/connectors/ ${default_jdbc_connector_url}
 ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-kafka-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-mysql-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-jdbc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 # audit
 ENV AUDIT_QUERY_URL=127.0.0.1:10080
 ADD manager-docker.sh bin/

--- a/inlong-manager/manager-docker/Dockerfile
+++ b/inlong-manager/manager-docker/Dockerfile
@@ -47,21 +47,10 @@ RUN wget -P lib/ ${default_jdbc_connector_url}
 # add sort resource
 ADD target/sort-dist-${VERSION}.jar /opt/inlong-sort/
 RUN wget -P /opt/inlong-sort/connectors/ ${default_jdbc_connector_url}
-ADD target/sort-connector-hbase-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-hudi-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-iceberg-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-jdbc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-kafka-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-mongodb-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-mysql-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-postgres-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 ADD target/sort-connector-pulsar-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-redis-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-sqlserver-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-starrocks-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-ADD target/sort-connector-tubemq-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
-
-
+ADD target/sort-connector-kafka-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-mysql-cdc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
+ADD target/sort-connector-jdbc-v1.15-${VERSION}.jar /opt/inlong-sort/connectors/
 # audit
 ENV AUDIT_QUERY_URL=127.0.0.1:10080
 ADD manager-docker.sh bin/

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -54,7 +54,22 @@
         <!-- copy sort-connectors to the manager-docker/target path -->
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-pulsar-v1.15</artifactId>
+            <artifactId>sort-connector-hbase-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-hudi-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-iceberg-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-jdbc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
@@ -64,12 +79,27 @@
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-mysql-cdc-v1.15</artifactId>
+            <artifactId>sort-connector-mongodb-cdc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-jdbc-v1.15</artifactId>
+            <artifactId>sort-connector-postgres-cdc-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-pulsar-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-redis-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-sqlserver-cdc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -107,6 +107,11 @@
             <artifactId>sort-connector-starrocks-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-tubemq-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -165,7 +170,8 @@
                                         sort-connector-kafka-v1.15,sort-connector-mongodb-cdc-v1.15,
                                         sort-connector-mysql-cdc-v1.15,sort-connector-postgres-cdc-v1.15,
                                         sort-connector-pulsar-v1.15,sort-connector-redis-v1.15,
-                                        sort-connector-sqlserver-cdc-v1.15,sort-connector-starrocks-v1.15</includeArtifactIds>
+                                        sort-connector-sqlserver-cdc-v1.15,sort-connector-starrocks-v1.15，
+                                        sort-connector-tubemq-v1.15</includeArtifactIds>
                                     <excludeTransitive>true</excludeTransitive>
                                 </configuration>
                             </execution>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -54,22 +54,7 @@
         <!-- copy sort-connectors to the manager-docker/target path -->
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-hbase-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-hudi-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-iceberg-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-jdbc-v1.15</artifactId>
+            <artifactId>sort-connector-pulsar-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
@@ -79,37 +64,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-mongodb-cdc-v1.15</artifactId>
+            <artifactId>sort-connector-mysql-cdc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-postgres-cdc-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-pulsar-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-redis-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-sqlserver-cdc-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-starrocks-v1.15</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.inlong</groupId>
-            <artifactId>sort-connector-tubemq-v1.15</artifactId>
+            <artifactId>sort-connector-jdbc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
     </dependencies>
@@ -165,13 +125,8 @@
                                 <configuration>
                                     <outputDirectory>target/</outputDirectory>
                                     <includeArtifactIds>manager-web,
-                                        sort-dist,sort-connector-hbase-v1.15,sort-connector-hudi-v1.15,
-                                        sort-connector-iceberg-v1.15,sort-connector-jdbc-v1.15,
-                                        sort-connector-kafka-v1.15,sort-connector-mongodb-cdc-v1.15,
-                                        sort-connector-mysql-cdc-v1.15,sort-connector-postgres-cdc-v1.15,
-                                        sort-connector-pulsar-v1.15,sort-connector-redis-v1.15,
-                                        sort-connector-sqlserver-cdc-v1.15,sort-connector-starrocks-v1.15，
-                                        sort-connector-tubemq-v1.15</includeArtifactIds>
+                                        sort-dist,sort-connector-pulsar-v1.15,sort-connector-kafka-v1.15,
+                                        sort-connector-mysql-cdc-v1.15,sort-connector-jdbc-v1.15</includeArtifactIds>
                                     <excludeTransitive>true</excludeTransitive>
                                 </configuration>
                             </execution>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -102,6 +102,11 @@
             <artifactId>sort-connector-sqlserver-cdc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-starrocks-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -155,8 +160,12 @@
                                 <configuration>
                                     <outputDirectory>target/</outputDirectory>
                                     <includeArtifactIds>manager-web,
-                                        sort-dist,sort-connector-pulsar-v1.15,sort-connector-kafka-v1.15,
-                                        sort-connector-mysql-cdc-v1.15,sort-connector-jdbc-v1.15</includeArtifactIds>
+                                        sort-dist,sort-connector-hbase-v1.15,sort-connector-hudi-v1.15,
+                                        sort-connector-iceberg-v1.15,sort-connector-jdbc-v1.15,
+                                        sort-connector-kafka-v1.15,sort-connector-mongodb-cdc-v1.15,
+                                        sort-connector-mysql-cdc-v1.15,sort-connector-postgres-cdc-v1.15,
+                                        sort-connector-pulsar-v1.15,sort-connector-redis-v1.15,
+                                        sort-connector-sqlserver-cdc-v1.15,sort-connector-starrocks-v1.15</includeArtifactIds>
                                     <excludeTransitive>true</excludeTransitive>
                                 </configuration>
                             </execution>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -67,6 +67,11 @@
             <artifactId>sort-connector-mysql-cdc-v1.15</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-jdbc-v1.15</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
     </dependencies>
 
     <profiles>
@@ -121,7 +126,7 @@
                                     <outputDirectory>target/</outputDirectory>
                                     <includeArtifactIds>manager-web,
                                         sort-dist,sort-connector-pulsar-v1.15,sort-connector-kafka-v1.15,
-                                        sort-connector-mysql-cdc-v1.15</includeArtifactIds>
+                                        sort-connector-mysql-cdc-v1.15,sort-connector-jdbc-v1.15</includeArtifactIds>
                                     <excludeTransitive>true</excludeTransitive>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
### [INLONG-10516][Manager] Add flink 1.15 jdbc connectors to manager image

Fixes #10516 

### Motivation

The Jdbc module was not package in sort-flink1.15, and the Jdbc module was developed. So, The projects need to add it to pom.xml.

### Modifications

The dockerfile and pom.xml
