### PR TITLE
[INLONG-10561][Manager] Support configrations for bounded source

### DIFF
--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongGroupClient.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/inner/client/InlongGroupClient.java
@@ -36,6 +36,7 @@ import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupResetRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest;
+import org.apache.inlong.manager.pojo.schedule.OfflineJobSubmitRequest;
 import org.apache.inlong.manager.pojo.sort.SortStatusInfo;
 import org.apache.inlong.manager.pojo.sort.SortStatusRequest;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
@@ -320,8 +321,8 @@ public class InlongGroupClient {
         return response.getData();
     }
 
-    public Boolean submitOfflineJob(String groupId) {
-        Response<Boolean> responseBody = ClientUtils.executeHttpCall(inlongGroupApi.submitOfflineJob(groupId));
+    public Boolean submitOfflineJob(OfflineJobSubmitRequest request) {
+        Response<Boolean> responseBody = ClientUtils.executeHttpCall(inlongGroupApi.submitOfflineJob(request));
         ClientUtils.assertRespSuccess(responseBody);
         return responseBody.getData();
     }

--- a/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongGroupApi.java
+++ b/inlong-manager/manager-client/src/main/java/org/apache/inlong/manager/client/api/service/InlongGroupApi.java
@@ -26,6 +26,7 @@ import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupResetRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest;
+import org.apache.inlong.manager.pojo.schedule.OfflineJobSubmitRequest;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
 
 import retrofit2.Call;
@@ -99,6 +100,6 @@ public interface InlongGroupApi {
     @GET("group/switch/finish/{groupId}")
     Call<Response<Boolean>> finishTagSwitch(@Path("groupId") String groupId);
 
-    @POST("group/submitOfflineJob/{groupId}")
-    Call<Response<Boolean>> submitOfflineJob(@Path("groupId") String groupId);
+    @POST("group/submitOfflineJob")
+    Call<Response<Boolean>> submitOfflineJob(@Body OfflineJobSubmitRequest request);
 }

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/consts/InlongConstants.java
@@ -93,6 +93,10 @@ public class InlongConstants {
     public static final String RUNTIME_EXECUTION_MODE_STREAM = "stream";
     public static final String RUNTIME_EXECUTION_MODE_BATCH = "batch";
 
+    public static final String BOUNDARY_TYPE = "BOUNDARY_TYPE";
+    public static final String LOWER_BOUNDARY = "LOWER_BOUNDARY";
+    public static final String UPPER_BOUNDARY = "UPPER_BOUNDARY";
+
     public static final Integer DISABLE_ZK = 0;
     public static final Integer ENABLE_ZK = 1;
 

--- a/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
+++ b/inlong-manager/manager-common/src/main/java/org/apache/inlong/manager/common/enums/ErrorCodeEnum.java
@@ -130,6 +130,10 @@ public enum ErrorCodeEnum {
     SCHEDULE_ENGINE_NOT_SUPPORTED(1702, "Schedule engine type not supported"),
     SCHEDULE_STATUS_TRANSITION_NOT_ALLOWED(1703, "Schedule status transition is not allowed"),
 
+    BOUNDED_SOURCE_TYPE_NOT_SUPPORTED(1801, "Bounded source type %s not supported"),
+    BOUNDARY_TYPE_NOT_SUPPORTED(1802, "Boundary type %s not supported"),
+    BOUNDARIES_NOT_FOUND(1803, "Boundaries not found"),
+
     WORKFLOW_EXE_FAILED(4000, "Workflow execution exception"),
     WORKFLOW_APPROVER_NOT_FOUND(4001, "Workflow approver does not exist/no operation authority"),
     WORKFLOW_DELETE_RECORD_FAILED(4002, "Workflow delete record failure"),

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/FlinkService.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.plugin.flink;
 
+import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkConfig;
 import org.apache.inlong.manager.plugin.flink.dto.FlinkInfo;
@@ -258,8 +259,16 @@ public class FlinkService {
         list.add(flinkInfo.getLocalConfPath());
         list.add("-checkpoint.interval");
         list.add("60000");
-        list.add("-runtime.execution.mode");
-        list.add(flinkInfo.getRuntimeExecutionMode());
+        if (InlongConstants.RUNTIME_EXECUTION_MODE_BATCH.equalsIgnoreCase(flinkInfo.getRuntimeExecutionMode())) {
+            list.add("-runtime.execution.mode");
+            list.add(flinkInfo.getRuntimeExecutionMode());
+            list.add("-source.boundary.type");
+            list.add(flinkInfo.getBoundaryType());
+            list.add("-source.lower.boundary");
+            list.add(flinkInfo.getLowerBoundary());
+            list.add("-source.upper.boundary");
+            list.add(flinkInfo.getUpperBoundary());
+        }
         return list.toArray(new String[0]);
     }
 

--- a/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/dto/FlinkInfo.java
+++ b/inlong-manager/manager-plugins/base/src/main/java/org/apache/inlong/manager/plugin/flink/dto/FlinkInfo.java
@@ -54,4 +54,10 @@ public class FlinkInfo {
     private String exceptionMsg;
 
     private String runtimeExecutionMode;
+
+    private String boundaryType;
+
+    private String lowerBoundary;
+
+    private String upperBoundary;
 }

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/OfflineJobSubmitRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/schedule/OfflineJobSubmitRequest.java
@@ -15,24 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.manager.plugin.offline;
+package org.apache.inlong.manager.pojo.schedule;
 
-import org.apache.inlong.common.bounded.Boundaries;
-import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
-import org.apache.inlong.manager.workflow.processor.OfflineJobOperator;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
 
-import lombok.NoArgsConstructor;
+import javax.validation.constraints.NotNull;
 
-import java.util.List;
+@Data
+public class OfflineJobSubmitRequest {
 
-import static org.apache.inlong.manager.plugin.util.FlinkUtils.submitFlinkJobs;
+    @ApiModelProperty("Inlong Group ID")
+    @NotNull
+    private String groupId;
 
-@NoArgsConstructor
-public class FlinkOfflineJobOperator implements OfflineJobOperator {
+    @ApiModelProperty("Source boundary type, TIME and OFFSET are supported")
+    @NotNull
+    private String boundaryType;
 
-    @Override
-    public void submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList, Boundaries boundaries)
-            throws Exception {
-        submitFlinkJobs(groupId, streamInfoList, true, boundaries);
-    }
+    @ApiModelProperty("The lower bound for bounded source")
+    @NotNull
+    private String lowerBoundary;
+
+    @ApiModelProperty("The upper bound for bounded source")
+    @NotNull
+    private String upperBoundary;
 }

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/util/ScheduleUtils.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/util/ScheduleUtils.java
@@ -48,17 +48,20 @@ public class ScheduleUtils {
 
     public static final String MANAGER_HOST = "HOST";
     public static final String MANAGER_PORT = "PORT";
-    public static final String SECRETE_ID = "SECRETE_ID";
-    public static final String SECRETE_KEY = "SECRETE_KEY";
+    public static final String USERNAME = "USERNAME";
+    public static final String PASSWORD = "PASSWORD";
+    public static final String END_TIME = "END_TIME";
 
     public static JobDetail genQuartzJobDetail(ScheduleInfo scheduleInfo, Class<? extends Job> clz,
-            String host, Integer port, String secreteId, String secreteKey) {
+            String host, Integer port, String username, String password) {
+
         return JobBuilder.newJob(clz)
                 .withIdentity(scheduleInfo.getInlongGroupId())
                 .usingJobData(MANAGER_HOST, host)
                 .usingJobData(MANAGER_PORT, port)
-                .usingJobData(SECRETE_ID, secreteId)
-                .usingJobData(SECRETE_KEY, secreteKey)
+                .usingJobData(USERNAME, username)
+                .usingJobData(PASSWORD, password)
+                .usingJobData(END_TIME, scheduleInfo.getEndTime().getTime())
                 .build();
     }
 

--- a/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/BaseScheduleTest.java
+++ b/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/BaseScheduleTest.java
@@ -22,6 +22,7 @@ import org.apache.inlong.manager.schedule.exception.QuartzScheduleException;
 
 import java.sql.Timestamp;
 
+import static org.apache.inlong.manager.schedule.ScheduleUnit.ONE_ROUND;
 import static org.apache.inlong.manager.schedule.ScheduleUnit.SECOND;
 
 public class BaseScheduleTest {
@@ -40,6 +41,10 @@ public class BaseScheduleTest {
 
     public ScheduleInfo genDefaultScheduleInfo() {
         return genNormalScheduleInfo(GROUP_ID, SECOND.getUnit(), DEFAULT_INTERVAL, DEFAULT_SPAN_IN_MS);
+    }
+
+    public ScheduleInfo genOneroundScheduleInfo() {
+        return genNormalScheduleInfo(GROUP_ID, ONE_ROUND.getUnit(), DEFAULT_INTERVAL, DEFAULT_SPAN_IN_MS);
     }
 
     public ScheduleInfo genNormalScheduleInfo(String groupId, String scheduleUnit, int scheduleInterval,

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupService.java
@@ -29,6 +29,7 @@ import org.apache.inlong.manager.pojo.group.InlongGroupPageRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest;
+import org.apache.inlong.manager.pojo.schedule.OfflineJobSubmitRequest;
 import org.apache.inlong.manager.pojo.user.UserInfo;
 
 import javax.validation.Valid;
@@ -219,10 +220,10 @@ public interface InlongGroupService {
     List<GroupFullInfo> getGroupByBackUpClusterTag(String clusterTag);
 
     /**
-     * Submitting offline job for the given group.
-     * @param groupId the inlong group to submit offline job
+     * Submitting offline job.
+     * @param request request to submit offline sync job
      *
      * */
-    Boolean submitOfflineJob(String groupId);
+    Boolean submitOfflineJob(OfflineJobSubmitRequest request);
 
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperator.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.service.schedule;
 
+import org.apache.inlong.common.bounded.Boundaries;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfo;
 import org.apache.inlong.manager.pojo.schedule.ScheduleInfoRequest;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
@@ -100,7 +101,8 @@ public interface ScheduleOperator {
      * Start offline sync job when the schedule instance callback.
      * @param groupId groupId to start offline job
      * @param streamInfoList stream list to start offline job
+     * @param boundaries source boundaries for bounded source
      * @Return whether succeed
      * */
-    Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList);
+    Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList, Boundaries boundaries);
 }

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/schedule/ScheduleOperatorImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.manager.service.schedule;
 
+import org.apache.inlong.common.bounded.Boundaries;
 import org.apache.inlong.manager.common.consts.InlongConstants;
 import org.apache.inlong.manager.common.exceptions.BusinessException;
 import org.apache.inlong.manager.common.util.CommonBeanUtils;
@@ -178,12 +179,12 @@ public class ScheduleOperatorImpl implements ScheduleOperator {
     }
 
     @Override
-    public Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList) {
+    public Boolean submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList, Boundaries boundaries) {
         if (offlineJobOperator == null) {
             offlineJobOperator = OfflineJobOperatorFactory.getOfflineJobOperator();
         }
         try {
-            offlineJobOperator.submitOfflineJob(groupId, streamInfoList);
+            offlineJobOperator.submitOfflineJob(groupId, streamInfoList, boundaries);
             LOGGER.info("Submit offline job for group {} and stream list {} success.", groupId,
                     streamInfoList.stream().map(InlongStreamInfo::getName).collect(Collectors.toList()));
         } catch (Exception e) {

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/bounded/BoundedSourceType.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/bounded/BoundedSourceType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.service.source.bounded;
+
+import org.apache.inlong.manager.common.enums.ErrorCodeEnum;
+import org.apache.inlong.manager.common.exceptions.BusinessException;
+
+import lombok.Getter;
+
+@Getter
+public enum BoundedSourceType {
+
+    PULSAR("pulsar");
+
+    private final String sourceType;
+
+    BoundedSourceType(String name) {
+        this.sourceType = name;
+    }
+
+    public static BoundedSourceType getInstance(String name) {
+        for (BoundedSourceType source : values()) {
+            if (source.getSourceType().equalsIgnoreCase(name)) {
+                return source;
+            }
+        }
+        throw new BusinessException(ErrorCodeEnum.BOUNDED_SOURCE_TYPE_NOT_SUPPORTED,
+                String.format(ErrorCodeEnum.BOUNDED_SOURCE_TYPE_NOT_SUPPORTED.getMessage(), name));
+    }
+
+    public static boolean isBoundedSource(String name) {
+        for (BoundedSourceType source : values()) {
+            if (source.getSourceType().equalsIgnoreCase(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongGroupController.java
@@ -33,6 +33,7 @@ import org.apache.inlong.manager.pojo.group.InlongGroupRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupResetRequest;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicInfo;
 import org.apache.inlong.manager.pojo.group.InlongGroupTopicRequest;
+import org.apache.inlong.manager.pojo.schedule.OfflineJobSubmitRequest;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
 import org.apache.inlong.manager.pojo.workflow.WorkflowResult;
 import org.apache.inlong.manager.service.group.InlongGroupProcessService;
@@ -43,6 +44,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -65,6 +68,7 @@ import java.util.Map;
 @Api(tags = "Inlong-Group-API")
 public class InlongGroupController {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(InlongGroupController.class);
     @Autowired
     private InlongGroupService groupService;
     @Autowired
@@ -252,10 +256,10 @@ public class InlongGroupController {
         return Response.success(groupService.finishTagSwitch(groupId));
     }
 
-    @RequestMapping(value = "/group/submitOfflineJob/{groupId}", method = RequestMethod.POST)
+    @RequestMapping(value = "/group/submitOfflineJob", method = RequestMethod.POST)
     @ApiOperation(value = "Submitting inlong offline job process")
-    @ApiImplicitParam(name = "groupId", value = "Inlong group id", dataTypeClass = String.class)
-    public Response<Boolean> submitOfflineJob(@PathVariable String groupId) {
-        return Response.success(groupService.submitOfflineJob(groupId));
+    public Response<Boolean> submitOfflineJob(@RequestBody OfflineJobSubmitRequest request) {
+        LOGGER.info("Received offline job submit request {}", request);
+        return Response.success(groupService.submitOfflineJob(request));
     }
 }

--- a/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/processor/OfflineJobOperator.java
+++ b/inlong-manager/manager-workflow/src/main/java/org/apache/inlong/manager/workflow/processor/OfflineJobOperator.java
@@ -17,11 +17,13 @@
 
 package org.apache.inlong.manager.workflow.processor;
 
+import org.apache.inlong.common.bounded.Boundaries;
 import org.apache.inlong.manager.pojo.stream.InlongStreamInfo;
 
 import java.util.List;
 
 public interface OfflineJobOperator {
 
-    void submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList) throws Exception;
+    void submitOfflineJob(String groupId, List<InlongStreamInfo> streamInfoList, Boundaries boundaries)
+            throws Exception;
 }


### PR DESCRIPTION
Fixes #10561 

### Motivation

We already support bounded pulsar source in #10560, this pull request provides the ability to configure the boundaries from InLong-Manager.

### Modifications
1. modify the manager-client and InLong manager to support set boundaries for sources
2. built-in quartz schedule engine supports set boundaries for batch Flink job


### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (yes )
