### PR TITLE
[INLONG-10776][SDK] Fix incorrect parsing of parameter types in DateFormatFunction

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/DateFormatFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/DateFormatFunction.java
@@ -25,7 +25,7 @@ import org.apache.inlong.sdk.transform.process.parser.ValueParser;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.Function;
 
-import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -65,11 +65,10 @@ public class DateFormatFunction implements ValueParser {
     public Object parse(SourceData sourceData, int rowIndex, Context context) {
         Object timestampObj = timestampParser.parse(sourceData, rowIndex, context);
         Object formatObj = formatParser.parse(sourceData, rowIndex, context);
-        BigDecimal timestamp = OperatorTools.parseBigDecimal(timestampObj);
+        Timestamp timestamp = OperatorTools.parseTimestamp(timestampObj);
         String format = OperatorTools.parseString(formatObj);
         SimpleDateFormat sdf = getSimpleDateFormat(format);
-        // the timestamp is in seconds, multiply 1000 to get milliseconds
-        Date date = new Date(timestamp.longValue() * 1000);
+        Date date = new Date(timestamp.getTime());
         return sdf.format(date);
     }
 

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformTemporalFunctionsProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformTemporalFunctionsProcessor.java
@@ -98,25 +98,43 @@ public class TestTransformTemporalFunctionsProcessor {
 
     @Test
     public void testDateFormatFunction() throws Exception {
-        String transformSql = "select date_format(numeric1, string1) from source";
-        TransformConfig config = new TransformConfig(transformSql);
+        String transformSql1 = "select date_format(string1, 'yyyy-MM-dd HH:mm:ss') from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
         TransformProcessor<String, String> processor1 = TransformProcessor
-                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
                         SinkEncoderFactory.createKvEncoder(kvSink));
-        // case1: date_format(1722524216, 'yyyy-MM-dd HH:mm:ss')
-        List<String> output1 = processor1.transform("yyyy-MM-dd HH:mm:ss|apple|cloud|1722524216|1|3", new HashMap<>());
+        // case1: date_format('2024-08-01 22:56:56', 'yyyy-MM-dd HH:mm:ss')
+        List<String> output1 = processor1.transform("2024-08-01 22:56:56", new HashMap<>());
         Assert.assertEquals(1, output1.size());
         Assert.assertEquals(output1.get(0), "result=2024-08-01 22:56:56");
-        // case2: date_format(1722524216, 'yyyy-MM-dd')
-        List<String> output2 = processor1.transform("yyyy-MM-dd|apple|cloud|1722524216|1|3", new HashMap<>());
+
+        String transformSql2 = "select date_format(string1, 'yyyy-MM-dd') from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case2: date_format('2024-08-01 22:56:56', 'yyyy-MM-dd')
+        List<String> output2 = processor2.transform("2024-08-01 22:56:56", new HashMap<>());
         Assert.assertEquals(1, output2.size());
         Assert.assertEquals(output2.get(0), "result=2024-08-01");
-        // case3: date_format(1722524216, 'yyyyMMddHHmmss')
-        List<String> output3 = processor1.transform("yyyyMMddHHmmss|apple|cloud|1722524216|1|3", new HashMap<>());
+
+        String transformSql3 = "select date_format(string1, 'yyyyMMddHHmmss') from source";
+        TransformConfig config3 = new TransformConfig(transformSql3);
+        TransformProcessor<String, String> processor3 = TransformProcessor
+                .create(config3, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case3: date_format('2024-08-01 22:56:56', 'yyyyMMddHHmmss')
+        List<String> output3 = processor3.transform("2024-08-01 22:56:56", new HashMap<>());
         Assert.assertEquals(1, output3.size());
         Assert.assertEquals(output3.get(0), "result=20240801225656");
-        // case4: date_format(1722524216, 'yyyy/MM/dd HH:mm:ss')
-        List<String> output4 = processor1.transform("yyyy/MM/dd HH:mm:ss|apple|cloud|1722524216|1|3", new HashMap<>());
+
+        String transformSql4 = "select date_format(string1, 'yyyy/MM/dd HH:mm:ss') from source";
+        TransformConfig config4 = new TransformConfig(transformSql4);
+        TransformProcessor<String, String> processor4 = TransformProcessor
+                .create(config4, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: date_format('2024-08-01 22:56:56', 'yyyy/MM/dd HH:mm:ss')
+        List<String> output4 = processor4.transform("2024-08-01 22:56:56", new HashMap<>());
         Assert.assertEquals(1, output4.size());
         Assert.assertEquals(output4.get(0), "result=2024/08/01 22:56:56");
     }


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10776

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
In `DateFormatFunction.java`, the first parameter(timestamp) is currently parsed as a `BigDecimal` type. It's incorrect according to the Flink documentation, it should be parsed as a `java.sql.Timestamp` type.
### Modifications

<!--Describe the modifications you've done.-->
Modify the class `DateFormatFunction` and the correspoding unit test codes

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests in `TestTransformTemporalFunctionsProcessor.java`

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
