### PR TITLE
[INLONG-10687][Audit] Independent the Audit items of Agent from module reconciliation

### DIFF
--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/AuditReporterImpl.java
@@ -591,6 +591,10 @@ public class AuditReporterImpl implements Serializable {
         return AuditManagerUtils.getAllAuditInformation();
     }
 
+    public List<AuditInformation> getAllMetricInformation() {
+        return AuditManagerUtils.getAllMetricInformation();
+    }
+
     public List<AuditInformation> getAllAuditInformation(String auditType) {
         return AuditManagerUtils.getAllAuditInformation(auditType);
     }

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
@@ -139,6 +139,11 @@ public class AuditManagerUtils {
         return auditInformationList;
     }
 
+    /**
+     * Obtain all metric Audit items.
+     * All metric indicators are defined in the MetricIdEnum class.
+     * @return List of AuditInformation objects representing the metric Audit items.
+     */
     public static List<AuditInformation> getAllMetricInformation() {
         List<AuditInformation> metricInformationList = new LinkedList<>();
         for (MetricIdEnum metricIdEnum : MetricIdEnum.values()) {

--- a/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
+++ b/inlong-audit/audit-sdk/src/main/java/org/apache/inlong/audit/util/AuditManagerUtils.java
@@ -136,11 +136,17 @@ public class AuditManagerUtils {
             auditInformationList.addAll(combineAuditInformation(auditIdEnum.getAuditType().value(),
                     auditIdEnum.getFlowType()));
         }
-        for (MetricIdEnum metricIdEnum : MetricIdEnum.values()) {
-            auditInformationList.add(new AuditInformation(metricIdEnum.getValue(), metricIdEnum.getEnglishDescription(),
-                    metricIdEnum.getChineseDescription()));
-        }
         return auditInformationList;
+    }
+
+    public static List<AuditInformation> getAllMetricInformation() {
+        List<AuditInformation> metricInformationList = new LinkedList<>();
+        for (MetricIdEnum metricIdEnum : MetricIdEnum.values()) {
+            metricInformationList
+                    .add(new AuditInformation(metricIdEnum.getValue(), metricIdEnum.getEnglishDescription(),
+                            metricIdEnum.getChineseDescription()));
+        }
+        return metricInformationList;
     }
 
     public static List<AuditInformation> getAllAuditInformation(String auditType) {

--- a/inlong-audit/audit-sdk/src/test/java/org/apache/inlong/audit/util/AuditManagerUtilsTest.java
+++ b/inlong-audit/audit-sdk/src/test/java/org/apache/inlong/audit/util/AuditManagerUtilsTest.java
@@ -127,8 +127,8 @@ public class AuditManagerUtilsTest {
 
     @Test
     public void getAllMetricInformation() {
-        List<AuditInformation> MetricInformationList = AuditOperator.getInstance().getAllMetricInformation();
-        System.out.println(MetricInformationList);
-        assertTrue(MetricInformationList.size() > 0);
+        List<AuditInformation> metricInformationList = AuditOperator.getInstance().getAllMetricInformation();
+        System.out.println(metricInformationList);
+        assertTrue(metricInformationList.size() > 0);
     }
 }

--- a/inlong-audit/audit-sdk/src/test/java/org/apache/inlong/audit/util/AuditManagerUtilsTest.java
+++ b/inlong-audit/audit-sdk/src/test/java/org/apache/inlong/audit/util/AuditManagerUtilsTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.audit.util;
 
+import org.apache.inlong.audit.AuditOperator;
 import org.apache.inlong.audit.entity.AuditInformation;
 import org.apache.inlong.audit.entity.FlowType;
 
@@ -122,5 +123,12 @@ public class AuditManagerUtilsTest {
         int auditId = AuditManagerUtils.getStartAuditIdForMetric();
         assertTrue(auditId > 0);
         assertTrue(auditId <= (1 << 30));
+    }
+
+    @Test
+    public void getAllMetricInformation() {
+        List<AuditInformation> MetricInformationList = AuditOperator.getInstance().getAllMetricInformation();
+        System.out.println(MetricInformationList);
+        assertTrue(MetricInformationList.size() > 0);
     }
 }


### PR DESCRIPTION

- Fixes #10687

### Motivation

Independent the Audit items of Agent from module reconciliation to make page query auditing clearer.

### Modifications

Independent the Audit items of Agent from module reconciliation.
