### PR TITLE
[INLONG-11056][SDK] Transform support RAND_INTEGER() function

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/RandIntegerFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/RandIntegerFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.util.List;
+import java.util.Random;
+
+/**
+ * RandIntegerFunction
+ * description: RAND_INTEGER(INT1)--Returns a pseudorandom integer value in the range [0, INT)
+ *              RAND_INTEGER(INT1, INT2)--Returns a pseudorandom integer value in the range [0, INT2) with an initial seed INT1.
+ *              Two RAND_INTEGER functions will return idential sequences of numbers if they have the same initial seed and bound.
+ */
+@TransformFunction(names = {"rand_integer"})
+public class RandIntegerFunction implements ValueParser {
+
+    private ValueParser firstIntParser;
+
+    private ValueParser secondIntParser;
+
+    private Random random;
+
+    public RandIntegerFunction(Function expr) {
+        random = new Random();
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        if (expressions != null) {
+            firstIntParser = OperatorTools.buildParser(expressions.get(0));
+            if (expressions.size() >= 2) {
+                secondIntParser = OperatorTools.buildParser(expressions.get(1));
+            }
+        }
+    }
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object firstIntObj = firstIntParser.parse(sourceData, rowIndex, context);
+        int firstInt = OperatorTools.parseBigDecimal(firstIntObj).intValue();
+        if (secondIntParser != null) {
+            Object secondIntObj = secondIntParser.parse(sourceData, rowIndex, context);
+            int secondInt = OperatorTools.parseBigDecimal(secondIntObj).intValue();
+            return randInteger(firstInt, secondInt);
+        }
+        return randInteger(firstInt);
+    }
+
+    private int randInteger(int range) {
+        return random.nextInt(range);
+    }
+
+    private int randInteger(int seed, int range) {
+        random.setSeed(seed);
+        return random.nextInt(range);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/RandIntegerFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/RandIntegerFunction.java
@@ -31,7 +31,7 @@ import java.util.Random;
 /**
  * RandIntegerFunction
  * description: RAND_INTEGER(INT1)--Returns a pseudorandom integer value in the range [0, INT)
- *              RAND_INTEGER(INT1, INT2)--Returns a pseudorandom integer value in the range [0, INT2) with an initial seed INT1.
+ *              RAND_INTEGER(INT1, INT2)--Returns a pseudorandom integer value in the range [0, INT1) with an initial seed INT2.
  *              Two RAND_INTEGER functions will return idential sequences of numbers if they have the same initial seed and bound.
  */
 @TransformFunction(names = {"rand_integer"})
@@ -69,7 +69,7 @@ public class RandIntegerFunction implements ValueParser {
         return random.nextInt(range);
     }
 
-    private int randInteger(int seed, int range) {
+    private int randInteger(int range, int seed) {
         random.setSeed(seed);
         return random.nextInt(range);
     }

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/arithmetic/TestRandIntegerFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/arithmetic/TestRandIntegerFunction.java
@@ -53,9 +53,9 @@ public class TestRandIntegerFunction extends AbstractFunctionArithmeticTestBase 
         TransformProcessor<String, String> processor2 = TransformProcessor
                 .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
                         SinkEncoderFactory.createKvEncoder(kvSink));
-        // case: rand_integer(2, 89)
-        List<String> output3 = processor2.transform("2|89||", new HashMap<>());
+        // case: rand_integer(88, 89)
+        List<String> output3 = processor2.transform("88|89||", new HashMap<>());
         Assert.assertEquals(1, output3.size());
-        Assert.assertEquals(output3.get(0), "result=" + new Random(2).nextInt(89));
+        Assert.assertEquals(output3.get(0), "result=" + new Random(89).nextInt(88));
     }
 }

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/arithmetic/TestRandIntegerFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/arithmetic/TestRandIntegerFunction.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.arithmetic;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+
+public class TestRandIntegerFunction extends AbstractFunctionArithmeticTestBase {
+
+    @Test
+    public void testRandIntegerFunction() throws Exception {
+        String transformSql1 = "select rand_integer(numeric1) from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case: rand_integer(10)
+        List<String> output1 = processor1.transform("10|4|6|8", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        int res1 = Integer.parseInt(output1.get(0).substring(7));
+        Assert.assertTrue(res1 >= 0 && res1 < 10);
+        // case: rand_integer(89)
+        List<String> output2 = processor1.transform("89|4|6|8", new HashMap<>());
+        Assert.assertEquals(1, output2.size());
+        int res2 = Integer.parseInt(output2.get(0).substring(7));
+        Assert.assertTrue(res2 >= 0 && res2 < 89);
+        String transformSql2 = "select rand_integer(numeric1,numeric2) from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case: rand_integer(2, 89)
+        List<String> output3 = processor2.transform("2|89||", new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals(output3.get(0), "result=" + new Random(2).nextInt(89));
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11056 

### Motivation
add RantIntegerFunction class and provide unit tests
* RAND_INTEGER(INT1)--Returns a pseudorandom integer value in the range [0, INT)
* RAND_INTEGER(INT1, INT2)--Returns a pseudorandom integer value in the range [0, INT2) with an initial seed INT1.
* Two RAND_INTEGER functions will return idential sequences of numbers if they have the same initial seed and bound.
<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
