### PR TITLE
[INLONG-10592][Dashboard] When there are too many selections in the drop-down box, omit some of them

### DIFF
--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -920,5 +920,7 @@
   "pages.GroupDataTemplate.Modifier":"修改人",
   "pages.GroupDataTemplate.VisibleRange.All":"全局",
   "pages.GroupDataTemplate.VisibleRange.InCharges":"责任人",
-  "pages.GroupDataTemplate.VisibleRange.Tenant":"租户"
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"租户",
+  "miscellaneous.total": "... 共",
+  "miscellaneous.tenants": "个租户"
 }

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -920,5 +920,7 @@
   "pages.GroupDataTemplate.Modifier":"Modifier",
   "pages.GroupDataTemplate.VisibleRange.All":"Global",
   "pages.GroupDataTemplate.VisibleRange.InCharges":"Owner",
-  "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenant"
+  "pages.GroupDataTemplate.VisibleRange.Tenant":"Tenant",
+  "miscellaneous.total": "... total ",
+  "miscellaneous.tenants": " tenants"
 }

--- a/inlong-dashboard/src/ui/pages/ClusterTags/TagDetailModal.tsx
+++ b/inlong-dashboard/src/ui/pages/ClusterTags/TagDetailModal.tsx
@@ -104,6 +104,18 @@ const TagDetailModal: React.FC<TagDetailModalProps> = ({ id, ...modalProps }) =>
           showSearch: true,
           allowClear: true,
           mode: 'multiple',
+          maxTagCount: 9,
+          maxTagTextLength: 20,
+          maxTagPlaceholder: omittedValues => {
+            console.log('omittedValues', omittedValues);
+            return (
+              <span>
+                {i18n.t('miscellaneous.total')}
+                {omittedValues.length}
+                {i18n.t('miscellaneous.tenants')}
+              </span>
+            );
+          },
           options: {
             requestTrigger: ['onOpen', 'onSearch'],
             requestService: keyword => ({
@@ -136,6 +148,7 @@ const TagDetailModal: React.FC<TagDetailModalProps> = ({ id, ...modalProps }) =>
 
   return (
     <Modal
+      width={600}
       {...modalProps}
       title={i18n.t(id ? 'basic.Edit' : 'basic.Create') + i18n.t('pages.ClusterTags.Name')}
       onOk={onOk}


### PR DESCRIPTION

Fixes #10592 

### Motivation

 When there are too many selections in the drop-down box, omit some of them

### Modifications

Set the drop-down box Attributes, When the drop-down box displays more than 9, the extra parts will be omitted, and the total number will be added to the remaining tenants.

### Verifying this change
before
![image](https://github.com/apache/inlong/assets/165994047/0457ed7c-c4c8-4023-b705-d1acef103b74)
after
![image](https://github.com/apache/inlong/assets/165994047/f9e2f9b1-4ffc-4c92-ac91-9cc4a82fde8d)


