### PR TITLE
[INLONG-11166][SDK] Fixes Mongodb2StarRocksTest failure due to potential dependency conflicts

### DIFF
--- a/inlong-sdk/transform-sdk/pom.xml
+++ b/inlong-sdk/transform-sdk/pom.xml
@@ -32,6 +32,7 @@
 
     <properties>
         <inlong.root.dir>${project.parent.parent.basedir}</inlong.root.dir>
+        <bson.version>4.9.1</bson.version>
     </properties>
 
     <dependencies>
@@ -61,7 +62,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>bson</artifactId>
-            <version>4.9.1</version>
+            <version>${bson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/inlong-sdk/transform-sdk/pom.xml
+++ b/inlong-sdk/transform-sdk/pom.xml
@@ -61,6 +61,7 @@
         <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>bson</artifactId>
+            <version>4.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,6 @@
         <curator.version>4.2.0</curator.version>
 
         <avro.version>1.10.1</avro.version>
-        <bson.version>4.9.1</bson.version>
         <orc.core.version>1.6.7</orc.core.version>
         <parquet.version>1.12.2</parquet.version>
         <oro.version>2.0.8</oro.version>
@@ -210,12 +209,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.mongodb</groupId>
-                <artifactId>bson</artifactId>
-                <version>${bson.version}</version>
-            </dependency>
-
             <!--opentelemetry-->
             <dependency>
                 <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
Fixes [#11166 [Bug][Sort] Mongodb2StarRocksTest Failure Due to Potential Dependency Conflicts](https://github.com/apache/inlong/issues/11166)

### Motivation
When running the `Mongodb2StarRocksTest` in the `sort-end-to-end-test-v1.15` module, the test failed due to a `NoClassDefFoundError` exception caused by a missing `org.mongodb.bson` module. 

This issue arose because Pull Request #11136  added the `org.mongodb.bson` dependency in the `pom.xml` file of the project root directory, leading to a conflict with the existing `org.mongodb.bson` dependency in `inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc`. 

Therefore, the problematic POM must be revised to limit the impact of the newly introduced BSON dependency.

### Modifications

- Removed the `org.mongodb.bson` dependency from the `pom.xml` in the root directory.
- Introduced the `org.mongodb.bson` dependency in the `pom.xml` file of `inlong-sdk/transform-sdk` to decrease the affecting range of the newly introduced dependency from Pull Request #11136.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  `Mongodb2StarRocksTest `

- [ ] This change added tests and can be verified as follows:


### Documentation

  - Does this pull request introduce a new feature? **No**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) **Not Applicable**
  - If a feature is not applicable for documentation, explain why? **Bug Fix. No new feature introduced**

### Additional Notes
- It is advisable to run all existing tests in the module before creating PR to ensure compatibility across all dependencies and to prevent similar issues in the future, as GitHub action only runs Unit Tests for the edited part, not all UTs.
