### PR TITLE
[INLONG-10355][Sort] Make Iceberg source support report audit information exactly once

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/source/reader/IcebergSourceReader.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/source/reader/IcebergSourceReader.java
@@ -67,8 +67,15 @@ public class IcebergSourceReader<T>
     }
     @Override
     public List<IcebergSourceSplit> snapshotState(long checkpointId) {
-        metrics.flushAudit();
+        metrics.updateCurrentCheckpointId(checkpointId);
         return super.snapshotState(checkpointId);
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        super.notifyCheckpointComplete(checkpointId);
+        metrics.flushAudit();
+        metrics.updateLastCheckpointId(checkpointId);
     }
 
     @Override

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/source/reader/InlongIcebergSourceReaderMetrics.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/src/main/java/org/apache/inlong/sort/iceberg/source/reader/InlongIcebergSourceReaderMetrics.java
@@ -18,7 +18,7 @@
 package org.apache.inlong.sort.iceberg.source.reader;
 
 import org.apache.inlong.sort.base.metric.MetricOption;
-import org.apache.inlong.sort.base.metric.SourceMetricData;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
 import org.apache.inlong.sort.iceberg.utils.RecyclableJoinedRowData;
 
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 public class InlongIcebergSourceReaderMetrics<T> extends IcebergSourceReaderMetrics {
 
     private final MetricGroup metrics;
-    private SourceMetricData sourceMetricData;
+    private SourceExactlyMetric sourceExactlyMetric;
 
     public InlongIcebergSourceReaderMetrics(MetricGroup metrics, String fullTableName) {
         super(metrics, fullTableName);
@@ -44,20 +44,20 @@ public class InlongIcebergSourceReaderMetrics<T> extends IcebergSourceReaderMetr
 
     public void registerMetrics(MetricOption metricOption) {
         if (metricOption != null) {
-            sourceMetricData = new SourceMetricData(metricOption, metrics);
+            sourceExactlyMetric = new SourceExactlyMetric(metricOption, metrics);
         } else {
             log.warn("failed to init sourceMetricData since the metricOption is null");
         }
     }
 
     public void outputMetricsWithEstimate(ArrayBatchRecords<T> batchRecord) {
-        if (sourceMetricData != null) {
+        if (sourceExactlyMetric != null) {
             int dataCount = batchRecord.numberOfRecords();
             T[] records = batchRecord.records();
             for (int i = 0; i < dataCount; i++) {
                 long dataSize = getDataSize(records[i]);
                 long dataTime = getDataTime(records[i]);
-                sourceMetricData.outputMetrics(1, dataSize, dataTime);
+                sourceExactlyMetric.outputMetrics(1, dataSize, dataTime);
             }
 
         }
@@ -79,8 +79,20 @@ public class InlongIcebergSourceReaderMetrics<T> extends IcebergSourceReaderMetr
     }
 
     void flushAudit() {
-        if (sourceMetricData != null) {
-            sourceMetricData.flushAuditData();
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.flushAudit();
+        }
+    }
+
+    void updateCurrentCheckpointId(long checkpointId) {
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateCurrentCheckpointId(checkpointId);
+        }
+    }
+
+    void updateLastCheckpointId(long checkpointId) {
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateLastCheckpointId(checkpointId);
         }
     }
 }


### PR DESCRIPTION
### [INLONG-10355][Sort] Make Iceberg source support report audit information exactly once

Fixes #10355

### Modifications
1. Using the checkpoint principle in Flink to modify the process, the modified flow chart is shown in Figure 1 and Figure 2. In Figure 1, the callback method of notifyCompleteCheckpoint is used to upload audit information instead of scheduled upload.Each Source/Sink will save the checkpointId of the currently ongoing checkpoint, which is nowCheckpointId in the figure. When the audit information is written to the Buffer, nowCheckpointId will be attached, indicating that the audit information
is written during this ongoing checkpoint. The audit information and checkpointId are in a many-to-one relationship.

![image](https://github.com/apache/inlong/assets/58425449/2f09c6c6-e9c2-4383-bca7-965333ccab65)
When a snapshot request is received, the current operator's nowCheckpointId is updated to (snapshot) checkpointId + 1. When all operators in a task complete the snapshot, the notifyCompleteCheckpoint method is called back.

At this time, AuditBuffer uploads audit information less than or equal to checkpointId (parameters in the notifyCompleteCheckpoint method).

![image](https://github.com/apache/inlong/assets/58425449/33d2de48-df21-49ce-96c7-d044d25f37b0)

2. The getCurConsumedPartitions method gets the partitions assigned to the client by the tube server, including the partitions where the client has consumed data and the client has not consumed data. According to the previous logic, the offsets of the partitions that have not been consumed are not recorded. Here, the offsets of the partitions that have not been consumed are added.

