### PR TITLE
[INLONG-10584][Dashboard]  New cluster type adds sortkafka types

### DIFF
--- a/inlong-dashboard/src/plugins/clusters/defaults/SortKafka.ts
+++ b/inlong-dashboard/src/plugins/clusters/defaults/SortKafka.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DataWithBackend } from '@/plugins/DataWithBackend';
+import { RenderRow } from '@/plugins/RenderRow';
+import { RenderList } from '@/plugins/RenderList';
+import { ClusterInfo } from '../common/ClusterInfo';
+
+export default class SortCKafka
+  extends ClusterInfo
+  implements DataWithBackend, RenderRow, RenderList {}

--- a/inlong-dashboard/src/plugins/clusters/defaults/index.ts
+++ b/inlong-dashboard/src/plugins/clusters/defaults/index.ts
@@ -66,4 +66,9 @@ export const allDefaultClusters: MetaExportWithBackendList<ClusterMetaType> = [
     value: 'SORT_PULSAR',
     LoadEntity: () => import('./SortPulsar'),
   },
+  {
+    label: 'Sort Kafka',
+    value: 'SORT_KAFKA',
+    LoadEntity: () => import('./SortKafka'),
+  },
 ];


### PR DESCRIPTION
Fixes #10584 

### Motivation

 New cluster type adds sortkafka types

### Modifications

Added sortkafka type on the new cluster page

### Verifying this change

before
![image](https://github.com/apache/inlong/assets/165994047/32785a62-ad9c-4aed-83c6-cd9cc6d388f0)
after
![image](https://github.com/apache/inlong/assets/165994047/a33ba402-d408-418b-8daf-4e5ee1fa3905)

