### PR TITLE
[INLONG-10357][Sort] Make StarRocks sink support report audit information exactly once

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
@@ -18,7 +18,7 @@
 package org.apache.inlong.sort.starrocks.table.sink.table;
 
 import org.apache.inlong.sort.base.metric.MetricOption;
-import org.apache.inlong.sort.base.metric.SinkMetricData;
+import org.apache.inlong.sort.base.metric.SinkExactlyMetric;
 import org.apache.inlong.sort.starrocks.table.sink.utils.SchemaUtils;
 
 import com.google.common.base.Strings;
@@ -70,6 +70,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+import static org.apache.inlong.sort.base.util.CalculateObjectSizeUtils.getDataSize;
+
 /**
  * StarRocks dynamic sink function. It supports insert, upsert, delete in Starrocks.
  * @param <T>
@@ -87,7 +89,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     private transient volatile ListState<StarrocksSnapshotState> snapshotStates;
     private final Map<Long, List<StreamLoadSnapshot>> snapshotMap = new ConcurrentHashMap<>();
-    private transient SinkMetricData sinkMetricData;
+    private transient SinkExactlyMetric sinkExactlyMetric;
 
     @Deprecated
     private transient ListState<Map<String, StarRocksSinkBufferEntity>> legacyState;
@@ -207,19 +209,18 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
         Object[] data = rowTransformer.transform(value, sinkOptions.supportUpsertDelete());
 
-        ouputMetrics(value, data);
-
         sinkManager.write(
                 null,
                 sinkOptions.getDatabaseName(),
                 sinkOptions.getTableName(),
                 serializer.serialize(schemaUtils.filterOutTimeField(data)));
 
+        ouputMetrics(value, data);
     }
 
     private void ouputMetrics(T value, Object[] data) {
-        if (sinkMetricData != null) {
-            sinkMetricData.invokeWithEstimate(value, schemaUtils.getDataTime(data));
+        if (sinkExactlyMetric != null) {
+            sinkExactlyMetric.invoke(1, getDataSize(value), schemaUtils.getDataTime(data));
         }
     }
 
@@ -237,7 +238,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                 .build();
 
         if (metricOption != null) {
-            sinkMetricData = new SinkMetricData(metricOption, getRuntimeContext().getMetricGroup());
+            sinkExactlyMetric = new SinkExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
         }
 
         notifyCheckpointComplete(Long.MAX_VALUE);
@@ -265,9 +266,8 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
+        updateCurrentCheckpointId(functionSnapshotContext.getCheckpointId());
         sinkManager.flush();
-
-        flushAudit();
 
         if (sinkOptions.getSemantic() != StarRocksSinkSemantic.EXACTLY_ONCE) {
             return;
@@ -287,12 +287,6 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
         if (legacyState != null) {
             legacyState.clear();
-        }
-    }
-
-    private void flushAudit() {
-        if (sinkMetricData != null) {
-            sinkMetricData.flushAuditData();
         }
     }
 
@@ -346,6 +340,10 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
+        if (checkpointId != Long.MAX_VALUE) {
+            flushAudit();
+            updateLastCheckpointId(checkpointId);
+        }
 
         boolean succeed = true;
 
@@ -393,6 +391,24 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
                     entity.getBuffer().size(), entity.getDatabase(), entity.getTable());
         }
         legacyData.clear();
+    }
+
+    private void flushAudit() {
+        if (sinkExactlyMetric != null) {
+            sinkExactlyMetric.flushAudit();
+        }
+    }
+
+    private void updateCurrentCheckpointId(long checkpointId) {
+        if (sinkExactlyMetric != null) {
+            sinkExactlyMetric.updateCurrentCheckpointId(checkpointId);
+        }
+    }
+
+    private void updateLastCheckpointId(long checkpointId) {
+        if (sinkExactlyMetric != null) {
+            sinkExactlyMetric.updateLastCheckpointId(checkpointId);
+        }
     }
 
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
@@ -241,7 +241,7 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
             sinkExactlyMetric = new SinkExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
         }
 
-        notifyCheckpointComplete(Long.MAX_VALUE);
+        commitTransaction(Long.MAX_VALUE);
         log.info("Open sink function v2. {}", EnvUtils.getGitInformation());
     }
 
@@ -340,11 +340,12 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
-        if (checkpointId != Long.MAX_VALUE) {
-            flushAudit();
-            updateLastCheckpointId(checkpointId);
-        }
+        flushAudit();
+        updateLastCheckpointId(checkpointId);
+        commitTransaction(checkpointId);
+    }
 
+    private void commitTransaction(long checkpointId) {
         boolean succeed = true;
 
         List<Long> commitCheckpointIds = snapshotMap.keySet().stream()

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/table/StarRocksDynamicSinkFunctionV2.java
@@ -340,9 +340,9 @@ public class StarRocksDynamicSinkFunctionV2<T> extends StarRocksDynamicSinkFunct
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) {
+        commitTransaction(checkpointId);
         flushAudit();
         updateLastCheckpointId(checkpointId);
-        commitTransaction(checkpointId);
     }
 
     private void commitTransaction(long checkpointId) {

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/utils/SchemaUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/src/main/java/org/apache/inlong/sort/starrocks/table/sink/utils/SchemaUtils.java
@@ -31,7 +31,7 @@ public class SchemaUtils implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final String AUDIT_DATA_TIME = "audit_data_time";
+    private final String AUDIT_DATA_TIME = "AUDIT_DATA_TIME";
     private final int DATA_TIME_ABSENT_INDEX = -1;
     private final int dataTimeFieldIndex;
 
@@ -73,7 +73,7 @@ public class SchemaUtils implements Serializable {
      */
     public String[] filterOutTimeField(TableSchema schema) {
         return Arrays.stream(schema.getFieldNames())
-                .filter(field -> !AUDIT_DATA_TIME.equals(field))
+                .filter(field -> !AUDIT_DATA_TIME.equalsIgnoreCase(field))
                 .toArray(String[]::new);
     }
 
@@ -84,7 +84,7 @@ public class SchemaUtils implements Serializable {
      */
     private int getDataTimeIndex(String[] fieldNames) {
         for (int i = 0; i < fieldNames.length; i++) {
-            if (AUDIT_DATA_TIME.equals(fieldNames[i])) {
+            if (AUDIT_DATA_TIME.equalsIgnoreCase(fieldNames[i])) {
                 return i;
             }
         }


### PR DESCRIPTION
### [INLONG-10357][Sort] Make StarRocks sink support report audit information exactly once

Fixes #10357 

### Modifications
1. Using the checkpoint principle in Flink to modify the process, the modified flow chart is shown in Figure 1 and Figure 2. In Figure 1, the callback method of notifyCompleteCheckpoint is used to upload audit information instead of scheduled upload.Each Source/Sink will save the checkpointId of the currently ongoing checkpoint, which is nowCheckpointId in the figure. When the audit information is written to the Buffer, nowCheckpointId will be attached, indicating that the audit information
is written during this ongoing checkpoint. The audit information and checkpointId are in a many-to-one relationship.

![image](https://github.com/apache/inlong/assets/58425449/2f09c6c6-e9c2-4383-bca7-965333ccab65)
When a snapshot request is received, the current operator's nowCheckpointId is updated to (snapshot) checkpointId + 1. When all operators in a task complete the snapshot, the notifyCompleteCheckpoint method is called back.

At this time, AuditBuffer uploads audit information less than or equal to checkpointId (parameters in the notifyCompleteCheckpoint method).

![image](https://github.com/apache/inlong/assets/58425449/33d2de48-df21-49ce-96c7-d044d25f37b0)

2. The getCurConsumedPartitions method gets the partitions assigned to the client by the tube server, including the partitions where the client has consumed data and the client has not consumed data. According to the previous logic, the offsets of the partitions that have not been consumed are not recorded. Here, the offsets of the partitions that have not been consumed are added.