### PR TITLE
[INLONG-10531][SDK] Add InLong dataproxy python SDK based on C++ SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+cmake_minimum_required(VERSION 3.5)
+project(dataproxy-sdk-python)
+
+set(CMAKE_CXX_STANDARD 11)
+
+include_directories("./dataproxy-sdk-cpp/src/core")
+
+include_directories("./dataproxy-sdk-cpp/third_party/lib")
+include_directories("./dataproxy-sdk-cpp/third_party/lib64")
+
+add_subdirectory(pybind11)
+add_subdirectory(dataproxy-sdk-cpp)
+
+link_directories("./dataproxy-sdk-cpp/third_party/lib")
+link_directories("./dataproxy-sdk-cpp/third_party/lib64")
+
+pybind11_add_module(inlong_dataproxy inlong_dataproxy.cpp)
+
+target_link_libraries(inlong_dataproxy PRIVATE pybind11::module dataproxy_sdk)

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
@@ -1,0 +1,41 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# DataProxy-SDK-Python
+Dataproxy-SDK Python version, used for sending data to InLong dataproxy.
+
+InLong Dataproxy Python SDK is a wrapper over the existing [C++ SDK](https://github.com/apache/inlong/tree/master/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp) and exposes all of the same features.
+
+## Prerequisites
+- CMake 3.5+
+- Python 3.6+
+
+## Build
+Go to the dataproxy-sdk-python root directory, and run
+
+```bash
+chmod +x ./build.sh
+./build.sh
+```
+
+After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
+
+> **Note**: When the C++ SDK or the version of Python you're using is updated, you'll need to rebuild it by re-executing the `build.sh` script

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Initialize the configuration files of inlong components
+#
+
+# Check CMake version
+CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d " " -f 3)
+CMAKE_REQUIRED="3.5"
+if [ "$(printf '%s\n' "$CMAKE_REQUIRED" "$CMAKE_VERSION" | sort -V | head -n1)" != "$CMAKE_REQUIRED" ]; then
+    echo "CMake version must be greater than or equal to $CMAKE_REQUIRED"
+    exit 1
+fi
+
+# Check Python version
+PYTHON_VERSION=$(python --version 2>&1 | cut -d " " -f 2)
+PYTHON_REQUIRED="3.6"
+if [ "$(printf '%s\n' "$PYTHON_REQUIRED" "$PYTHON_VERSION" | sort -V | head -n1)" != "$PYTHON_REQUIRED" ]; then
+    echo "Python version must be greater than or equal to $PYTHON_REQUIRED"
+    exit 1
+fi
+
+# Clone and build pybind11
+git clone https://github.com/pybind/pybind11.git
+cd pybind11
+mkdir build
+cd build
+cmake ..
+cmake --build . --config Release --target check
+make check -j 4
+cd ../..
+
+# Clone and build dataproxy-sdk-cpp
+git clone https://github.com/apache/inlong.git
+mv ./inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp ./
+rm -r ./inlong
+cd ./dataproxy-sdk-cpp
+chmod +x ./build.sh
+./build.sh
+cd ..
+
+# Build Python SDK
+if [ -d "./build" ]; then
+    rm -r ./build
+fi
+mkdir build
+cd build
+cmake ..
+make
+cd ..
+
+# Get Python site-packages directory
+SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
+
+# Copy generated .so file to site-packages directory
+find ./build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $SITE_PACKAGES_DIR {}
+
+# Clean
+rm -r ./pybind11
+rm -r ./dataproxy-sdk-cpp

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -18,6 +18,8 @@
 
 #!/bin/bash
 
+BASE_DIR=$(pwd)
+
 # Check CMake version
 CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d " " -f 3)
 CMAKE_REQUIRED="3.5"
@@ -37,12 +39,11 @@ fi
 # Clone and build pybind11
 git clone https://github.com/pybind/pybind11.git
 cd pybind11
-mkdir build
-cd build
+mkdir build && cd build
 cmake ..
 cmake --build . --config Release --target check
 make check -j 4
-cd ../..
+cd $BASE_DIR
 
 # Clone and build dataproxy-sdk-cpp
 git clone https://github.com/apache/inlong.git
@@ -51,17 +52,16 @@ rm -r ./inlong
 cd ./dataproxy-sdk-cpp
 chmod +x ./build.sh
 ./build.sh
-cd ..
+cd $BASE_DIR
 
 # Build Python SDK
 if [ -d "./build" ]; then
     rm -r ./build
 fi
-mkdir build
-cd build
+mkdir build && cd build
 cmake ..
 make
-cd ..
+cd $BASE_DIR
 
 # Get Python site-packages directory
 SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
@@ -70,5 +70,4 @@ SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
 find ./build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $SITE_PACKAGES_DIR {}
 
 # Clean
-rm -r ./pybind11
-rm -r ./dataproxy-sdk-cpp
+rm -r ./pybind11 ./dataproxy-sdk-cpp

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +15,8 @@
 # limitations under the License.
 # Initialize the configuration files of inlong components
 #
+
+#!/bin/bash
 
 # Check CMake version
 CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d " " -f 3)

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/inlong_dataproxy.cpp
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/inlong_dataproxy.cpp
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <inlong_api.h>
+
+namespace py = pybind11;
+using namespace inlong;
+
+class PyInLongApi : public InLongApi {
+public:
+    int32_t PySend(const char *inlong_group_id, const char *inlong_stream_id, const char *msg, int32_t msg_len, py::function callback_func) {
+        if (callback_func) {
+            py_callback = callback_func;
+            return Send(inlong_group_id, inlong_stream_id, msg, msg_len, &PyInLongApi::CallbackFunc);
+        } else {
+            return Send(inlong_group_id, inlong_stream_id, msg, msg_len, nullptr);
+        }
+    }
+
+private:
+    static py::function py_callback;
+
+    static int CallbackFunc(const char *a, const char *b, const char *c, int32_t d, const int64_t e, const char *f) {
+        return py_callback(a, b, c, d, e, f).cast<int>();
+    }
+};
+
+py::function PyInLongApi::py_callback;
+
+PYBIND11_MODULE(inlong_dataproxy, m) {
+    m.doc() = "This module provides InLong dataproxy api to send message to InLong dataproxy.";
+
+    py::class_<PyInLongApi>(m, "InLongApi")
+        .def(py::init<>())
+        .def("init_api", &PyInLongApi::InitApi, py::arg("config_path"))
+        .def("add_bid", &PyInLongApi::AddBid, py::arg("group_ids"))
+        .def("send", &PyInLongApi::PySend, py::arg("inlong_group_id"), py::arg("inlong_stream_id"), py::arg("msg"), py::arg("msg_len"), py::arg("callback_func") = nullptr)
+        .def("close_api", &PyInLongApi::CloseApi, py::arg("max_waitms"));
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10531 

### Motivation

InLong dataproxy SDK now supports Java, C++ and Go, We want to extend the language scope so that python developers can use the InLong dataproxy SDK in their projects.

### Modifications

1. Use pybind11 to wrap the existing C++ SDK to create a python module
2. Provide a build srcipt for developers to install this module easily.
The overview of build procedure is as follows:
![image](https://github.com/apache/inlong/assets/61183968/b57aecfa-0f11-4f5a-bf8b-28a019277d3c)

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs