### PR TITLE
[INLONG-10607][SDK] Transform SQL support arithmetic functions(Including log10, log2, log and exp)

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/AbsFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/AbsFunction.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class AbsFunction implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public AbsFunction(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class AbsFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return numberValue.abs();
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/ExpFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/ExpFunction.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class ExpFunction implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public ExpFunction(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class ExpFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return Math.exp(numberValue.doubleValue());
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/ExpFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/ExpFunction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Function;
+
+import java.math.BigDecimal;
+
+/**
+ * ExpFunction
+ * description: exp(numeric)--returns e raised to the power of numeric
+ */
+public class ExpFunction implements ValueParser {
+
+    private ValueParser number;
+
+    /**
+     * Constructor
+     * @param expr
+     */
+    public ExpFunction(Function expr) {
+        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+    }
+
+    /**
+     * parse
+     * @param sourceData
+     * @param rowIndex
+     * @return
+     */
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex) {
+        Object numberObj = number.parse(sourceData, rowIndex);
+        BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
+        return Math.exp(numberValue.doubleValue());
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LnFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LnFunction.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class LnFunction implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public LnFunction(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class LnFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return Math.log(numberValue.doubleValue());
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log10Function.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log10Function.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Function;
+
+import java.math.BigDecimal;
+
+/**
+ * Log10Function
+ * description: log10(numeric)--returns the base 10 logarithm of numeric
+ */
+public class Log10Function implements ValueParser {
+
+    private ValueParser number;
+
+    /**
+     * Constructor
+     * @param expr
+     */
+    public Log10Function(Function expr) {
+        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+    }
+
+    /**
+     * parse
+     * @param sourceData
+     * @param rowIndex
+     * @return
+     */
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex) {
+        Object numberObj = number.parse(sourceData, rowIndex);
+        BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
+        return Math.log10(numberValue.doubleValue());
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log10Function.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log10Function.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class Log10Function implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public Log10Function(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class Log10Function implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return Math.log10(numberValue.doubleValue());
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log2Function.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log2Function.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Function;
+
+import java.math.BigDecimal;
+
+/**
+ * Log2Function
+ * description: log2(numeric)--returns the base 2 logarithm of numeric
+ */
+public class Log2Function implements ValueParser {
+
+    private ValueParser number;
+
+    /**
+     * Constructor
+     * @param expr
+     */
+    public Log2Function(Function expr) {
+        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+    }
+
+    /**
+     * parse
+     * @param sourceData
+     * @param rowIndex
+     * @return
+     */
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex) {
+        Object numberObj = number.parse(sourceData, rowIndex);
+        BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
+        return Math.log(numberValue.doubleValue()) / Math.log(2);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log2Function.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/Log2Function.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class Log2Function implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public Log2Function(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class Log2Function implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return Math.log(numberValue.doubleValue()) / Math.log(2);
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LogFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LogFunction.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * LogFunction
+ * description: log(numeric) or log(numeric1, numeric2)--When called with one argument, returns the natural logarithm
+ * of numeric. When called with two arguments, this function returns the logarithm of numeric2 to the base numeric1
+ */
+public class LogFunction implements ValueParser {
+
+    private ValueParser base;
+    private ValueParser number;
+
+    /**
+     * Constructor
+     * @param expr
+     */
+    public LogFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        // Determine the number of arguments and build parser
+        if (expressions.size() == 1) {
+            number = OperatorTools.buildParser(expressions.get(0));
+        } else {
+            base = OperatorTools.buildParser(expressions.get(0));
+            number = OperatorTools.buildParser(expressions.get(1));
+        }
+    }
+
+    /**
+     * parse
+     * @param sourceData
+     * @param rowIndex
+     * @return
+     */
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex) {
+        Object numberObj = number.parse(sourceData, rowIndex);
+        BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
+        if (base != null) {
+            Object baseObj = base.parse(sourceData, rowIndex);
+            BigDecimal baseValue = OperatorTools.parseBigDecimal(baseObj);
+            return Math.log(numberValue.doubleValue()) / Math.log(baseValue.doubleValue());
+        } else {
+            return Math.log(numberValue.doubleValue());
+        }
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LogFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LogFunction.java
@@ -34,8 +34,8 @@ import java.util.List;
  */
 public class LogFunction implements ValueParser {
 
-    private ValueParser base;
-    private ValueParser number;
+    private ValueParser baseParser;
+    private ValueParser numberParser;
 
     /**
      * Constructor
@@ -45,10 +45,10 @@ public class LogFunction implements ValueParser {
         List<Expression> expressions = expr.getParameters().getExpressions();
         // Determine the number of arguments and build parser
         if (expressions.size() == 1) {
-            number = OperatorTools.buildParser(expressions.get(0));
+            numberParser = OperatorTools.buildParser(expressions.get(0));
         } else {
-            base = OperatorTools.buildParser(expressions.get(0));
-            number = OperatorTools.buildParser(expressions.get(1));
+            baseParser = OperatorTools.buildParser(expressions.get(0));
+            numberParser = OperatorTools.buildParser(expressions.get(1));
         }
     }
 
@@ -60,10 +60,10 @@ public class LogFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
-        if (base != null) {
-            Object baseObj = base.parse(sourceData, rowIndex);
+        if (baseParser != null) {
+            Object baseObj = baseParser.parse(sourceData, rowIndex);
             BigDecimal baseValue = OperatorTools.parseBigDecimal(baseObj);
             return Math.log(numberValue.doubleValue()) / Math.log(baseValue.doubleValue());
         } else {

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/PowerFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/PowerFunction.java
@@ -31,16 +31,16 @@ import java.math.BigDecimal;
  */
 public class PowerFunction implements ValueParser {
 
-    private ValueParser base;
-    private ValueParser exponent;
+    private ValueParser baseParser;
+    private ValueParser exponentParser;
 
     /**
      * Constructor
      * @param expr
      */
     public PowerFunction(Function expr) {
-        base = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
-        exponent = OperatorTools.buildParser(expr.getParameters().getExpressions().get(1));
+        baseParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        exponentParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(1));
     }
 
     /**
@@ -51,8 +51,8 @@ public class PowerFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object baseObj = base.parse(sourceData, rowIndex);
-        Object exponentObj = exponent.parse(sourceData, rowIndex);
+        Object baseObj = baseParser.parse(sourceData, rowIndex);
+        Object exponentObj = exponentParser.parse(sourceData, rowIndex);
         BigDecimal baseValue = OperatorTools.parseBigDecimal(baseObj);
         BigDecimal exponentValue = OperatorTools.parseBigDecimal(exponentObj);
         return Math.pow(baseValue.doubleValue(), exponentValue.doubleValue());

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/SqrtFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/SqrtFunction.java
@@ -31,14 +31,14 @@ import java.math.BigDecimal;
  */
 public class SqrtFunction implements ValueParser {
 
-    private ValueParser number;
+    private ValueParser numberParser;
 
     /**
      * Constructor
      * @param expr
      */
     public SqrtFunction(Function expr) {
-        number = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+        numberParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
     }
 
     /**
@@ -49,7 +49,7 @@ public class SqrtFunction implements ValueParser {
      */
     @Override
     public Object parse(SourceData sourceData, int rowIndex) {
-        Object numberObj = number.parse(sourceData, rowIndex);
+        Object numberObj = numberParser.parse(sourceData, rowIndex);
         BigDecimal numberValue = OperatorTools.parseBigDecimal(numberObj);
         return Math.sqrt(numberValue.doubleValue());
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
@@ -19,7 +19,11 @@ package org.apache.inlong.sdk.transform.process.operator;
 
 import org.apache.inlong.sdk.transform.process.function.AbsFunction;
 import org.apache.inlong.sdk.transform.process.function.ConcatFunction;
+import org.apache.inlong.sdk.transform.process.function.ExpFunction;
 import org.apache.inlong.sdk.transform.process.function.LnFunction;
+import org.apache.inlong.sdk.transform.process.function.Log10Function;
+import org.apache.inlong.sdk.transform.process.function.Log2Function;
+import org.apache.inlong.sdk.transform.process.function.LogFunction;
 import org.apache.inlong.sdk.transform.process.function.NowFunction;
 import org.apache.inlong.sdk.transform.process.function.PowerFunction;
 import org.apache.inlong.sdk.transform.process.function.SqrtFunction;
@@ -77,6 +81,10 @@ public class OperatorTools {
         functionMap.put("abs", AbsFunction::new);
         functionMap.put("sqrt", SqrtFunction::new);
         functionMap.put("ln", LnFunction::new);
+        functionMap.put("log10", Log10Function::new);
+        functionMap.put("log2", Log2Function::new);
+        functionMap.put("log", LogFunction::new);
+        functionMap.put("exp", ExpFunction::new);
     }
 
     public static ExpressionOperator buildOperator(Expression expr) {

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformArithmeticFunctionsProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformArithmeticFunctionsProcessor.java
@@ -117,4 +117,72 @@ public class TestTransformArithmeticFunctionsProcessor {
         Assert.assertTrue(output2.size() == 1);
         Assert.assertEquals(output2.get(0), "result=2.302585092994046");
     }
+
+    @Test
+    public void testLog10Function() throws Exception {
+        String transformSql = "select log10(numeric1) from source";
+        TransformConfig config = new TransformConfig(csvSource, kvSink, transformSql);
+        // case1: log10(1)
+        TransformProcessor processor = new TransformProcessor(config);
+        List<String> output1 = processor.transform("1|4|6|8", new HashMap<>());
+        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(output1.get(0), "result=0.0");
+        // case2: log10(1000)
+        List<String> output2 = processor.transform("1000|4|6|8", new HashMap<>());
+        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(output2.get(0), "result=3.0");
+    }
+
+    @Test
+    public void testLog2Function() throws Exception {
+        String transformSql = "select log2(numeric1) from source";
+        TransformConfig config = new TransformConfig(csvSource, kvSink, transformSql);
+        // case1: log2(1)
+        TransformProcessor processor = new TransformProcessor(config);
+        List<String> output1 = processor.transform("1|4|6|8", new HashMap<>());
+        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(output1.get(0), "result=0.0");
+        // case2: log2(32)
+        List<String> output2 = processor.transform("32|4|6|8", new HashMap<>());
+        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(output2.get(0), "result=5.0");
+    }
+
+    @Test
+    public void testLogFunction() throws Exception {
+        String transformSql1 = "select log(numeric1) from source";
+        TransformConfig config1 = new TransformConfig(csvSource, kvSink, transformSql1);
+        // case1: ln(1)
+        TransformProcessor processor1 = new TransformProcessor(config1);
+        List<String> output1 = processor1.transform("1|4|6|8", new HashMap<>());
+        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(output1.get(0), "result=0.0");
+        String transformSql2 = "select log(numeric1, numeric2) from source";
+        TransformConfig config2 = new TransformConfig(csvSource, kvSink, transformSql2);
+        // case2: log2(8)
+        TransformProcessor processor2 = new TransformProcessor(config2);
+        List<String> output2 = processor2.transform("2|8|6|8", new HashMap<>());
+        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(output2.get(0), "result=3.0");
+        // case3: log10(100)
+        TransformProcessor processor3 = new TransformProcessor(config2);
+        List<String> output3 = processor3.transform("10|100|6|8", new HashMap<>());
+        Assert.assertTrue(output3.size() == 1);
+        Assert.assertEquals(output3.get(0), "result=2.0");
+    }
+
+    @Test
+    public void testExpFunction() throws Exception {
+        String transformSql = "select exp(numeric1) from source";
+        TransformConfig config = new TransformConfig(csvSource, kvSink, transformSql);
+        // case1: e^0
+        TransformProcessor processor = new TransformProcessor(config);
+        List<String> output1 = processor.transform("0|4|6|8", new HashMap<>());
+        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(output1.get(0), "result=1.0");
+        // case2: e^2
+        List<String> output2 = processor.transform("2|4|6|8", new HashMap<>());
+        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(output2.get(0), "result=7.38905609893065");
+    }
 }

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformArithmeticFunctionsProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformArithmeticFunctionsProcessor.java
@@ -61,15 +61,15 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: 2^4
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("2|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=16.0");
         // case2: 2^(-2)
         List<String> output2 = processor.transform("2|-2|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=0.25");
         // case3: 4^(0.5)
         List<String> output3 = processor.transform("4|0.5|6|8", new HashMap<>());
-        Assert.assertTrue(output3.size() == 1);
+        Assert.assertEquals(1, output3.size());
         Assert.assertEquals(output3.get(0), "result=2.0");
     }
 
@@ -80,11 +80,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: |2|
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("2|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=2");
         // case2: |-4.25|
         List<String> output2 = processor.transform("-4.25|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=4.25");
     }
 
@@ -95,11 +95,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: sqrt(9)
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("9|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=3.0");
         // case2: sqrt(5)
         List<String> output2 = processor.transform("5|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=2.23606797749979");
     }
 
@@ -110,11 +110,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: ln(1)
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("1|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=0.0");
         // case2: ln(10)
         List<String> output2 = processor.transform("10|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=2.302585092994046");
     }
 
@@ -125,11 +125,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: log10(1)
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("1|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=0.0");
         // case2: log10(1000)
         List<String> output2 = processor.transform("1000|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=3.0");
     }
 
@@ -140,11 +140,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: log2(1)
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("1|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=0.0");
         // case2: log2(32)
         List<String> output2 = processor.transform("32|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=5.0");
     }
 
@@ -155,19 +155,19 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: ln(1)
         TransformProcessor processor1 = new TransformProcessor(config1);
         List<String> output1 = processor1.transform("1|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=0.0");
         String transformSql2 = "select log(numeric1, numeric2) from source";
         TransformConfig config2 = new TransformConfig(csvSource, kvSink, transformSql2);
         // case2: log2(8)
         TransformProcessor processor2 = new TransformProcessor(config2);
         List<String> output2 = processor2.transform("2|8|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=3.0");
         // case3: log10(100)
         TransformProcessor processor3 = new TransformProcessor(config2);
         List<String> output3 = processor3.transform("10|100|6|8", new HashMap<>());
-        Assert.assertTrue(output3.size() == 1);
+        Assert.assertEquals(1, output3.size());
         Assert.assertEquals(output3.get(0), "result=2.0");
     }
 
@@ -178,11 +178,11 @@ public class TestTransformArithmeticFunctionsProcessor {
         // case1: e^0
         TransformProcessor processor = new TransformProcessor(config);
         List<String> output1 = processor.transform("0|4|6|8", new HashMap<>());
-        Assert.assertTrue(output1.size() == 1);
+        Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=1.0");
         // case2: e^2
         List<String> output2 = processor.transform("2|4|6|8", new HashMap<>());
-        Assert.assertTrue(output2.size() == 1);
+        Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=7.38905609893065");
     }
 }


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10607 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Transform SQL support arithmetic functions(Including log10, log2, log and exp)

### Modifications

<!--Describe the modifications you've done.-->
Add four arithmetic function classes: Log2Function, Log10Function, LogFunction, and ExpFunction. Also, add the corresponding unit test codes

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests in `TestTransformArithmeticFunctionsProcessor.java`

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
