### PR TITLE
[INLONG-10591][Dashboard] Audit item query ignores case

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -304,14 +304,25 @@ export const getFormContent = (inlongGroupId, initialValues, onSearch, onDataStr
           return request('/audit/getAuditBases');
         },
         requestParams: {
-          formatResult: result =>
-            result?.map(item => ({
-              label: item.nameInChinese,
-              value: item.auditId,
-            })) || [],
+          formatResult: result => {
+            return result?.reduce((accumulator, item) => {
+              const existingItem = accumulator.find(
+                (i: { value: any }) => i.value === item.auditId,
+              );
+              if (!existingItem) {
+                accumulator.push({
+                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+                  value: item.auditId,
+                });
+              }
+              return accumulator;
+            }, []);
+          },
         },
       },
-      filterOption: (keyword, option) => option.label.includes(keyword),
+      filterOption: (keyword: string, option: { label: any }) => {
+        return (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase());
+      },
     },
   },
   {

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
@@ -145,14 +145,24 @@ export const getFormContent = (initialValues, onSearch) => [
           return request('/audit/getAuditBases');
         },
         requestParams: {
-          formatResult: result =>
-            result?.map(item => ({
-              label: item.nameInChinese,
-              value: item.auditId,
-            })) || [],
+          formatResult: (result: any[]) => {
+            return result?.reduce((accumulator, item) => {
+              const existingItem = accumulator.find(
+                (i: { value: any }) => i.value === item.auditId,
+              );
+              if (!existingItem) {
+                accumulator.push({
+                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+                  value: item.auditId,
+                });
+              }
+              return accumulator;
+            }, []);
+          },
         },
       },
-      filterOption: (keyword, option) => option.label.includes(keyword),
+      filterOption: (keyword: string, option: { label: any }) =>
+        (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
   },
   {
@@ -170,14 +180,24 @@ export const getFormContent = (initialValues, onSearch) => [
           return request('/audit/getAuditBases');
         },
         requestParams: {
-          formatResult: result =>
-            result?.map(item => ({
-              label: item.nameInChinese,
-              value: item.auditId,
-            })) || [],
+          formatResult: (result: any[]) => {
+            return result?.reduce((accumulator, item) => {
+              const existingItem = accumulator.find(
+                (i: { value: any }) => i.value === item.auditId,
+              );
+              if (!existingItem) {
+                accumulator.push({
+                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+                  value: item.auditId,
+                });
+              }
+              return accumulator;
+            }, []);
+          },
         },
       },
-      filterOption: (keyword, option) => option.label.includes(keyword),
+      filterOption: (keyword: string, option: { label: any }) =>
+        (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
   },
   {

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
@@ -99,14 +99,24 @@ export const getFormContent = (initialValues, onSearch) => [
           return request('/audit/getAuditBases');
         },
         requestParams: {
-          formatResult: result =>
-            result?.map(item => ({
-              label: item.nameInChinese,
-              value: item.auditId,
-            })) || [],
+          formatResult: (result: any[]) => {
+            return result?.reduce((accumulator, item) => {
+              const existingItem = accumulator.find(
+                (i: { value: any }) => i.value === item.auditId,
+              );
+              if (!existingItem) {
+                accumulator.push({
+                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+                  value: item.auditId,
+                });
+              }
+              return accumulator;
+            }, []);
+          },
         },
       },
-      filterOption: (keyword, option) => option.label.includes(keyword),
+      filterOption: (keyword: any, option: { label: any }) =>
+        (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
   },
   {
@@ -124,14 +134,24 @@ export const getFormContent = (initialValues, onSearch) => [
           return request('/audit/getAuditBases');
         },
         requestParams: {
-          formatResult: result =>
-            result?.map(item => ({
-              label: item.nameInChinese,
-              value: item.auditId,
-            })) || [],
+          formatResult: (result: any[]) => {
+            return result?.reduce((accumulator, item) => {
+              const existingItem = accumulator.find(
+                (i: { value: any }) => i.value === item.auditId,
+              );
+              if (!existingItem) {
+                accumulator.push({
+                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+                  value: item.auditId,
+                });
+              }
+              return accumulator;
+            }, []);
+          },
         },
       },
-      filterOption: (keyword, option) => option.label.includes(keyword),
+      filterOption: (keyword: string, option: { label: any }) =>
+        (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
   },
   {


### PR DESCRIPTION


Fixes #10591 

### Motivation
Audit item query ignores case,If the values ​​of the drop-down boxes have the same value, the filter search will fail,When the language is English, the option is not displayed in English

### Modifications

Modify the filtering method, filter and modify the value of option

### Verifying this change
before
language is English ,the option is not displayed in English
![image](https://github.com/apache/inlong/assets/165994047/27b7a068-2846-467a-80c4-04f1f6f083fe)
after
![image](https://github.com/apache/inlong/assets/165994047/24b5e269-29f5-40fa-a08f-af286d7dd221)

before
Audit item query  not ignores case 
![image](https://github.com/apache/inlong/assets/165994047/e2a9493d-b84d-4e5c-ab0a-6e72e1faf3ee)
![image](https://github.com/apache/inlong/assets/165994047/1a9f6825-37de-408e-82c4-ef23a07ee060)
after
![image](https://github.com/apache/inlong/assets/165994047/779baab5-755d-4b2c-b997-13b18997f34f)

