### PR TITLE
[INLONG-11183][Dashboard] Module audit page indicator items are merged with other items

### DIFF
--- a/inlong-dashboard/src/ui/pages/ModuleAudit/AuditModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/AuditModule/config.tsx
@@ -158,7 +158,7 @@ export const getSourceDataWithCommas = sourceData => {
 
 let endTimeVisible = true;
 
-export const getFormContent = (initialValues, onSearch, onDataStreamSuccess) => [
+export const getFormContent = (initialValues, onSearch, onDataStreamSuccess, auditData) => [
   {
     type: 'select',
     label: i18n.t('pages.ModuleAudit.config.InlongGroupId'),
@@ -303,34 +303,16 @@ export const getFormContent = (initialValues, onSearch, onDataStreamSuccess) => 
       allowClear: true,
       showSearch: true,
       dropdownMatchSelectWidth: false,
-      options: {
-        requestAuto: true,
-        requestTrigger: ['onOpen'],
-        requestService: () => {
-          return request({
-            url: '/audit/getAuditBases',
-            params: {
-              isMetric: true,
-            },
+      options: auditData?.reduce((accumulator, item) => {
+        const existingItem = accumulator.find((i: { value: any }) => i.value === item.auditId);
+        if (!existingItem) {
+          accumulator.push({
+            label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+            value: item.auditId,
           });
-        },
-        requestParams: {
-          formatResult: result => {
-            return result?.reduce((accumulator, item) => {
-              const existingItem = accumulator.find(
-                (i: { value: any }) => i.value === item.auditId,
-              );
-              if (!existingItem) {
-                accumulator.push({
-                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
-                  value: item.auditId,
-                });
-              }
-              return accumulator;
-            }, []);
-          },
-        },
-      },
+        }
+        return accumulator;
+      }, []),
       filterOption: (keyword: string, option: { label: any }) => {
         return (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase());
       },

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/AuditModule/index.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/AuditModule/index.tsx
@@ -32,9 +32,10 @@ import {
 } from './config';
 import { Table } from 'antd';
 import i18n from '@/i18n';
+import { AuditProps } from '@/ui/pages/ModuleAudit';
 
 export const auditModule = 'audit';
-const Comp: React.FC = () => {
+const Comp: React.FC<AuditProps> = ({ auditData }) => {
   const [form] = useForm();
 
   const [query, setQuery] = useState({
@@ -114,7 +115,7 @@ const Comp: React.FC = () => {
         <FormGenerator
           form={form}
           layout="inline"
-          content={getFormContent(query, onSearch, onDataStreamSuccess)}
+          content={getFormContent(query, onSearch, onDataStreamSuccess, auditData)}
           style={{ marginBottom: 30 }}
           onFilter={allValues =>
             setQuery({

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/config.tsx
@@ -47,7 +47,7 @@ export const toTableData = (source, sourceDataMap) => {
     }));
 };
 
-export const getFormContent = (initialValues, onSearch) => [
+export const getFormContent = (initialValues, onSearch, auditData) => [
   {
     type: 'select',
     label: i18n.t('pages.ModuleAudit.config.InlongGroupId'),
@@ -138,29 +138,16 @@ export const getFormContent = (initialValues, onSearch) => [
       allowClear: true,
       showSearch: true,
       dropdownMatchSelectWidth: false,
-      options: {
-        requestAuto: true,
-        requestTrigger: ['onOpen'],
-        requestService: () => {
-          return request('/audit/getAuditBases');
-        },
-        requestParams: {
-          formatResult: (result: any[]) => {
-            return result?.reduce((accumulator, item) => {
-              const existingItem = accumulator.find(
-                (i: { value: any }) => i.value === item.auditId,
-              );
-              if (!existingItem) {
-                accumulator.push({
-                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
-                  value: item.auditId,
-                });
-              }
-              return accumulator;
-            }, []);
-          },
-        },
-      },
+      options: auditData?.reduce((accumulator, item) => {
+        const existingItem = accumulator.find((i: { value: any }) => i.value === item.auditId);
+        if (!existingItem) {
+          accumulator.push({
+            label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+            value: item.auditId,
+          });
+        }
+        return accumulator;
+      }, []),
       filterOption: (keyword: string, option: { label: any }) =>
         (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
@@ -173,29 +160,16 @@ export const getFormContent = (initialValues, onSearch) => [
       allowClear: true,
       showSearch: true,
       dropdownMatchSelectWidth: false,
-      options: {
-        requestAuto: true,
-        requestTrigger: ['onOpen'],
-        requestService: () => {
-          return request('/audit/getAuditBases');
-        },
-        requestParams: {
-          formatResult: (result: any[]) => {
-            return result?.reduce((accumulator, item) => {
-              const existingItem = accumulator.find(
-                (i: { value: any }) => i.value === item.auditId,
-              );
-              if (!existingItem) {
-                accumulator.push({
-                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
-                  value: item.auditId,
-                });
-              }
-              return accumulator;
-            }, []);
-          },
-        },
-      },
+      options: auditData?.reduce((accumulator, item) => {
+        const existingItem = accumulator.find((i: { value: any }) => i.value === item.auditId);
+        if (!existingItem) {
+          accumulator.push({
+            label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+            value: item.auditId,
+          });
+        }
+        return accumulator;
+      }, []),
       filterOption: (keyword: string, option: { label: any }) =>
         (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/index.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IdModule/index.tsx
@@ -22,10 +22,10 @@ import HighTable, { useForm } from '@/ui/components/HighTable';
 import { useRequest } from '@/ui/hooks';
 import { timestampFormat } from '@/core/utils';
 import { getFormContent, toTableData, getTableColumns } from './config';
+import { AuditProps } from '@/ui/pages/ModuleAudit';
 
 export const idModule = 'id';
-
-const Comp: React.FC = () => {
+const Comp: React.FC<AuditProps> = ({ auditData }) => {
   const [form] = useForm();
 
   const [query, setQuery] = useState({
@@ -101,7 +101,7 @@ const Comp: React.FC = () => {
     <>
       <HighTable
         filterForm={{
-          content: getFormContent(query, onSearch),
+          content: getFormContent(query, onSearch, auditData),
           onFilter,
         }}
         table={{

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/config.tsx
@@ -56,7 +56,7 @@ export const toTableData = (source, sourceDataMap) => {
     }));
 };
 
-export const getFormContent = (initialValues, onSearch) => [
+export const getFormContent = (initialValues, onSearch, auditData) => [
   {
     type: 'input',
     label: i18n.t('pages.ModuleAudit.config.Ip'),
@@ -92,29 +92,16 @@ export const getFormContent = (initialValues, onSearch) => [
       allowClear: true,
       showSearch: true,
       dropdownMatchSelectWidth: false,
-      options: {
-        requestAuto: true,
-        requestTrigger: ['onOpen'],
-        requestService: () => {
-          return request('/audit/getAuditBases');
-        },
-        requestParams: {
-          formatResult: (result: any[]) => {
-            return result?.reduce((accumulator, item) => {
-              const existingItem = accumulator.find(
-                (i: { value: any }) => i.value === item.auditId,
-              );
-              if (!existingItem) {
-                accumulator.push({
-                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
-                  value: item.auditId,
-                });
-              }
-              return accumulator;
-            }, []);
-          },
-        },
-      },
+      options: auditData?.reduce((accumulator, item) => {
+        const existingItem = accumulator.find((i: { value: any }) => i.value === item.auditId);
+        if (!existingItem) {
+          accumulator.push({
+            label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+            value: item.auditId,
+          });
+        }
+        return accumulator;
+      }, []),
       filterOption: (keyword: any, option: { label: any }) =>
         (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },
@@ -127,29 +114,16 @@ export const getFormContent = (initialValues, onSearch) => [
       allowClear: true,
       showSearch: true,
       dropdownMatchSelectWidth: false,
-      options: {
-        requestAuto: true,
-        requestTrigger: ['onOpen'],
-        requestService: () => {
-          return request('/audit/getAuditBases');
-        },
-        requestParams: {
-          formatResult: (result: any[]) => {
-            return result?.reduce((accumulator, item) => {
-              const existingItem = accumulator.find(
-                (i: { value: any }) => i.value === item.auditId,
-              );
-              if (!existingItem) {
-                accumulator.push({
-                  label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
-                  value: item.auditId,
-                });
-              }
-              return accumulator;
-            }, []);
-          },
-        },
-      },
+      options: auditData?.reduce((accumulator, item) => {
+        const existingItem = accumulator.find((i: { value: any }) => i.value === item.auditId);
+        if (!existingItem) {
+          accumulator.push({
+            label: i18n?.language === 'cn' ? item.nameInChinese : item.nameInEnglish,
+            value: item.auditId,
+          });
+        }
+        return accumulator;
+      }, []),
       filterOption: (keyword: string, option: { label: any }) =>
         (option?.label ?? '').toLowerCase().includes(keyword.toLowerCase()),
     },

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/index.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/IpModule/index.tsx
@@ -23,10 +23,10 @@ import HighTable from '@/ui/components/HighTable';
 import { useRequest } from '@/ui/hooks';
 import { timestampFormat } from '@/core/utils';
 import { getFormContent, toTableData, getTableColumns } from './config';
+import { AuditProps } from '@/ui/pages/ModuleAudit';
 
 export const ipModule = 'ip';
-
-const Comp: React.FC = () => {
+const Comp: React.FC<AuditProps> = ({ auditData }) => {
   const [form] = useForm();
 
   const [query, setQuery] = useState({
@@ -100,7 +100,7 @@ const Comp: React.FC = () => {
     <>
       <HighTable
         filterForm={{
-          content: getFormContent(query, onSearch),
+          content: getFormContent(query, onSearch, auditData),
           onFilter,
         }}
         table={{

--- a/inlong-dashboard/src/ui/pages/ModuleAudit/index.tsx
+++ b/inlong-dashboard/src/ui/pages/ModuleAudit/index.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card } from 'antd';
 import { PageContainer, Container } from '@/ui/components/PageContainer';
 import { useHistory, useParams } from '@/ui/hooks';
@@ -25,6 +25,7 @@ import i18n from '@/i18n';
 import IpModule, { ipModule as ipModuleName } from './IpModule';
 import IdModule, { idModule as idModuleName } from './IdModule';
 import AuditModule, { auditModule as auditModuleName } from '@/ui/pages/ModuleAudit/AuditModule';
+import request from '@/core/utils/request';
 const tabList = [
   {
     tab: i18n.t('pages.ModuleAudit.Id'),
@@ -50,7 +51,9 @@ const tabListMap = tabList.reduce(
   }),
   {},
 );
-
+export interface AuditProps {
+  auditData?: any[];
+}
 const Comp: React.FC = () => {
   const history = useHistory();
   const { type } = useParams<Record<string, string>>();
@@ -63,7 +66,20 @@ const Comp: React.FC = () => {
       pathname: `/system/${value}`,
     });
   };
-
+  const [auditData, setAuditData] = useState([]);
+  useEffect(() => {
+    request('/audit/getAuditBases').then(res1 => {
+      request({
+        url: '/audit/getAuditBases',
+        params: {
+          isMetric: true,
+        },
+      }).then(res2 => {
+        res1.push(...res2);
+        setAuditData(res1);
+      });
+    });
+  }, []);
   return (
     <PageContainer useDefaultBreadcrumb={false} useDefaultContainer={false}>
       <Container>
@@ -76,7 +92,7 @@ const Comp: React.FC = () => {
           headStyle={{ border: 'none' }}
           tabProps={{ size: 'middle' }}
         >
-          {tabListMap[module]}
+          {React.cloneElement(tabListMap[module], { auditData: auditData })}
         </Card>
       </Container>
     </PageContainer>


### PR DESCRIPTION


Fixes #11183 

### Motivation

Module audit page indicator items are merged with other items

### Modifications
Separate request logic to reduce the number of requests, merge indicator items and other categories of items

### Verifying this change
before:
id,ip
![image](https://github.com/user-attachments/assets/d6b17e53-4242-412c-bcbe-ccea0ca986a9)
metric:
![image](https://github.com/user-attachments/assets/1e4472fb-f872-464b-8425-460c016c8722)

after:
id,ip
![image](https://github.com/user-attachments/assets/7bcdc5db-4b2f-4492-b199-5643ec172043)
metric:
![image](https://github.com/user-attachments/assets/9924d615-f15b-4c64-b8fe-eaba5ec48450)

