### PR TITLE
[INLONG-10704][Sort] Sort Add Oceanbase Support

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
@@ -26,6 +26,7 @@ import org.apache.inlong.sort.protocol.node.extract.IcebergExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.KafkaExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.MongoExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.OceanBaseExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.OracleExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PostgresExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
@@ -67,6 +68,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = DorisExtractNode.class, name = "dorisExtract"),
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
+        @JsonSubTypes.Type(value = OceanBaseExtractNode.class, name = "oceanbaseExtract"),
 })
 @Data
 @NoArgsConstructor

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/LoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/LoadNode.java
@@ -30,6 +30,7 @@ import org.apache.inlong.sort.protocol.node.load.HudiLoadNode;
 import org.apache.inlong.sort.protocol.node.load.IcebergLoadNode;
 import org.apache.inlong.sort.protocol.node.load.KafkaLoadNode;
 import org.apache.inlong.sort.protocol.node.load.MySqlLoadNode;
+import org.apache.inlong.sort.protocol.node.load.OceanBaseLoadNode;
 import org.apache.inlong.sort.protocol.node.load.OracleLoadNode;
 import org.apache.inlong.sort.protocol.node.load.PostgresLoadNode;
 import org.apache.inlong.sort.protocol.node.load.RedisLoadNode;
@@ -76,6 +77,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = StarRocksLoadNode.class, name = "starRocksLoad"),
         @JsonSubTypes.Type(value = HudiLoadNode.class, name = "hudiLoad"),
         @JsonSubTypes.Type(value = RedisLoadNode.class, name = "redisLoad"),
+        @JsonSubTypes.Type(value = OceanBaseLoadNode.class, name = "oceanBaseLoad"),
 })
 @NoArgsConstructor
 @Data

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
@@ -25,6 +25,7 @@ import org.apache.inlong.sort.protocol.node.extract.IcebergExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.KafkaExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.MongoExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.OceanBaseExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.OracleExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PostgresExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
@@ -43,6 +44,7 @@ import org.apache.inlong.sort.protocol.node.load.IcebergLoadNode;
 import org.apache.inlong.sort.protocol.node.load.KafkaLoadNode;
 import org.apache.inlong.sort.protocol.node.load.KuduLoadNode;
 import org.apache.inlong.sort.protocol.node.load.MySqlLoadNode;
+import org.apache.inlong.sort.protocol.node.load.OceanBaseLoadNode;
 import org.apache.inlong.sort.protocol.node.load.OracleLoadNode;
 import org.apache.inlong.sort.protocol.node.load.PostgresLoadNode;
 import org.apache.inlong.sort.protocol.node.load.RedisLoadNode;
@@ -80,6 +82,7 @@ import java.util.TreeMap;
         @JsonSubTypes.Type(value = DorisExtractNode.class, name = "dorisExtract"),
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
+        @JsonSubTypes.Type(value = OceanBaseExtractNode.class, name = "oceanbaseExtract"),
         @JsonSubTypes.Type(value = TransformNode.class, name = "baseTransform"),
         @JsonSubTypes.Type(value = DistinctNode.class, name = "distinct"),
         @JsonSubTypes.Type(value = KafkaLoadNode.class, name = "kafkaLoad"),
@@ -101,6 +104,7 @@ import java.util.TreeMap;
         @JsonSubTypes.Type(value = StarRocksLoadNode.class, name = "starRocksLoad"),
         @JsonSubTypes.Type(value = RedisLoadNode.class, name = "redisLoad"),
         @JsonSubTypes.Type(value = KuduLoadNode.class, name = "kuduLoad"),
+        @JsonSubTypes.Type(value = OceanBaseLoadNode.class, name = "oceanBaseLoad"),
 })
 public interface Node {
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNode.java
@@ -47,7 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Mysql extract node using debezium engine
+ * OceanBase extract node using debezium engine
  */
 @EqualsAndHashCode(callSuper = true)
 @JsonTypeName("oceanbaseExtract")

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNode.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.extract;
+
+import org.apache.inlong.common.enums.MetaField;
+import org.apache.inlong.common.enums.RowKindEnum;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InlongMetric;
+import org.apache.inlong.sort.protocol.Metadata;
+import org.apache.inlong.sort.protocol.enums.ExtractMode;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+import org.apache.inlong.sort.protocol.transformation.WatermarkField;
+
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Mysql extract node using debezium engine
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("oceanbaseExtract")
+@JsonInclude(Include.NON_NULL)
+@Data
+public class OceanBaseExtractNode extends ExtractNode implements Metadata, InlongMetric, Serializable {
+
+    private static final long serialVersionUID = -5521981462461235277L;
+
+    @JsonProperty("primaryKey")
+    private String primaryKey;
+    @JsonProperty("tableNames")
+    @Nonnull
+    private List<String> tableNames;
+    @JsonProperty("hostname")
+    private String hostname;
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("password")
+    private String password;
+    @JsonProperty("database")
+    private String database;
+    @JsonProperty("port")
+    private Integer port;
+    @JsonProperty("serverId")
+    private Integer serverId;
+    @JsonProperty("incrementalSnapshotEnabled")
+    private Boolean incrementalSnapshotEnabled;
+    @JsonProperty("serverTimeZone")
+    private String serverTimeZone;
+    @Nonnull
+    @JsonProperty("extractMode")
+    private ExtractMode extractMode;
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("rowKindsFiltered")
+    private List<RowKindEnum> rowKindsFiltered;
+
+    /**
+     * Constructor only used for {@link ExtractMode#CDC}
+     *
+     * @param id The id of node
+     * @param name The name of node
+     * @param fields The field list of node
+     * @param watermarkField The watermark field of node only used for {@link ExtractMode#CDC}
+     * @param properties The properties connect to mysql
+     * @param primaryKey The primark key connect to mysql
+     * @param tableNames The table names connect to mysql
+     * @param hostname The hostname connect to mysql only used for {@link ExtractMode#CDC}
+     * @param username The username connect to mysql
+     * @param password The password connect to mysql
+     * @param database The database connect to mysql only used for {@link ExtractMode#CDC}
+     * @param port The port connect to mysql only used for {@link ExtractMode#CDC}
+     * @param serverId The server id connect to mysql only used for {@link ExtractMode#CDC}
+     * @param incrementalSnapshotEnabled The incremental snapshot enabled connect to mysql
+     *         only used for {@link ExtractMode#CDC}
+     * @param serverTimeZone The server time zone connect to mysql only used for {@link ExtractMode#CDC}
+     */
+    public OceanBaseExtractNode(@Nonnull @JsonProperty("id") String id,
+            @Nonnull @JsonProperty("name") String name,
+            @Nonnull @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("watermarkField") WatermarkField watermarkField,
+            @Nullable @JsonProperty("properties") Map<String, String> properties,
+            @Nullable @JsonProperty("primaryKey") String primaryKey,
+            @Nonnull @JsonProperty("tableNames") List<String> tableNames,
+            @Nonnull @JsonProperty("hostname") String hostname,
+            @Nonnull @JsonProperty("username") String username,
+            @Nonnull @JsonProperty("password") String password,
+            @Nonnull @JsonProperty("database") String database,
+            @Nullable @JsonProperty("port") Integer port,
+            @Nullable @JsonProperty("serverId") Integer serverId,
+            @Nullable @JsonProperty("incrementalSnapshotEnabled") Boolean incrementalSnapshotEnabled,
+            @Nullable @JsonProperty("serverTimeZone") String serverTimeZone) {
+        this(id, name, fields, watermarkField, properties, primaryKey, tableNames, hostname, username, password,
+                database, port, serverId, incrementalSnapshotEnabled, serverTimeZone, ExtractMode.CDC, null, null);
+    }
+
+    /**
+     * Constructor only used for {@link ExtractMode#SCAN}
+     *
+     * @param id The id of node
+     * @param name The name of node
+     * @param fields The field list of node
+     * @param properties The properties connect to mysql
+     * @param primaryKey The primark key connect to mysql
+     * @param tableNames The table names connect to mysql
+     * @param username The username connect to mysql
+     * @param password The password connect to mysql
+     * @param url The url connect to mysql only used for {@link ExtractMode#SCAN}
+     */
+    public OceanBaseExtractNode(@JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("properties") Map<String, String> properties,
+            @Nullable @JsonProperty("primaryKey") String primaryKey,
+            @JsonProperty("tableNames") @Nonnull List<String> tableNames,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @Nullable @JsonProperty("url") String url) {
+        this(id, name, fields, null, properties, primaryKey, tableNames, null, username,
+                password, null, null, null, null, null,
+                ExtractMode.SCAN, url, null);
+    }
+
+    /**
+     * Base constructor
+     *
+     * @param id The id of node
+     * @param name The name of node
+     * @param fields The field list of node
+     * @param watermarkField The watermark field of node only used for {@link ExtractMode#CDC}
+     * @param properties The properties connect to mysql
+     * @param primaryKey The primark key connect to mysql
+     * @param tableNames The table names connect to mysql
+     * @param hostname The hostname connect to mysql only used for {@link ExtractMode#CDC}
+     * @param username The username connect to mysql
+     * @param password The password connect to mysql
+     * @param database The database connect to mysql only used for {@link ExtractMode#CDC}
+     * @param port The port connect to mysql only used for {@link ExtractMode#CDC}
+     * @param serverId The server id connect to mysql only used for {@link ExtractMode#CDC}
+     * @param incrementalSnapshotEnabled The incremental snapshot enabled connect to mysql
+     *         only used for {@link ExtractMode#CDC}
+     * @param serverTimeZone The server time zone connect to mysql only used for {@link ExtractMode#CDC}
+     * @param extractMode The extract mode connect mysql {@link ExtractMode}
+     * @param url The url connect to mysql only used for {@link ExtractMode#SCAN}
+     */
+    @JsonCreator
+    public OceanBaseExtractNode(@JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("watermarkField") WatermarkField watermarkField,
+            @Nullable @JsonProperty("properties") Map<String, String> properties,
+            @Nullable @JsonProperty("primaryKey") String primaryKey,
+            @JsonProperty("tableNames") @Nonnull List<String> tableNames,
+            @Nullable @JsonProperty("hostname") String hostname,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @Nullable @JsonProperty("database") String database,
+            @Nullable @JsonProperty("port") Integer port,
+            @Nullable @JsonProperty("serverId") Integer serverId,
+            @Nullable @JsonProperty("incrementalSnapshotEnabled") Boolean incrementalSnapshotEnabled,
+            @Nullable @JsonProperty("serverTimeZone") String serverTimeZone,
+            @Nonnull @JsonProperty("extractMode") ExtractMode extractMode,
+            @Nullable @JsonProperty("url") String url,
+            @Nullable @JsonProperty("rowKindsFiltered") List<RowKindEnum> rowKindsFiltered) {
+        super(id, name, fields, watermarkField, properties);
+        this.tableNames = Preconditions.checkNotNull(tableNames, "tableNames is null");
+        Preconditions.checkState(!tableNames.isEmpty(), "tableNames is empty");
+        if (extractMode == ExtractMode.SCAN) {
+            this.hostname = hostname;
+            this.database = database;
+            this.url = Preconditions.checkNotNull(url, "url is null");
+        } else {
+            extractMode = ExtractMode.CDC;
+            this.hostname = Preconditions.checkNotNull(hostname, "hostname is null");
+            this.database = Preconditions.checkNotNull(database, "database is null");
+        }
+        this.username = Preconditions.checkNotNull(username, "username is null");
+        this.password = Preconditions.checkNotNull(password, "password is null");
+        this.primaryKey = primaryKey;
+        this.port = port;
+        this.serverId = serverId;
+        this.incrementalSnapshotEnabled = incrementalSnapshotEnabled;
+        this.serverTimeZone = serverTimeZone;
+        this.extractMode = extractMode;
+        this.rowKindsFiltered = rowKindsFiltered;
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+
+    @Override
+    public String getPrimaryKey() {
+        return primaryKey;
+    }
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        if (extractMode == ExtractMode.CDC) {
+            options.put("connector", "mysql-cdc-inlong");
+            options.put("hostname", hostname);
+            options.put("database-name", database);
+            if (rowKindsFiltered != null) {
+                List<String> rowKinds = rowKindsFiltered.stream().map(RowKindEnum::shortString)
+                        .collect(Collectors.toList());
+                options.put("row-kinds-filtered", StringUtils.join(rowKinds, "&"));
+            }
+            if (port != null) {
+                options.put("port", port.toString());
+            }
+            if (serverId != null) {
+                options.put("server-id", serverId.toString());
+            }
+            if (incrementalSnapshotEnabled != null) {
+                options.put("scan.incremental.snapshot.enabled", incrementalSnapshotEnabled.toString());
+            }
+            if (serverTimeZone != null) {
+                options.put("server-time-zone", serverTimeZone);
+            }
+        } else {
+            options.put("connector", "jdbc-inlong");
+            options.put("url", url);
+            Preconditions.checkState(tableNames.size() == 1,
+                    "Only support one table for scan extract mode");
+        }
+        options.put("username", username);
+        options.put("password", password);
+        String formatTable =
+                tableNames.size() == 1 ? tableNames.get(0) : String.format("(%s)", StringUtils.join(tableNames, "|"));
+        options.put("table-name", String.format("%s", formatTable));
+        return options;
+    }
+
+    @Override
+    public String getMetadataKey(MetaField metaField) {
+        String metadataKey;
+        switch (metaField) {
+            case TABLE_NAME:
+                metadataKey = "meta.table_name";
+                break;
+            case DATABASE_NAME:
+                metadataKey = "meta.database_name";
+                break;
+            case OP_TS:
+                metadataKey = "meta.op_ts";
+                break;
+            case OP_TYPE:
+                metadataKey = "meta.op_type";
+                break;
+            case DATA:
+            case DATA_BYTES:
+            case DATA_CANAL:
+            case DATA_BYTES_CANAL:
+                metadataKey = "meta.data_canal";
+                break;
+            case DATA_DEBEZIUM:
+            case DATA_BYTES_DEBEZIUM:
+                metadataKey = "meta.data_debezium";
+                break;
+            case IS_DDL:
+                metadataKey = "meta.is_ddl";
+                break;
+            case TS:
+            case AUDIT_DATA_TIME:
+                metadataKey = "meta.ts";
+                break;
+            case SQL_TYPE:
+                metadataKey = "meta.sql_type";
+                break;
+            case MYSQL_TYPE:
+                metadataKey = "meta.mysql_type";
+                break;
+            case PK_NAMES:
+                metadataKey = "meta.pk_names";
+                break;
+            case BATCH_ID:
+                metadataKey = "meta.batch_id";
+                break;
+            case UPDATE_BEFORE:
+                metadataKey = "meta.update_before";
+                break;
+            default:
+                throw new UnsupportedOperationException(String.format("Unsupport meta field for %s: %s",
+                        this.getClass().getSimpleName(), metaField));
+        }
+        return metadataKey;
+    }
+
+    @Override
+    public boolean isVirtual(MetaField metaField) {
+        return true;
+    }
+
+    @Override
+    public Set<MetaField> supportedMetaFields() {
+        return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME, MetaField.DATA_CANAL,
+                MetaField.DATABASE_NAME, MetaField.OP_TYPE, MetaField.OP_TS, MetaField.IS_DDL,
+                MetaField.TS, MetaField.SQL_TYPE, MetaField.MYSQL_TYPE, MetaField.PK_NAMES,
+                MetaField.BATCH_ID, MetaField.UPDATE_BEFORE, MetaField.DATA_BYTES_DEBEZIUM,
+                MetaField.DATA_DEBEZIUM, MetaField.DATA_BYTES_CANAL, MetaField.DATA, MetaField.DATA_BYTES,
+                MetaField.AUDIT_DATA_TIME);
+    }
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/OceanBaseLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/OceanBaseLoadNode.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.load;
+
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InlongMetric;
+import org.apache.inlong.sort.protocol.enums.FilterStrategy;
+import org.apache.inlong.sort.protocol.node.LoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.FilterFunction;
+
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OceanBase load node can load data into OceanBase
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("oceanBaseLoad")
+@Data
+@NoArgsConstructor
+public class OceanBaseLoadNode extends LoadNode implements InlongMetric, Serializable {
+
+    /**
+     * use mysql protocol,jdbc:mysql://host:port/database
+     */
+    @JsonProperty("url")
+    private String url;
+    @JsonProperty("username")
+    private String username;
+    @JsonProperty("password")
+    private String password;
+    @JsonProperty("tableName")
+    private String tableName;
+    @JsonProperty("primaryKey")
+    private String primaryKey;
+
+    @JsonCreator
+    public OceanBaseLoadNode(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @JsonProperty("fieldRelations") List<FieldRelation> fieldRelations,
+            @JsonProperty("filters") List<FilterFunction> filters,
+            @JsonProperty("filterStrategy") FilterStrategy filterStrategy,
+            @JsonProperty("sinkParallelism") Integer sinkParallelism,
+            @JsonProperty("properties") Map<String, String> properties,
+            @JsonProperty("url") String url,
+            @JsonProperty("username") String username,
+            @JsonProperty("password") String password,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("primaryKey") String primaryKey) {
+        super(id, name, fields, fieldRelations, filters, filterStrategy, sinkParallelism, properties);
+        this.url = Preconditions.checkNotNull(url, "url is null");
+        this.username = Preconditions.checkNotNull(username, "username is null");
+        this.password = Preconditions.checkNotNull(password, "password is null");
+        this.tableName = Preconditions.checkNotNull(tableName, "tableName is null");
+        this.primaryKey = primaryKey;
+    }
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        options.put("connector", "jdbc-inlong");
+        options.put("url", url);
+        options.put("username", username);
+        options.put("password", password);
+        options.put("table-name", tableName);
+        return options;
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+
+    @Override
+    public String getPrimaryKey() {
+        return primaryKey;
+    }
+}

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/extract/OceanBaseExtractNodeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.extract;
+
+import org.apache.inlong.common.enums.MetaField;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.StringFormatInfo;
+import org.apache.inlong.sort.SerializeBaseTest;
+import org.apache.inlong.sort.protocol.FieldInfo;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test for {@link OceanBaseExtractNode}
+ */
+public class OceanBaseExtractNodeTest extends SerializeBaseTest<OceanBaseExtractNode> {
+
+    @Override
+    public OceanBaseExtractNode getTestObject() {
+        return new OceanBaseExtractNode("1", null,
+                Collections.singletonList(new FieldInfo("field", new StringFormatInfo())), null, null,
+                "primary_key_field", Arrays.asList("table1", "table2"),
+                "localhost", "username",
+                "password", "dabasename", 3306, 123,
+                true, null);
+    }
+
+    @Test
+    public void testMetaFields() {
+        Map<MetaField, String> formatMap = new HashMap<>();
+        formatMap.put(MetaField.PROCESS_TIME, "AS PROCTIME()");
+        formatMap.put(MetaField.TABLE_NAME, "STRING METADATA FROM 'meta.table_name' VIRTUAL");
+        formatMap.put(MetaField.DATA_CANAL, "STRING METADATA FROM 'meta.data_canal' VIRTUAL");
+        formatMap.put(MetaField.DATABASE_NAME, "STRING METADATA FROM 'meta.database_name' VIRTUAL");
+        formatMap.put(MetaField.OP_TYPE, "STRING METADATA FROM 'meta.op_type' VIRTUAL");
+        formatMap.put(MetaField.OP_TS, "TIMESTAMP_LTZ(3) METADATA FROM 'meta.op_ts' VIRTUAL");
+        formatMap.put(MetaField.IS_DDL, "BOOLEAN METADATA FROM 'meta.is_ddl' VIRTUAL");
+        formatMap.put(MetaField.TS, "TIMESTAMP_LTZ(3) METADATA FROM 'meta.ts' VIRTUAL");
+        formatMap.put(MetaField.SQL_TYPE, "MAP<STRING, INT> METADATA FROM 'meta.sql_type' VIRTUAL");
+        formatMap.put(MetaField.MYSQL_TYPE, "MAP<STRING, STRING> METADATA FROM 'meta.mysql_type' VIRTUAL");
+        formatMap.put(MetaField.PK_NAMES, "ARRAY<STRING> METADATA FROM 'meta.pk_names' VIRTUAL");
+        formatMap.put(MetaField.BATCH_ID, "BIGINT METADATA FROM 'meta.batch_id' VIRTUAL");
+        formatMap.put(MetaField.UPDATE_BEFORE, "ARRAY<MAP<STRING, STRING>> METADATA FROM 'meta.update_before' VIRTUAL");
+        formatMap.put(MetaField.DATA_BYTES_DEBEZIUM, "BYTES METADATA FROM 'meta.data_debezium' VIRTUAL");
+        formatMap.put(MetaField.DATA_DEBEZIUM, "STRING METADATA FROM 'meta.data_debezium' VIRTUAL");
+        formatMap.put(MetaField.DATA_BYTES_CANAL, "BYTES METADATA FROM 'meta.data_canal' VIRTUAL");
+        formatMap.put(MetaField.DATA, "STRING METADATA FROM 'meta.data_canal' VIRTUAL");
+        formatMap.put(MetaField.DATA_BYTES, "BYTES METADATA FROM 'meta.data_canal' VIRTUAL");
+        formatMap.put(MetaField.AUDIT_DATA_TIME, "BIGINT METADATA FROM 'meta.ts' VIRTUAL");
+
+        OceanBaseExtractNode node = getTestObject();
+        boolean formatEquals = true;
+        for (MetaField metaField : node.supportedMetaFields()) {
+            formatEquals = node.format(metaField).equals(formatMap.get(metaField));
+            if (!formatEquals) {
+                break;
+            }
+        }
+        Assert.assertTrue(formatEquals);
+    }
+}

--- a/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/OceanBaseLoadNodeTest.java
+++ b/inlong-sort/sort-common/src/test/java/org/apache/inlong/sort/protocol/node/load/OceanBaseLoadNodeTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.load;
+
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.StringFormatInfo;
+import org.apache.inlong.sort.SerializeBaseTest;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+
+import java.util.Collections;
+
+/**
+ * Test for {@link OceanBaseLoadNode}
+ */
+public class OceanBaseLoadNodeTest extends SerializeBaseTest<OceanBaseLoadNode> {
+
+    @Override
+    public OceanBaseLoadNode getTestObject() {
+        return new OceanBaseLoadNode("1", "mysql_output",
+                Collections.singletonList(new FieldInfo("name", new StringFormatInfo())),
+                Collections.singletonList(new FieldRelation(new FieldInfo("name",
+                        new StringFormatInfo()), new FieldInfo("name", new StringFormatInfo()))),
+                null, null, 1, null,
+                "jdbc:mysql://localhost:3306/inlong",
+                "inlong",
+                "inlong",
+                "user",
+                "name");
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
@@ -28,7 +28,6 @@ import org.apache.inlong.sort.protocol.node.Node;
 import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
 import org.apache.inlong.sort.protocol.node.load.OceanBaseLoadNode;
 import org.apache.inlong.sort.protocol.transformation.FieldRelation;
-import org.apache.inlong.sort.protocol.transformation.FilterFunction;
 import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
 
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +38,6 @@ import org.apache.flink.test.util.AbstractTestBase;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -80,7 +78,6 @@ public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
                         new FieldRelation(new FieldInfo("phone", new IntFormatInfo()),
                                 new FieldInfo("phone", new IntFormatInfo())));
 
-        // Support delete event (sink.enable-delete='true'), requires OceanBase table to enable batch delete function
         Map<String, String> properties = new HashMap<>();
         properties.put("dirty.side-output.connector", "log");
         properties.put("dirty.ignore", "true");
@@ -88,7 +85,6 @@ public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
         properties.put("dirty.side-output.format", "csv");
         properties.put("dirty.side-output.labels",
                 "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=inlong&table=inlong_oceanbase");
-        List<FilterFunction> filters = new ArrayList<>();
         return new OceanBaseLoadNode("2", "mysql_output", fields, fieldRelations, null,
                 null, null, properties, "jdbc:mysql://localhost:2883/test",
                 "root", "123456", "t_ds_user", "id");
@@ -111,7 +107,7 @@ public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
      * Test flink sql task for extract is mysql {@link MySqlExtractNode} and load is oceanbase {@link OceanBaseLoadNode}
      */
     @Test
-    public void testMySqlExtractNodeToOceanBaseLoadNodeSqlParse() throws Exception {
+    public void testMySqlExtractNodeToOceanBaseLoadNodeSqlParse() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         env.enableCheckpointing(10000);

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
@@ -80,7 +80,7 @@ public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
                         new FieldRelation(new FieldInfo("phone", new IntFormatInfo()),
                                 new FieldInfo("phone", new IntFormatInfo())));
 
-        // Support delete event (sink.enable-delete='true'), requires Doris table to enable batch delete function
+        // Support delete event (sink.enable-delete='true'), requires OceanBase table to enable batch delete function
         Map<String, String> properties = new HashMap<>();
         properties.put("dirty.side-output.connector", "log");
         properties.put("dirty.ignore", "true");
@@ -108,7 +108,7 @@ public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
     }
 
     /**
-     * Test flink sql task for extract is mysql {@link MySqlExtractNode} and load is doris {@link OceanBaseLoadNode}
+     * Test flink sql task for extract is mysql {@link MySqlExtractNode} and load is oceanbase {@link OceanBaseLoadNode}
      */
     @Test
     public void testMySqlExtractNodeToOceanBaseLoadNodeSqlParse() throws Exception {

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractNodeToOceanBaseLoadNodeTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.IntFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.StringFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+import org.apache.inlong.sort.protocol.node.load.OceanBaseLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.FilterFunction;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Test mysql cdc for {@link OceanBaseLoadNode}
+ */
+@Slf4j
+public class MySqlExtractNodeToOceanBaseLoadNodeTest extends AbstractTestBase {
+
+    private MySqlExtractNode buildMysqlExtractNode() {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new IntFormatInfo()),
+                new FieldInfo("user_name", new StringFormatInfo()),
+                new FieldInfo("phone", new StringFormatInfo()));
+        Map<String, String> map = new HashMap<>();
+        return new MySqlExtractNode("1", "mysql_input", fields,
+                null, map, "id",
+                Collections.singletonList("t_ds_user"), "localhost", "root", "root",
+                "dolphinscheduler", 3308, 10011,
+                true, null);
+    }
+
+    private OceanBaseLoadNode buildMysqlLoadNode() {
+        final List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new IntFormatInfo()),
+                new FieldInfo("user_name", new StringFormatInfo()),
+                new FieldInfo("phone", new StringFormatInfo()));
+
+        final List<FieldRelation> fieldRelations = Arrays
+                .asList(new FieldRelation(new FieldInfo("id", new IntFormatInfo()),
+                        new FieldInfo("id", new IntFormatInfo())),
+                        new FieldRelation(new FieldInfo("user_name", new StringFormatInfo()),
+                                new FieldInfo("user_name", new StringFormatInfo())),
+                        new FieldRelation(new FieldInfo("phone", new IntFormatInfo()),
+                                new FieldInfo("phone", new IntFormatInfo())));
+
+        // Support delete event (sink.enable-delete='true'), requires Doris table to enable batch delete function
+        Map<String, String> properties = new HashMap<>();
+        properties.put("dirty.side-output.connector", "log");
+        properties.put("dirty.ignore", "true");
+        properties.put("dirty.side-output.enable", "true");
+        properties.put("dirty.side-output.format", "csv");
+        properties.put("dirty.side-output.labels",
+                "SYSTEM_TIME=${SYSTEM_TIME}&DIRTY_TYPE=${DIRTY_TYPE}&database=inlong&table=inlong_oceanbase");
+        List<FilterFunction> filters = new ArrayList<>();
+        return new OceanBaseLoadNode("2", "mysql_output", fields, fieldRelations, null,
+                null, null, properties, "jdbc:mysql://localhost:2883/test",
+                "root", "123456", "t_ds_user", "id");
+    }
+
+    /**
+     * build node relation
+     *
+     * @param inputs  extract node
+     * @param outputs load node
+     * @return node relation
+     */
+    private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    /**
+     * Test flink sql task for extract is mysql {@link MySqlExtractNode} and load is doris {@link OceanBaseLoadNode}
+     */
+    @Test
+    public void testMySqlExtractNodeToOceanBaseLoadNodeSqlParse() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        env.disableOperatorChaining();
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+        Node inputNode = buildMysqlExtractNode();
+        Node outputNode = buildMysqlLoadNode();
+        StreamInfo streamInfo = new StreamInfo("1", Arrays.asList(inputNode, outputNode),
+                Collections.singletonList(buildNodeRelation(Collections.singletonList(inputNode),
+                        Collections.singletonList(outputNode))));
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+        try {
+            Assert.assertTrue(result.tryExecute());
+        } catch (Exception e) {
+            log.error("An exception occurred: {}", e.getMessage());
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 /**
- * JDBC dialect for ClickHouse SQL.
+ * JDBC dialect for SQL.
  */
 public class JdbcDialect extends AbstractDialect {
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.jdbc.dialect.jdbc;
+
+import org.apache.inlong.sort.jdbc.converter.clickhouse.ClickHouseRowConverter;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+/**
+ * JDBC dialect for ClickHouse SQL.
+ */
+public class JdbcDialect extends AbstractDialect {
+
+    public static final Logger LOG = LoggerFactory.getLogger(JdbcDialect.class);
+
+    // Define MAX/MIN precision of TIMESTAMP type according to ClickHouse docs:
+    // https://clickhouse.com/docs/zh/sql-reference/data-types/datetime64
+    private static final int MAX_TIMESTAMP_PRECISION = 8;
+    private static final int MIN_TIMESTAMP_PRECISION = 0;
+
+    // Define MAX/MIN precision of DECIMAL type according to ClickHouse docs:
+    // https://clickhouse.com/docs/zh/sql-reference/data-types/decimal/
+    private static final int MAX_DECIMAL_PRECISION = 128;
+    private static final int MIN_DECIMAL_PRECISION = 32;
+    private static final String POINT = ".";
+
+    @Override
+    public String dialectName() {
+        return "mysql";
+    }
+
+    @Override
+    public JdbcRowConverter getRowConverter(RowType rowType) {
+        return new ClickHouseRowConverter(rowType);
+    }
+
+    @Override
+    public String getLimitClause(long limit) {
+        return "LIMIT " + limit;
+    }
+
+    @Override
+    public Optional<String> defaultDriverName() {
+        return Optional.of("com.mysql.cj.jdbc.Driver");
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        return "`" + identifier + "`";
+    }
+
+    @Override
+    public Optional<String> getUpsertStatement(String tableName, String[] fieldNames, String[] uniqueKeyFields) {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Range> decimalPrecisionRange() {
+        return Optional.of(Range.of(MIN_DECIMAL_PRECISION, MAX_DECIMAL_PRECISION));
+    }
+
+    /**
+     * Defines the supported types for the dialect.
+     *
+     * @return a set of logical type roots.
+     */
+    @Override
+    public Set<LogicalTypeRoot> supportedTypes() {
+        return new HashSet<LogicalTypeRoot>() {
+
+            {
+                add(LogicalTypeRoot.CHAR);
+                add(LogicalTypeRoot.VARCHAR);
+                add(LogicalTypeRoot.BOOLEAN);
+                add(LogicalTypeRoot.DECIMAL);
+                add(LogicalTypeRoot.TINYINT);
+                add(LogicalTypeRoot.SMALLINT);
+                add(LogicalTypeRoot.INTEGER);
+                add(LogicalTypeRoot.BIGINT);
+                add(LogicalTypeRoot.FLOAT);
+                add(LogicalTypeRoot.DOUBLE);
+                add(LogicalTypeRoot.DATE);
+                add(LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE);
+                add(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+            }
+        };
+
+    }
+
+    @Override
+    public Optional<Range> timestampPrecisionRange() {
+        return Optional.of(Range.of(MIN_TIMESTAMP_PRECISION, MAX_TIMESTAMP_PRECISION));
+    }
+
+    /**
+     * Get update one row statement by condition fields
+     */
+    @Override
+    public String getUpdateStatement(
+            String tableName, String[] fieldNames, String[] conditionFields) {
+        List<String> conditionFieldList = Arrays.asList(conditionFields);
+        String setClause =
+                Arrays.stream(fieldNames)
+                        .filter(fieldName -> !conditionFieldList.contains(fieldName))
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(", "));
+
+        String conditionClause =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        Pair<String, String> databaseAndTableName = getDatabaseAndTableName(tableName);
+        return "ALTER TABLE "
+                + quoteIdentifier(databaseAndTableName.getLeft())
+                + POINT
+                + quoteIdentifier(databaseAndTableName.getRight())
+                + " UPDATE "
+                + setClause
+                + " WHERE "
+                + conditionClause;
+    }
+
+    /**
+     * ClickHouse throw exception "Table default.test_user doesn't exist". But jdbc-url have database name.
+     * So we specify database when exec query. This method parse tableName to database and table.
+     * @param tableName include database.table
+     * @return pair left is database, right is table
+     */
+    private Pair<String, String> getDatabaseAndTableName(String tableName) {
+        String databaseName = "default";
+        if (tableName.contains(POINT)) {
+            String[] tableNameArray = tableName.split("\\.");
+            databaseName = tableNameArray[0];
+            tableName = tableNameArray[1];
+        } else {
+            LOG.warn("TableName doesn't include database name, so using default as database name");
+        }
+        return Pair.of(databaseName, tableName);
+    }
+
+    /**
+     * Get delete one row statement by condition fields
+     */
+    @Override
+    public String getDeleteStatement(String tableName, String[] conditionFields) {
+        String conditionClause =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        Pair<String, String> databaseAndTableName = getDatabaseAndTableName(tableName);
+        return "ALTER TABLE "
+                + quoteIdentifier(databaseAndTableName.getLeft())
+                + POINT
+                + quoteIdentifier(databaseAndTableName.getRight())
+                + " DELETE WHERE " + conditionClause;
+    }
+
+    @Override
+    public String getInsertIntoStatement(String tableName, String[] fieldNames) {
+        String columns =
+                Arrays.stream(fieldNames)
+                        .map(this::quoteIdentifier)
+                        .collect(Collectors.joining(", "));
+        String placeholders =
+                Arrays.stream(fieldNames).map(f -> ":" + f).collect(Collectors.joining(", "));
+        Pair<String, String> databaseAndTableName = getDatabaseAndTableName(tableName);
+        return "INSERT INTO "
+                + quoteIdentifier(databaseAndTableName.getLeft())
+                + POINT
+                + quoteIdentifier(databaseAndTableName.getRight())
+                + "("
+                + columns
+                + ")"
+                + " VALUES ("
+                + placeholders
+                + ")";
+    }
+
+    @Override
+    public String getSelectFromStatement(
+            String tableName, String[] selectFields, String[] conditionFields) {
+        String selectExpressions =
+                Arrays.stream(selectFields)
+                        .map(this::quoteIdentifier)
+                        .collect(Collectors.joining(", "));
+        String fieldExpressions =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        Pair<String, String> databaseAndTableName = getDatabaseAndTableName(tableName);
+        return "SELECT "
+                + selectExpressions
+                + " FROM "
+                + quoteIdentifier(databaseAndTableName.getLeft())
+                + POINT
+                + quoteIdentifier(databaseAndTableName.getRight())
+                + (conditionFields.length > 0 ? " WHERE " + fieldExpressions : "");
+    }
+
+    @Override
+    public String getRowExistsStatement(String tableName, String[] conditionFields) {
+        String fieldExpressions =
+                Arrays.stream(conditionFields)
+                        .map(f -> format("%s = :%s", quoteIdentifier(f), f))
+                        .collect(Collectors.joining(" AND "));
+        Pair<String, String> pair = getDatabaseAndTableName(tableName);
+        return "SELECT 1 FROM "
+                + quoteIdentifier(pair.getLeft())
+                + POINT
+                + quoteIdentifier(pair.getRight())
+                + " WHERE " + fieldExpressions;
+    }
+
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialect.java
@@ -17,11 +17,10 @@
 
 package org.apache.inlong.sort.jdbc.dialect.jdbc;
 
-import org.apache.inlong.sort.jdbc.converter.clickhouse.ClickHouseRowConverter;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
 import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
+import org.apache.flink.connector.jdbc.internal.converter.MySQLRowConverter;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
@@ -43,13 +42,9 @@ public class JdbcDialect extends AbstractDialect {
 
     public static final Logger LOG = LoggerFactory.getLogger(JdbcDialect.class);
 
-    // Define MAX/MIN precision of TIMESTAMP type according to ClickHouse docs:
-    // https://clickhouse.com/docs/zh/sql-reference/data-types/datetime64
     private static final int MAX_TIMESTAMP_PRECISION = 8;
     private static final int MIN_TIMESTAMP_PRECISION = 0;
 
-    // Define MAX/MIN precision of DECIMAL type according to ClickHouse docs:
-    // https://clickhouse.com/docs/zh/sql-reference/data-types/decimal/
     private static final int MAX_DECIMAL_PRECISION = 128;
     private static final int MIN_DECIMAL_PRECISION = 32;
     private static final String POINT = ".";
@@ -61,7 +56,7 @@ public class JdbcDialect extends AbstractDialect {
 
     @Override
     public JdbcRowConverter getRowConverter(RowType rowType) {
-        return new ClickHouseRowConverter(rowType);
+        return new MySQLRowConverter(rowType);
     }
 
     @Override
@@ -151,7 +146,7 @@ public class JdbcDialect extends AbstractDialect {
     }
 
     /**
-     * ClickHouse throw exception "Table default.test_user doesn't exist". But jdbc-url have database name.
+     * mysql throw exception "Table default.test_user doesn't exist". But jdbc-url have database name.
      * So we specify database when exec query. This method parse tableName to database and table.
      * @param tableName include database.table
      * @return pair left is database, right is table

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialectFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/java/org/apache/inlong/sort/jdbc/dialect/jdbc/JdbcDialectFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.jdbc.dialect.jdbc;
+
+public class JdbcDialectFactory implements org.apache.inlong.sort.jdbc.dialect.JdbcDialectFactory {
+
+    @Override
+    public boolean acceptsURL(String url) {
+        return url.startsWith("jdbc:mysql:");
+    }
+
+    @Override
+    public org.apache.flink.connector.jdbc.dialect.JdbcDialect create() {
+        return new JdbcDialect();
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/resources/META-INF/services/org.apache.inlong.sort.jdbc.dialect.JdbcDialectFactory
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/src/main/resources/META-INF/services/org.apache.inlong.sort.jdbc.dialect.JdbcDialectFactory
@@ -13,4 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+org.apache.inlong.sort.jdbc.dialect.jdbc.JdbcDialectFactory
 org.apache.inlong.sort.jdbc.dialect.clickhouse.ClickHouseDialectFactory


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10704

### Motivation
Added support for Oceanbase data sources to adapt to the Oceanbase ecosystem. close #10704
<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications
It mainly adds oceanbase data source support and uses the oceanbase-client driver to connect.
<!--Describe the modifications you've done.-->
It mainly adds oceanbase data source support and uses the oceanbase-client driver to connect. And write oceanbase's ExtractNode logic and LoadNode logic. The specific implementation logic is the same as mysql.Added support for oceanbase on the front-end page. Since the jdbc-inlong processing logic in the flink15 connection lacks the jdbc dialect, an error is reported. This is modified here.
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*
Here's how the page test works
![image](https://github.com/user-attachments/assets/5fc8d69b-4536-4f55-9eb7-4bce1cdeb089)
![image](https://github.com/user-attachments/assets/23a29bd4-c33e-408c-9cfa-4bf778b1a9c3)
![image](https://github.com/user-attachments/assets/7fcb9917-6054-4783-9aa7-06305887d853)
![image](https://github.com/user-attachments/assets/89468952-232a-4cc8-a1a9-aee0df308c86)

- [ ] This change added tests and can be verified as follows:
Please use the following test classes for testing  org.apache.inlong.sort.parser.MySqlExtractNodeToOceanBaseLoadNodeTest
  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)  Data source types have been added to the README.md
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
