### PR TITLE
[INLONG-10736][SDK] Python sdk build script support for skipping c++ sdk build step

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -51,10 +51,8 @@ cmake --build . --config Release --target check
 make check -j 4
 cd $BASE_DIR
 
-# Build dataproxy-sdk-cpp(Optional)
-read -p "Have you already built dataproxy-sdk-cpp before? (y/n): " user_choice
-
-if [ "$user_choice" != "y" ] || [ "$user_choice" != "Y" ]; then
+# Build dataproxy-sdk-cpp(If the dataproxy-sdk-cpp has been compiled, this step will be skipped)
+if [ ! -e "../dataproxy-sdk-cpp/release/lib/libdataproxy_sdk.a" ]; then
     cp -r ../dataproxy-sdk-cpp ./
     cd ./dataproxy-sdk-cpp
     chmod +x ./build.sh

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -20,6 +20,12 @@
 
 BASE_DIR=$(pwd)
 
+# Check if dataproxy-sdk-cpp directory exists in the parent directory
+if [ ! -d "../dataproxy-sdk-cpp" ]; then
+    echo "Error: dataproxy-sdk-cpp directory not found in the parent directory."
+    exit 1
+fi
+
 # Check CMake version
 CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d " " -f 3)
 CMAKE_REQUIRED="3.5"
@@ -45,14 +51,19 @@ cmake --build . --config Release --target check
 make check -j 4
 cd $BASE_DIR
 
-# Clone and build dataproxy-sdk-cpp
-git clone https://github.com/apache/inlong.git
-mv ./inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp ./
-rm -r ./inlong
-cd ./dataproxy-sdk-cpp
-chmod +x ./build.sh
-./build.sh
-cd $BASE_DIR
+# Build dataproxy-sdk-cpp(Optional)
+read -p "Have you already built dataproxy-sdk-cpp before? (y/n): " user_choice
+
+if [ "$user_choice" != "y" ] || [ "$user_choice" != "Y" ]; then
+    cp -r ../dataproxy-sdk-cpp ./
+    cd ./dataproxy-sdk-cpp
+    chmod +x ./build.sh
+    ./build.sh
+    cd $BASE_DIR
+else
+    cp -r ../dataproxy-sdk-cpp ./
+    echo "Skipped build dataproxy-sdk-cpp"
+fi
 
 # Build Python SDK
 if [ -d "./build" ]; then

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -18,13 +18,20 @@
 
 #!/bin/bash
 
-BASE_DIR=$(pwd)
+BASE_DIR=`dirname "$0"`
+PY_SDK_DIR=`cd "$BASE_DIR";pwd`
+
+echo "The python sdk directory is: $PY_SDK_DIR"
 
 # Check if dataproxy-sdk-cpp directory exists in the parent directory
-if [ ! -d "../dataproxy-sdk-cpp" ]; then
-    echo "Error: dataproxy-sdk-cpp directory not found in the parent directory."
+if [ ! -d "$PY_SDK_DIR/../dataproxy-sdk-cpp" ]; then
+    echo "Error: cannot find the dataproxy-cpp-sdk directory! The dataproxy-cpp-sdk directory must be located in the same directory as the dataproxy-python-sdk directory."
     exit 1
 fi
+
+CPP_SDK_DIR=`cd "$PY_SDK_DIR/../dataproxy-sdk-cpp";pwd`
+
+echo "The cpp sdk directory is: $CPP_SDK_DIR"
 
 # Check CMake version
 CMAKE_VERSION=$(cmake --version | head -n 1 | cut -d " " -f 3)
@@ -43,40 +50,36 @@ if [ "$(printf '%s\n' "$PYTHON_REQUIRED" "$PYTHON_VERSION" | sort -V | head -n1)
 fi
 
 # Clone and build pybind11
-git clone https://github.com/pybind/pybind11.git
-cd pybind11
-mkdir build && cd build
-cmake ..
-cmake --build . --config Release --target check
+git clone https://github.com/pybind/pybind11.git $PY_SDK_DIR/pybind11
+mkdir $PY_SDK_DIR/pybind11/build && cd $PY_SDK_DIR/pybind11/build
+cmake $PY_SDK_DIR/pybind11
+cmake --build $PY_SDK_DIR/pybind11/build --config Release --target check
 make check -j 4
-cd $BASE_DIR
 
 # Build dataproxy-sdk-cpp(If the dataproxy-sdk-cpp has been compiled, this step will be skipped)
-if [ ! -e "../dataproxy-sdk-cpp/release/lib/libdataproxy_sdk.a" ]; then
-    cp -r ../dataproxy-sdk-cpp ./
-    cd ./dataproxy-sdk-cpp
-    chmod +x ./build.sh
-    ./build.sh
-    cd $BASE_DIR
+if [ ! -e "$CPP_SDK_DIR/release/lib/dataproxy_sdk.a" ]; then
+    chmod +x $CPP_SDK_DIR/build.sh
+    cd $CPP_SDK_DIR
+    . $CPP_SDK_DIR/build.sh
+    cp -r $CPP_SDK_DIR $PY_SDK_DIR
 else
-    cp -r ../dataproxy-sdk-cpp ./
+    cp -r $CPP_SDK_DIR $PY_SDK_DIR
     echo "Skipped build dataproxy-sdk-cpp"
 fi
 
 # Build Python SDK
-if [ -d "./build" ]; then
-    rm -r ./build
+if [ -d "$PY_SDK_DIR/build" ]; then
+    rm -r $PY_SDK_DIR/build
 fi
-mkdir build && cd build
-cmake ..
+mkdir $PY_SDK_DIR/build && cd $PY_SDK_DIR/build
+cmake $PY_SDK_DIR
 make
-cd $BASE_DIR
 
 # Get Python site-packages directory
 SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
 
 # Copy generated .so file to site-packages directory
-find ./build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $SITE_PACKAGES_DIR {}
+find $PY_SDK_DIR/build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $SITE_PACKAGES_DIR {}
 
 # Clean
-rm -r ./pybind11 ./dataproxy-sdk-cpp
+rm -r $PY_SDK_DIR/pybind11 $PY_SDK_DIR/dataproxy-sdk-cpp


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10736

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Enable python sdk build script to automatically skip the c++ sdk build process when it has been compiled.

### Modifications
Modify the python sdk build script.

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
