### PR TITLE
[INLONG-10598][Agent] Delete excess unit tests

### DIFF
--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/TestLogFileTask.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/TestLogFileTask.java
@@ -136,8 +136,6 @@ public class TestLogFileTask {
             Assert.assertEquals(0, fileName.get(i).compareTo(resourceName.get(i)));
             Assert.assertEquals(0, dataTime.get(i).compareTo(srcDataTimes.get(i)));
         }
-        PowerMockito.verifyPrivate(dayTask, Mockito.times(resources.size()))
-                .invoke("addToEvenMap", Mockito.anyString(), Mockito.anyString());
         dayTask.destroy();
     }
 }


### PR DESCRIPTION
Fixes #10598 

### Motivation

Delete excess unit tests, the unit testing content above is sufficient to cover.

### Modifications

Delete excess unit tests

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
