### PR TITLE
[INLONG-10651][Dashboard] File Type data stream supports minute-level periods

### DIFF
--- a/inlong-dashboard/src/plugins/sources/defaults/File.ts
+++ b/inlong-dashboard/src/plugins/sources/defaults/File.ts
@@ -178,6 +178,10 @@ export default class PulsarSource
           value: 'H',
         },
         {
+          label: i18n.t('meta.Sources.File.Cycle.Minute'),
+          value: 'm',
+        },
+        {
           label: i18n.t('meta.Sources.File.Cycle.RealTime'),
           value: 'R',
         },

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -43,6 +43,7 @@
   "meta.Sources.File.Cycle.Day": "天",
   "meta.Sources.File.Cycle.Hour": "小时",
   "meta.Sources.File.Cycle.RealTime": "实时",
+  "meta.Sources.File.Cycle.Minute": "分钟",
   "meta.Sources.File.TimeZone": "时区",
   "meta.Sources.Db.Server": "服务器地址",
   "meta.Sources.Db.Port": "服务器端口",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -43,6 +43,7 @@
   "meta.Sources.File.Cycle.Day": "Day",
   "meta.Sources.File.Cycle.Hour": "Hour",
   "meta.Sources.File.Cycle.RealTime": "Real time",
+  "meta.Sources.File.Cycle.Minute": "Minute",
   "meta.Sources.File.TimeZone": "Time zone",
   "meta.Sources.Db.Server": "Server",
   "meta.Sources.Db.Port": "Port",


### PR DESCRIPTION


Fixes #10651

### Motivation

 Let the File Type data stream support minute-level periods

### Modifications


Add data minute-level period type in File.ts file

### Verifying this change
before:
![image](https://github.com/user-attachments/assets/4349b31a-8f89-4400-ad9c-40f7a4e51132)
after:
![image](https://github.com/user-attachments/assets/bd8e330b-28a2-474d-a40e-e0e5e3b0deac)

