### PR TITLE
[INLONG-10975][Manager] Fix the problem of when saving the group, only the existence of the groupid under the current tenant was verified

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -205,7 +205,7 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         Preconditions.expectNotNull(request, "inlong group request cannot be empty");
 
         String groupId = request.getInlongGroupId();
-        InlongGroupEntity entity = groupMapper.selectByGroupId(groupId);
+        InlongGroupEntity entity = groupMapper.selectByGroupIdWithoutTenant(groupId);
         if (entity != null) {
             LOGGER.error("groupId={} has already exists", groupId);
             throw new BusinessException(ErrorCodeEnum.GROUP_DUPLICATE);
@@ -278,7 +278,7 @@ public class InlongGroupServiceImpl implements InlongGroupService {
     @Override
     public Boolean exist(String groupId) {
         Preconditions.expectNotNull(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY.getMessage());
-        InlongGroupEntity entity = groupMapper.selectByGroupId(groupId);
+        InlongGroupEntity entity = groupMapper.selectByGroupIdWithoutTenant(groupId);
         LOGGER.debug("success to check inlong group {}, exist? {}", groupId, entity != null);
         return entity != null;
     }


### PR DESCRIPTION


<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10975

### Motivation

 Fix the problem of when saving the group, only the existence of the groupid under the current tenant was verified.

### Modifications

When saving group information, check whether the group exists based on the groupid instead of the groupid and tenant.
