### PR TITLE
[INLONG-10610][Sort] Make MongoDB source support report audit information exactly once

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
@@ -320,7 +320,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     @Override
     public void notifyCheckpointAborted(long checkpointId) {
-        if (deserializer instanceof  MongoDBConnectorDeserializationSchema) {
+        if (deserializer instanceof MongoDBConnectorDeserializationSchema) {
             MongoDBConnectorDeserializationSchema schema = (MongoDBConnectorDeserializationSchema) deserializer;
             schema.flushAudit();
             schema.updateLastCheckpointId(checkpointId);

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
@@ -312,6 +312,19 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             snapshotOffsetState(functionSnapshotContext.getCheckpointId());
             snapshotHistoryRecordsState();
         }
+        if (deserializer instanceof MongoDBConnectorDeserializationSchema) {
+            ((MongoDBConnectorDeserializationSchema) deserializer)
+                    .updateCurrentCheckpointId(functionSnapshotContext.getCheckpointId());
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        if (deserializer instanceof  MongoDBConnectorDeserializationSchema) {
+            MongoDBConnectorDeserializationSchema schema = (MongoDBConnectorDeserializationSchema) deserializer;
+            schema.flushAudit();
+            schema.updateLastCheckpointId(checkpointId);
+        }
     }
 
     private void snapshotOffsetState(long checkpointId) throws Exception {

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBConnectorDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBConnectorDeserializationSchema.java
@@ -20,7 +20,6 @@ package org.apache.inlong.sort.mongodb;
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricsCollector;
 import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
-import org.apache.inlong.sort.base.metric.SourceMetricData;
 
 import com.mongodb.client.model.changestream.OperationType;
 import com.mongodb.internal.HexUtils;
@@ -158,7 +157,8 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
             case DELETE:
                 GenericRowData delete = extractRowData(documentKey);
                 delete.setRowKind(RowKind.DELETE);
-                emit(record, delete, sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
+                emit(record, delete,
+                        sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
                 break;
             case UPDATE:
                 // It’s null if another operation deletes the document

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBConnectorDeserializationSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBConnectorDeserializationSchema.java
@@ -19,6 +19,7 @@ package org.apache.inlong.sort.mongodb;
 
 import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.base.metric.MetricsCollector;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
 import org.apache.inlong.sort.base.metric.SourceMetricData;
 
 import com.mongodb.client.model.changestream.OperationType;
@@ -112,7 +113,7 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
 
     private final MetricOption metricOption;
 
-    private SourceMetricData sourceMetricData;
+    private SourceExactlyMetric sourceExactlyMetric;
 
     public MongoDBConnectorDeserializationSchema(
             RowType physicalDataType,
@@ -131,7 +132,7 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
     @Override
     public void open() {
         if (metricOption != null) {
-            sourceMetricData = new SourceMetricData(metricOption);
+            sourceExactlyMetric = new SourceExactlyMetric(metricOption);
         }
     }
 
@@ -152,12 +153,12 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
                 GenericRowData insert = extractRowData(fullDocument);
                 insert.setRowKind(RowKind.INSERT);
                 emit(record, insert,
-                        sourceMetricData == null ? out : new MetricsCollector<>(out, sourceMetricData));
+                        sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
                 break;
             case DELETE:
                 GenericRowData delete = extractRowData(documentKey);
                 delete.setRowKind(RowKind.DELETE);
-                emit(record, delete, sourceMetricData == null ? out : new MetricsCollector<>(out, sourceMetricData));
+                emit(record, delete, sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
                 break;
             case UPDATE:
                 // It’s null if another operation deletes the document
@@ -168,13 +169,13 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
                 GenericRowData updateAfter = extractRowData(fullDocument);
                 updateAfter.setRowKind(RowKind.UPDATE_AFTER);
                 emit(record, updateAfter,
-                        sourceMetricData == null ? out : new MetricsCollector<>(out, sourceMetricData));
+                        sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
                 break;
             case REPLACE:
                 GenericRowData replaceAfter = extractRowData(fullDocument);
                 replaceAfter.setRowKind(RowKind.UPDATE_AFTER);
                 emit(record, replaceAfter,
-                        sourceMetricData == null ? out : new MetricsCollector<>(out, sourceMetricData));
+                        sourceExactlyMetric == null ? out : new MetricsCollector<>(out, sourceExactlyMetric));
                 break;
             case INVALIDATE:
             case DROP:
@@ -807,5 +808,23 @@ public class MongoDBConnectorDeserializationSchema implements DebeziumDeserializ
             }
             return converter.convert(docObj);
         };
+    }
+
+    public void flushAudit() {
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.flushAudit();
+        }
+    }
+
+    public void updateCurrentCheckpointId(long checkpointId) {
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateCurrentCheckpointId(checkpointId);
+        }
+    }
+
+    public void updateLastCheckpointId(long checkpointId) {
+        if (sourceExactlyMetric != null) {
+            sourceExactlyMetric.updateLastCheckpointId(checkpointId);
+        }
     }
 }


### PR DESCRIPTION
### [INLONG-10610][Sort] Make MongoDB source support report audit information exactly once

Fixes #10610 

### Modifications
1. Using the checkpoint principle in Flink to modify the process, the modified flow chart is shown in Figure 1 and Figure 2. In Figure 1, the callback method of notifyCompleteCheckpoint is used to upload audit information instead of scheduled upload.Each Source/Sink will save the checkpointId of the currently ongoing checkpoint, which is nowCheckpointId in the figure. When the audit information is written to the Buffer, nowCheckpointId will be attached, indicating that the audit information
is written during this ongoing checkpoint. The audit information and checkpointId are in a many-to-one relationship.

![image](https://github.com/apache/inlong/assets/58425449/2f09c6c6-e9c2-4383-bca7-965333ccab65)
When a snapshot request is received, the current operator's nowCheckpointId is updated to (snapshot) checkpointId + 1. When all operators in a task complete the snapshot, the notifyCompleteCheckpoint method is called back.

At this time, AuditBuffer uploads audit information less than or equal to checkpointId (parameters in the notifyCompleteCheckpoint method).

![image](https://github.com/apache/inlong/assets/58425449/33d2de48-df21-49ce-96c7-d044d25f37b0)

2. The getCurConsumedPartitions method gets the partitions assigned to the client by the tube server, including the partitions where the client has consumed data and the client has not consumed data. According to the previous logic, the offsets of the partitions that have not been consumed are not recorded. Here, the offsets of the partitions that have not been consumed are added.


