### PR TITLE
[INLONG-11233][SDK] Transform SQL supports mid function

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/SubstringFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/SubstringFunction.java
@@ -33,7 +33,7 @@ import java.util.List;
  * description:
  * return a substring of STRING starting from position INT1 with length INT2 (to the end by default)
  */
-@TransformFunction(names = {"substring", "substr"})
+@TransformFunction(names = {"substring", "substr", "mid"})
 public class SubstringFunction implements ValueParser {
 
     private ValueParser stringParser;

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestSubstringFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestSubstringFunction.java
@@ -93,5 +93,25 @@ public class TestSubstringFunction extends AbstractFunctionStringTestBase {
         output = processor.transform(data, new HashMap<>());
         Assert.assertEquals(1, output.size());
         Assert.assertEquals("result=", output.get(0));
+
+        String transformSql3 = "select mid(string2, numeric1) from source";
+        TransformConfig config3 = new TransformConfig(transformSql3);
+        TransformProcessor<String, String> processor3 = TransformProcessor
+                .create(config3, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case7: mid('banana', 2)
+        List<String> output4 = processor3.transform("apple|banana|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "result=anana");
+
+        String transformSql4 = "select mid(string1, numeric1, numeric3) from source";
+        TransformConfig config4 = new TransformConfig(transformSql4);
+        TransformProcessor<String, String> processor4 = TransformProcessor
+                .create(config4, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case8: mid('apple', 2, 3)
+        List<String> output5 = processor4.transform("apple|banana|cloud|2|1|3", new HashMap<>());
+        Assert.assertEquals(1, output5.size());
+        Assert.assertEquals(output5.get(0), "result=ppl");
     }
 }


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11233 

### Motivation

Add a mid function name to the SubstringFunction class. And add test case code.

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*