### PR TITLE
[INLONG-10749][Agent] Fix Instance store leak bug

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/OffsetManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/OffsetManager.java
@@ -149,9 +149,6 @@ public class OffsetManager extends AbstractDaemon {
             InstanceProfile instanceFromDb = iterator.next();
             String taskId = instanceFromDb.getTaskId();
             String instanceId = instanceFromDb.getInstanceId();
-            if (instanceFromDb.getState() != InstanceStateEnum.FINISHED) {
-                continue;
-            }
             TaskProfile taskFromDb = taskStore.getTask(taskId);
             if (taskFromDb != null) {
                 if (taskFromDb.getCycleUnit().compareToIgnoreCase(CycleUnitType.REAL_TIME) == 0) {


### PR DESCRIPTION
Fixes #10749 

### Motivation

After the task is deleted, the instance records of the local database may be leaked

### Modifications

After the task is deleted, the instance local record will be cleared after timeout

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation
No doc needed
