### PR TITLE
[INLONG-10504][Dashboard] Added details button to tag management

### DIFF
--- a/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
+++ b/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
@@ -151,6 +151,11 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
         title: i18n.t('pages.Clusters.Type'),
         dataIndex: 'type',
         ellipsisMulti: 2,
+        render: (text, record) => (
+          <>
+            <div>{text.toLowerCase()}</div>
+          </>
+        ),
       },
       {
         title: i18n.t('basic.Creator'),

--- a/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
+++ b/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
@@ -27,6 +27,7 @@ import { clusters } from '@/plugins/clusters';
 import ClusterBindModal from './ClusterBindModal';
 import request from '@/core/utils/request';
 import { timestampFormat } from '@/core/utils';
+import CreateModal from '@/ui/pages/Clusters/CreateModal';
 
 export interface ClusterListProps {
   clusterTag: string;
@@ -106,7 +107,12 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
     },
     [clusterTag, getList],
   );
-
+  const [createModal, setCreateModal] = useState<Record<string, unknown>>({
+    open: false,
+  });
+  function onshowCluster(id, type) {
+    setCreateModal({ open: true, id: id, type: type });
+  }
   const onChange = ({ current: pageNum, pageSize }) => {
     setOptions(prev => ({
       ...prev,
@@ -181,6 +187,9 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
             <Button type="link" onClick={() => onDelete(record)}>
               {i18n.t('pages.ClusterTags.DelCluster')}
             </Button>
+            <Button type="link" onClick={() => onshowCluster(record.id, record.type)}>
+              {i18n.t('basic.Detail')}
+            </Button>
           </>
         ),
       } as any,
@@ -218,6 +227,16 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
           setClusterBindModal({ open: false });
         }}
         onCancel={() => setClusterBindModal({ open: false })}
+      />
+      <CreateModal
+        {...createModal}
+        defaultType={options.type}
+        open={createModal.open as boolean}
+        onOk={async () => {
+          await getList();
+          setCreateModal({ open: false });
+        }}
+        onCancel={() => setCreateModal({ open: false })}
       />
     </>
   );

--- a/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
+++ b/inlong-dashboard/src/ui/pages/ClusterTags/ClusterList.tsx
@@ -148,8 +148,8 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
         ellipsisMulti: 2,
       },
       {
-        title: i18n.t('pages.Clusters.Description'),
-        dataIndex: 'description',
+        title: i18n.t('pages.Clusters.Type'),
+        dataIndex: 'type',
         ellipsisMulti: 2,
       },
       {
@@ -180,14 +180,18 @@ const Comp: React.FC<ClusterListProps> = ({ clusterTag }) => {
       {
         title: i18n.t('basic.Operating'),
         dataIndex: 'action',
-        width: 200,
+        width: 150,
         render: (text, record) => (
           <>
             {/* <Button type="link">{i18n.t('basic.Detail')}</Button> */}
             <Button type="link" onClick={() => onDelete(record)}>
               {i18n.t('pages.ClusterTags.DelCluster')}
             </Button>
-            <Button type="link" onClick={() => onshowCluster(record.id, record.type)}>
+            <Button
+              style={{ marginLeft: '20px' }}
+              type="link"
+              onClick={() => onshowCluster(record.id, record.type)}
+            >
               {i18n.t('basic.Detail')}
             </Button>
           </>


### PR DESCRIPTION
Fixes #10504 

### Motivation

Added details button to tag management
### Modifications

Added details button to tag management

### Verifying this change
before
![image](https://github.com/apache/inlong/assets/165994047/b12811da-e898-4d6f-b73c-6784437b06ac)

after
![image](https://github.com/apache/inlong/assets/165994047/84cf3345-cb98-41b9-8b1e-a0110c6ff6c8)
