### PR TITLE
[INLONG-11210][Dashboard] Version management removes related interface calls and adds default values

### DIFF
--- a/inlong-dashboard/src/ui/pages/AgentModule/CreateModal.tsx
+++ b/inlong-dashboard/src/ui/pages/AgentModule/CreateModal.tsx
@@ -91,6 +91,7 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
         type: 'textarea',
         label: i18n.t('pages.ModuleAgent.Config.CheckCommand'),
         name: 'checkCommand',
+        initialValue: "ps aux | grep core.AgentMain | grep java | grep -v grep | awk '{print $2}'",
         props: {
           showCount: true,
           maxLength: 1000,
@@ -100,6 +101,8 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
         type: 'textarea',
         label: i18n.t('pages.ModuleAgent.Config.InstallCommand'),
         name: 'installCommand',
+        initialValue:
+          'cd ~/inlong/inlong-agent/bin;sh agent.sh stop;rm -rf ~/inlong/inlong-agent-temp;mkdir -p ~/inlong/inlong-agent-temp;cp -r ~/inlong/inlong-agent/.localdb ',
         props: {
           showCount: true,
           maxLength: 1000,
@@ -109,6 +112,7 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
         type: 'textarea',
         label: i18n.t('pages.ModuleAgent.Config.StartCommand'),
         name: 'startCommand',
+        initialValue: 'cd ~/inlong/inlong-agent/bin;sh agent.sh start',
         props: {
           showCount: true,
           maxLength: 1000,
@@ -118,6 +122,7 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
         type: 'textarea',
         label: i18n.t('pages.ModuleAgent.Config.StopCommand'),
         name: 'stopCommand',
+        initialValue: 'cd ~/inlong/inlong-agent/bin;sh agent.sh stop',
         props: {
           showCount: true,
           maxLength: 1000,
@@ -127,6 +132,7 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
         type: 'textarea',
         label: i18n.t('pages.ModuleAgent.Config.UninstallCommand'),
         name: 'uninstallCommand',
+        initialValue: 'echo empty uninstall  cmd',
         props: {
           showCount: true,
           maxLength: 1000,
@@ -142,12 +148,7 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
     {
       manual: true,
       onSuccess: result => {
-        if (isCreate) {
-          form.resetFields();
-          form.setFieldsValue({ ...result, name: '', version: '', packageId: '' });
-        } else {
-          form.setFieldsValue(result);
-        }
+        form.setFieldsValue(result);
       },
     },
   );
@@ -177,7 +178,6 @@ const Comp: React.FC<Props> = ({ id, type, ...modalProps }) => {
       } else {
         setCreate(true);
         // here need a data which id is 1 to init create form
-        getData(1);
       }
     } else {
       form.resetFields();


### PR DESCRIPTION

Fixes #11210 

### Motivation

Version management removes related interface calls and adds default values

### Modifications

Version management removes related interface calls and adds default values

### Verifying this change
before :
When entering the version management page, the get/1 interface will be called


after:
remove the interface and set default values for new Module
![image](https://github.com/user-attachments/assets/6fbc155a-d2b3-4a59-8129-1516e8f0dca7)


