### PR TITLE
[INLONG-10614][Dashboard] The template list does not need to display Id

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/CreateModal.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/CreateModal.tsx
@@ -96,7 +96,7 @@ const Comp: React.FC<Props> = ({ id, templateName, ...modalProps }) => {
   const content = useMemo(() => {
     return new GroupDataTemplateInfo().renderRow().map(item => {
       if (item.name === 'tenantList') {
-        item = { ...item, hidden: hidden };
+        item = { ...item, hidden: hidden, rules: [{ required: !hidden }] };
       }
       return item;
     });

--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
@@ -104,12 +104,6 @@ const Comp: React.FC = () => {
   const entityColumns = useMemo(() => {
     return [
       {
-        title: 'id',
-        dataIndex: 'id',
-        key: 'id',
-        width: 100,
-      },
-      {
         title: i18n.t('pages.GroupDataTemplate.Name'),
         dataIndex: 'name',
         key: 'name',
@@ -119,7 +113,7 @@ const Comp: React.FC = () => {
         title: i18n.t('pages.GroupDataTemplate.InCharges'),
         dataIndex: 'inCharges',
         key: 'inCharges',
-        width: 200,
+        width: 300,
       },
       {
         title: i18n.t('pages.GroupDataTemplate.TenantList'),


### PR DESCRIPTION


Fixes #10614 

### Motivation
The template list does not need to display Id

### Modifications

Remove the id from the list
### Verifying this change
before
![image](https://github.com/user-attachments/assets/ef1d79ed-2bde-4168-9f28-076fda31f1fd)
after
![image](https://github.com/user-attachments/assets/c3c6b3db-36d1-400d-bf66-a5fed8595787)
