### PR TITLE
[INLONG-10633][Agent] The initialization function of AuditUtils pass in the configuration

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.agent.metrics.audit;
 
-import org.apache.inlong.agent.conf.AgentConfiguration;
+import org.apache.inlong.agent.conf.AbstractConfiguration;
 import org.apache.inlong.audit.AuditOperator;
 import org.apache.inlong.audit.entity.AuditComponent;
 
@@ -59,12 +59,12 @@ public class AuditUtils {
     public static int AUDIT_ID_AGENT_ADD_INSTANCE_MEM_FAILED = 1073741842;
     public static int AUDIT_ID_AGENT_DEL_INSTANCE_MEM_UNUSUAL = 1073741843;
     private static boolean IS_AUDIT = true;
+    private static AbstractConfiguration conf;
 
     /**
      * Init audit config
      */
-    public static void initAudit() {
-        AgentConfiguration conf = AgentConfiguration.getAgentConf();
+    public static void initAudit(AbstractConfiguration conf) {
         IS_AUDIT = conf.getBoolean(AUDIT_ENABLE, DEFAULT_AUDIT_ENABLE);
         if (IS_AUDIT) {
             AuditOperator.getInstance().setAuditProxy(AuditComponent.AGENT, conf.get(AGENT_MANAGER_ADDR),

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentMain.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentMain.java
@@ -110,7 +110,7 @@ public class AgentMain {
         CommandLine cl = initOptions(args);
         assert cl != null;
         initAgentConf(cl);
-        AuditUtils.initAudit();
+        AuditUtils.initAudit(AgentConfiguration.getAgentConf());
         AgentManager manager = new AgentManager();
         try {
             manager.start();

--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/Main.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/Main.java
@@ -110,7 +110,7 @@ public class Main {
         CommandLine cl = initOptions(args);
         assert cl != null;
         initAgentConf(cl);
-        AuditUtils.initAudit();
+        AuditUtils.initAudit(InstallerConfiguration.getInstallerConf());
         Manager manager = new Manager();
         try {
             manager.start();


### PR DESCRIPTION
Fixes #10633 

### Motivation
The initialization function of AuditUtils needs to pass in the configuration, because the config files of installer and agent are different.
### Modifications
Initialize function adds configuration input parameters
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
