### PR TITLE
[INLONG-11018][SDK] Transform SQL supports COMPRESS and UNCOMPRESS Functions

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/CompressFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/CompressFunction.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.function.factory.CompressionAlgorithmFactory;
+import org.apache.inlong.sdk.transform.process.function.handler.CompressHandler;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import lombok.extern.slf4j.Slf4j;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+/**
+ * CompressFunction
+ * description: compress(string_to_compress[,compress_type(default:deflater)])
+ * - Return NULL if string_to_compress is NULL.
+ * - Return "" if string_to_compress is "".
+ * - Return the result as a binary string.
+ */
+@Slf4j
+@TransformFunction(names = {"compress"})
+public class CompressFunction implements ValueParser {
+
+    private final ValueParser stringParser;
+    private final ValueParser compressTypeParser;
+
+    // ISO-8859-1 encoding does not convert negative numbers and can preserve the original values of byte arrays.
+    private final Charset CHARSET = StandardCharsets.ISO_8859_1;
+    private final String DEFAULT_COMPRESS_TYPE = "deflater";
+
+    public CompressFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        stringParser = OperatorTools.buildParser(expressions.get(0));
+        if (expressions.size() == 2) {
+            compressTypeParser = OperatorTools.buildParser(expressions.get(1));
+        } else {
+            compressTypeParser = null;
+        }
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object stringObject = stringParser.parse(sourceData, rowIndex, context);
+        if (stringObject == null) {
+            return null;
+        }
+        String str = OperatorTools.parseString(stringObject);
+        if (str.isEmpty()) {
+            return "";
+        }
+
+        // parse compress type
+        String compressType = DEFAULT_COMPRESS_TYPE;
+        if (compressTypeParser != null) {
+            Object compressTypeObj = compressTypeParser.parse(sourceData, rowIndex, context);
+            if (compressTypeObj != null) {
+                compressType = OperatorTools.parseString(compressTypeObj);
+            }
+        }
+        compressType = compressType.toLowerCase();
+
+        try {
+            byte[] lengthBytes = intToLowByteArray(str.length());
+            CompressHandler handler = CompressionAlgorithmFactory.getCompressHandlerByName(compressType);
+            if (handler == null) {
+                throw new RuntimeException(compressType + " is not supported.");
+            }
+            byte[] compressBytes = handler.compress(str.getBytes(CHARSET));
+            return mergeByteArray(lengthBytes, compressBytes);
+        } catch (Exception e) {
+            log.error("Compression failed", e);
+            return null;
+        }
+    }
+
+    private String mergeByteArray(byte[] lengthBytes, byte[] dateBytes) throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(
+                lengthBytes.length + dateBytes.length);
+        outputStream.write(lengthBytes);
+        outputStream.write(dateBytes);
+        return new String(outputStream.toByteArray(), CHARSET);
+    }
+
+    // low byte first
+    public static byte[] intToLowByteArray(int length) {
+        return new byte[]{
+                (byte) (length & 0xFF),
+                (byte) ((length >> 8) & 0xFF),
+                (byte) ((length >> 16) & 0xFF),
+                (byte) ((length >> 24) & 0xFF)
+        };
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UnCompressFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UnCompressFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.function.factory.UnCompressionAlgorithmFactory;
+import org.apache.inlong.sdk.transform.process.function.handler.UncompressHandler;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import lombok.extern.slf4j.Slf4j;
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * UnCompressFunction
+ * description: uncompress(string_to_uncompress[,compress_type(default:deflater)])
+ * - Return NULL if string_to_uncompress is NULL.
+ * - Return "" if string_to_uncompress is "".
+ * - Return the result as a string.
+ */
+@Slf4j
+@TransformFunction(names = {"uncompress"})
+public class UnCompressFunction implements ValueParser {
+
+    private final ValueParser stringParser;
+    private final ValueParser uncompressTypeParser;
+
+    // ISO-8859-1 encoding does not convert negative numbers and can preserve the original values of byte arrays.
+    private final Charset CHARSET = StandardCharsets.ISO_8859_1;
+    private final String DEFAULT_UNCOMPRESS_TYPE = "deflater";
+
+    public UnCompressFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        stringParser = OperatorTools.buildParser(expressions.get(0));
+        if (expressions.size() == 2) {
+            uncompressTypeParser = OperatorTools.buildParser(expressions.get(1));
+        } else {
+            uncompressTypeParser = null;
+        }
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        // parse data
+        Object stringObject = stringParser.parse(sourceData, rowIndex, context);
+        if (stringObject == null) {
+            return null;
+        }
+        String str = OperatorTools.parseString(stringObject);
+        if (str.isEmpty()) {
+            return "";
+        } else if (str.startsWith("null")) {
+            return null;
+        }
+        // parse uncompress type
+        String uncompressType = DEFAULT_UNCOMPRESS_TYPE;
+        if (uncompressTypeParser != null) {
+            Object compressTypeObj = uncompressTypeParser.parse(sourceData, rowIndex, context);
+            if (compressTypeObj != null) {
+                uncompressType = OperatorTools.parseString(compressTypeObj);
+            }
+        }
+        uncompressType = uncompressType.toLowerCase();
+        // uncompress
+        try {
+            // The first four bytes are the data length
+            byte[] compressData = Arrays.copyOfRange(str.getBytes(CHARSET), 4, str.length());
+            UncompressHandler handler = UnCompressionAlgorithmFactory.getCompressHandlerByName(uncompressType);
+            if (handler == null) {
+                throw new RuntimeException(uncompressType + " is not supported.");
+            }
+            return new String(handler.uncompress(compressData));
+        } catch (Exception e) {
+            log.error("UnCompression failed", e);
+            return null;
+        }
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/factory/CompressionAlgorithmFactory.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/factory/CompressionAlgorithmFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.factory;
+
+import org.apache.inlong.sdk.transform.process.function.handler.CompressHandler;
+import org.apache.inlong.sdk.transform.process.function.handler.DeflaterCompress;
+import org.apache.inlong.sdk.transform.process.function.handler.GzipCompress;
+import org.apache.inlong.sdk.transform.process.function.handler.ZipCompress;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CompressionAlgorithmFactory {
+
+    private static Map<String, CompressHandler> compressMap = new ConcurrentHashMap<>();
+
+    static {
+        compressMap.put("deflater", new DeflaterCompress());
+        compressMap.put("gzip", new GzipCompress());
+        compressMap.put("zip", new ZipCompress());
+    }
+
+    public static CompressHandler getCompressHandlerByName(String name) {
+        return compressMap.get(name);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/factory/UnCompressionAlgorithmFactory.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/factory/UnCompressionAlgorithmFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.factory;
+
+import org.apache.inlong.sdk.transform.process.function.handler.DeflaterUncompress;
+import org.apache.inlong.sdk.transform.process.function.handler.GzipUncompress;
+import org.apache.inlong.sdk.transform.process.function.handler.UncompressHandler;
+import org.apache.inlong.sdk.transform.process.function.handler.ZipUncompress;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class UnCompressionAlgorithmFactory {
+
+    private static Map<String, UncompressHandler> unCompressMap = new ConcurrentHashMap<>();
+
+    static {
+        unCompressMap.put("deflater", new DeflaterUncompress());
+        unCompressMap.put("gzip", new GzipUncompress());
+        unCompressMap.put("zip", new ZipUncompress());
+    }
+
+    public static UncompressHandler getCompressHandlerByName(String name) {
+        return unCompressMap.get(name);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/CompressHandler.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/CompressHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+public interface CompressHandler {
+
+    byte[] compress(byte[] data) throws Exception;
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/DeflaterCompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/DeflaterCompress.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.Deflater;
+
+public class DeflaterCompress implements CompressHandler {
+
+    @Override
+    public byte[] compress(byte[] data) throws Exception {
+        Deflater deflater = new Deflater();
+        deflater.setInput(data);
+        deflater.finish();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        byte[] buffer = new byte[1024];
+        while (!deflater.finished()) {
+            int count = deflater.deflate(buffer);
+            outputStream.write(buffer, 0, count);
+        }
+        outputStream.close();
+        return outputStream.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/DeflaterUncompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/DeflaterUncompress.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.Inflater;
+
+public class DeflaterUncompress implements UncompressHandler {
+
+    @Override
+    public byte[] uncompress(byte[] data) throws Exception {
+        Inflater inflater = new Inflater();
+        inflater.setInput(data);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream(data.length);
+        byte[] buffer = new byte[1024];
+        while (!inflater.finished()) {
+            int count = inflater.inflate(buffer);
+            outputStream.write(buffer, 0, count);
+        }
+        outputStream.close();
+        return outputStream.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/GzipCompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/GzipCompress.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipCompress implements CompressHandler {
+
+    @Override
+    public byte[] compress(byte[] data) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(baos);
+        gzipOutputStream.write(data);
+        gzipOutputStream.close();
+        return baos.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/GzipUncompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/GzipUncompress.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPInputStream;
+
+public class GzipUncompress implements UncompressHandler {
+
+    @Override
+    public byte[] uncompress(byte[] data) throws Exception {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        GZIPInputStream gzipInputStream = new GZIPInputStream(bais);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        int len;
+        while ((len = gzipInputStream.read(buffer)) > 0) {
+            baos.write(buffer, 0, len);
+        }
+        gzipInputStream.close();
+        return baos.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/UncompressHandler.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/UncompressHandler.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+public interface UncompressHandler {
+
+    byte[] uncompress(byte[] data) throws Exception;
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/ZipCompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/ZipCompress.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class ZipCompress implements CompressHandler {
+
+    @Override
+    public byte[] compress(byte[] data) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ZipOutputStream zipOutputStream = new ZipOutputStream(baos);
+        ZipEntry entry = new ZipEntry("");
+        zipOutputStream.putNextEntry(entry);
+        zipOutputStream.write(data);
+        zipOutputStream.closeEntry();
+        zipOutputStream.close();
+        return baos.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/ZipUncompress.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/handler/ZipUncompress.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.handler;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+public class ZipUncompress implements UncompressHandler {
+
+    @Override
+    public byte[] uncompress(byte[] data) throws Exception {
+        ByteArrayInputStream bais = new ByteArrayInputStream(data);
+        ZipInputStream zipInputStream = new ZipInputStream(bais);
+        ZipEntry entry;
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buffer = new byte[1024];
+        while ((entry = zipInputStream.getNextEntry()) != null) {
+            int len;
+            while ((len = zipInputStream.read(buffer)) > 0) {
+                baos.write(buffer, 0, len);
+            }
+        }
+        zipInputStream.close();
+        return baos.toByteArray();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestCompressFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestCompressFunction.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class TestCompressFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testCompressFunction() throws Exception {
+        String transformSql = "select length(compress(replicate(string1,100))) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case1: length(compress(replicate(string1,100)))
+        List<String> output1 = processor1.transform("abcdefghijk|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=33", output1.get(0));
+
+        transformSql = "select length(compress(string1)) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case2: length(compress(''))
+        output1 = processor1.transform("|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=0", output1.get(0));
+
+        transformSql = "select length(compress(xxd)) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case3: length(compress(null))
+        output1 = processor1.transform("hello world|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+
+        transformSql = "select length(compress(string1,string2)) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: length(compress('hello world','Gzip'))
+        output1 = processor1.transform("hello world|Gzip|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=35", output1.get(0));
+
+        // case5: length(compress('hello world','zip'))
+        output1 = processor1.transform("hello world|zip|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=131", output1.get(0));
+
+        // case5: length(compress('hello world','undefinedType'))
+        output1 = processor1.transform("hello world|undefinedType|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUnCompressFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUnCompressFunction.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class TestUnCompressFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testUnCompressFunction() throws Exception {
+        String transformSql = "select length(uncompress(compress(replicate(string1,100)))) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case1: length(uncompress(compress(repeat(string1,100))))
+        List<String> output1 = processor1.transform("abcdefghijk|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=1100", output1.get(0));
+
+        transformSql = "select uncompress(compress(replicate(string1,10))) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case2: uncompress(compress(repeat('h',10)))
+        output1 = processor1.transform("h|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=hhhhhhhhhh", output1.get(0));
+
+        transformSql = "select uncompress(compress(xxd)) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case3: uncompress(compress(null))
+        output1 = processor1.transform("h|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+
+        transformSql = "select uncompress(compress(string1)) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: uncompress(compress(''))
+        output1 = processor1.transform("|apple|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=", output1.get(0));
+
+        transformSql = "select uncompress(compress(string1,string2),string3) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case5: uncompress(compress('hello world','Gzip'),'Gzip')
+        output1 = processor1.transform("hello world|Gzip|Gzip|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=hello world", output1.get(0));
+
+        // case6: uncompress(compress('hello world','zip'),'zip')
+        output1 = processor1.transform("hello world|zip|zip|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=hello world", output1.get(0));
+
+        transformSql = "select uncompress(compress(stringx,string2),string3) from source";
+        config = new TransformConfig(transformSql);
+        processor1 = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case7: uncompress(compress(null,'Gzip'),'Gzip')
+        output1 = processor1.transform("hello world|Gzip|Gzip|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+
+        // case8: uncompress(compress(null,'zip'),'zip')
+        output1 = processor1.transform("hello world|zip|zip|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+
+        // case8: uncompress(compress(null,'zip'),'undefinedType')
+        output1 = processor1.transform("hello world|zip|undefinedType|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals("result=null", output1.get(0));
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11018 

### Motivation

Add two function classes: CompressFunction, UnCompressFunction. Also, add the corresponding unit test classes: TestCompressFunction, TestUnCompressFunction.

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*