### PR TITLE
[INLONG-10770][Agent] Delete audit proxy configuration related code

### DIFF
--- a/inlong-agent/agent-installer/conf/installer.properties
+++ b/inlong-agent/agent-installer/conf/installer.properties
@@ -39,5 +39,3 @@ agent.cluster.name=default_agent
 ############################
 # whether to enable audit
 audit.enable=true
-# Use the audit proxy address if the audit proxy address is configured; otherwise get the proxy address from the manager
-audit.proxys=127.0.0.1:10081

--- a/inlong-agent/bin/agent-config.sh
+++ b/inlong-agent/bin/agent-config.sh
@@ -25,7 +25,6 @@ clusterTag=$(cat $installerConfigFile|grep -i 'agent.cluster.tag'|awk -F = '{pri
 clusterName=$(cat $installerConfigFile|grep -i 'agent.cluster.name'|awk -F = '{print $2}')
 tdwSecurityUrl=$(cat $installerConfigFile|grep -i 'tdw.security.url'|awk -F = '{print $2}')
 auditFlag=$(cat $installerConfigFile|grep -i 'audit.enable'|awk -F = '{print $2}')
-auditProxy=$(cat $installerConfigFile|grep -i 'audit.proxys'|grep -v '#'|awk -F = '{print $2}')
 
 if [ ${#managerAddr} -gt 0 ]; then
   sed -i "/agent.manager.addr=*/c\agent.manager.addr=$managerAddr" $agentConfigFile
@@ -61,11 +60,4 @@ if [ ${#auditFlag} -gt 0 ]; then
   sed -i "/audit.enable=*/c\audit.enable=$auditFlag" $agentConfigFile
 else
   echo "audit flag empty"
-fi
-
-if [ ${#auditProxy} -gt 0 ]; then
-  sed -i "/audit.proxys=*/c\audit.proxys=$auditProxy" $agentConfigFile
-else
-  sed -i "/audit.proxys=*/c\# audit.proxys=$auditProxy" $agentConfigFile
-  echo "audit proxy empty"
 fi

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -98,5 +98,3 @@ agent.prometheus.exporter.port=9080
 ############################
 # whether to enable audit
 audit.enable=true
-# Use the audit proxy address if the audit proxy address is configured; otherwise get the proxy address from the manager
-audit.proxys=127.0.0.1:10081


### PR DESCRIPTION
Fixes #10770 

### Motivation

The code related to audit proxy configuration is no longer useful

### Modifications

Delete audit proxy configuration related code

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
