### PR TITLE
[INLONG-11197][Dashboard] Add delete button to cluster management and template management

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDataTemplate/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import { Button } from 'antd';
+import { Button, message, Modal } from 'antd';
 import i18n from '@/i18n';
 import HighTable from '@/ui/components/HighTable';
 import { PageContainer } from '@/ui/components/PageContainer';
@@ -26,6 +26,7 @@ import { defaultSize } from '@/configs/pagination';
 import { useRequest } from '@/ui/hooks';
 import CreateModal from './CreateModal';
 import { timestampFormat } from '@/core/utils';
+import request from '@/core/utils/request';
 
 const Comp: React.FC = () => {
   const [options, setOptions] = useState({
@@ -101,6 +102,26 @@ const Comp: React.FC = () => {
     ],
     [],
   );
+  const onDelete = useCallback(
+    record => {
+      console.log(record);
+      Modal.confirm({
+        title: i18n.t('basic.DeleteConfirm'),
+        onOk: async () => {
+          await request({
+            url: `/template/delete`,
+            method: 'DELETE',
+            params: {
+              templateName: record.name,
+            },
+          });
+          await getList();
+          message.success(i18n.t('basic.DeleteSuccess'));
+        },
+      });
+    },
+    [getList],
+  );
   const entityColumns = useMemo(() => {
     return [
       {
@@ -157,11 +178,14 @@ const Comp: React.FC = () => {
       {
         title: i18n.t('basic.Operating'),
         dataIndex: 'action',
-        width: 100,
+        width: 150,
         render: (text, record) => (
           <>
             <Button type="link" onClick={() => onEdit(record)}>
               {i18n.t('basic.Edit')}
+            </Button>
+            <Button type="link" onClick={() => onDelete(record)}>
+              {i18n.t('basic.Delete')}
             </Button>
           </>
         ),

--- a/inlong-dashboard/src/ui/pages/TenantManagement/config.tsx
+++ b/inlong-dashboard/src/ui/pages/TenantManagement/config.tsx
@@ -29,7 +29,7 @@ export const getFilterFormContent = () => [
   },
 ];
 
-export const getColumns = ({ onEdit }) => {
+export const getColumns = ({ onEdit, onDelete }) => {
   return [
     {
       title: i18n.t('pages.Tenant.config.Name'),
@@ -70,10 +70,14 @@ export const getColumns = ({ onEdit }) => {
     {
       title: i18n.t('basic.Operating'),
       dataIndex: 'action',
+      width: 150,
       render: (text, record) => (
         <>
           <Button type="link" onClick={() => onEdit(record)}>
             {i18n.t('basic.Edit')}
+          </Button>
+          <Button type="link" onClick={() => onDelete(record)}>
+            {i18n.t('basic.Delete')}
           </Button>
         </>
       ),

--- a/inlong-dashboard/src/ui/pages/TenantManagement/index.tsx
+++ b/inlong-dashboard/src/ui/pages/TenantManagement/index.tsx
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { Button, Card } from 'antd';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Button, Card, message, Modal } from 'antd';
 import { PageContainer, Container } from '@/ui/components/PageContainer';
 import HighTable from '@/ui/components/HighTable';
 import { useRequest } from '@/ui/hooks';
@@ -26,6 +26,8 @@ import { useTranslation } from 'react-i18next';
 import { defaultSize } from '@/configs/pagination';
 import DetailModal from './DetailModal';
 import { getFilterFormContent, getColumns } from './config';
+import i18n from 'i18next';
+import request from '@/core/utils/request';
 
 const Comp: React.FC = () => {
   const { t } = useTranslation();
@@ -114,7 +116,22 @@ const Comp: React.FC = () => {
     current: options.pageNum,
     total: data?.total,
   };
-
+  const onDelete = useCallback(
+    ({ id }) => {
+      Modal.confirm({
+        title: i18n.t('basic.DeleteConfirm'),
+        onOk: async () => {
+          await request({
+            url: `/role/tenant/delete/${id}`,
+            method: 'DELETE',
+          });
+          await getList();
+          message.success(i18n.t('basic.DeleteSuccess'));
+        },
+      });
+    },
+    [getList],
+  );
   return (
     <PageContainer useDefaultBreadcrumb={false} useDefaultContainer={false}>
       <Container>
@@ -130,7 +147,7 @@ const Comp: React.FC = () => {
               onFilter,
             }}
             table={{
-              columns: getColumns({ onEdit }),
+              columns: getColumns({ onEdit, onDelete }),
               rowKey: 'id',
               dataSource: data?.list,
               pagination,


### PR DESCRIPTION


Fixes #11197 

### Motivation

Add delete button to cluster management and template management

### Modifications

Add delete button to cluster management and template management

### Verifying this change
1. template:
 before:
![image](https://github.com/user-attachments/assets/640e406e-62c3-4b52-961c-a7528ddc34e8)
after:
![image](https://github.com/user-attachments/assets/0123eff8-d62c-4af8-b84d-224649686109)
2. tenant:
 before:
![image](https://github.com/user-attachments/assets/cd92aaf2-ea19-46a0-8f08-70a09578aaa7)
after:
![image](https://github.com/user-attachments/assets/650ca076-d7d6-45d3-93bb-998cc1ce7f0a)

 

