### PR TITLE
[INLONG-10573][Sort] Make pulsar source connector report audit attach input time

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/PulsarTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/PulsarTableFactory.java
@@ -47,7 +47,6 @@ import java.util.stream.Stream;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_ADMIN_URL;
 import static org.apache.flink.connector.pulsar.common.config.PulsarOptions.PULSAR_SERVICE_URL;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
-import static org.apache.flink.table.factories.FactoryUtil.FORMAT;
 import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
 import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
 import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
@@ -104,7 +103,6 @@ public class PulsarTableFactory implements DynamicTableSourceFactory {
         final DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat =
                 getValueDecodingFormat(helper);
         ReadableConfig tableOptions = helper.getOptions();
-
 
         // Validate configs are not conflict; each options is consumed; no unwanted configs
         // PulsarOptions, PulsarSourceOptions and PulsarSinkOptions is not part of the validation.

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/PulsarTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/PulsarTableFactory.java
@@ -95,8 +95,6 @@ public class PulsarTableFactory implements DynamicTableSourceFactory {
 
     public static final boolean UPSERT_DISABLED = false;
 
-    public static boolean innerFormat = false;
-
     @Override
     public DynamicTableSource createDynamicTableSource(Context context) {
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
@@ -107,7 +105,6 @@ public class PulsarTableFactory implements DynamicTableSourceFactory {
                 getValueDecodingFormat(helper);
         ReadableConfig tableOptions = helper.getOptions();
 
-        innerFormat = ExtractNode.INLONG_MSG.equals(tableOptions.get(FORMAT));
 
         // Validate configs are not conflict; each options is consumed; no unwanted configs
         // PulsarOptions, PulsarSourceOptions and PulsarSinkOptions is not part of the validation.
@@ -160,7 +157,6 @@ public class PulsarTableFactory implements DynamicTableSourceFactory {
                         valueDecodingFormat,
                         valueProjection,
                         UPSERT_DISABLED,
-                        innerFormat,
                         inlongMetric,
                         auditHostAndPorts,
                         auditKeys);

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarReadableMetadata.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarReadableMetadata.java
@@ -17,14 +17,16 @@
 
 package org.apache.inlong.sort.pulsar.table;
 
-import org.apache.inlong.sort.protocol.node.ExtractNode;
-
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.Collector;
+import org.apache.inlong.sort.base.metric.MetricsCollector;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.pulsar.client.api.Message;
 
 import java.io.Serializable;
@@ -33,6 +35,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static org.apache.inlong.sort.pulsar.table.PulsarReadableMetadata.ReadableMetadata.CONSUME_TIME;
 
 /**
  * Class for reading metadata fields from a Pulsar message and put in corresponding Flink row
@@ -66,10 +70,16 @@ public class PulsarReadableMetadata implements Serializable {
     }
 
     public void appendProducedRowWithMetadata(
-            GenericRowData producedRowData, int physicalArity, Message<?> message) {
+            GenericRowData producedRowData, int physicalArity, Message<?> message, Collector<RowData> collector) {
         for (int metadataPos = 0; metadataPos < metadataConverters.size(); metadataPos++) {
+            Object metadata = metadataConverters.get(metadataPos).read(message);
             producedRowData.setField(
-                    physicalArity + metadataPos, metadataConverters.get(metadataPos).read(message));
+                    physicalArity + metadataPos, metadata);
+            if (CONSUME_TIME.key.equals(connectorMetadataKeys.get(metadataPos)) &&
+                    collector instanceof MetricsCollector) {
+                ((MetricsCollector<RowData>) collector).resetTimestamp((Long) metadata);
+            }
+
         }
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarReadableMetadata.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarReadableMetadata.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.sort.pulsar.table;
 
+import org.apache.inlong.sort.base.metric.MetricsCollector;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.GenericRowData;
@@ -25,8 +28,6 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Collector;
-import org.apache.inlong.sort.base.metric.MetricsCollector;
-import org.apache.inlong.sort.protocol.node.ExtractNode;
 import org.apache.pulsar.client.api.Message;
 
 import java.io.Serializable;

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarRowDataConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarRowDataConverter.java
@@ -25,6 +25,7 @@ import org.apache.flink.util.Collector;
 import org.apache.pulsar.client.api.Message;
 
 import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.util.List;
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarRowDataConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarRowDataConverter.java
@@ -25,7 +25,6 @@ import org.apache.flink.util.Collector;
 import org.apache.pulsar.client.api.Message;
 
 import javax.annotation.Nullable;
-
 import java.io.Serializable;
 import java.util.List;
 
@@ -122,7 +121,7 @@ public class PulsarRowDataConverter implements Serializable {
             producedRow.setField(keyProjection[keyPos], physicalKeyRow.getField(keyPos));
         }
 
-        readableMetadata.appendProducedRowWithMetadata(producedRow, physicalArity, message);
+        readableMetadata.appendProducedRowWithMetadata(producedRow, physicalArity, message, collector);
         collector.collect(producedRow);
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableDeserializationSchema.java
@@ -17,6 +17,10 @@
 
 package org.apache.inlong.sort.pulsar.table;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.MetricsCollector;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
+
 import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -24,12 +28,10 @@ import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
-import org.apache.inlong.sort.base.metric.MetricOption;
-import org.apache.inlong.sort.base.metric.MetricsCollector;
-import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
 import org.apache.pulsar.client.api.Message;
 
 import javax.annotation.Nullable;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableDeserializationSchemaFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/src/main/java/org/apache/inlong/sort/pulsar/table/PulsarTableDeserializationSchemaFactory.java
@@ -80,8 +80,6 @@ public class PulsarTableDeserializationSchemaFactory implements Serializable {
 
     private final int[] valueProjection;
 
-    private final boolean innerFormat;
-
     // --------------------------------------------------------------------------------------------
     // Mutable attributes. Will be updated after the applyReadableMetadata()
     // --------------------------------------------------------------------------------------------
@@ -103,7 +101,6 @@ public class PulsarTableDeserializationSchemaFactory implements Serializable {
             DecodingFormat<DeserializationSchema<RowData>> valueDecodingFormat,
             int[] valueProjection,
             boolean upsertMode,
-            boolean innerFormat,
             String inlongMetric,
             String auditHostAndPorts,
             String auditKeys) {
@@ -119,8 +116,6 @@ public class PulsarTableDeserializationSchemaFactory implements Serializable {
         this.producedDataType = physicalDataType;
         this.connectorMetadataKeys = Collections.emptyList();
         this.upsertMode = upsertMode;
-        this.innerFormat = innerFormat;
-
         this.inlongMetric = inlongMetric;
         this.auditHostAndPorts = auditHostAndPorts;
         this.auditKeys = auditKeys;
@@ -182,7 +177,6 @@ public class PulsarTableDeserializationSchemaFactory implements Serializable {
                 producedTypeInfo,
                 rowDataConverter,
                 upsertMode,
-                innerFormat,
                 metricOption);
     }
 


### PR DESCRIPTION
### [INLONG-10573][Sort] Make pulsar source connector report audit attach input time

Fixes #10573

### Motivation

Pulsar source connector not attach input time when send audit. It will due to the report audit time not same with input time

### Modifications

- Remove innerFormat field
- Make MetricCollector's timestamp as same as metadata timestamp

