### PR TITLE
[INLONG-10809][SDK] Improvements to TypeConverter field types and CompareValue in OperatorTools

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/CsvSourceData.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/CsvSourceData.java
@@ -28,14 +28,14 @@ import java.util.Map;
  */
 public class CsvSourceData implements SourceData {
 
-    private List<Map<String, String>> rows = new ArrayList<>();
+    private List<Map<String, Object>> rows = new ArrayList<>();
 
-    private Map<String, String> currentRow;
+    private Map<String, Object> currentRow;
 
     public CsvSourceData() {
     }
 
-    public void putField(String fieldName, String fieldValue) {
+    public void putField(String fieldName, Object fieldValue) {
         this.currentRow.put(fieldName, fieldValue);
     }
 
@@ -50,11 +50,11 @@ public class CsvSourceData implements SourceData {
     }
 
     @Override
-    public String getField(int rowNum, String fieldName) {
+    public Object getField(int rowNum, String fieldName) {
         if (rowNum >= this.rows.size()) {
             return null;
         }
-        Map<String, String> targetRow = this.rows.get(rowNum);
+        Map<String, Object> targetRow = this.rows.get(rowNum);
         return targetRow.get(fieldName);
     }
 }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/CsvSourceDecoder.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/CsvSourceDecoder.java
@@ -76,9 +76,13 @@ public class CsvSourceDecoder implements SourceDecoder<String> {
             int fieldIndex = 0;
             for (FieldInfo field : fields) {
                 String fieldName = field.getName();
-                String fieldValue = null;
+                Object fieldValue = null;
                 if (fieldIndex < fieldValues.length) {
-                    fieldValue = fieldValues[fieldIndex];
+                    try {
+                        fieldValue = field.getConverter().convert(fieldValues[fieldIndex]);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
                 }
                 sourceData.putField(fieldName, fieldValue);
                 fieldIndex++;

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/SourceData.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/SourceData.java
@@ -26,5 +26,5 @@ public interface SourceData {
 
     int getRowCount();
 
-    String getField(int rowNum, String fieldName);
+    Object getField(int rowNum, String fieldName);
 }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/converter/DoubleConverter.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/converter/DoubleConverter.java
@@ -15,27 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.sdk.transform.pojo;
+package org.apache.inlong.sdk.transform.process.converter;
 
-import org.apache.inlong.sdk.transform.process.converter.TypeConverter;
+public class DoubleConverter implements TypeConverter {
 
-import lombok.Data;
-
-/**
- * FieldInfo
- */
-@Data
-public class FieldInfo {
-
-    private String name;
-    private TypeConverter converter = TypeConverter.DefaultTypeConverter();
-
-    public FieldInfo() {
-
-    }
-
-    public FieldInfo(String name, TypeConverter converter) {
-        this.name = name;
-        this.converter = converter;
+    @Override
+    public Object convert(String value) throws Exception {
+        return Double.parseDouble(value);
     }
 }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/converter/LongConverter.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/converter/LongConverter.java
@@ -15,27 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.sdk.transform.pojo;
+package org.apache.inlong.sdk.transform.process.converter;
 
-import org.apache.inlong.sdk.transform.process.converter.TypeConverter;
+public class LongConverter implements TypeConverter {
 
-import lombok.Data;
-
-/**
- * FieldInfo
- */
-@Data
-public class FieldInfo {
-
-    private String name;
-    private TypeConverter converter = TypeConverter.DefaultTypeConverter();
-
-    public FieldInfo() {
-
-    }
-
-    public FieldInfo(String name, TypeConverter converter) {
-        this.name = name;
-        this.converter = converter;
+    @Override
+    public Object convert(String value) throws Exception {
+        return Long.parseLong(value);
     }
 }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/IfFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/IfFunction.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.operator.ExpressionOperator;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.util.List;
+
+/**
+ * IfFunction
+ * description: if(expr,r1,r2) -- expr is an expression, if it holds, return r1; otherwise, return r2
+ */
+@TransformFunction(names = {"if"})
+public class IfFunction implements ValueParser {
+
+    private final ExpressionOperator expressionOperator;
+    private final ValueParser tureValueParser;
+    private final ValueParser falseValueParser;
+
+    public IfFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        expressionOperator = OperatorTools.buildOperator(expressions.get(0));
+        tureValueParser = OperatorTools.buildParser(expressions.get(1));
+        falseValueParser = OperatorTools.buildParser(expressions.get(2));
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        boolean condition = expressionOperator.check(sourceData, rowIndex, context);
+        return condition ? tureValueParser.parse(sourceData, rowIndex, context)
+                : falseValueParser.parse(sourceData, rowIndex, context);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
@@ -183,19 +183,18 @@ public class OperatorTools {
         if (right == null) {
             return 1;
         }
-        if (left instanceof String) {
-            if (right instanceof String) {
-                return ObjectUtils.compare(left, right);
-            } else {
-                BigDecimal leftValue = parseBigDecimal(left);
-                return ObjectUtils.compare(leftValue, right);
-            }
+
+        if (((Object) left).getClass() == ((Object) right).getClass()) {
+            return ObjectUtils.compare(left, right);
         } else {
-            if (right instanceof String) {
+            try {
+                BigDecimal leftValue = parseBigDecimal(left);
                 BigDecimal rightValue = parseBigDecimal(right);
-                return ObjectUtils.compare(left, rightValue);
-            } else {
-                return ObjectUtils.compare(left, right);
+                return ObjectUtils.compare(leftValue, rightValue);
+            } catch (Exception e) {
+                String leftValue = parseString(left);
+                String rightValue = parseString(right);
+                return ObjectUtils.compare(leftValue, rightValue);
             }
         }
     }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/DoubleParser.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/DoubleParser.java
@@ -24,6 +24,7 @@ import net.sf.jsqlparser.expression.DoubleValue;
 
 /**
  * LongParser
+ *
  */
 public class DoubleParser implements ValueParser {
 

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformExpressionOperatorsProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/TestTransformExpressionOperatorsProcessor.java
@@ -1,0 +1,354 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.CsvSourceInfo;
+import org.apache.inlong.sdk.transform.pojo.FieldInfo;
+import org.apache.inlong.sdk.transform.pojo.KvSinkInfo;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.converter.DoubleConverter;
+import org.apache.inlong.sdk.transform.process.converter.LongConverter;
+import org.apache.inlong.sdk.transform.process.converter.TypeConverter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * TestArithmeticFunctionsTransformProcessor
+ * description: test the arithmetic functions in transform processor
+ */
+public class TestTransformExpressionOperatorsProcessor {
+
+    private static final List<FieldInfo> srcFields = new ArrayList<>();
+    private static final List<FieldInfo> dstFields = new ArrayList<>();
+    private static final CsvSourceInfo csvSource;
+    private static final KvSinkInfo kvSink;
+
+    static {
+        srcFields.add(new FieldInfo("numeric1", new DoubleConverter()));
+        srcFields.add(new FieldInfo("string2", TypeConverter.DefaultTypeConverter()));
+        srcFields.add(new FieldInfo("numeric3", new DoubleConverter()));
+        srcFields.add(new FieldInfo("numeric4", new LongConverter()));
+
+        FieldInfo field = new FieldInfo();
+        field.setName("result");
+        dstFields.add(field);
+        csvSource = new CsvSourceInfo("UTF-8", '|', '\\', srcFields);
+        kvSink = new KvSinkInfo("UTF-8", dstFields);
+    }
+
+    @Test
+    public void testEqualsToOperator() throws Exception {
+        String transformSql = "select if(string2 = 4,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|4a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|4a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=0");
+        // case2: "3.14159265358979323846|4|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+
+        transformSql = "select if(numeric3 = 4,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=1");
+        // case4: "3.14159265358979323846|4|4.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=0");
+    }
+
+    @Test
+    public void testNotEqualsToOperator() throws Exception {
+        String transformSql = "select if(string2 != 4,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|4a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|4a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=1");
+        // case2: "3.14159265358979323846|4|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=0");
+
+        transformSql = "select if(numeric3 != 4,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=0");
+        // case4: "3.14159265358979323846|4|4.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=1");
+    }
+
+    @Test
+    public void testGreaterThanEqualsOperator() throws Exception {
+        String transformSql = "select if(string2 >= 4,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=0");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+
+        transformSql = "select if(numeric3 >= 4,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=1");
+        // case4: "3.14159265358979323846|4|3.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|3.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=0");
+    }
+
+    @Test
+    public void testGreaterThanOperator() throws Exception {
+        String transformSql = "select if(string2 > 4.1,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=0");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+
+        transformSql = "select if(numeric3 > 4.1,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=0");
+        // case4: "3.14159265358979323846|4|4.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=1");
+    }
+
+    @Test
+    public void testMinorThanEqualsOperator() throws Exception {
+        String transformSql = "select if(string2 <= 4,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=1");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=0");
+
+        transformSql = "select if(numeric3 <= 4,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=1");
+        // case4: "3.14159265358979323846|4|4.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=0");
+    }
+
+    @Test
+    public void testMinorThanOperator() throws Exception {
+        String transformSql = "select if(string2 < 4.1,1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=1");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=0");
+
+        transformSql = "select if(numeric3 < 4,1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=0");
+        // case4: "3.14159265358979323846|4|3.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|3.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=1");
+    }
+
+    @Test
+    public void testNotOperator() throws Exception {
+        String transformSql = "select if(!(string2 < 4),1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=0");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+
+        transformSql = "select if(!(numeric3 < 3.9),1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case3: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=1");
+        // case4: "3.14159265358979323846|4|3.2|8"
+        List<String> output4 = processor.transform("3.14159265358979323846|4|3.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=0");
+    }
+
+    @Test
+    public void testOrOperator() throws Exception {
+        String transformSql = "select if((string2 < 4) or (numeric4 > 5),1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|8"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=1");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+        // case3: "3.14159265358979323846|5|4|4"
+        List<String> output3 = processor.transform("3.14159265358979323846|5|4|4");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=0");
+
+        transformSql = "select if((numeric3 < 4) or (numeric4 > 5),1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case4: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=1");
+        // case5: "3.14159265358979323846|4|3.2|8"
+        List<String> output5 = processor.transform("3.14159265358979323846|4|3.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output5.get(0), "result=1");
+        // case6: "3.14159265358979323846|4|4.2|5"
+        List<String> output6 = processor.transform("3.14159265358979323846|4|4.2|5");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output6.get(0), "result=0");
+    }
+
+    @Test
+    public void testAndOperator() throws Exception {
+        String transformSql = "select if((string2 < 4) and (numeric4 > 5),1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|4"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|4");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=0");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=0");
+        // case3: "3.14159265358979323846|3|4|8"
+        List<String> output3 = processor.transform("3.14159265358979323846|3|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=1");
+
+        transformSql = "select if((numeric3 < 4) and (numeric4 > 5),1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case4: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=0");
+        // case5: "3.14159265358979323846|4|3.2|4"
+        List<String> output5 = processor.transform("3.14159265358979323846|4|3.2|4");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output5.get(0), "result=0");
+        // case6: "3.14159265358979323846|4|3.2|8"
+        List<String> output6 = processor.transform("3.14159265358979323846|4|3.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output6.get(0), "result=1");
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10809 

### Motivation

- Modified the SourceData interface to enable it to return multiple data types; Based on this, the CsvSourceData class was modified.

  - The ValueParser interface has reserved the ability to return multiple data types, so SourceData only needs to be aligned with it.

- To enable the functionality of field types, modify the FieldInfo class to have a default TypeConverter.

  - If the original FieldInfo class needs to pass TypeConverter through the constructor, otherwise it will be null, causing each Field to have no type; This requires specifying the default implementation of TypeConverter.

- Based on the TypeConverter interface, two converters, DoubleConverter and LongConverter, have been implemented.

- In order to enable InLong Transform to parse floating-point data types in SQL statements, the DoubleParser class is added.

  For example, the following SQL statement:

  ```sql
  select if(numeric1 < 4.3,1,0) from source
  ```

  InLong Transform cannot parse `4.3`, resulting in the expression being parsed as `null` on the right-hand side.

- Modify the OperatorTool.compareValue method to align the types of both parties being compared. The specific processing is as follows:

  -  If the types on both sides are the same, compare them directly.
  -  If the types on both sides are different, try constructing them as the `BigDecimal` type:
     -  If the construction process passes normally, it means that numerical comparison can be made.
     -  If an exception is thrown during the construction process, indicating the existence of a non numeric type, then it should be uniformly converted to the `String` type for comparison.

- Add IfFunction class for testing various classes of ExpressionOperator.


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*