### PR TITLE
[INLONG-11080][SDK] Transform SQL supports DATE_SUB function

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/DateSubFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/DateSubFunction.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+import org.apache.inlong.sdk.transform.process.utils.DateUtil;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.time.temporal.ChronoField;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * DateAddFunction
+ * Description:
+ * - return NULL if date is NULL.
+ * - return DATE if the date argument is a DATE value and your calculations involve only YEAR, MONTH, and DAY parts
+ *          (that is, no time parts).
+ * - return TIME if the date argument is a TIME value and the calculations involve only HOURS, MINUTES,
+ *          and SECONDS parts (that is, no date parts).
+ * - return DATETIME if the first argument is a DATETIME (or TIMESTAMP) value, or if the first argument is a DATE
+ *          and the unit value uses HOURS, MINUTES, or SECONDS, or if the first argument is of type TIME and the
+ *          unit value uses YEAR, MONTH, or DAY.
+ * - return If the first argument is a dynamic parameter (for example, of a prepared statement), its resolved type
+ *          is DATE if the second argument is an interval that contains some combination of YEAR, MONTH, or DAY values
+ *          only; otherwise, its type is DATETIME.
+ * - return String otherwise (type VARCHAR).
+ */
+@TransformFunction(names = {"date_sub", "datesub"})
+public class DateSubFunction implements ValueParser {
+
+    private ValueParser datetimeParser;
+    private ValueParser intervalParser;
+
+    public DateSubFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        datetimeParser = OperatorTools.buildParser(expressions.get(0));
+        intervalParser = OperatorTools.buildParser(expressions.get(1));
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object intervalPairObj = intervalParser.parse(sourceData, rowIndex, context);
+        Object dateObj = datetimeParser.parse(sourceData, rowIndex, context);
+        if (intervalPairObj == null || dateObj == null) {
+            return null;
+        }
+        return DateUtil.dateAdd(OperatorTools.parseString(dateObj),
+                (Pair<Integer, Map<ChronoField, Long>>) intervalPairObj, -1);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/temporal/TestDateSubFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/temporal/TestDateSubFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.function.temporal;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class TestDateSubFunction extends AbstractFunctionTemporalTestBase {
+
+    @Test
+    public void testDateSubFunction() throws Exception {
+        String transformSql = null;
+        TransformConfig config = null;
+        TransformProcessor<String, String> processor = null;
+        List<String> output = null;
+
+        transformSql = "select DATE_SUB(string1,  INTERVAL string2 DAY) from source";
+        config = new TransformConfig(transformSql);
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case1: DATE_SUB('2020-12-31 23:59:59',INTERVAL 999 DAY)
+        output = processor.transform("2020-12-31 23:59:59|999", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=2018-04-07 23:59:59", output.get(0));
+
+        // case2: DATE_SUB('2020-12-31 23:59:59',INTERVAL -999 DAY)
+        output = processor.transform("2020-12-31 23:59:59|-999", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=2023-09-26 23:59:59", output.get(0));
+
+        transformSql = "select DATE_SUB(string1,  INTERVAL string2 MINUTE_SECOND) from source";
+        config = new TransformConfig(transformSql);
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case3: DATE_SUB('2020-12-31',INTERVAL '-1:1' MINUTE_SECOND)
+        output = processor.transform("2020-12-31|-1:1", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=2020-12-31 00:01:01", output.get(0));
+
+        transformSql = "select DATE_SUB(string1,  INTERVAL string2 SECOND_MICROSECOND) from source";
+        config = new TransformConfig(transformSql);
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: DATE_SUB('1992-12-31 23:59:59', INTERVAL '-1.999999' SECOND_MICROSECOND)
+        output = processor.transform("1992-12-31 23:59:59|-1.999999", new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("result=1993-01-01 00:00:00.999999", output.get(0));
+
+    }
+}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11080 

### Motivation

Add one function class: DateSubFunction. Also, add the corresponding unit test classe: TestDateSubFunction.

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*