### PR TITLE
[INLONG-10582][ASF] Disable merge and rebase merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -40,9 +40,9 @@ github:
     # enable squash button:
     squash:  true
     # disable merge button:
-    merge:   true
+    merge:   false
     # disable rebase button:
-    rebase:  true
+    rebase:  false
   # enable the dependabot_alerts
   dependabot_alerts: true
   # disable the dependabot_updates


### PR DESCRIPTION
Fixes #10582 

### Motivation
Since https://github.com/apache/inlong/pull/10579 merges the dev-offline-sync branch to master and we keep the whole commit history list, so https://github.com/apache/inlong/issues/10580 enables merge and rebase-merge.
Now https://github.com/apache/inlong/pull/10579 is closed so that we can change the merge behavior back.
### Modifications

Disable merge and rebase merge

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
