### PR TITLE
[INLONG-11020][SDK] Add BSON formatted data source for Transform

### DIFF
--- a/inlong-sdk/transform-sdk/pom.xml
+++ b/inlong-sdk/transform-sdk/pom.xml
@@ -59,6 +59,10 @@
             <version>${protobuf.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/BsonSourceData.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/BsonSourceData.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.decode;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+/**
+ * BsonSourceData
+ */
+public class BsonSourceData extends JsonSourceData {
+
+    public BsonSourceData(JsonObject root, JsonArray childRoot) {
+        super(root, childRoot);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/BsonSourceDecoder.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/BsonSourceDecoder.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.decode;
+
+import org.apache.inlong.sdk.transform.pojo.BsonSourceInfo;
+import org.apache.inlong.sdk.transform.process.Context;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
+import java.math.BigDecimal;
+
+/**
+ * BsonSourceDecoder
+ */
+@Slf4j
+public class BsonSourceDecoder implements SourceDecoder<byte[]> {
+
+    private final JsonSourceDecoder decoder;
+
+    public BsonSourceDecoder(BsonSourceInfo sourceInfo) {
+        decoder = new JsonSourceDecoder(sourceInfo);
+    }
+
+    @Override
+    public SourceData decode(byte[] srcBytes, Context context) {
+        return decoder.decode(parse(srcBytes), context);
+    }
+
+    public String parse(byte[] bsonData) {
+        try {
+            RawBsonDocument rawBsonDocument = new RawBsonDocument(bsonData);
+            JsonWriterSettings writerSettings = JsonWriterSettings.builder()
+                    .outputMode(JsonMode.RELAXED)
+                    .decimal128Converter((value, writer) -> writer.writeNumber(value.bigDecimalValue().toPlainString()))
+                    .doubleConverter((value, writer) -> writer.writeNumber(new BigDecimal(value).toString()))
+                    .build();
+            BsonDocument bsonDocument = BsonDocument.parse(rawBsonDocument.toJson(writerSettings));
+            bsonDocument.remove("_id");
+            return bsonDocument.toJson();
+        } catch (Exception e) {
+            log.error(e.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/SourceDecoderFactory.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/SourceDecoderFactory.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sdk.transform.decode;
 
 import org.apache.inlong.sdk.transform.pojo.AvroSourceInfo;
+import org.apache.inlong.sdk.transform.pojo.BsonSourceInfo;
 import org.apache.inlong.sdk.transform.pojo.CsvSourceInfo;
 import org.apache.inlong.sdk.transform.pojo.JsonSourceInfo;
 import org.apache.inlong.sdk.transform.pojo.KvSourceInfo;
@@ -43,5 +44,8 @@ public class SourceDecoderFactory {
 
     public static AvroSourceDecoder createAvroDecoder(AvroSourceInfo sourceInfo) {
         return new AvroSourceDecoder(sourceInfo);
+    }
+    public static BsonSourceDecoder createBsonDecoder(BsonSourceInfo sourceInfo) {
+        return new BsonSourceDecoder(sourceInfo);
     }
 }

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/pojo/BsonSourceInfo.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/pojo/BsonSourceInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.pojo;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * BsonSourceInfo
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BsonSourceInfo extends JsonSourceInfo {
+
+    @JsonCreator
+    public BsonSourceInfo(
+            @JsonProperty("charset") String charset,
+            @JsonProperty("rowsNodePath") String rowsNodePath) {
+        super(charset, rowsNodePath);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestBson2CsvProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestBson2CsvProcessor.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.processor;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.BsonSourceInfo;
+import org.apache.inlong.sdk.transform.pojo.CsvSinkInfo;
+import org.apache.inlong.sdk.transform.pojo.FieldInfo;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+
+public class TestBson2CsvProcessor extends AbstractProcessorTestBase {
+
+    @Test
+    public void testBson2Csv() throws Exception {
+        List<FieldInfo> fields1 = this.getTestFieldList("sid", "packageID", "msgTime", "msg");
+        BsonSourceInfo bsonSourceInfo1 = new BsonSourceInfo("UTF-8", "msgs");
+        CsvSinkInfo csvSink1 = new CsvSinkInfo("UTF-8", '|', '\\', fields1);
+        String transformSql1 = "select $root.sid,$root.packageID,$child.msgTime,$child.msg from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        // case1
+        TransformProcessor<byte[], String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createBsonDecoder(bsonSourceInfo1),
+                        SinkEncoderFactory.createCsvEncoder(csvSink1));
+        String srcBase64String1 = "lQAAAAdfaWQAZugcR0pfeo8607hFAnNpZAAHAAAAdmFsdWUxAAJ" +
+                "wYWNrYWdlSUQABwAAAHZhbHVlMgAEbXNncwBTAAAAAzAAJgAAAAJtc2cABwAAAHZhbHVl" +
+                "NAABbXNnVGltZQAAAOu4VO54QgADMQAiAAAAAm1zZwADAAAAdjQAAW1zZ1RpbWUAAADru" +
+                "FTueEIAAAA=";
+        byte[] srcByte1 = Base64.getDecoder().decode(srcBase64String1);
+        List<String> output1 = processor1.transform(srcByte1, new HashMap<>());
+        Assert.assertEquals(2, output1.size());
+        Assert.assertEquals("value1|value2|1713243918000|value4", output1.get(0));
+        Assert.assertEquals("value1|value2|1713243918000|v4", output1.get(1));
+
+        // case2
+        List<FieldInfo> fields2 = this.getTestFieldList("id", "itemId", "subItemId", "msg");
+        BsonSourceInfo bsonSourceInfo2 = new BsonSourceInfo("UTF-8", "items");
+        CsvSinkInfo csvSink2 = new CsvSinkInfo("UTF-8", '|', '\\', fields2);
+        String transformSql2 =
+                "select $root.id,$child.itemId,$child.subItems(0).subItemId,$child.subItems(1).msg from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<byte[], String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createBsonDecoder(bsonSourceInfo2),
+                        SinkEncoderFactory.createCsvEncoder(csvSink2));
+        String srcBase64String2 = "SAEAAAdfaWQAZueeaQg0im27chcAAmlkAAcAAAB2YWx1ZTEAAm5hb" +
+                "WUABwAAAHZhbHVlMgAEaXRlbXMACwEAAAMwAIAAAAACaXRlbUlkAAYAAABpdGVtMQAEc" +
+                "3ViSXRlbXMAXwAAAAMwACoAAAACc3ViSXRlbUlkAAUAAAAxMDAxAAJtc2cACAAAADEwM" +
+                "DFtc2cAAAMxACoAAAACc3ViSXRlbUlkAAUAAAAxMDAyAAJtc2cACAAAADEwMDJtc2cAA" +
+                "AAAAzEAgAAAAAJpdGVtSWQABgAAAGl0ZW0yAARzdWJJdGVtcwBfAAAAAzAAKgAAAAJzd" +
+                "WJJdGVtSWQABQAAADIwMDEAAm1zZwAIAAAAMjAwMW1zZwAAAzEAKgAAAAJzdWJJdGVtS" +
+                "WQABQAAADIwMDIAAm1zZwAIAAAAMjAwMm1zZwAAAAAAAA==";
+        byte[] srcByte2 = Base64.getDecoder().decode(srcBase64String2);
+        List<String> output2 = processor2.transform(srcByte2, new HashMap<>());
+        Assert.assertEquals(2, output2.size());
+        Assert.assertEquals("value1|item1|1001|1002msg", output2.get(0));
+        Assert.assertEquals("value1|item2|2001|2002msg", output2.get(1));
+
+        // case3
+        List<FieldInfo> fields3 = this.getTestFieldList("matrix(0,0)", "matrix(1,1)", "matrix(2,2)");
+        BsonSourceInfo bsonSourceInfo3 = new BsonSourceInfo("UTF-8", "");
+        CsvSinkInfo csvSink3 = new CsvSinkInfo("UTF-8", '|', '\\', fields3);
+        String transformSql3 = "select $root.matrix(0, 0), $root.matrix(1, 1), $root.matrix(2, 2) from source";
+        TransformConfig config3 = new TransformConfig(transformSql3);
+        TransformProcessor<byte[], String> processor3 = TransformProcessor
+                .create(config3, SourceDecoderFactory.createBsonDecoder(bsonSourceInfo3),
+                        SinkEncoderFactory.createCsvEncoder(csvSink3));
+        String srcBase64String3 = "ngAAAAdfaWQAZugj40pfeo8607hGBG1hdHJpeACAAAAABDAAJgAAAA" +
+                "EwAAAAAAAAAPA/ATEAAAAAAAAAAEABMgAAAAAAAAAIQAAEMQAmAAAAATAAAAAAAAAAEEABMQ" +
+                "AAAAAAAAAUQAEyAAAAAAAAABhAAAQyACYAAAABMAAAAAAAAAAcQAExAAAAAAAAACBAATIAAA" +
+                "AAAAAAIkAAAAA=";
+        byte[] srcByte3 = Base64.getDecoder().decode(srcBase64String3);
+        List<String> output3 = processor3.transform(srcByte3, new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals("1|5|9", output3.get(0));
+
+        // case 4
+        List<FieldInfo> fields4 = this.getTestFieldList("department_name", "course_id", "num");
+        BsonSourceInfo bsonSourceInfo4 = new BsonSourceInfo("UTF-8", "");
+        CsvSinkInfo csvSink4 = new CsvSinkInfo("UTF-8", '|', '\\', fields4);
+        String transformSql4 =
+                "select $root.departments(0).name, $root.departments(0).courses(0,1).courseId, sqrt($root.departments(0).courses(0,1).courseId - 2) from source";
+        TransformConfig config4 = new TransformConfig(transformSql4);
+        TransformProcessor<byte[], String> processor4 = TransformProcessor
+                .create(config4, SourceDecoderFactory.createBsonDecoder(bsonSourceInfo4),
+                        SinkEncoderFactory.createCsvEncoder(csvSink4));
+        String srcBase64String4 = "KwEAAAdfaWQAZugoCEpfeo8607hHBGRlcGFydG1lbnRzAAgBAAADMAA" +
+                "AAQAAAm5hbWUADAAAAE1hdGhlbWF0aWNzAARjb3Vyc2VzANwAAAAEMABnAAAAAzAALAAAAAJj" +
+                "b3Vyc2VJZAAEAAAAMTAxAAJ0aXRsZQAKAAAAQ2FsY3VsdXNJAAADMQAwAAAAAmNvdXJzZUlkA" +
+                "AQAAAAxMDIAAnRpdGxlAA4AAABMaW5lYXJBbGdlYnJhAAAABDEAagAAAAMwAC0AAAACY291cn" +
+                "NlSWQABAAAADIwMQACdGl0bGUACwAAAENhbGN1bHVzSUkAAAMxADIAAAACY291cnNlSWQABAA" +
+                "AADIwMgACdGl0bGUAEAAAAEFic3RyYWN0QWxnZWJyYQAAAAAAAAA=";
+        byte[] srcByte4 = Base64.getDecoder().decode(srcBase64String4);
+        List<String> output4 = processor4.transform(srcByte4, new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "Mathematics|102|10.0");
+    }
+
+    @Test
+    public void testBson2CsvForOne() throws Exception {
+        List<FieldInfo> fields = this.getTestFieldList("sid", "packageID", "msgTime", "msg");
+        BsonSourceInfo bsonSourceInfo = new BsonSourceInfo("UTF-8", "");
+        CsvSinkInfo csvSink = new CsvSinkInfo("UTF-8", '|', '\\', fields);
+        String transformSql = "select $root.sid,$root.packageID,$root.msgs(1).msgTime,$root.msgs(0).msg from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1
+        TransformProcessor<byte[], String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createBsonDecoder(bsonSourceInfo),
+                        SinkEncoderFactory.createCsvEncoder(csvSink));
+        String srcBase64String = "lQAAAAdfaWQAZugcR0pfeo8607hFAnNpZAAHAAAAdmFsdWUxAAJ" +
+                "wYWNrYWdlSUQABwAAAHZhbHVlMgAEbXNncwBTAAAAAzAAJgAAAAJtc2cABwAAAHZhbHVl" +
+                "NAABbXNnVGltZQAAAOu4VO54QgADMQAiAAAAAm1zZwADAAAAdjQAAW1zZ1RpbWUAAADru" +
+                "FTueEIAAAA=";
+        byte[] srcByte = Base64.getDecoder().decode(srcBase64String);
+        List<String> output = processor.transform(srcByte, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals(output.get(0), "value1|value2|1713243918000|value4");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
         <curator.version>4.2.0</curator.version>
 
         <avro.version>1.10.1</avro.version>
+        <bson.version>4.9.1</bson.version>
         <orc.core.version>1.6.7</orc.core.version>
         <parquet.version>1.12.2</parquet.version>
         <oro.version>2.0.8</oro.version>
@@ -209,6 +210,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.mongodb</groupId>
+                <artifactId>bson</artifactId>
+                <version>${bson.version}</version>
+            </dependency>
+
             <!--opentelemetry-->
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11020 

### Motivation

Added the parsing capability of Bson data source for Transform.
The following classes have been added: BsonSourceData, BsonSourceDecoder, BsonSourceInfo. 
And added a testing class: TestBson2CsvProcessor.

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*