### PR TITLE
[INLONG-11156][SDK] SortSDK support that the token configuration of pulsar cluster is null

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
@@ -35,6 +35,7 @@ import org.apache.inlong.tubemq.client.factory.TubeSingleSessionFactory;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -213,10 +214,19 @@ public class InlongMultiTopicManager extends TopicManager {
                 topic.getInLongCluster().getBootstraps(), consumerSize);
         for (int i = 0; i < consumerSize; i++) {
             try {
+                String token = topic.getInLongCluster().getToken();
+                Authentication auth = null;
+                if (StringUtils.isNoneBlank(token)) {
+                    auth = AuthenticationFactory.token(token);
+                }
                 PulsarClient pulsarClient = PulsarClient.builder()
                         .serviceUrl(topic.getInLongCluster().getBootstraps())
-                        .authentication(AuthenticationFactory.token(topic.getInLongCluster().getToken()))
+                        .authentication(auth)
                         .build();
+                LOGGER.info("create pulsar client succ cluster:{}, topic:{}, token:{}",
+                        topic.getInLongCluster().getClusterId(),
+                        topic.getTopic(),
+                        topic.getInLongCluster().getToken());
                 TopicFetcher fetcher = TopicFetcherBuilder.newPulsarBuilder()
                         .pulsarClient(pulsarClient)
                         .topic(topics)

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -33,6 +33,7 @@ import org.apache.inlong.tubemq.client.factory.MessageSessionFactory;
 import org.apache.inlong.tubemq.client.factory.TubeSingleSessionFactory;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.slf4j.Logger;
@@ -363,15 +364,20 @@ public class InlongSingleTopicManager extends TopicManager {
         if (!pulsarClients.containsKey(topic.getInLongCluster().getClusterId())) {
             if (topic.getInLongCluster().getBootstraps() != null) {
                 try {
+                    String token = topic.getInLongCluster().getToken();
+                    Authentication auth = null;
+                    if (StringUtils.isNoneBlank(token)) {
+                        auth = AuthenticationFactory.token(token);
+                    }
                     PulsarClient pulsarClient = PulsarClient.builder()
                             .serviceUrl(topic.getInLongCluster().getBootstraps())
-                            .authentication(AuthenticationFactory.token(topic.getInLongCluster().getToken()))
+                            .authentication(auth)
                             .build();
                     pulsarClients.put(topic.getInLongCluster().getClusterId(), pulsarClient);
-                    LOGGER.debug("create pulsar client succ {}",
-                            new String[]{topic.getInLongCluster().getClusterId(),
-                                    topic.getInLongCluster().getBootstraps(),
-                                    topic.getInLongCluster().getToken()});
+                    LOGGER.info("create pulsar client succ cluster:{}, topic:{}, token:{}",
+                            topic.getInLongCluster().getClusterId(),
+                            topic.getTopic(),
+                            topic.getInLongCluster().getToken());
                 } catch (Exception e) {
                     LOGGER.error("create pulsar client error {}", topic);
                     LOGGER.error(e.getMessage(), e);


### PR DESCRIPTION
Fixes #11156 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
