### PR TITLE
[INLONG-10641][Dashboard] Switching theme font color without inverse color

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/Audit/config.tsx
@@ -339,13 +339,12 @@ export const getTableColumns = (source, dim) => {
     title: item.auditName,
     dataIndex: item.auditId,
     render: text => {
-      let color = 'black';
       if (text?.includes('+')) {
-        color = 'red';
+        return <span style={{ color: 'red' }}>{text}</span>;
       } else if (text?.includes('-')) {
-        color = 'green';
+        return <span style={{ color: 'green' }}>{text}</span>;
       }
-      return <span style={{ color: color }}>{text}</span>;
+      return <span>{text}</span>;
     },
   }));
   return [


### PR DESCRIPTION


Fixes #10461 

### Motivation

After modifying the theme, the corresponding text will be inverted.

### Modifications
Modify the logic of color judgment on the audit page

### Verifying this change
before: The theme color is black, but the data color in the table on the audit page is not white, making it unclear.
![image](https://github.com/user-attachments/assets/8c479f0c-671c-4514-9650-192fb542c30c)
after: 
The theme color is black and the font color will become white
![image](https://github.com/user-attachments/assets/b26ea298-73c5-488b-be69-3e2e90b3d14e)



