### PR TITLE
[INLONG-10831][Sort] SortStandalone support HTTP sink

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/constant/SinkType.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/constant/SinkType.java
@@ -24,5 +24,6 @@ public class SinkType {
     public static final String CLS = "CLS";
     public static final String ELASTICSEARCH = "ELASTICSEARCH";
     public static final String STARROCKS = "STARROCKS";
+    public static final String HTTP = "HTTP";
 
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/HttpSinkConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/HttpSinkConfig.java
@@ -15,13 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.common.constant;
+package org.apache.inlong.common.pojo.sort.dataflow.sink;
 
-public class DataNodeType {
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
-    public static final String KAFKA = "KAFKA";
-    public static final String PULSAR = "PULSAR";
-    public static final String CLS = "CLS";
-    public static final String ELASTICSEARCH = "ELASTICSEARCH";
-    public static final String HTTP = "HTTP";
+import java.util.Map;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class HttpSinkConfig extends SinkConfig {
+
+    private String path;
+    private String method;
+    private Map<String, String> headers;
+    private Integer maxRetryTimes;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/SinkConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/SinkConfig.java
@@ -34,6 +34,7 @@ import java.util.List;
         @JsonSubTypes.Type(value = EsSinkConfig.class, name = SinkType.ELASTICSEARCH),
         @JsonSubTypes.Type(value = PulsarSinkConfig.class, name = SinkType.PULSAR),
         @JsonSubTypes.Type(value = KafkaSinkConfig.class, name = SinkType.KAFKA),
+        @JsonSubTypes.Type(value = HttpSinkConfig.class, name = SinkType.HTTP),
 })
 public abstract class SinkConfig implements Serializable {
 

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
@@ -27,4 +27,5 @@ public class HttpNodeConfig extends NodeConfig {
     private String username;
     private String password;
     private Integer maxConnect;
+    private String NodeType;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
@@ -15,13 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.common.constant;
+package org.apache.inlong.common.pojo.sort.node;
 
-public class DataNodeType {
+import lombok.Data;
 
-    public static final String KAFKA = "KAFKA";
-    public static final String PULSAR = "PULSAR";
-    public static final String CLS = "CLS";
-    public static final String ELASTICSEARCH = "ELASTICSEARCH";
-    public static final String HTTP = "HTTP";
+@Data
+public class HttpNodeConfig extends NodeConfig {
+
+    private String baseUrl;
+    private Boolean enableCredential;
+    private String username;
+    private String password;
+    private Integer maxConnect;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/HttpNodeConfig.java
@@ -27,5 +27,4 @@ public class HttpNodeConfig extends NodeConfig {
     private String username;
     private String password;
     private Integer maxConnect;
-    private String NodeType;
 }

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/NodeConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/node/NodeConfig.java
@@ -33,6 +33,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = EsNodeConfig.class, name = DataNodeType.ELASTICSEARCH),
         @JsonSubTypes.Type(value = PulsarNodeConfig.class, name = DataNodeType.PULSAR),
         @JsonSubTypes.Type(value = KafkaNodeConfig.class, name = DataNodeType.KAFKA),
+        @JsonSubTypes.Type(value = HttpNodeConfig.class, name = DataNodeType.HTTP),
 })
 public abstract class NodeConfig implements Serializable {
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.apache.inlong.sort.standalone.utils.UnescapeHelper;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandler {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(DefaultEvent2HttpRequestHandler.class);
+
+    @Override
+    public HttpRequest parse(HttpSinkContext context, ProfileEvent event)
+            throws URISyntaxException, JsonProcessingException {
+        String uid = event.getUid();
+        HttpIdConfig idConfig = context.getIdConfig(uid);
+        if (idConfig == null) {
+            context.addSendResultMetric(event, context.getTaskName(), false, System.currentTimeMillis());
+            return null;
+        }
+        // get the delimiter
+        String delimiter = idConfig.getSeparator();
+        char cDelimiter = delimiter.charAt(0);
+        // for tab separator
+        byte[] bodyBytes = event.getBody();
+        String strContext = new String(bodyBytes, Charset.defaultCharset());
+        // unescape
+        List<String> columnValues = UnescapeHelper.toFiledList(strContext, cDelimiter);
+        int valueLength = columnValues.size();
+        List<String> fieldList = idConfig.getFieldList();
+        int columnLength = fieldList.size();
+        // get field value
+        Map<String, String> fieldMap = new HashMap<>();
+        for (int i = 0; i < columnLength; ++i) {
+            String fieldName = fieldList.get(i);
+            String fieldValue = i < valueLength ? columnValues.get(i) : "";
+            fieldMap.put(fieldName, fieldValue);
+        }
+
+        // build
+        String uriString = context.getBaseUrl() + idConfig.getPath();
+        if (!uriString.startsWith("http://") && !uriString.startsWith("https://")) {
+            uriString = "http://" + uriString;
+        }
+        URI uri = new URI(uriString);
+        String jsonData = new ObjectMapper().writeValueAsString(fieldMap);
+        HttpUriRequest request;
+        switch (idConfig.getMethod().toUpperCase()) {
+            case "GET":
+                String params = fieldMap.entrySet().stream()
+                        .map(entry -> {
+                            try {
+                                return URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.name()) + "="
+                                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8.name());
+                            } catch (UnsupportedEncodingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                        .collect(Collectors.joining("&"));
+                request = new HttpGet(uri + "?" + params);
+                for (Map.Entry<String, String> entry : idConfig.getHeaders().entrySet()) {
+                    request.setHeader(entry.getKey(), entry.getValue());
+                }
+                request.setHeader("InlongGroupID", idConfig.getInlongGroupId());
+                request.setHeader("InlongStreamID", idConfig.getInlongStreamId());
+                break;
+            case "POST":
+                request = new HttpPost(uri);
+                for (Map.Entry<String, String> entry : idConfig.getHeaders().entrySet()) {
+                    request.setHeader(entry.getKey(), entry.getValue());
+                }
+                request.setHeader("InlongGroupID", idConfig.getInlongGroupId());
+                request.setHeader("InlongStreamID", idConfig.getInlongStreamId());
+                setEntity((HttpEntityEnclosingRequestBase) request, jsonData);
+                break;
+            case "PUT":
+                request = new HttpPut(uri);
+                for (Map.Entry<String, String> entry : idConfig.getHeaders().entrySet()) {
+                    request.setHeader(entry.getKey(), entry.getValue());
+                }
+                request.setHeader("InlongGroupID", idConfig.getInlongGroupId());
+                request.setHeader("InlongStreamID", idConfig.getInlongStreamId());
+                setEntity((HttpEntityEnclosingRequestBase) request, jsonData);
+                break;
+            default:
+                LOG.error("Unsupported method: {}", idConfig.getMethod().toUpperCase());
+                return null;
+        }
+        return new HttpRequest(request, event, idConfig.getMaxRetryTimes());
+    }
+
+    private static void setEntity(HttpEntityEnclosingRequestBase request, String jsonData) {
+        StringEntity requestEntity = new StringEntity(jsonData, ContentType.APPLICATION_JSON);
+        request.setEntity(requestEntity);
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandler {
 
     public static final Logger LOG = InlongLoggerFactory.getLogger(DefaultEvent2HttpRequestHandler.class);
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public HttpRequest parse(HttpSinkContext context, ProfileEvent event)
@@ -81,7 +82,7 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
             uriString = "http://" + uriString;
         }
         URI uri = new URI(uriString);
-        String jsonData = new ObjectMapper().writeValueAsString(fieldMap);
+        String jsonData;
         HttpUriRequest request;
         switch (idConfig.getMethod().toUpperCase()) {
             case "GET":
@@ -109,6 +110,7 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
                 }
                 request.setHeader("InlongGroupID", idConfig.getInlongGroupId());
                 request.setHeader("InlongStreamID", idConfig.getInlongStreamId());
+                jsonData = objectMapper.writeValueAsString(fieldMap);
                 setEntity((HttpEntityEnclosingRequestBase) request, jsonData);
                 break;
             case "PUT":
@@ -118,6 +120,7 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
                 }
                 request.setHeader("InlongGroupID", idConfig.getInlongGroupId());
                 request.setHeader("InlongStreamID", idConfig.getInlongStreamId());
+                jsonData = objectMapper.writeValueAsString(fieldMap);
                 setEntity((HttpEntityEnclosingRequestBase) request, jsonData);
                 break;
             default:

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
@@ -36,8 +36,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +64,7 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
         char cDelimiter = delimiter.charAt(0);
         // for tab separator
         byte[] bodyBytes = event.getBody();
-        String strContext = new String(bodyBytes, Charset.defaultCharset());
+        String strContext = new String(bodyBytes, idConfig.getSourceCharset());
         // unescape
         List<String> columnValues = UnescapeHelper.toFiledList(strContext, cDelimiter);
         int valueLength = columnValues.size();
@@ -94,8 +92,8 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
                 String params = fieldMap.entrySet().stream()
                         .map(entry -> {
                             try {
-                                return URLEncoder.encode(entry.getKey() + "=" + entry.getValue(),
-                                        StandardCharsets.UTF_8.name());
+                                return entry.getKey() + "="
+                                        + URLEncoder.encode(entry.getValue(), idConfig.getSinkCharset().name());
                             } catch (UnsupportedEncodingException e) {
                                 throw new RuntimeException(e);
                             }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpCallback.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.concurrent.FutureCallback;
+import org.slf4j.Logger;
+
+public class HttpCallback implements FutureCallback<HttpResponse> {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(HttpCallback.class);
+
+    private HttpSinkContext context;
+    private HttpRequest requestItem;
+
+    public HttpCallback(HttpSinkContext context, HttpRequest requestItem) {
+        this.context = context;
+        this.requestItem = requestItem;
+    }
+
+    @Override
+    public void completed(HttpResponse httpResponse) {
+        int statusCode = httpResponse.getStatusLine().getStatusCode();
+        ProfileEvent event = requestItem.getEvent();
+        long sendTime = requestItem.getSendTime();
+
+        // is fail
+        if (statusCode != 200) {
+            context.addSendResultMetric(event, context.getTaskName(), false, sendTime);
+            // if reach the max retry times, release the request
+            int remainRetryTimes = requestItem.getRemainRetryTimes();
+            if (remainRetryTimes == 1) {
+                context.releaseDispatchQueue(requestItem);
+                return;
+            }
+            if (remainRetryTimes > 1) {
+                requestItem.setRemainRetryTimes(remainRetryTimes - 1);
+            }
+            context.backDispatchQueue(requestItem);
+        } else {
+            context.addSendResultMetric(event, context.getTaskName(), true, sendTime);
+            context.releaseDispatchQueue(requestItem);
+            event.ack();
+        }
+    }
+
+    @Override
+    public void failed(Exception e) {
+        LOG.error("Http request failed,errorMsg:" + e.getMessage(), e);
+        ProfileEvent event = requestItem.getEvent();
+        long sendTime = requestItem.getSendTime();
+        int remainRetryTimes = requestItem.getRemainRetryTimes();
+        context.addSendResultMetric(event, context.getTaskName(), false, sendTime);
+        // if reach the max retry times, release the request
+        if (remainRetryTimes == 1) {
+            context.releaseDispatchQueue(requestItem);
+            return;
+        }
+        if (remainRetryTimes > 1) {
+            requestItem.setRemainRetryTimes(remainRetryTimes - 1);
+        }
+        context.backDispatchQueue(requestItem);
+    }
+
+    @Override
+    public void cancelled() {
+        LOG.info("Request cancelled");
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpChannelWorker.java
@@ -46,12 +46,13 @@ public class HttpChannelWorker extends Thread {
     @Override
     public void run() {
         status = LifecycleState.START;
-        LOG.info("start to HttpChannelWorker:{},status:{},index:{}", context.getTaskName(), status, workerIndex);
+        LOG.info("Starting HttpChannelWorker:{},status:{},index:{}", context.getTaskName(), status, workerIndex);
         while (status == LifecycleState.START) {
             try {
                 this.doRun();
             } catch (Throwable t) {
-                LOG.error(t.getMessage(), t);
+                LOG.error("Error occurred while starting HttpChannelWorker:{},status:{},index:{}",
+                        context.getTaskName(), status, workerIndex, t);
             }
         }
     }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpChannelWorker.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpChannelWorker.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+
+import org.apache.flume.Channel;
+import org.apache.flume.Event;
+import org.apache.flume.Transaction;
+import org.apache.flume.lifecycle.LifecycleState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpChannelWorker extends Thread {
+
+    public static final Logger LOG = LoggerFactory.getLogger(HttpChannelWorker.class);
+
+    private final HttpSinkContext context;
+    private final int workerIndex;
+
+    private LifecycleState status;
+    private IEvent2HttpRequestHandler handler;
+
+    public HttpChannelWorker(HttpSinkContext context, int workerIndex) {
+        this.context = context;
+        this.workerIndex = workerIndex;
+        this.status = LifecycleState.IDLE;
+        this.handler = context.createHttpRequestHandler();
+    }
+
+    @Override
+    public void run() {
+        status = LifecycleState.START;
+        LOG.info("start to HttpChannelWorker:{},status:{},index:{}", context.getTaskName(), status, workerIndex);
+        while (status == LifecycleState.START) {
+            try {
+                this.doRun();
+            } catch (Throwable t) {
+                LOG.error(t.getMessage(), t);
+            }
+        }
+    }
+
+    public void doRun() {
+        Channel channel = context.getChannel();
+        Transaction tx = channel.getTransaction();
+        tx.begin();
+        try {
+            Event event = channel.take();
+            if (event == null) {
+                tx.commit();
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            if (!(event instanceof ProfileEvent)) {
+                tx.commit();
+                this.context.addSendFailMetric();
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            // to profileEvent
+            ProfileEvent profileEvent = (ProfileEvent) event;
+            HttpRequest httpRequest = handler.parse(context, profileEvent);
+            // offer queue
+            if (httpRequest != null) {
+                context.offerDispatchQueue(httpRequest);
+            } else {
+                context.addSendFailMetric();
+                profileEvent.ack();
+            }
+            tx.commit();
+        } catch (Throwable t) {
+            LOG.error("Process event failed!{}", this.getName(), t);
+            try {
+                tx.rollback();
+            } catch (Throwable e) {
+                LOG.error("Channel take transaction rollback exception:{}", getName(), e);
+            }
+        } finally {
+            tx.close();
+        }
+    }
+
+    public void close() {
+        this.status = LifecycleState.STOP;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpIdConfig.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpIdConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.common.pojo.sort.dataflow.DataFlowConfig;
+import org.apache.inlong.common.pojo.sort.dataflow.field.FieldConfig;
+import org.apache.inlong.common.pojo.sort.dataflow.sink.HttpSinkConfig;
+import org.apache.inlong.sort.standalone.config.pojo.IdConfig;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class HttpIdConfig extends IdConfig {
+
+    private String path;
+    private String method;
+    private Map<String, String> headers;
+    private Integer maxRetryTimes;
+    private String separator = "|";
+    private List<String> fieldList;
+
+    public static HttpIdConfig create(DataFlowConfig dataFlowConfig) {
+        HttpSinkConfig sinkConfig = (HttpSinkConfig) dataFlowConfig.getSinkConfig();
+        List<String> fields = sinkConfig.getFieldConfigs()
+                .stream()
+                .map(FieldConfig::getName)
+                .collect(Collectors.toList());
+        return HttpIdConfig.builder()
+                .inlongGroupId(dataFlowConfig.getInlongGroupId())
+                .inlongStreamId(dataFlowConfig.getInlongStreamId())
+                .path(sinkConfig.getPath())
+                .method(sinkConfig.getMethod())
+                .headers(sinkConfig.getHeaders())
+                .maxRetryTimes(sinkConfig.getMaxRetryTimes())
+                .separator("|")
+                .fieldList(fields)
+                .build();
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpOutputChannel.java
@@ -99,12 +99,13 @@ public class HttpOutputChannel extends Thread {
     @Override
     public void run() {
         status = LifecycleState.START;
-        LOG.info("start to HttpOutputChannel:{},status:{}", context.getTaskName(), status);
+        LOG.info("Starting HttpOutputChannel:{},status:{}", context.getTaskName(), status);
         while (status == LifecycleState.START) {
             try {
                 send();
             } catch (Throwable t) {
-                LOG.error(t.getMessage(), t);
+                LOG.error("Error occurred while starting HttpOutputChannel:{},status:{}", context.getTaskName(), status,
+                        t);
             }
         }
     }
@@ -129,7 +130,7 @@ public class HttpOutputChannel extends Thread {
             httpClient.execute(httpRequest.getRequest(), new HttpCallback(context, httpRequest));
             context.addSendMetric(httpRequest.getEvent(), context.getTaskName());
         } catch (Throwable e) {
-            LOG.error(e.getMessage(), e);
+            LOG.error("Failed to send HttpRequest '{}': {}", httpRequest, e.getMessage(), e);
             if (httpRequest != null) {
                 context.backDispatchQueue(httpRequest);
                 context.addSendResultMetric(httpRequest.getEvent(), context.getTaskName(), false,
@@ -138,7 +139,7 @@ public class HttpOutputChannel extends Thread {
             try {
                 Thread.sleep(context.getProcessInterval());
             } catch (InterruptedException e1) {
-                LOG.error(e1.getMessage(), e1);
+                LOG.error("Thread interrupted while sleeping, error: {}", e1.getMessage(), e1);
             }
         }
     }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpOutputChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpOutputChannel.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+
+import org.apache.flume.lifecycle.LifecycleState;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+
+public class HttpOutputChannel extends Thread {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(HttpOutputChannel.class);
+
+    private LifecycleState status;
+    private HttpSinkContext context;
+    private CloseableHttpAsyncClient httpClient;
+
+    public HttpOutputChannel(HttpSinkContext context) {
+        super(context.getTaskName());
+        this.context = context;
+        this.status = LifecycleState.IDLE;
+    }
+
+    public void init() {
+        initHttpClient();
+    }
+
+    private boolean initHttpClient() {
+        try {
+            if (httpClient == null) {
+                String userName = context.getUsername();
+                String password = context.getPassword();
+                LOG.info("initHttpAsyncClient:url:{}", context.getBaseUrl());
+
+                HttpAsyncClientBuilder builder = HttpAsyncClients.custom();
+                final CredentialsProvider provider = new BasicCredentialsProvider();
+                if (context.getEnableCredential()) {
+                    provider.setCredentials(AuthScope.ANY,
+                            new UsernamePasswordCredentials(userName, password));
+                    builder.setDefaultCredentialsProvider(provider);
+                }
+
+                RequestConfig requestConfig = RequestConfig.custom()
+                        .setConnectionRequestTimeout(context.getConnectionRequestTimeout())
+                        .setSocketTimeout(context.getSocketTimeout())
+                        .setMaxRedirects(context.getMaxRedirects())
+                        .setConnectTimeout(120 * 1000)
+                        .build();
+
+                builder.setDefaultRequestConfig(requestConfig)
+                        .setMaxConnTotal(context.getMaxConnect())
+                        .setMaxConnPerRoute(context.getMaxConnectPerRoute());
+
+                httpClient = HttpSinkFactory.createHttpAsyncClient(builder);
+                httpClient.start();
+            }
+        } catch (Exception e) {
+            LOG.error("init httpclient failed.", e);
+            httpClient = null;
+            return false;
+        }
+        return true;
+    }
+
+    public void close() {
+        status = LifecycleState.STOP;
+        try {
+            httpClient.close();
+        } catch (IOException e) {
+            LOG.error(String.format("close HttpClient:%s", e.getMessage()), e);
+        }
+    }
+
+    @Override
+    public void run() {
+        status = LifecycleState.START;
+        LOG.info("start to HttpOutputChannel:{},status:{}", context.getTaskName(), status);
+        while (status == LifecycleState.START) {
+            try {
+                send();
+            } catch (Throwable t) {
+                LOG.error(t.getMessage(), t);
+            }
+        }
+    }
+
+    public void send() throws InterruptedException {
+        HttpRequest httpRequest = null;
+        try {
+            // get httpRequest
+            httpRequest = context.takeDispatchQueue();
+            if (httpRequest == null) {
+                Thread.sleep(context.getProcessInterval());
+                return;
+            }
+            // get id config
+            String uid = httpRequest.getEvent().getUid();
+            if (context.getIdConfig(uid) == null) {
+                context.addSendResultMetric(httpRequest.getEvent(), context.getTaskName(), false,
+                        httpRequest.getSendTime());
+                return;
+            }
+            // send
+            httpClient.execute(httpRequest.getRequest(), new HttpCallback(context, httpRequest));
+            context.addSendMetric(httpRequest.getEvent(), context.getTaskName());
+        } catch (Throwable e) {
+            LOG.error(e.getMessage(), e);
+            if (httpRequest != null) {
+                context.backDispatchQueue(httpRequest);
+                context.addSendResultMetric(httpRequest.getEvent(), context.getTaskName(), false,
+                        httpRequest.getSendTime());
+            }
+            try {
+                Thread.sleep(context.getProcessInterval());
+            } catch (InterruptedException e1) {
+                LOG.error(e1.getMessage(), e1);
+            }
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpRequest.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpRequest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+
+import org.apache.http.client.methods.HttpUriRequest;
+
+public class HttpRequest {
+
+    private final HttpUriRequest request;
+    private final ProfileEvent event;
+    private final long sendTime;
+    private int remainRetryTimes;
+
+    public HttpRequest(HttpUriRequest request, ProfileEvent event, int remainRetryTimes) {
+        this.request = request;
+        this.event = event;
+        this.sendTime = System.currentTimeMillis();
+        this.remainRetryTimes = remainRetryTimes;
+    }
+
+    public HttpUriRequest getRequest() {
+        return request;
+    }
+
+    public ProfileEvent getEvent() {
+        return event;
+    }
+
+    public long getSendTime() {
+        return sendTime;
+    }
+
+    public int getRemainRetryTimes() {
+        return remainRetryTimes;
+    }
+
+    public void setRemainRetryTimes(int remainRetryTimes) {
+        this.remainRetryTimes = remainRetryTimes;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
@@ -58,7 +58,7 @@ public class HttpSink extends AbstractSink implements Configurable {
             this.outputChannel.init();
             this.outputChannel.start();
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            LOG.error("Failed to start HttpSink '{}': {}", this.getName(), e.getMessage());
         }
     }
 
@@ -73,7 +73,7 @@ public class HttpSink extends AbstractSink implements Configurable {
             this.workers.clear();
             this.outputChannel.close();
         } catch (Exception e) {
-            LOG.error(e.getMessage(), e);
+            LOG.error("Failed to stop HttpSink '{}': {}", this.getName(), e.getMessage());
         }
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
+
+import org.apache.flume.Context;
+import org.apache.flume.EventDeliveryException;
+import org.apache.flume.conf.Configurable;
+import org.apache.flume.sink.AbstractSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HttpSink extends AbstractSink implements Configurable {
+
+    public static final Logger LOG = LoggerFactory.getLogger(HttpSink.class);
+
+    private Context parentContext;
+    private BufferQueue<HttpRequest> dispatchQueue;
+    private HttpSinkContext context;
+    // workers
+    private List<HttpChannelWorker> workers = new ArrayList<>();
+    // output
+    private HttpOutputChannel outputChannel;
+
+    @Override
+    public void start() {
+        super.start();
+        try {
+            this.dispatchQueue = SinkContext.createBufferQueue();
+            this.context = new HttpSinkContext(getName(), parentContext, getChannel(), dispatchQueue);
+            this.context.start();
+            for (int i = 0; i < context.getMaxThreads(); i++) {
+                HttpChannelWorker worker = new HttpChannelWorker(context, i);
+                this.workers.add(worker);
+                worker.start();
+            }
+            this.outputChannel = HttpSinkFactory.createHttpOutputChannel(context);
+            this.outputChannel.init();
+            this.outputChannel.start();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        try {
+            this.context.close();
+            for (HttpChannelWorker worker : this.workers) {
+                worker.close();
+            }
+            this.workers.clear();
+            this.outputChannel.close();
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void configure(Context context) {
+        LOG.info("start to configure:{}, context:{}.", this.getName(), context.toString());
+        this.parentContext = context;
+    }
+
+    @Override
+    public Status process() throws EventDeliveryException {
+        return Status.BACKOFF;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSink.java
@@ -79,7 +79,7 @@ public class HttpSink extends AbstractSink implements Configurable {
 
     @Override
     public void configure(Context context) {
-        LOG.info("start to configure:{}, context:{}.", this.getName(), context.toString());
+        LOG.info("Start to configure:{}, context:{}.", this.getName(), context.toString());
         this.parentContext = context;
     }
 

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
@@ -64,7 +64,7 @@ public class HttpSinkContext extends SinkContext {
     public static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
     public static final String KEY_MAX_REDIRECTS = "maxRedirects";
     public static final String KEY_LOG_MAX_LENGTH = "logMaxLength";
-    public static final String KEY_EVENT_HTTPREQUEST_HANDLER = "httpRequestHandler";
+    public static final String KEY_EVENT_HTTP_REQUEST_HANDLER = "httpRequestHandler";
 
     public static final boolean DEFAULT_ENABLE_CREDENTIAL = false;
     public static final int DEFAULT_MAX_CONNECT_TOTAL = 1000;
@@ -138,7 +138,7 @@ public class HttpSinkContext extends SinkContext {
             }
             SortConfigMetricReporter.reportClusterDiff(clusterId, taskName, fromTaskConfig, fromSortTaskConfig);
             // log
-            LOG.info("end to get SortTaskConfig:taskName:{}:newIdConfigMap:{}", taskName,
+            LOG.info("End to get SortTaskConfig:taskName:{}:newIdConfigMap:{}", taskName,
                     objectMapper.writeValueAsString(idConfigMap));
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
@@ -386,14 +386,13 @@ public class HttpSinkContext extends SinkContext {
 
     public IEvent2HttpRequestHandler createHttpRequestHandler() {
         // IEvent2HttpRequestHandler
-        String httpRequestHandlerClass = CommonPropertiesHolder.getString(KEY_EVENT_HTTPREQUEST_HANDLER,
+        String httpRequestHandlerClass = CommonPropertiesHolder.getString(KEY_EVENT_HTTP_REQUEST_HANDLER,
                 DefaultEvent2HttpRequestHandler.class.getName());
         try {
             Class<?> handlerClass = ClassUtils.getClass(httpRequestHandlerClass);
             Object handlerObject = handlerClass.getDeclaredConstructor().newInstance();
             if (handlerObject instanceof IEvent2HttpRequestHandler) {
-                IEvent2HttpRequestHandler handler = (IEvent2HttpRequestHandler) handlerObject;
-                return handler;
+                return (IEvent2HttpRequestHandler) handlerObject;
             }
         } catch (Throwable t) {
             LOG.error("Fail to init IEvent2HttpRequestHandler,handlerClass:{},error:{}",

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
@@ -1,0 +1,405 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.common.pojo.sort.ClusterTagConfig;
+import org.apache.inlong.common.pojo.sort.TaskConfig;
+import org.apache.inlong.common.pojo.sort.node.HttpNodeConfig;
+import org.apache.inlong.common.pojo.sortstandalone.SortTaskConfig;
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
+import org.apache.inlong.sort.standalone.config.holder.v2.SortConfigHolder;
+import org.apache.inlong.sort.standalone.config.pojo.InlongId;
+import org.apache.inlong.sort.standalone.metrics.SortConfigMetricReporter;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.metrics.audit.AuditUtils;
+import org.apache.inlong.sort.standalone.sink.SinkContext;
+import org.apache.inlong.sort.standalone.utils.BufferQueue;
+import org.apache.inlong.sort.standalone.utils.Constants;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.flume.Channel;
+import org.apache.flume.Context;
+import org.slf4j.Logger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+
+public class HttpSinkContext extends SinkContext {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(HttpSinkContext.class);
+    public static final String KEY_NODE_ID = "nodeId";
+    public static final String KEY_BASE_URL = "baseUrl";
+    public static final String KEY_ENABLE_CREDENTIAL = "enableCredential";
+    public static final String KEY_USERNAME = "username";
+    public static final String KEY_PASSWORD = "password";
+    public static final String KEY_MAX_CONNECT_TOTAL = "maxConnect";
+    public static final String KEY_MAX_CONNECT_PER_ROUTE = "maxConnectPerRoute";
+    public static final String KEY_CONNECTION_REQUEST_TIMEOUT = "connectionRequestTimeout";
+    public static final String KEY_SOCKET_TIMEOUT = "socketTimeout";
+    public static final String KEY_MAX_REDIRECTS = "maxRedirects";
+    public static final String KEY_LOG_MAX_LENGTH = "logMaxLength";
+    public static final String KEY_EVENT_HTTPREQUEST_HANDLER = "httpRequestHandler";
+
+    public static final boolean DEFAULT_ENABLE_CREDENTIAL = false;
+    public static final int DEFAULT_MAX_CONNECT_TOTAL = 1000;
+    public static final int DEFAULT_MAX_CONNECT_PER_ROUTE = 1000;
+    public static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT = 0;
+    public static final int DEFAULT_SOCKET_TIMEOUT = 0;
+    public static final int DEFAULT_MAX_REDIRECTS = 0;
+    public static final int DEFAULT_LOG_MAX_LENGTH = 32 * 1024;
+
+    private Context sinkContext;
+    private HttpNodeConfig httpNodeConfig;
+    private String nodeId;
+    private Map<String, HttpIdConfig> idConfigMap = new ConcurrentHashMap<>();
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private final BufferQueue<HttpRequest> dispatchQueue;
+    private AtomicLong offerCounter = new AtomicLong(0);
+    private AtomicLong takeCounter = new AtomicLong(0);
+    private AtomicLong backCounter = new AtomicLong(0);
+    // rest client
+    private String baseUrl;
+    private boolean enableCredential;
+    private String username;
+    private String password;
+    private int maxConnect = DEFAULT_MAX_CONNECT_TOTAL;
+    private int maxConnectPerRoute = DEFAULT_MAX_CONNECT_PER_ROUTE;
+    private int connectionRequestTimeout = DEFAULT_CONNECTION_REQUEST_TIMEOUT;
+    private int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
+    private int maxRedirects = DEFAULT_MAX_REDIRECTS;
+    private int logMaxLength = DEFAULT_LOG_MAX_LENGTH;
+
+    public HttpSinkContext(String sinkName, Context context, Channel channel,
+            BufferQueue<HttpRequest> dispatchQueue) {
+        super(sinkName, context, channel);
+        this.sinkContext = context;
+        this.dispatchQueue = dispatchQueue;
+        this.nodeId = CommonPropertiesHolder.getString(KEY_NODE_ID);
+    }
+
+    public void reload() {
+        try {
+            LOG.info("SortTask:{},dispatchQueue:{},offer:{},take:{},back:{}",
+                    taskName, dispatchQueue.size(), offerCounter.getAndSet(0),
+                    takeCounter.getAndSet(0), backCounter.getAndSet(0));
+            TaskConfig newTaskConfig = SortConfigHolder.getTaskConfig(taskName);
+            SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
+            if ((newTaskConfig == null || newTaskConfig.equals(taskConfig))
+                    && (newSortTaskConfig == null || newSortTaskConfig.equals(sortTaskConfig))) {
+                return;
+            }
+            LOG.info("get new SortTaskConfig:taskName:{}", taskName);
+
+            if (newTaskConfig != null) {
+                HttpNodeConfig requestNodeConfig = (HttpNodeConfig) newTaskConfig.getNodeConfig();
+                if (httpNodeConfig == null || requestNodeConfig.getVersion() > httpNodeConfig.getVersion()) {
+                    this.httpNodeConfig = requestNodeConfig;
+                }
+            }
+
+            this.taskConfig = newTaskConfig;
+            this.sortTaskConfig = newSortTaskConfig;
+
+            // change current config
+            Map<String, HttpIdConfig> fromTaskConfig = reloadIdParamsFromTaskConfig(taskConfig);
+            Map<String, HttpIdConfig> fromSortTaskConfig = reloadIdParamsFromSortTaskConfig(sortTaskConfig);
+            if (unifiedConfiguration) {
+                idConfigMap = fromTaskConfig;
+                reloadClientsFromNodeConfig(httpNodeConfig);
+            } else {
+                idConfigMap = fromSortTaskConfig;
+                reloadClientsFromSortTaskConfig(sortTaskConfig);
+            }
+            SortConfigMetricReporter.reportClusterDiff(clusterId, taskName, fromTaskConfig, fromSortTaskConfig);
+            // log
+            LOG.info("end to get SortTaskConfig:taskName:{}:newIdConfigMap:{}", taskName,
+                    objectMapper.writeValueAsString(idConfigMap));
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    private Map<String, HttpIdConfig> reloadIdParamsFromTaskConfig(TaskConfig taskConfig) {
+        if (taskConfig == null) {
+            return new HashMap<>();
+        }
+        return taskConfig.getClusterTagConfigs()
+                .stream()
+                .map(ClusterTagConfig::getDataFlowConfigs)
+                .flatMap(Collection::stream)
+                .map(HttpIdConfig::create)
+                .collect(Collectors.toMap(
+                        config -> InlongId.generateUid(config.getInlongGroupId(), config.getInlongStreamId()),
+                        v -> v,
+                        (flow1, flow2) -> flow1));
+    }
+
+    private Map<String, HttpIdConfig> reloadIdParamsFromSortTaskConfig(SortTaskConfig sortTaskConfig)
+            throws JsonProcessingException {
+        if (sortTaskConfig == null) {
+            return new HashMap<>();
+        }
+        Map<String, HttpIdConfig> newIdConfigMap = new ConcurrentHashMap<>();
+        List<Map<String, String>> idList = this.sortTaskConfig.getIdParams();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        for (Map<String, String> idParam : idList) {
+            String inlongGroupId = idParam.get(Constants.INLONG_GROUP_ID);
+            String inlongStreamId = idParam.get(Constants.INLONG_STREAM_ID);
+            String uid = InlongId.generateUid(inlongGroupId, inlongStreamId);
+            String jsonIdConfig = objectMapper.writeValueAsString(idParam);
+            HttpIdConfig idConfig = objectMapper.readValue(jsonIdConfig, HttpIdConfig.class);
+            newIdConfigMap.put(uid, idConfig);
+        }
+        return newIdConfigMap;
+    }
+
+    private void reloadClientsFromNodeConfig(HttpNodeConfig httpNodeConfig) {
+        Map<String, String> properties = httpNodeConfig.getProperties();
+        this.sinkContext = new Context(properties != null ? properties : new HashMap<>());
+        this.baseUrl = httpNodeConfig.getBaseUrl();
+        this.enableCredential = httpNodeConfig.getEnableCredential();;
+        this.username = httpNodeConfig.getUsername();
+        this.password = httpNodeConfig.getPassword();
+        this.maxConnect = httpNodeConfig.getMaxConnect();
+
+        this.maxConnectPerRoute = sinkContext.getInteger(KEY_MAX_CONNECT_PER_ROUTE, DEFAULT_MAX_CONNECT_PER_ROUTE);
+        this.connectionRequestTimeout =
+                sinkContext.getInteger(KEY_CONNECTION_REQUEST_TIMEOUT, DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+        this.socketTimeout = sinkContext.getInteger(KEY_SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+        this.maxRedirects = sinkContext.getInteger(KEY_MAX_REDIRECTS, DEFAULT_MAX_REDIRECTS);
+        this.logMaxLength = sinkContext.getInteger(KEY_LOG_MAX_LENGTH, DEFAULT_LOG_MAX_LENGTH);
+    }
+
+    private void reloadClientsFromSortTaskConfig(SortTaskConfig sortTaskConfig) {
+        this.sinkContext = new Context(sortTaskConfig.getSinkParams());
+        this.baseUrl = sinkContext.getString(KEY_BASE_URL);
+        this.enableCredential = sinkContext.getBoolean(KEY_ENABLE_CREDENTIAL, DEFAULT_ENABLE_CREDENTIAL);
+        this.username = sinkContext.getString(KEY_USERNAME);
+        this.password = sinkContext.getString(KEY_PASSWORD);
+        this.maxConnect = sinkContext.getInteger(KEY_MAX_CONNECT_TOTAL, DEFAULT_MAX_CONNECT_TOTAL);
+
+        this.maxConnectPerRoute = sinkContext.getInteger(KEY_MAX_CONNECT_PER_ROUTE, DEFAULT_MAX_CONNECT_PER_ROUTE);
+        this.connectionRequestTimeout =
+                sinkContext.getInteger(KEY_CONNECTION_REQUEST_TIMEOUT, DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+        this.socketTimeout = sinkContext.getInteger(KEY_SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+        this.maxRedirects = sinkContext.getInteger(KEY_MAX_REDIRECTS, DEFAULT_MAX_REDIRECTS);
+        this.logMaxLength = sinkContext.getInteger(KEY_LOG_MAX_LENGTH, DEFAULT_LOG_MAX_LENGTH);
+    }
+
+    public void addSendMetric(ProfileEvent currentRecord, String bid) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, this.getTaskName());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, bid);
+        long msgTime = currentRecord.getRawLogTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        long count = 1;
+        long size = currentRecord.getBody().length;
+        metricItem.sendCount.addAndGet(count);
+        metricItem.sendSize.addAndGet(size);
+    }
+
+    public void addSendFailMetric() {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        long msgTime = System.currentTimeMillis();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        metricItem.readFailCount.incrementAndGet();
+    }
+
+    public void addSendResultMetric(ProfileEvent currentRecord, String bid, boolean result, long sendTime) {
+        Map<String, String> dimensions = new HashMap<>();
+        dimensions.put(SortMetricItem.KEY_CLUSTER_ID, this.getClusterId());
+        dimensions.put(SortMetricItem.KEY_TASK_NAME, this.getTaskName());
+        // metric
+        fillInlongId(currentRecord, dimensions);
+        dimensions.put(SortMetricItem.KEY_SINK_ID, this.getSinkName());
+        dimensions.put(SortMetricItem.KEY_SINK_DATA_ID, bid);
+        final long currentTime = System.currentTimeMillis();
+        long msgTime = currentRecord.getRawLogTime();
+        long auditFormatTime = msgTime - msgTime % CommonPropertiesHolder.getAuditFormatInterval();
+        dimensions.put(SortMetricItem.KEY_MESSAGE_TIME, String.valueOf(auditFormatTime));
+        SortMetricItem metricItem = this.getMetricItemSet().findMetricItem(dimensions);
+        if (result) {
+            metricItem.sendSuccessCount.incrementAndGet();
+            metricItem.sendSuccessSize.addAndGet(currentRecord.getBody().length);
+            AuditUtils.add(AuditUtils.AUDIT_ID_SEND_SUCCESS, currentRecord);
+            if (sendTime > 0) {
+                long sinkDuration = currentTime - sendTime;
+                long nodeDuration = currentTime - currentRecord.getFetchTime();
+                long wholeDuration = currentTime - currentRecord.getRawLogTime();
+                metricItem.sinkDuration.addAndGet(sinkDuration);
+                metricItem.nodeDuration.addAndGet(nodeDuration);
+                metricItem.wholeDuration.addAndGet(wholeDuration);
+            }
+        } else {
+            metricItem.sendFailCount.incrementAndGet();
+            metricItem.sendFailSize.addAndGet(currentRecord.getBody().length);
+        }
+    }
+
+    public HttpIdConfig getIdConfig(String uid) {
+        return this.idConfigMap.get(uid);
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public Map<String, HttpIdConfig> getIdConfigMap() {
+        return idConfigMap;
+    }
+
+    public Context getSinkContext() {
+        return sinkContext;
+    }
+
+    public void setSinkContext(Context sinkContext) {
+        this.sinkContext = sinkContext;
+    }
+
+    public void offerDispatchQueue(HttpRequest httpRequest) {
+        this.offerCounter.incrementAndGet();
+        dispatchQueue.acquire(httpRequest.getEvent().getBody().length);
+        dispatchQueue.offer(httpRequest);
+    }
+
+    public HttpRequest takeDispatchQueue() {
+        HttpRequest httpRequest = this.dispatchQueue.pollRecord();
+        if (httpRequest != null) {
+            this.takeCounter.incrementAndGet();
+        }
+        return httpRequest;
+    }
+
+    public void backDispatchQueue(HttpRequest httpRequest) {
+        this.backCounter.incrementAndGet();
+        dispatchQueue.offer(httpRequest);
+    }
+
+    public void releaseDispatchQueue(HttpRequest httpRequest) {
+        dispatchQueue.release(httpRequest.getEvent().getBody().length);
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public boolean getEnableCredential() {
+        return enableCredential;
+    }
+
+    public void setEnableCredential(boolean enableCredential) {
+        this.enableCredential = enableCredential;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public int getMaxConnect() {
+        return maxConnect;
+    }
+
+    public int getMaxConnectPerRoute() {
+        return maxConnectPerRoute;
+    }
+
+    public int getConnectionRequestTimeout() {
+        return connectionRequestTimeout;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public int getMaxRedirects() {
+        return maxRedirects;
+    }
+
+    public int getLogMaxLength() {
+        return logMaxLength;
+    }
+
+    public void setMaxConnect(int maxConnect) {
+        this.maxConnect = maxConnect;
+    }
+
+    public void setNodeId(String nodeId) {
+        this.nodeId = nodeId;
+    }
+
+    public void setIdConfigMap(Map<String, HttpIdConfig> idConfigMap) {
+        this.idConfigMap = idConfigMap;
+    }
+
+    public IEvent2HttpRequestHandler createHttpRequestHandler() {
+        // IEvent2HttpRequestHandler
+        String httpRequestHandlerClass = CommonPropertiesHolder.getString(KEY_EVENT_HTTPREQUEST_HANDLER,
+                DefaultEvent2HttpRequestHandler.class.getName());
+        try {
+            Class<?> handlerClass = ClassUtils.getClass(httpRequestHandlerClass);
+            Object handlerObject = handlerClass.getDeclaredConstructor().newInstance();
+            if (handlerObject instanceof IEvent2HttpRequestHandler) {
+                IEvent2HttpRequestHandler handler = (IEvent2HttpRequestHandler) handlerObject;
+                return handler;
+            }
+        } catch (Throwable t) {
+            LOG.error("Fail to init IEvent2HttpRequestHandler,handlerClass:{},error:{}",
+                    httpRequestHandlerClass, t.getMessage(), t);
+        }
+        return null;
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkFactory.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+
+public class HttpSinkFactory {
+
+    public static HttpOutputChannel createHttpOutputChannel(HttpSinkContext context) {
+        return new HttpOutputChannel(context);
+    }
+
+    public static CloseableHttpAsyncClient createHttpAsyncClient(HttpAsyncClientBuilder builder) {
+        return builder.build();
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/IEvent2HttpRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/IEvent2HttpRequestHandler.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.sink.http;
+
+import org.apache.inlong.sort.standalone.channel.ProfileEvent;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import java.net.URISyntaxException;
+
+public interface IEvent2HttpRequestHandler {
+
+    HttpRequest parse(HttpSinkContext context, ProfileEvent event) throws URISyntaxException, JsonProcessingException;
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10831

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Add a new sink type: `HTTP` for SortStandalone, which can report data to the specific HTTP interface. The flow diagram is shown below:
![处理逻辑流程图v3-en drawio](https://github.com/user-attachments/assets/5e1d8e33-50aa-4830-95cc-e58043ada4bc)


### Modifications

<!--Describe the modifications you've done.-->
Add a new sink type package `http` in `sort-standalone-source`.


### Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
