### PR TITLE
[INLONG-11145][Agent] Optimize the logic of supplementing data

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
@@ -52,6 +52,7 @@ public abstract class AbstractTask extends Task {
     protected boolean initOK = false;
     protected long lastPrintTime = 0;
     protected long auditVersion;
+    protected long instanceCount = 0;
 
     @Override
     public void init(Object srcManager, TaskProfile taskProfile, Store basicStore) throws IOException {
@@ -152,7 +153,7 @@ public abstract class AbstractTask extends Task {
     }
 
     protected boolean allInstanceFinished() {
-        return instanceManager.allInstanceFinished();
+        return instanceCount == instanceManager.getFinishedInstanceCount();
     }
 
     protected boolean shouldAddAgain(String fileName, long lastModifyTime) {

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/file/LogFileTask.java
@@ -241,7 +241,7 @@ public class LogFileTask extends AbstractTask {
             runAtLeastOneTime = true;
         }
         dealWithEventMap();
-        if (instanceQueue.isEmpty() && allInstanceFinished()) {
+        if (allInstanceFinished()) {
             LOGGER.info("retry task finished, send action to task manager, taskId {}", getTaskId());
             TaskAction action = new TaskAction(org.apache.inlong.agent.core.task.ActionType.FINISH, taskProfile);
             taskManager.submitAction(action);
@@ -264,6 +264,9 @@ public class LogFileTask extends AbstractTask {
             LOGGER.info("taskId {} scan {} get file count {}", getTaskId(), originPattern, fileInfos.size());
             fileInfos.forEach((fileInfo) -> {
                 addToEvenMap(fileInfo.fileName, fileInfo.dataTime);
+                if (retry) {
+                    instanceCount++;
+                }
             });
         });
     }


### PR DESCRIPTION
Fixes #11145 

### Motivation

The logic for supplementing data needs to be optimized to prevent data loss

### Modifications

1. If the action queue is full, the action cannot be directly discarded
2. Determination of completion of supplementary data task: The number of scanned files is equal to the number of collected files

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
