### PR TITLE
[INLONG-10645][Agent] Installer adds process protection

### DIFF
--- a/inlong-agent/agent-installer/bin/crontab.sh
+++ b/inlong-agent/agent-installer/bin/crontab.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
+cd $BASE_DIR
+
+LOG_DIR=${BASE_DIR}/logs/
+
+CRON_CMD="*/5 * * * * (cd ${BASE_DIR};sh ./bin/installer.sh start > ${BASE_DIR}/logs/monitor.log 2>&1)"
+
+CRON_COUNT=`crontab -l | grep -Ew "${BASE_DIR}" | grep "^[^#+]" | wc -l`
+if [ $CRON_COUNT -eq 0 ]; then
+	mkdir -p $LOG_DIR
+	CRON_TMP=${LOG_DIR}/crontab.tmp
+	crontab -l > $CRON_TMP
+	echo "${CRON_CMD}" >> $CRON_TMP
+	crontab $CRON_TMP
+fi

--- a/inlong-agent/agent-installer/bin/crontab.sh
+++ b/inlong-agent/agent-installer/bin/crontab.sh
@@ -1,4 +1,20 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 BASE_DIR=$(cd "$(dirname "$0")"/../;pwd)
 cd $BASE_DIR


### PR DESCRIPTION
Fixes #10645 

### Motivation

Installer needs to add process protection

### Modifications

Add process daemon in crontab

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
