### PR TITLE
[INLONG-11129][Sort] Enhanced source metric instrumentation for InLong Sort Flink Connector

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -67,6 +67,20 @@ public final class Constants {
 
     public static final String CURRENT_EMIT_EVENT_TIME_LAG = "currentEmitEventTimeLag";
 
+    public static final String DESERIALIZE_TIME_LAG = "deserializeTimeLag";
+
+    public static final String NUM_DESERIALIZE_SUCCESS = "numDeserializeSuccess";
+
+    public static final String NUM_DESERIALIZE_ERROR = "numDeserializeError";
+
+    public static final String NUM_SNAPSHOT_CREATE = "numSnapshotCreate";
+
+    public static final String NUM_SNAPSHOT_ERROR = "numSnapshotError";
+
+    public static final String NUM_COMPLETED_SNAPSHOTS = "numCompletedSnapshots";
+
+    public static final String SNAPSHOT_TO_CHECKPOINT_TIME_LAG = "snapshotToCheckpointTimeLag";
+
     /**
      * Timestamp when the read phase changed
      */

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/Constants.java
@@ -77,7 +77,7 @@ public final class Constants {
 
     public static final String NUM_SNAPSHOT_ERROR = "numSnapshotError";
 
-    public static final String NUM_COMPLETED_SNAPSHOTS = "numCompletedSnapshots";
+    public static final String NUM_SNAPSHOT_COMPLETE = "numSnapshotComplete";
 
     public static final String SNAPSHOT_TO_CHECKPOINT_TIME_LAG = "snapshotToCheckpointTimeLag";
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -124,6 +124,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
                 registerMetricsForCurrentFetchEventTimeLag();
                 registerMetricsForCurrentEmitEventTimeLag();
                 registerMetricsForDeserializeTimeLag();
+                registerMetricsForNumCompletedSnapshots(new ThreadSafeCounter());
                 registerMetricsForNumDeserializeSuccess(new ThreadSafeCounter());
                 registerMetricsForNumDeserializeError(new ThreadSafeCounter());
                 registerMetricsForNumSnapshotCreate(new ThreadSafeCounter());
@@ -229,7 +230,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         numSnapshotError = registerCounter(NUM_SNAPSHOT_ERROR, counter);
     }
 
-    public void registerMetricsForNumCompletedCheckpoints(Counter counter) {
+    public void registerMetricsForNumCompletedSnapshots(Counter counter) {
         numCompletedSnapshots = registerCounter(NUM_COMPLETED_SNAPSHOTS, counter);
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -37,12 +37,12 @@ import static org.apache.inlong.sort.base.Constants.DESERIALIZE_TIME_LAG;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN_FOR_METER;
 import static org.apache.inlong.sort.base.Constants.NUM_BYTES_IN_PER_SECOND;
-import static org.apache.inlong.sort.base.Constants.NUM_COMPLETED_SNAPSHOTS;
 import static org.apache.inlong.sort.base.Constants.NUM_DESERIALIZE_ERROR;
 import static org.apache.inlong.sort.base.Constants.NUM_DESERIALIZE_SUCCESS;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN_FOR_METER;
 import static org.apache.inlong.sort.base.Constants.NUM_RECORDS_IN_PER_SECOND;
+import static org.apache.inlong.sort.base.Constants.NUM_SNAPSHOT_COMPLETE;
 import static org.apache.inlong.sort.base.Constants.NUM_SNAPSHOT_CREATE;
 import static org.apache.inlong.sort.base.Constants.NUM_SNAPSHOT_ERROR;
 import static org.apache.inlong.sort.base.Constants.SNAPSHOT_TO_CHECKPOINT_TIME_LAG;
@@ -62,7 +62,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
     private Gauge<Long> deserializeTimeLag;
     private Counter numSnapshotCreate;
     private Counter numSnapshotError;
-    private Counter numCompletedSnapshots;
+    private Counter numSnapshotComplete;
     private Gauge<Long> snapshotToCheckpointTimeLag;
     private Meter numRecordsInPerSecond;
     private Meter numBytesInPerSecond;
@@ -124,7 +124,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
                 registerMetricsForCurrentFetchEventTimeLag();
                 registerMetricsForCurrentEmitEventTimeLag();
                 registerMetricsForDeserializeTimeLag();
-                registerMetricsForNumCompletedSnapshots(new ThreadSafeCounter());
+                registerMetricsForNumSnapshotComplete(new ThreadSafeCounter());
                 registerMetricsForNumDeserializeSuccess(new ThreadSafeCounter());
                 registerMetricsForNumDeserializeError(new ThreadSafeCounter());
                 registerMetricsForNumSnapshotCreate(new ThreadSafeCounter());
@@ -230,8 +230,8 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         numSnapshotError = registerCounter(NUM_SNAPSHOT_ERROR, counter);
     }
 
-    public void registerMetricsForNumCompletedSnapshots(Counter counter) {
-        numCompletedSnapshots = registerCounter(NUM_COMPLETED_SNAPSHOTS, counter);
+    public void registerMetricsForNumSnapshotComplete(Counter counter) {
+        numSnapshotComplete = registerCounter(NUM_SNAPSHOT_COMPLETE, counter);
     }
 
     public void registerMetricsForSnapshotToCheckpointTimeLag() {
@@ -303,8 +303,8 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         return snapshotToCheckpointDelay;
     }
 
-    public Counter getNumCompletedSnapshots() {
-        return numCompletedSnapshots;
+    public Counter getNumSnapshotComplete() {
+        return numSnapshotComplete;
     }
 
     public void recordDeserializeDelay(long deserializeDelay) {
@@ -390,9 +390,9 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         }
     }
 
-    public void incNumCompletedSnapshots() {
-        if (numCompletedSnapshots != null) {
-            numCompletedSnapshots.inc();
+    public void incNumSnapshotComplete() {
+        if (numSnapshotComplete != null) {
+            numSnapshotComplete.inc();
         }
     }
 

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -432,6 +432,7 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
                 + ", numSnapshotCreate=" + numSnapshotCreate.getCount()
                 + ", numSnapshotError=" + numSnapshotError.getCount()
                 + ", snapshotToCheckpointTimeLag=" + snapshotToCheckpointTimeLag.getValue()
+                + ", numSnapshotComplete=" + numSnapshotComplete.getCount()
                 + ", numRecordsInPerSecond=" + numRecordsInPerSecond.getRate()
                 + ", numBytesInPerSecond=" + numBytesInPerSecond.getRate()
                 + ", auditReporter=" + auditReporter

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
@@ -236,7 +236,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         this.executor = Executors.newSingleThreadExecutor(threadFactory);
         this.handover = new Handover();
         this.changeConsumer = new DebeziumChangeConsumer(handover);
-        if (sourceExactlyMetric == null) {
+        if (sourceExactlyMetric == null && metricOption != null) {
             sourceExactlyMetric = new SourceExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
         }
         if (deserializer instanceof RowDataDebeziumDeserializeSchema) {

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
@@ -353,9 +353,8 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                     .updateCurrentCheckpointId(functionSnapshotContext.getCheckpointId());
         }
         // record the start time of each checkpoint
-        Long checkpointId = functionSnapshotContext.getCheckpointId();
         if (checkpointStartTimeMap != null) {
-            checkpointStartTimeMap.put(checkpointId, System.currentTimeMillis());
+            checkpointStartTimeMap.put(functionSnapshotContext.getCheckpointId(), System.currentTimeMillis());
         } else {
             LOG.error("checkpointStartTimeMap is null, can't record the start time of checkpoint");
         }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/DebeziumSourceFunction.java
@@ -544,7 +544,7 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
             if (checkpointStartTimeMap != null) {
                 Long snapShotStartTimeById = checkpointStartTimeMap.remove(checkpointId);
                 if (snapShotStartTimeById != null && sourceExactlyMetric != null) {
-                    sourceExactlyMetric.incNumCompletedSnapshots();
+                    sourceExactlyMetric.incNumSnapshotComplete();
                     sourceExactlyMetric
                             .recordSnapshotToCheckpointDelay(System.currentTimeMillis() - snapShotStartTimeById);
                 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/PostgreSQLSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/PostgreSQLSource.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.postgre;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+
 import com.ververica.cdc.debezium.Validator;
 import io.debezium.connector.postgresql.PostgresConnector;
 
@@ -53,6 +55,7 @@ public class PostgreSQLSource {
         private String[] tableList;
         private Properties dbzProperties;
         private DebeziumDeserializationSchema<T> deserializer;
+        private MetricOption metricOption;
 
         /**
          * The name of the Postgres logical decoding plug-in installed on the server. Supported
@@ -146,6 +149,12 @@ public class PostgreSQLSource {
             return this;
         }
 
+        /** metricOption used to instantiate SourceExactlyMetric */
+        public Builder<T> metricOption(MetricOption metricOption) {
+            this.metricOption = metricOption;
+            return this;
+        }
+
         public DebeziumSourceFunction<T> build() {
             Properties props = new Properties();
             props.setProperty("connector.class", PostgresConnector.class.getCanonicalName());
@@ -178,7 +187,7 @@ public class PostgreSQLSource {
             }
 
             return new DebeziumSourceFunction<>(
-                    deserializer, props, null, Validator.getDefaultValidator());
+                    deserializer, props, null, Validator.getDefaultValidator(), metricOption);
         }
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/PostgreSQLTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/PostgreSQLTableSource.java
@@ -135,7 +135,6 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                                 PostgreSQLDeserializationConverterFactory.instance())
                         .setValueValidator(new PostgresValueValidator(schemaName, tableName))
                         .setChangelogMode(changelogMode)
-                        .setMetricOption(metricOption)
                         .build();
         DebeziumSourceFunction<RowData> sourceFunction =
                 PostgreSQLSource.<RowData>builder()
@@ -150,6 +149,7 @@ public class PostgreSQLTableSource implements ScanTableSource, SupportsReadingMe
                         .slotName(slotName)
                         .debeziumProperties(dbzProperties)
                         .deserializer(deserializer)
+                        .metricOption(metricOption)
                         .build();
         return SourceFunctionProvider.of(sourceFunction, false);
     }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/RowDataDebeziumDeserializeSchema.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/src/main/java/org/apache/inlong/sort/postgre/RowDataDebeziumDeserializeSchema.java
@@ -34,7 +34,6 @@ import io.debezium.time.MicroTimestamp;
 import io.debezium.time.NanoTime;
 import io.debezium.time.NanoTimestamp;
 import io.debezium.time.Timestamp;
-import lombok.Setter;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
@@ -102,7 +101,6 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
     private final DebeziumChangelogMode changelogMode;
 
     /** Self-defined Flink metrics, which will be set by DebeziumSourceFunction with setter */
-    @Setter
     private SourceExactlyMetric sourceExactlyMetric;
 
     /** Returns a builder to build {@link RowDataDebeziumDeserializeSchema}. */
@@ -711,5 +709,10 @@ public final class RowDataDebeziumDeserializeSchema implements DebeziumDeseriali
         if (sourceExactlyMetric != null) {
             sourceExactlyMetric.updateLastCheckpointId(checkpointId);
         }
+    }
+
+    /** setter to enable DebeziumSourceFunction to set the metric */
+    public void setSourceExactlyMetric(SourceExactlyMetric sourceExactlyMetric) {
+        this.sourceExactlyMetric = sourceExactlyMetric;
     }
 }


### PR DESCRIPTION
Fixes #11129

### Motivation

The primary goal of this PR is to enhance metric instrumentation for the InLong Sort Flink Connector, specifically for the Postgres-CDC connector. This change is aimed at improving observability by introducing additional metrics that track serialization/deserialization, snapshot states, and checkpoint completion.

### Modifications
**This feature focuses on SourceMetric only**

**Deserialization Metrics:**
Added counters to track successful and failed deserialization attempts (`numDeserializeSuccess`, `numDeserializeError`).
Added latency gauge to measure time taken for deserialization (`deserializeTimeLag`).

**SnapshotState Metrics:**
Added counters for the number of snapshots created (`numSnapshotCreate`) and errors encountered during snapshot operations (`numSnapshotError`).

**NotifyComplete Metrics:**
Added a counter to track completed snapshots (`numCompletedSnapshots`).
Added latency gauge for the time between snapshot creation and checkpoint completion (`snapshotToCheckpointTimeLag`).

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

Make Flink `takemanager `report the metrics, with Slf4jReporter for example.
Add the following configurations to `conf/flink-conf.yaml` of flink `taskmanager` and the above mentioned metrics will be printed to the logging file once `inlong-sort` starts to process data.
``` properties
metrics.reporter.slf4j.class: org.apache.flink.metrics.slf4j.Slf4jReporter 
metrics.reporter.slf4j.interval: 15 SECONDS
```

### Documentation

  - Does this pull request introduce a new feature? **Yes**
  - If yes, how is the feature documented? **JavaDocs**
