### PR TITLE
[INLONG-10806][SDK] Optimize python dataproxy sdk build script

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
@@ -30,34 +30,34 @@ InLong Dataproxy Python SDK is a wrapper over the existing [C++ SDK](https://git
 
 ## Build
 
-1. Build the C++ SDK
+### Build the C++ SDK
 
-   Go to the `dataproxy-sdk-cpp` root directory, and run the following commands:
-   
-   ```bash
-   chmod +x ./build_third_party.sh && chmod +x ./build.sh
-   ./build_third_party.sh
-   ./build.sh
-   ```
+Go to the `dataproxy-sdk-cpp` root directory, and run the following commands:
 
-   If you have already built the C++ SDK, you can skip this step.
+```bash
+chmod +x ./build_third_party.sh && chmod +x ./build.sh
+./build_third_party.sh
+./build.sh
+```
 
-2. Build the Python SDK
+If you have already built the C++ SDK, you can skip this step.
 
-   Go to the `dataproxy-sdk-python` root directory, and run the following commands:
-   
-   ```bash
-   chmod +x ./build.sh
-   ./build.sh
-   ```
-   When the .so file is generated, you will see the following message, you can choose to enter the target directory for the .so files. By default, the .so file will be copied to the system python site-packages directory:
+### Build the Python SDK
 
-   ```txt
-   Your system's Python site-packages directory is: xxx/xxx
-   Enter the target directory for the .so files (Press Enter to use the default site-packages directory):
-   ```
+Go to the `dataproxy-sdk-python` root directory, and run the following commands:
 
-   After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
+```bash
+chmod +x ./build.sh
+./build.sh
+```
+When the .so file is generated, you will see the following message, you can choose to enter the target directory for the .so files. By default, the .so file will be copied to the system python site-packages directory:
+
+```txt
+Your system's Python site-packages directory is: xxx/xxx
+Enter the target directory for the .so files (Press Enter to use the default site-packages directory):
+```
+
+After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
 
 > **Note**: When the C++ SDK or the version of Python you're using is updated, you'll need to rebuild it by the above steps.
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
@@ -29,16 +29,37 @@ InLong Dataproxy Python SDK is a wrapper over the existing [C++ SDK](https://git
 - Python 3.6+
 
 ## Build
-Go to the dataproxy-sdk-python root directory, and run
 
-```bash
-chmod +x ./build.sh
-./build.sh
-```
+1. Build the C++ SDK
 
-After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
+   Go to the `dataproxy-sdk-cpp` root directory, and run the following commands:
+   
+   ```bash
+   chmod +x ./build_third_party.sh && chmod +x ./build.sh
+   ./build_third_party.sh
+   ./build.sh
+   ```
 
-> **Note**: When the C++ SDK or the version of Python you're using is updated, you'll need to rebuild it by re-executing the `build.sh` script
+   If you have already built the C++ SDK, you can skip this step.
+
+2. Build the Python SDK
+
+   Go to the `dataproxy-sdk-python` root directory, and run the following commands:
+   
+   ```bash
+   chmod +x ./build.sh
+   ./build.sh
+   ```
+   When the .so file is generated, you will see the following message, you can choose to enter the target directory for the .so files. By default, the .so file will be copied to the system python site-packages directory:
+
+   ```txt
+   Your system's Python site-packages directory is: xxx/xxx
+   Enter the target directory for the .so files (Press Enter to use the default site-packages directory):
+   ```
+
+   After the build process finished, you can import the package (`import inlong_dataproxy`) in your python project to use InLong dataproxy.
+
+> **Note**: When the C++ SDK or the version of Python you're using is updated, you'll need to rebuild it by the above steps.
 
 ## Config Parameters
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/build.sh
@@ -18,6 +18,8 @@
 
 #!/bin/bash
 
+set -e
+
 BASE_DIR=`dirname "$0"`
 PY_SDK_DIR=`cd "$BASE_DIR";pwd`
 
@@ -49,24 +51,35 @@ if [ "$(printf '%s\n' "$PYTHON_REQUIRED" "$PYTHON_VERSION" | sort -V | head -n1)
     exit 1
 fi
 
-# Clone and build pybind11
-git clone https://github.com/pybind/pybind11.git $PY_SDK_DIR/pybind11
-mkdir $PY_SDK_DIR/pybind11/build && cd $PY_SDK_DIR/pybind11/build
-cmake $PY_SDK_DIR/pybind11
-cmake --build $PY_SDK_DIR/pybind11/build --config Release --target check
-make check -j 4
+# Build pybind11(If the pybind11 has been compiled, this step will be skipped)
+if [ ! -d "$PY_SDK_DIR/pybind11/build" ]; then
+    if [ -d "$PY_SDK_DIR/pybind11" ]; then
+        rm -r $PY_SDK_DIR/pybind11
+    fi
+    git clone https://github.com/pybind/pybind11.git $PY_SDK_DIR/pybind11
+    mkdir $PY_SDK_DIR/pybind11/build && cd $PY_SDK_DIR/pybind11/build
+    cmake $PY_SDK_DIR/pybind11
+    cmake --build $PY_SDK_DIR/pybind11/build --config Release --target check
+    make -j 4
+else
+    echo "Skipped build pybind11"
+fi
 
 # Build dataproxy-sdk-cpp(If the dataproxy-sdk-cpp has been compiled, this step will be skipped)
 if [ ! -e "$CPP_SDK_DIR/release/lib/dataproxy_sdk.a" ]; then
-    chmod +x $CPP_SDK_DIR/build_third_party.sh
-    chmod +x $CPP_SDK_DIR/build.sh
-    cd $CPP_SDK_DIR
-    . $CPP_SDK_DIR/build_third_party.sh
-    . $CPP_SDK_DIR/build.sh
-    cp -r $CPP_SDK_DIR $PY_SDK_DIR
+    echo "The dataproxy-sdk-cpp is not compiled, you should run the following commands to compile it first:"
+    echo "----------------------------------------------------------------------------------------------"
+    echo "cd $CPP_SDK_DIR && chmod +x build_third_party.sh && chmod +x build.sh"
+    echo "./build_third_party.sh"
+    echo "./build.sh"
+    echo "----------------------------------------------------------------------------------------------"
+    exit 1
 else
+    if [ -d "$PY_SDK_DIR/dataproxy-sdk-cpp" ]; then
+        rm -r $PY_SDK_DIR/dataproxy-sdk-cpp
+    fi
     cp -r $CPP_SDK_DIR $PY_SDK_DIR
-    echo "Skipped build dataproxy-sdk-cpp"
+    echo "Copied the dataproxy-sdk-cpp directory to the current directory"
 fi
 
 # Build Python SDK
@@ -75,15 +88,24 @@ if [ -d "$PY_SDK_DIR/build" ]; then
 fi
 mkdir $PY_SDK_DIR/build && cd $PY_SDK_DIR/build
 cmake $PY_SDK_DIR
-make
+make -j 4
 
 # Get Python site-packages directory
 SITE_PACKAGES_DIR=$(python -c "import site; print(site.getsitepackages()[0])")
 
-# Copy generated .so file to site-packages directory
-find $PY_SDK_DIR/build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $SITE_PACKAGES_DIR {}
+# Prompt user for target directory
+echo "Your system's Python site-packages directory is: $SITE_PACKAGES_DIR"
+read -p "Enter the target directory for the .so files (Press Enter to use the default site-packages directory): " target_dir
+
+# Use default site-packages directory if user input is empty
+if [ -z "$target_dir" ]; then
+    target_dir=$SITE_PACKAGES_DIR
+fi
+
+# Copy the generated .so file to target directory
+find $PY_SDK_DIR/build -name "*.so" -print0 | xargs -0 -I {} bash -c 'rm -f $0/$1; cp $1 $0' $target_dir {}
 
 # Clean
-rm -r $PY_SDK_DIR/pybind11 $PY_SDK_DIR/dataproxy-sdk-cpp
+rm -r $PY_SDK_DIR/dataproxy-sdk-cpp
 
 echo "Build Python SDK successfully"


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10806

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Optimize the python dataproxy sdk build script with the following optimizations:
- Enable user to customize the dynamic repository directory in the build script process for the convenience of virtual environment users.
- The pybind11 folder is not deleted at the end of the build, the build process automatically detects if there is a compiled Pybind, and if there is, the Pybind download and build steps will be skipped.
- Do not build dataproxy-cpp-sdk in the python sdk build script, to avoid some potential problems, in the build process to automatically detect whether the c++ sdk has been compiled. If not compiled, it will provide the compilation commands to guide the user to compile the c++ sdk.
- Remove Pybind test step for faster build.

### Modifications

<!--Describe the modifications you've done.-->
Modify the python sdk build script and the correspoding README.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
