### PR TITLE
[INLONG-11071][Manager] Fix: failed to handle request on inlong_agent_system by admin

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java
@@ -910,6 +910,11 @@ public class InlongClusterServiceImpl implements InlongClusterService {
         LOGGER.debug("begin to get data proxy nodes for groupId={}, protocol={}", groupId, protocolType);
 
         InlongGroupEntity groupEntity = groupMapper.selectByGroupId(groupId);
+        if (groupEntity == null) {
+            String errMsg = String.format("group not found by groupId=%s", groupId);
+            LOGGER.error(errMsg);
+            throw new BusinessException(errMsg);
+        }
         GroupStatus groupStatus = GroupStatus.forCode(groupEntity.getStatus());
         if (!Objects.equals(groupStatus, GroupStatus.CONFIG_SUCCESSFUL)) {
             String errMsg =

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
@@ -56,7 +56,11 @@ public class DataProxyController {
     @ApiOperation(value = "Get data proxy IP list by InlongGroupId")
     public Response<DataProxyNodeResponse> getIpList(@PathVariable String inlongGroupId,
             @RequestParam(required = false) String protocolType) {
-        return Response.success(clusterService.getDataProxyNodes(inlongGroupId, protocolType));
+        try {
+            return Response.success(clusterService.getDataProxyNodes(inlongGroupId, protocolType));
+        } catch (Exception e) {
+            return Response.fail(e.getMessage());
+        }
     }
 
     @PostMapping(value = "/dataproxy/getIpListByClusterName/{clusterName}")

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/DataProxyController.java
@@ -56,11 +56,7 @@ public class DataProxyController {
     @ApiOperation(value = "Get data proxy IP list by InlongGroupId")
     public Response<DataProxyNodeResponse> getIpList(@PathVariable String inlongGroupId,
             @RequestParam(required = false) String protocolType) {
-        try {
-            return Response.success(clusterService.getDataProxyNodes(inlongGroupId, protocolType));
-        } catch (Exception e) {
-            return Response.fail(e.getMessage());
-        }
+        return Response.success(clusterService.getDataProxyNodes(inlongGroupId, protocolType));
     }
 
     @PostMapping(value = "/dataproxy/getIpListByClusterName/{clusterName}")


### PR DESCRIPTION

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11071 

### Motivation

When the dataproxy module requests the `/dataproxy/getIpList/inlong_agent_system` interface, an error occurs because there is no record in the `inlong_group` table where the `inlong_group_id` is equals to `inlong_agent_system`. This results in the manager console continuously outputting exceptions

### Modifications

<!--Describe the modifications you've done.-->

- Changed getDataProxyNodes function in the `org/apache/inlong/manager/service/cluster/InlongClusterServiceImpl.java` file to throw an exception when there is no record in the `inlong_group` table where the `inlong_group_id` is equals to `inlong_agent_system`

- Changed getIpList function in the `org/apache/inlong/manager/web/controller/openapi/DataProxyController.java` file to return fail response when an exception occurs in the `getDataProxyNodes` function. 


### Verifying this change

Previous error message：

```
[ ] 2024-09-09 14:26:04.467 -ERROR [http-nio-8083-exec-5] w.c.ControllerExceptionHandler:152 - failed to handle request on path: /inlong/manager/openapi/dataproxy/getIpList/inlong_agent_system by user: admin 
2024-09-09T14:26:04.608632436Z java.lang.NullPointerException: null
2024-09-09T14:26:04.608639991Z 	at org.apache.inlong.manager.service.cluster.InlongClusterServiceImpl.getDataProxyNodes(InlongClusterServiceImpl.java:913) ~[manager-service-1.14.0-SNAPSHOT.jar:1.14.0-SNAPSHOT]
2024-09-09T14:26:04.608655587Z 	at org.apache.inlong.manager.service.cluster.InlongClusterServiceImpl$$FastClassBySpringCGLIB$$5ac56ec1.invoke(<generated>) ~[manager-service-1.14.0-SNAPSHOT.jar:1.14.0-SNAPSHOT]
...
...
```
Current error log：

```
2024-09-13T11:43:02.098668598Z [ ] 2024-09-13 11:43:01.248 -ERROR [http-nio-8083-exec-3] m.s.c.InlongClusterServiceImpl:915 - group not found by groupId=inlong_agent_system 
```
