### PR TITLE
[INLONG-10742][Agent] Set the formatting of unix timestamp for SQLServerSource as optional

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -163,6 +163,8 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_SQLSERVER_SERVER_NAME = "task.sqlserverTask.serverName";
     public static final String TASK_SQLSERVER_SCHEMA_NAME = "task.sqlserverTask.schemaName";
     public static final String TASK_SQLSERVER_TABLE_NAME = "task.sqlserverTask.tableName";
+    public static final String TASK_SQLSERVER_UNIX_TIMESTAMP_FORMAT_ENABLE =
+            "task.sqlserverTask.unixTimestampFormatEnable";
 
     public static final String TASK_STATE = "task.state";
 

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/SqlServerTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/SqlServerTask.java
@@ -31,6 +31,7 @@ public class SqlServerTask {
     private String schemaName;
     private String tableName;
     private String serverTimezone;
+    private String unixTimestampFormatEnable;
 
     private SqlServerTask.Snapshot snapshot;
     private SqlServerTask.Offset offset;
@@ -68,6 +69,7 @@ public class SqlServerTask {
         private String schemaName;
         private String tableName;
         private String serverTimezone;
+        private String unixTimestampFormatEnable;
 
         private String snapshotMode;
         private String intervalMs;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -347,6 +347,7 @@ public class TaskProfileDto {
         sqlServerTask.setSchemaName(config.getSchemaName());
         sqlServerTask.setTableName(config.getSchemaName() + "." + config.getTableName());
         sqlServerTask.setServerTimezone(config.getServerTimezone());
+        sqlServerTask.setUnixTimestampFormatEnable(config.getUnixTimestampFormatEnable());
 
         SqlServerTask.Offset offset = new SqlServerTask.Offset();
         offset.setFilename(config.getOffsetFilename());

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/SQLServerSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/SQLServerSource.java
@@ -91,13 +91,15 @@ public class SQLServerSource extends AbstractSource {
             props.setProperty("value.converter.schemas.enable", "false");
             // ignore ddl
             props.setProperty("include.schema.changes", "false");
-            // convert time to formatted string
-            props.setProperty("converters", "datetime");
-            props.setProperty("datetime.type", "org.apache.inlong.agent.plugin.utils.SQLServerTimeConverter");
-            props.setProperty("datetime.format.date", "yyyy-MM-dd");
-            props.setProperty("datetime.format.time", "HH:mm:ss");
-            props.setProperty("datetime.format.datetime", "yyyy-MM-dd HH:mm:ss");
-            props.setProperty("datetime.format.timestamp", "yyyy-MM-dd HH:mm:ss");
+            if (Boolean.parseBoolean(profile.get(TaskConstants.TASK_SQLSERVER_UNIX_TIMESTAMP_FORMAT_ENABLE, "true"))) {
+                // convert time to formatted string
+                props.setProperty("converters", "datetime");
+                props.setProperty("datetime.type", "org.apache.inlong.agent.plugin.utils.SQLServerTimeConverter");
+                props.setProperty("datetime.format.date", "yyyy-MM-dd");
+                props.setProperty("datetime.format.time", "HH:mm:ss");
+                props.setProperty("datetime.format.datetime", "yyyy-MM-dd HH:mm:ss");
+                props.setProperty("datetime.format.timestamp", "yyyy-MM-dd HH:mm:ss");
+            }
 
             props.setProperty(String.valueOf(SqlServerConnectorConfig.HOSTNAME),
                     profile.get(TaskConstants.TASK_SQLSERVER_HOSTNAME));


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10742

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Set the formatting of Unix timestamp in Debezium JSON data for SQLServerSource to "yyyy-MM-dd HH:mm:ss" as optional

### Modifications

<!--Describe the modifications you've done.-->
Add a "unixTimestampFormatEnable" parameter to determine whether to format the Unix timestamp

### Verifying this change

<img width="1157" alt="image" src="https://github.com/user-attachments/assets/04a815a8-c92b-448d-adde-bab36e11a9ba">

