### PR TITLE
[INLONG-10640][Dashboard]  Approval page display item modification

### DIFF
--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -712,6 +712,7 @@
   "pages.Approvals.status.Canceled": "已取消",
   "pages.Approvals.status.Ok": "审批通过",
   "pages.Approvals.ApplicationTime": "申请时间",
+  "pages.Approvals.ProcessingTime": "审批时间",
   "pages.Approvals.ApplicationType": "申请类型",
   "pages.Approvals.Approval": "审批",
   "pages.Approvals.Approver": "审批人",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -712,6 +712,7 @@
   "pages.Approvals.status.Canceled": "Canceled",
   "pages.Approvals.status.Ok": "Approved",
   "pages.Approvals.ApplicationTime": "Time",
+  "pages.Approvals.ProcessingTime": "Processing Time",
   "pages.Approvals.ApplicationType": "Type",
   "pages.Approvals.Approval": "Approval",
   "pages.Approvals.Approver": "Approver",

--- a/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
+++ b/inlong-dashboard/src/ui/pages/Process/Approvals/config.tsx
@@ -127,6 +127,11 @@ export const getColumns = activedName => [
     render: text => timestampFormat(text),
   },
   {
+    title: i18n.t('pages.Approvals.ProcessingTime'),
+    dataIndex: 'endTime',
+    render: text => timestampFormat(text),
+  },
+  {
     title: i18n.t('basic.Status'),
     dataIndex: 'status',
     render: text => genStatusTag(text),
@@ -138,7 +143,7 @@ export const getColumns = activedName => [
       <Link
         to={`/process/${activedName}/${record.processId}?taskId=${record.id}&inlongGroupMode=${record.showInList?.[0]?.inlongGroupMode}`}
       >
-        {i18n.t('pages.Approvals.Approval')}
+        {record.status === 'PENDING' ? i18n.t('pages.Approvals.Approval') : i18n.t('basic.Detail')}
       </Link>
     ),
   },


### PR DESCRIPTION

Fixes #10640 

### Motivation

The navigation page increases the navigation time. When waiting for navigation, the operation will display the navigation and the details in other states.
### Modifications
1. Increased approval time
2. Add judgment logic for operation buttons

### Verifying this change
before: There is no approval time
![image](https://github.com/user-attachments/assets/7e5561a1-4fb7-463d-9f95-6edfa87d238c)
after: Increased ProcessingTime
![image](https://github.com/user-attachments/assets/78707ddb-a32c-4794-ba4e-4fcc2fa034f3)
before: The status is Review Completed, and the action button is also Approval
![image](https://github.com/user-attachments/assets/de086baf-c3d6-4a14-90f1-4e78e1ab51b3)
after: 
![image](https://github.com/user-attachments/assets/f2d937c4-caa2-4b38-893f-2469df608680)

