### PR TITLE
[INLONG-11012][SDK] Transform SQL supports LCASE and UCASE Functions

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LowerFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/LowerFunction.java
@@ -28,7 +28,7 @@ import net.sf.jsqlparser.expression.Function;
  * LowerFunction
  * description: LOWER(s): Convert all letters of the string s to lowercase letters
  */
-@TransformFunction(names = {"lower"})
+@TransformFunction(names = {"lower", "lcase"})
 public class LowerFunction implements ValueParser {
 
     private ValueParser stringParser;

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UpperFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UpperFunction.java
@@ -28,7 +28,7 @@ import net.sf.jsqlparser.expression.Function;
  * UpperFunction
  * description: UPPER(s): Convert a string to uppercase
  */
-@TransformFunction(names = {"upper"})
+@TransformFunction(names = {"upper", "ucase"})
 public class UpperFunction implements ValueParser {
 
     private ValueParser stringParser;

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestLcaseFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestLcaseFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * TestTransformFromBase64FunctionProcessor
+ * description: test the lcase function in transform processor
+ */
+public class TestLcaseFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testLcaseFunction() throws Exception {
+        String transformSql1 = "select lcase(string1) from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case1: lcase("ApPlE")
+        List<String> output1 = processor1.transform("ApPlE|", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=apple");
+
+        // case2: lcase("")
+        List<String> output2 = processor1.transform("|", new HashMap<>());
+        Assert.assertEquals(1, output2.size());
+        Assert.assertEquals(output2.get(0), "result=");
+
+        // case3: lcase(null)
+        String transformSql2 = "select lcase(xxd) from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor2.transform("ApPlE|", new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals(output3.get(0), "result=null");
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUcaseFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUcaseFunction.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * TestTransformFromBase64FunctionProcessor
+ * description: test the ucase function in transform processor
+ */
+public class TestUcaseFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testUcaseFunction() throws Exception {
+        String transformSql1 = "select ucase(string1) from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case1: ucase("ApPlE")
+        List<String> output1 = processor1.transform("ApPlE", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=APPLE");
+
+        // case2: ucase("")
+        List<String> output2 = processor1.transform("|", new HashMap<>());
+        Assert.assertEquals(1, output2.size());
+        Assert.assertEquals(output2.get(0), "result=");
+
+        // case3: ucase(null)
+        String transformSql2 = "select ucase(xxd) from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output3 = processor2.transform("ApPlE", new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals(output3.get(0), "result=null");
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11012 

### Motivation

Modify LowerFunction and UpperFunction. Also, add the corresponding unit test codes.

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*
