### PR TITLE
[INLONG-11110][SDK] Fix incorrect usage of isLocalVisit variable in client example of dataproxy-sdk module

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/HttpClientExample.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/HttpClientExample.java
@@ -29,40 +29,31 @@ import java.util.concurrent.TimeUnit;
 public class HttpClientExample {
 
     public static void main(String[] args) {
-        /*
-         * 1. if 'isLocalVisit' is true use local config from file in ${configBasePath} directory/${dataProxyGroupId}
-         * .local such as : configBasePath = /data/inlong/dataproxy/conf dataProxyGroupId = test so config file is :
-         * /data/inlong/dataproxy/conf/test.local and config context like this:
-         * {"isInterVisit":1,"clusterId":"1","size":1,"switch":1,"address":[{"host":"127.0.0
-         * .1","port":"46802"},{"host":"127.0.0.1","port":"46802"}]}
-         *
-         * 2. if 'isLocalVisit' is false sdk will get config from manager auto.
-         */
         String inlongGroupId = "test_group_id";
         String inlongStreamId = "test_stream_id";
-        String configBasePath = "/data/inlong/dataproxy/conf";
+        String configBasePath = "";
         String inLongManagerAddr = "127.0.0.1";
-        String inLongManagerPort = "8080";
+        String inLongManagerPort = "8083";
         String localIP = "127.0.0.1";
         String messageBody = "inlong message body!";
 
         HttpProxySender sender = getMessageSender(localIP, inLongManagerAddr,
-                inLongManagerPort, inlongGroupId, false, false,
+                inLongManagerPort, inlongGroupId, true, false,
                 configBasePath);
-
         sendHttpMessage(sender, inlongGroupId, inlongStreamId, messageBody);
+        sender.close(); // close the sender
     }
 
     public static HttpProxySender getMessageSender(String localIP, String inLongManagerAddr,
             String inLongManagerPort, String inlongGroupId,
-            boolean isLocalVisit, boolean isReadProxyIPFromLocal,
+            boolean requestByHttp, boolean isReadProxyIPFromLocal,
             String configBasePath) {
         ProxyClientConfig proxyConfig = null;
         HttpProxySender sender = null;
         try {
-            proxyConfig = new ProxyClientConfig(localIP, isLocalVisit, inLongManagerAddr,
+            proxyConfig = new ProxyClientConfig(localIP, requestByHttp, inLongManagerAddr,
                     Integer.valueOf(inLongManagerPort),
-                    inlongGroupId, "test", "123456");
+                    inlongGroupId, "admin", "inlong");// user and password of manager
             proxyConfig.setInlongGroupId(inlongGroupId);
             proxyConfig.setConfStoreBasePath(configBasePath);
             proxyConfig.setReadProxyIPFromLocal(isReadProxyIPFromLocal);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/example/TcpClientExample.java
@@ -40,22 +40,12 @@ public class TcpClientExample {
      */
     public static void main(String[] args) throws InterruptedException {
 
-        String inlongGroupId = "test_test";
-        String inlongStreamId = "test_test";
+        String inlongGroupId = "test_group_id";
+        String inlongStreamId = "test_stream_id";
 
-        /*
-         * 1. if isLocalVisit is true, will get dataproxy server info from local file in
-         * ${configBasePath}/${inlongGroupId}.local file
-         *
-         * for example: /data/inlong/config/test_test.local and file context like this:
-         * {"isInterVisit":1,"clusterId":"1","size":1,"switch":1,"address":[{"host":"127.0.0.1",
-         * "port":"46802"},{"host":"127.0.0.1","port":"46802"}]} 2. if isLocalVisit is false, will get dataproxy server
-         * info from manager so we must ensure that the manager server url is configured correctly!
-         */
-        String configBasePath = "/data/inlong/config";
-
+        String configBasePath = "";
         String inLongManagerAddr = "127.0.0.1";
-        String inLongManagerPort = "8000";
+        String inLongManagerPort = "8083";
 
         /*
          * It is recommended to use type 7. For others, please refer to the official related documents
@@ -66,19 +56,20 @@ public class TcpClientExample {
         TcpClientExample tcpClientExample = new TcpClientExample();
         DefaultMessageSender sender = tcpClientExample
                 .getMessageSender(localIP, inLongManagerAddr, inLongManagerPort,
-                        inlongGroupId, false, false, configBasePath, msgType);
+                        inlongGroupId, true, false, configBasePath, msgType);
         tcpClientExample.sendTcpMessage(sender, inlongGroupId, inlongStreamId,
                 messageBody, System.currentTimeMillis());
+        sender.close(); // close the sender
     }
 
     public DefaultMessageSender getMessageSender(String localIP, String inLongManagerAddr, String inLongManagerPort,
-            String inlongGroupId, boolean isLocalVisit, boolean isReadProxyIPFromLocal,
+            String inlongGroupId, boolean requestByHttp, boolean isReadProxyIPFromLocal,
             String configBasePath, int msgType) {
         ProxyClientConfig dataProxyConfig = null;
         DefaultMessageSender messageSender = null;
         try {
-            dataProxyConfig = new ProxyClientConfig(localIP, isLocalVisit, inLongManagerAddr,
-                    Integer.valueOf(inLongManagerPort), inlongGroupId, "test", "123456");
+            dataProxyConfig = new ProxyClientConfig(localIP, requestByHttp, inLongManagerAddr,
+                    Integer.valueOf(inLongManagerPort), inlongGroupId, "admin", "inlong");
             if (StringUtils.isNotEmpty(configBasePath)) {
                 dataProxyConfig.setConfStoreBasePath(configBasePath);
             }
@@ -98,9 +89,11 @@ public class TcpClientExample {
         try {
             result = sender.sendMessage(messageBody.getBytes("utf8"), inlongGroupId, inlongStreamId,
                     0, String.valueOf(dt), 20, TimeUnit.SECONDS);
+
         } catch (UnsupportedEncodingException e) {
             e.printStackTrace();
         }
+        System.out.println("messageSender" + result);
         logger.info("messageSender {}", result);
     }
 


### PR DESCRIPTION

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11110 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

Change the isLocalVisit parameter name to requestByHttp to avoid using https to process requests by default. 

### Modifications

- Changed the isLocalVisit parameter 
- Removed the incorrect description about isLocalVisit
- Added messageSender close operation 

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
