### PR TITLE
[INLONG-10844][Dashboard] Resource details page sort information interface switch

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/ResourceInfo/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/ResourceInfo/index.tsx
@@ -205,32 +205,30 @@ const Comp = ({ inlongGroupId, isCreate }: Props, ref) => {
           ></Table>
         </>
       )}
-      {data?.hasOwnProperty('SortInfo') && (
-        <>
-          <Divider orientation="left" style={{ marginTop: 60 }}>
-            Sort {t('pages.GroupDetail.Resource.Info')}
-          </Divider>
-          <HighTable
-            filterForm={{
-              content: content(),
-              onFilter,
-            }}
-            table={{
-              columns: [
-                { title: 'inlongStreamId', dataIndex: 'inlongStreamId' },
-                { title: 'dataflowId', dataIndex: 'id' },
-                { title: 'sinkName', dataIndex: 'sinkName' },
-                { title: 'topoName', dataIndex: 'inlongClusterName' },
-              ],
-              style: { marginTop: 20 },
-              dataSource: sortData?.list,
-              pagination,
-              rowKey: 'name',
-              onChange,
-            }}
-          />
-        </>
-      )}
+      <>
+        <Divider orientation="left" style={{ marginTop: 60 }}>
+          Sort {t('pages.GroupDetail.Resource.Info')}
+        </Divider>
+        <HighTable
+          filterForm={{
+            content: content(),
+            onFilter,
+          }}
+          table={{
+            columns: [
+              { title: 'inlongStreamId', dataIndex: 'inlongStreamId' },
+              { title: 'dataflowId', dataIndex: 'id' },
+              { title: 'sinkName', dataIndex: 'sinkName' },
+              { title: 'topoName', dataIndex: 'inlongClusterName' },
+            ],
+            style: { marginTop: 20 },
+            dataSource: sortData?.list,
+            pagination,
+            rowKey: 'name',
+            onChange,
+          }}
+        />
+      </>
     </div>
   );
 };


### PR DESCRIPTION


Fixes #10844 

### Motivation

Resource details page sort information interface switch

### Modifications
Resource details page sort information interface switch,before request /group/detail/${inlongGroupId} ,after /sink/listDetail

### Verifying this change
before
![image](https://github.com/user-attachments/assets/c8f28101-9635-4a5b-a34a-8589646e4c79)
after:
![image](https://github.com/user-attachments/assets/f9a13791-9c34-420a-a9eb-942bebc636d4)

