### PR TITLE
[INLONG-11306][Agent] Modify the naming of variables in the redis source

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/TaskConstants.java
@@ -186,12 +186,12 @@ public class TaskConstants extends CommonConstants {
     public static final String TASK_REDIS_READTIMEOUT = "task.redisTask.readTimeout";
     public static final String TASK_REDIS_REPLID = "task.redisTask.replId";
     public static final String TASK_REDIS_OFFSET = "task.redisTask.offset";
-    public static final String TASK_REDIS_DB_NUMBER = "task.redisTask.dbNumber";
+    public static final String TASK_REDIS_DB_NAME = "task.redisTask.dbName";
     public static final String TASK_REDIS_COMMAND = "task.redisTask.command";
     public static final String TASK_REDIS_KEYS = "task.redisTask.keys";
     public static final String TASK_REDIS_FIELD_OR_MEMBER = "task.redisTask.fieldOrMember";
     public static final String TASK_REDIS_IS_SUBSCRIBE = "task.redisTask.isSubscribe";
-    public static final String TASK_REDIS_SUBOPERATION = "task.redisTask.subOperation";
+    public static final String TASK_REDIS_SUBSCRIPTION_OPERATION = "task.redisTask.subscriptionOperation";
     public static final String TASK_REDIS_SYNC_FREQ = "task.redisTask.syncFreq";
 
     public static final String TASK_STATE = "task.state";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/RedisTask.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/RedisTask.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.agent.pojo;
 
 import lombok.Data;
+
 @Data
 public class RedisTask {
 
@@ -29,13 +30,13 @@ public class RedisTask {
     private String readTimeout;
     private String queueSize;
     private String replId;
-    private String dbNumber;
+    private String dbName;
     private String command;
     private String keys;
     private String fieldOrMember;
     private Boolean isSubscribe;
     private String syncFreq;
-    private String subOperations;
+    private String subscriptionOperation;
 
     @Data
     public static class RedisTaskConfig {
@@ -48,12 +49,12 @@ public class RedisTask {
         private String timeout;
         private String queueSize;
         private String replId;
-        private String dbNumber;
+        private String dbName;
         private String command;
         private String keys;
         private String fieldOrMember;
         private Boolean isSubscribe;
         private String syncFreq;
-        private String subOperations;
+        private String subscriptionOperation;
     }
 }

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/pojo/TaskProfileDto.java
@@ -277,12 +277,12 @@ public class TaskProfileDto {
         redisTask.setReadTimeout(config.getTimeout());
         redisTask.setReplId(config.getReplId());
         redisTask.setCommand(config.getCommand());
-        redisTask.setDbNumber(config.getDbNumber());
+        redisTask.setDbName(config.getDbName());
         redisTask.setKeys(config.getKeys());
         redisTask.setFieldOrMember(config.getFieldOrMember());
         redisTask.setIsSubscribe(config.getIsSubscribe());
         redisTask.setSyncFreq(config.getSyncFreq());
-        redisTask.setSubOperations(config.getSubOperations());
+        redisTask.setSubscriptionOperation(config.getSubscriptionOperation());
 
         return redisTask;
     }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestRedisSource.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestRedisSource.java
@@ -134,7 +134,7 @@ public class TestRedisSource {
         profile.set(TaskConstants.TASK_REDIS_COMMAND, command);
         profile.set(TaskConstants.TASK_REDIS_KEYS, keys);
         profile.set(TaskConstants.TASK_AUDIT_VERSION, "0");
-        profile.set(TaskConstants.TASK_REDIS_SUBOPERATION, subOperation);
+        profile.set(TaskConstants.TASK_REDIS_SUBSCRIPTION_OPERATION, subOperation);
         profile.setInstanceId(instanceId);
     }
 


### PR DESCRIPTION
Fixes #11306 

### Motivation

Some variables are named improperly

### Modifications

Modify the naming of variables in the redis source

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
