### PR TITLE
[INLONG-11298][Agent] Fix bug for pulsar source with empty data process and specified time consumption

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -59,7 +59,7 @@ public class CommonConstants {
     public static final int DEFAULT_PROXY_PACKAGE_MAX_TIMEOUT_MS = 4 * 1000;
 
     public static final String PROXY_BATCH_FLUSH_INTERVAL = "proxy.batch.flush.interval";
-    public static final int DEFAULT_PROXY_BATCH_FLUSH_INTERVAL = 100;
+    public static final int DEFAULT_PROXY_BATCH_FLUSH_INTERVAL = 1;
 
     public static final String PROXY_SENDER_MAX_TIMEOUT = "proxy.sender.maxTimeout";
     // max timeout in seconds.

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/instance/InstanceManager.java
@@ -317,7 +317,7 @@ public class InstanceManager extends AbstractDaemon {
     }
 
     private void addInstance(InstanceProfile profile) {
-        if (instanceMap.size() >= instanceLimit) {
+        if (instanceMap.size() > instanceLimit) {
             LOGGER.error("instanceMap size {} over limit {}", instanceMap.size(), instanceLimit);
             actionQueue.offer(new InstanceAction(ActionType.ADD, profile));
             AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME_MS);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/PulsarSource.java
@@ -50,7 +50,6 @@ public class PulsarSource extends AbstractSource {
     private String serviceUrl;
     private String subscription;
     private String subscriptionType;
-    private SubscriptionInitialPosition subscriptionPosition;
     private PulsarClient pulsarClient;
     private Long timestamp;
     private final static String PULSAR_SUBSCRIPTION_PREFIX = "inlong-agent-";
@@ -69,12 +68,6 @@ public class PulsarSource extends AbstractSource {
             topic = profile.getInstanceId();
             serviceUrl = profile.get(TASK_PULSAR_SERVICE_URL);
             subscription = profile.get(TASK_PULSAR_SUBSCRIPTION, PULSAR_SUBSCRIPTION_PREFIX + inlongStreamId);
-            String position = profile.get(TASK_PULSAR_SUBSCRIPTION_POSITION, SubscriptionInitialPosition.Latest.name());
-            if (position.equals(SUBSCRIPTION_CUSTOM)) {
-                subscriptionPosition = SubscriptionInitialPosition.Latest;
-            } else {
-                subscriptionPosition = SubscriptionInitialPosition.valueOf(position);
-            }
             subscriptionType = profile.get(TASK_PULSAR_SUBSCRIPTION_TYPE, SubscriptionType.Shared.name());
             timestamp = profile.getLong(TASK_PULSAR_RESET_TIME, 0);
             pulsarClient = PulsarClient.builder().serviceUrl(serviceUrl).build();
@@ -122,16 +115,28 @@ public class PulsarSource extends AbstractSource {
     private Consumer<byte[]> getConsumer() {
         Consumer<byte[]> consumer = null;
         try {
-            consumer = pulsarClient.newConsumer(Schema.BYTES)
-                    .topic(topic)
-                    .subscriptionName(subscription)
-                    .subscriptionInitialPosition(subscriptionPosition)
-                    .subscriptionType(SubscriptionType.valueOf(subscriptionType))
-                    .subscribe();
-            if (!isRestoreFromDB && timestamp != 0L) {
-                consumer.seek(timestamp);
-                LOGGER.info("Reset consume from {}", timestamp);
+            String position = profile.get(TASK_PULSAR_SUBSCRIPTION_POSITION, SubscriptionInitialPosition.Latest.name());
+            if (position.equals(SUBSCRIPTION_CUSTOM)) {
+                consumer = pulsarClient.newConsumer(Schema.BYTES)
+                        .topic(topic)
+                        .subscriptionName(subscription)
+                        .subscriptionType(SubscriptionType.valueOf(subscriptionType))
+                        .subscribe();
+                if (!isRestoreFromDB) {
+                    if (timestamp == 0L) {
+                        LOGGER.error("Reset consume but timestamp is 0L");
+                    } else {
+                        consumer.seek(timestamp);
+                        LOGGER.info("Reset consume from {}", timestamp);
+                    }
+                }
             } else {
+                consumer = pulsarClient.newConsumer(Schema.BYTES)
+                        .topic(topic)
+                        .subscriptionName(subscription)
+                        .subscriptionInitialPosition(SubscriptionInitialPosition.valueOf(position))
+                        .subscriptionType(SubscriptionType.valueOf(subscriptionType))
+                        .subscribe();
                 LOGGER.info("Skip to reset consume");
             }
             return consumer;

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
@@ -38,7 +38,6 @@ import org.apache.inlong.common.metric.MetricRegister;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,10 +54,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.apache.inlong.agent.constant.CommonConstants.DEFAULT_PROXY_PACKAGE_MAX_SIZE;
-import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_DATA;
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_KEY_STREAM_ID;
 import static org.apache.inlong.agent.constant.CommonConstants.PROXY_PACKAGE_MAX_SIZE;
-import static org.apache.inlong.agent.constant.CommonConstants.PROXY_SEND_PARTITION_KEY;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_QUEUE_PERMIT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_SOURCE_PERMIT;
 import static org.apache.inlong.agent.constant.TaskConstants.DEFAULT_FILE_SOURCE_EXTEND_CLASS;
@@ -356,9 +353,7 @@ public abstract class AbstractSource implements Source {
     }
 
     private Message createMessage(SourceData sourceData) {
-        String proxyPartitionKey = profile.get(PROXY_SEND_PARTITION_KEY, DigestUtils.md5Hex(inlongGroupId));
         Map<String, String> header = new HashMap<>();
-        header.put(PROXY_KEY_DATA, proxyPartitionKey);
         header.put(OFFSET, sourceData.getOffset());
         header.put(PROXY_KEY_STREAM_ID, inlongStreamId);
         if (extendedHandler != null) {
@@ -424,6 +419,9 @@ public abstract class AbstractSource implements Source {
 
     @Override
     public boolean sourceFinish() {
+        if (isRealTime) {
+            return false;
+        }
         return emptyCount > EMPTY_CHECK_COUNT_AT_LEAST;
     }
 }


### PR DESCRIPTION
Fixes #11298 

### Motivation

Fix bug for pulsar source

### Modifications

1 Do not obtain offset when no data is read

2 When reading data at a specified time, the subscription site defaults to Lastest.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
