### PR TITLE
[INLONG-10463][SDK] Optimization of ultra-long field processing in InlongSDK (Temp)

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
@@ -73,5 +73,6 @@ public class ConfigConstants {
 
     public static String HTTP = "http://";
     public static String HTTPS = "https://";
+    public static int MAX_MESSAGE_LENGTH = 500 * 1024;
 
 }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/DefaultMessageSender.java
@@ -44,6 +44,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.inlong.sdk.dataproxy.utils.DataBodyUtil.getDataSize;
+
 public class DefaultMessageSender implements MessageSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMessageSender.class);
@@ -99,7 +101,7 @@ public class DefaultMessageSender implements MessageSender {
      * @return - sender
      */
     public static DefaultMessageSender generateSenderByClusterId(ProxyClientConfig configure,
-            ThreadFactory selfDefineFactory) throws Exception {
+                                                                 ThreadFactory selfDefineFactory) throws Exception {
         // correct ProtocolType settings
         if (!ProtocolType.TCP.equals(configure.getProtocolType())) {
             configure.setProtocolType(ProtocolType.TCP);
@@ -193,13 +195,13 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     public SendResult sendMessage(byte[] body, String attributes, String msgUUID,
-            long timeout, TimeUnit timeUnit) {
+                                  long timeout, TimeUnit timeUnit) {
         return sender.syncSendMessage(new EncodeObject(body, attributes,
                 idGenerator.getNextId()), msgUUID, timeout, timeUnit);
     }
 
     public SendResult sendMessage(byte[] body, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit) {
+                                  long timeout, TimeUnit timeUnit) {
         return sendMessage(body, groupId, streamId, dt, msgUUID, timeout, timeUnit, false);
     }
 
@@ -217,7 +219,10 @@ public class DefaultMessageSender implements MessageSender {
      * @return SendResult.OK means success
      */
     public SendResult sendMessage(byte[] body, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, boolean isProxySend) {
+                                  long timeout, TimeUnit timeUnit, boolean isProxySend) {
+        if (getDataSize(body) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            return SendResult.BODY_EXCEED_MAX_LEN;
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt)) {
             return SendResult.INVALID_ATTRIBUTES;
@@ -255,7 +260,7 @@ public class DefaultMessageSender implements MessageSender {
     }
 
     public SendResult sendMessage(byte[] body, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
+                                  long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
         return sendMessage(body, groupId, streamId, dt, msgUUID, timeout, timeUnit, extraAttrMap, false);
     }
 
@@ -274,8 +279,10 @@ public class DefaultMessageSender implements MessageSender {
      * @return SendResult.OK means success
      */
     public SendResult sendMessage(byte[] body, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend) {
-
+                                  long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend) {
+        if (getDataSize(body) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            return SendResult.BODY_EXCEED_MAX_LEN;
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt) || !ProxyUtils.isAttrKeysValid(extraAttrMap)) {
             return SendResult.INVALID_ATTRIBUTES;
@@ -300,11 +307,11 @@ public class DefaultMessageSender implements MessageSender {
             if (isCompressEnd) {
                 attrs.append("&cp=snappy");
                 return sender.syncSendMessage(new EncodeObject(body, attrs.toString(),
-                        idGenerator.getNextId(), this.getMsgtype(), true, groupId),
+                                idGenerator.getNextId(), this.getMsgtype(), true, groupId),
                         msgUUID, timeout, timeUnit);
             } else {
                 return sender.syncSendMessage(new EncodeObject(body, attrs.toString(),
-                        idGenerator.getNextId(), this.getMsgtype(), false, groupId), msgUUID,
+                                idGenerator.getNextId(), this.getMsgtype(), false, groupId), msgUUID,
                         timeout, timeUnit);
             }
         }
@@ -313,7 +320,7 @@ public class DefaultMessageSender implements MessageSender {
     }
 
     public SendResult sendMessage(List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit) {
+                                  long timeout, TimeUnit timeUnit) {
         return sendMessage(bodyList, groupId, streamId, dt, msgUUID, timeout, timeUnit, false);
     }
 
@@ -331,7 +338,10 @@ public class DefaultMessageSender implements MessageSender {
      * @return SendResult.OK means success
      */
     public SendResult sendMessage(List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, boolean isProxySend) {
+                                  long timeout, TimeUnit timeUnit, boolean isProxySend) {
+        if (getDataSize(bodyList) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            return SendResult.BODY_EXCEED_MAX_LEN;
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt)) {
             return SendResult.INVALID_ATTRIBUTES;
@@ -368,7 +378,7 @@ public class DefaultMessageSender implements MessageSender {
     }
 
     public SendResult sendMessage(List<byte[]> bodyList, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
+                                  String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
         return sendMessage(bodyList, groupId, streamId, dt, msgUUID, timeout, timeUnit, extraAttrMap, false);
     }
 
@@ -387,7 +397,10 @@ public class DefaultMessageSender implements MessageSender {
      * @return SendResult.OK means success
      */
     public SendResult sendMessage(List<byte[]> bodyList, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend) {
+                                  String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend) {
+        if (getDataSize(bodyList) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            return SendResult.BODY_EXCEED_MAX_LEN;
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt) || !ProxyUtils.isAttrKeysValid(
                 extraAttrMap)) {
@@ -411,11 +424,11 @@ public class DefaultMessageSender implements MessageSender {
             if (isCompress) {
                 attrs.append("&cp=snappy");
                 return sender.syncSendMessage(new EncodeObject(bodyList, attrs.toString(),
-                        idGenerator.getNextId(), this.getMsgtype(), true, groupId),
+                                idGenerator.getNextId(), this.getMsgtype(), true, groupId),
                         msgUUID, timeout, timeUnit);
             } else {
                 return sender.syncSendMessage(new EncodeObject(bodyList, attrs.toString(),
-                        idGenerator.getNextId(), this.getMsgtype(), false, groupId),
+                                idGenerator.getNextId(), this.getMsgtype(), false, groupId),
                         msgUUID, timeout, timeUnit);
             }
         }
@@ -424,13 +437,13 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String attributes,
-            String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
+                                 String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
         sender.asyncSendMessage(new EncodeObject(body, attributes, idGenerator.getNextId()),
                 callback, msgUUID, timeout, timeUnit);
     }
 
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
+                                 String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMessage(callback, body, groupId, streamId, dt, msgUUID, timeout, timeUnit, false);
     }
 
@@ -449,7 +462,10 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit, boolean isProxySend) throws ProxysdkException {
+                                 String msgUUID, long timeout, TimeUnit timeUnit, boolean isProxySend) throws ProxysdkException {
+        if (getDataSize(body) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            callback.onMessageAck(SendResult.BODY_EXCEED_MAX_LEN);
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt)) {
             throw new ProxysdkException(SendResult.INVALID_ATTRIBUTES.toString());
@@ -473,8 +489,8 @@ public class DefaultMessageSender implements MessageSender {
                     proxySend = "&" + proxySend;
                 }
                 sender.asyncSendMessage(new EncodeObject(body, "groupId="
-                        + groupId + "&streamId=" + streamId + "&dt=" + dt + "&cp=snappy" + proxySend,
-                        idGenerator.getNextId(), this.getMsgtype(), true, groupId),
+                                + groupId + "&streamId=" + streamId + "&dt=" + dt + "&cp=snappy" + proxySend,
+                                idGenerator.getNextId(), this.getMsgtype(), true, groupId),
                         callback, msgUUID, timeout, timeUnit);
             } else {
                 sender.asyncSendMessage(
@@ -489,7 +505,7 @@ public class DefaultMessageSender implements MessageSender {
     }
 
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap)
+                                 String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap)
             throws ProxysdkException {
         asyncSendMessage(callback, body, groupId, streamId, dt, msgUUID, timeout, timeUnit, extraAttrMap, false);
     }
@@ -510,8 +526,11 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(SendMessageCallback callback, byte[] body, String groupId, String streamId, long dt,
-            String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend)
+                                 String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap, boolean isProxySend)
             throws ProxysdkException {
+        if (getDataSize(body) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            callback.onMessageAck(SendResult.BODY_EXCEED_MAX_LEN);
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt) || !ProxyUtils.isAttrKeysValid(extraAttrMap)) {
             throw new ProxysdkException(SendResult.INVALID_ATTRIBUTES.toString());
@@ -534,18 +553,18 @@ public class DefaultMessageSender implements MessageSender {
             if (isCompressEnd) {
                 attrs.append("&cp=snappy");
                 sender.asyncSendMessage(new EncodeObject(body, attrs.toString(),
-                        idGenerator.getNextId(), this.getMsgtype(), true, groupId),
+                                idGenerator.getNextId(), this.getMsgtype(), true, groupId),
                         callback, msgUUID, timeout, timeUnit);
             } else {
                 sender.asyncSendMessage(new EncodeObject(body, attrs.toString(), idGenerator.getNextId(),
-                        this.getMsgtype(), false, groupId),
+                                this.getMsgtype(), false, groupId),
                         callback, msgUUID, timeout, timeUnit);
             }
         }
     }
 
     public void asyncSendMessage(SendMessageCallback callback, List<byte[]> bodyList, String groupId, String streamId,
-            long dt, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
+                                 long dt, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMessage(callback, bodyList, groupId, streamId, dt, msgUUID, timeout, timeUnit, false);
     }
 
@@ -564,8 +583,11 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(SendMessageCallback callback, List<byte[]> bodyList,
-            String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, boolean isProxySend) throws ProxysdkException {
+                                 String groupId, String streamId, long dt, String msgUUID,
+                                 long timeout, TimeUnit timeUnit, boolean isProxySend) throws ProxysdkException {
+        if (getDataSize(bodyList) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            callback.onMessageAck(SendResult.BODY_EXCEED_MAX_LEN);
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt)) {
             throw new ProxysdkException(SendResult.INVALID_ATTRIBUTES.toString());
@@ -604,8 +626,8 @@ public class DefaultMessageSender implements MessageSender {
     }
 
     public void asyncSendMessage(SendMessageCallback callback,
-            List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) throws ProxysdkException {
+                                 List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
+                                 long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) throws ProxysdkException {
         asyncSendMessage(callback, bodyList, groupId, streamId, dt, msgUUID, timeout, timeUnit, extraAttrMap, false);
     }
 
@@ -625,9 +647,12 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(SendMessageCallback callback,
-            List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
-            long timeout, TimeUnit timeUnit,
-            Map<String, String> extraAttrMap, boolean isProxySend) throws ProxysdkException {
+                                 List<byte[]> bodyList, String groupId, String streamId, long dt, String msgUUID,
+                                 long timeout, TimeUnit timeUnit,
+                                 Map<String, String> extraAttrMap, boolean isProxySend) throws ProxysdkException {
+        if (getDataSize(bodyList) > ConfigConstants.MAX_MESSAGE_LENGTH) {
+            callback.onMessageAck(SendResult.BODY_EXCEED_MAX_LEN);
+        }
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt) || !ProxyUtils.isAttrKeysValid(
                 extraAttrMap)) {
@@ -688,7 +713,7 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(String inlongGroupId, String inlongStreamId, byte[] body, SendMessageCallback callback,
-            boolean isProxySend) throws ProxysdkException {
+                                 boolean isProxySend) throws ProxysdkException {
         this.asyncSendMessage(callback, body, inlongGroupId, inlongStreamId, System.currentTimeMillis(),
                 idGenerator.getNextId(), DEFAULT_SEND_TIMEOUT, DEFAULT_SEND_TIMEUNIT, isProxySend);
     }
@@ -704,7 +729,7 @@ public class DefaultMessageSender implements MessageSender {
      */
     @Override
     public void asyncSendMessage(String inlongGroupId, String inlongStreamId, List<byte[]> bodyList,
-            SendMessageCallback callback) throws ProxysdkException {
+                                 SendMessageCallback callback) throws ProxysdkException {
         this.asyncSendMessage(callback, bodyList, inlongGroupId, inlongStreamId, System.currentTimeMillis(),
                 idGenerator.getNextId(), DEFAULT_SEND_TIMEOUT, DEFAULT_SEND_TIMEUNIT);
     }
@@ -720,7 +745,7 @@ public class DefaultMessageSender implements MessageSender {
      * @throws ProxysdkException
      */
     public void asyncSendMessage(String inlongGroupId, String inlongStreamId, List<byte[]> bodyList,
-            SendMessageCallback callback, boolean isProxySend) throws ProxysdkException {
+                                 SendMessageCallback callback, boolean isProxySend) throws ProxysdkException {
         this.asyncSendMessage(callback, bodyList, inlongGroupId, inlongStreamId, System.currentTimeMillis(),
                 idGenerator.getNextId(), DEFAULT_SEND_TIMEOUT, DEFAULT_SEND_TIMEUNIT, isProxySend);
     }
@@ -741,8 +766,8 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     public void asyncsendMessageData(FileCallback callback, List<byte[]> bodyList, String groupId, String streamId,
-            long dt, int sid, boolean isSupportLF, String msgUUID, long timeout, TimeUnit timeUnit,
-            Map<String, String> extraAttrMap) throws ProxysdkException {
+                                     long dt, int sid, boolean isSupportLF, String msgUUID, long timeout, TimeUnit timeUnit,
+                                     Map<String, String> extraAttrMap) throws ProxysdkException {
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt)
                 || !ProxyUtils.isAttrKeysValid(extraAttrMap)) {
@@ -763,7 +788,7 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     private void asyncSendMetric(FileCallback callback, byte[] body, String groupId, String streamId, long dt, int sid,
-            String ip, String msgUUID, long timeout, TimeUnit timeUnit, String messageKey) throws ProxysdkException {
+                                 String ip, String msgUUID, long timeout, TimeUnit timeUnit, String messageKey) throws ProxysdkException {
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt)) {
             throw new ProxysdkException(SendResult.INVALID_ATTRIBUTES.toString());
@@ -778,21 +803,21 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     public void asyncsendMessageProxy(FileCallback callback, byte[] body, String groupId, String streamId, long dt,
-            int sid, String ip, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
+                                      int sid, String ip, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMetric(callback, body, groupId, streamId, dt, sid, ip, msgUUID, timeout,
                 timeUnit, "minute");
     }
 
     @Deprecated
     public void asyncsendMessageFile(FileCallback callback, byte[] body, String groupId, String streamId, long dt,
-            int sid, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
+                                     int sid, String msgUUID, long timeout, TimeUnit timeUnit) throws ProxysdkException {
         asyncSendMetric(callback, body, groupId, streamId, dt, sid, "", msgUUID, timeout, timeUnit,
                 "file");
     }
 
     @Deprecated
     public String sendMessageData(List<byte[]> bodyList, String groupId, String streamId, long dt, int sid,
-            boolean isSupportLF, String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
+                                  boolean isSupportLF, String msgUUID, long timeout, TimeUnit timeUnit, Map<String, String> extraAttrMap) {
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(bodyList) || !ProxyUtils.isDtValid(dt)
                 || !ProxyUtils.isAttrKeysValid(extraAttrMap)) {
@@ -814,7 +839,7 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     private String sendMetric(byte[] body, String groupId, String streamId, long dt, int sid, String ip, String msgUUID,
-            long timeout, TimeUnit timeUnit, String messageKey) {
+                              long timeout, TimeUnit timeUnit, String messageKey) {
         dt = ProxyUtils.covertZeroDt(dt);
         if (!ProxyUtils.isBodyValid(body) || !ProxyUtils.isDtValid(dt)) {
             return SendResult.INVALID_ATTRIBUTES.toString();
@@ -829,13 +854,13 @@ public class DefaultMessageSender implements MessageSender {
 
     @Deprecated
     public String sendMessageProxy(byte[] body, String groupId, String streamId, long dt, int sid, String ip,
-            String msgUUID, long timeout, TimeUnit timeUnit) {
+                                   String msgUUID, long timeout, TimeUnit timeUnit) {
         return sendMetric(body, groupId, streamId, dt, sid, ip, msgUUID, timeout, timeUnit, "minute");
     }
 
     @Deprecated
     public String sendMessageFile(byte[] body, String groupId, String streamId, long dt, int sid, String msgUUID,
-            long timeout, TimeUnit timeUnit) {
+                                  long timeout, TimeUnit timeUnit) {
         return sendMetric(body, groupId, streamId, dt, sid, "", msgUUID, timeout, timeUnit, "file");
     }
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/DataBodyUtil.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/DataBodyUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.dataproxy.utils;
+
+import java.util.List;
+
+public class DataBodyUtil {
+
+    /**
+     * get the data size of a single body
+     * @param body body
+     * @return size
+     */
+    public static int getDataSize(byte[] body) {
+        return body.length;
+    }
+
+    /**
+     * calculate the total data size of body list
+     * @param bodyList body list
+     * @return size
+     */
+    public static int getDataSize(List<byte[]> bodyList) {
+        int size = 0;
+        for (byte[] body : bodyList) {
+            size += body.length;
+        }
+        return size;
+    }
+}


### PR DESCRIPTION

<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #10463 
Last Pr: #11119 

### Motivation

In #11119 We discussed how to get the `max message size` configuration. Everyone had different ideas. Finally, we decided to temporarily configure it locally in the `DataProxy SDK`.

If the message is longer than the `ConfigConstants.MAX_MESSAGE_LENGTH`, it will directly return `BODY_EXCEED_MAX_LEN` error

### Modifications

- Added `ConfigConstants.MAX_MESSAGE_LENGTH` constant in the `ConfigConstants` file
- Added the `DataBodyUtil` to get the msg size of body or bodyList
- Added logic for handling body length for the `DefaultMessageSender`
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
