### PR TITLE
[INLONG-11122][SDK] Transform SQL supports UNHEX function

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UnHexFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/UnHexFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Function;
+
+/**
+ * UnHexFunction  -> unhex(str)
+ * description: unhex(str) interprets each pair of characters in the argument as a hexadecimal number and converts it to the byte represented by the number.
+ * return null if str is null;
+ * return a binary string otherwise.
+ */
+@TransformFunction(names = {"unhex"})
+public class UnHexFunction implements ValueParser {
+
+    private ValueParser valueParser;
+
+    public UnHexFunction(Function expr) {
+        valueParser = OperatorTools.buildParser(expr.getParameters().getExpressions().get(0));
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object valueObj = valueParser.parse(sourceData, rowIndex, context);
+        if (valueObj == null) {
+            return null;
+        }
+        return hexToString(OperatorTools.parseString(valueObj));
+    }
+
+    public static String hexToString(String hex) {
+        StringBuilder output = new StringBuilder();
+        for (int i = 0; i < hex.length(); i += 2) {
+            String str = hex.substring(i, i + 2);
+            char ch = (char) Integer.parseInt(str, 16);
+            output.append(ch);
+        }
+        return output.toString();
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUnHexFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestUnHexFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * TestUnHexFunction
+ * description: test the unhex function in transform processor
+ */
+public class TestUnHexFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testUnHexFunction() throws Exception {
+        String transformSql = null, data = null;
+        TransformConfig config = null;
+        TransformProcessor<String, String> processor = null;
+        List<String> output = null;
+
+        transformSql = "select unhex(string1) from source";
+        config = new TransformConfig(transformSql);
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case3: unhex("6")
+        output = processor.transform("6", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=", output.get(0));
+        // case1: unhex("696E6C6F6E67")
+        output = processor.transform("696E6C6F6E67", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=inlong", output.get(0));
+
+        // case2: unhex("")
+        output = processor.transform("|", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals(output.get(0), "result=");
+
+        // case3: unhex("6")
+        output = processor.transform("6", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=", output.get(0));
+
+        transformSql = "select unhex(hex(string1)) from source";
+        config = new TransformConfig(transformSql);
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: unhex(hex("inlong"))
+        output = processor.transform("inlong", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=inlong", output.get(0));
+
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11122 

### Motivation

Add one function class: UnHexFunction. Also, add the corresponding unit test classe: TestUnHexFunction.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*
