### PR TITLE
[INLONG-10617][Dashboard] The mq type should not exist on the data synchronization page

### DIFF
--- a/inlong-dashboard/src/plugins/sync/common/SyncDefaultInfo.ts
+++ b/inlong-dashboard/src/plugins/sync/common/SyncDefaultInfo.ts
@@ -103,9 +103,6 @@ export class SyncDefaultInfo implements DataWithBackend, RenderRow, RenderList {
     initialValue: 'NONE',
     hidden: true,
   })
-  @ColumnDecorator({
-    width: 300,
-  })
   @I18n('meta.Group.MQType')
   mqType: string;
 


### PR DESCRIPTION


Fixes #10617

### Motivation

The mq type should not exist on the data synchronization page

### Modifications
delete the mq type from the synchronization  list

### Verifying this change
before:

![image](https://github.com/user-attachments/assets/9885452c-242e-4968-a186-03e42fdab208)

after: remove the mq type
![image](https://github.com/user-attachments/assets/eb93c329-f638-4d41-a678-2ddb68fe6fb8)


