### PR TITLE
[INLONG-11029][SDK]  Transform SQL support StartsWith & EndsWith functions

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/EndsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/EndsWithFunction.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sdk.transform.process.function;
 
 import org.apache.inlong.sdk.transform.decode.SourceData;
@@ -12,8 +29,7 @@ import java.util.List;
 
 /**
  * EndsWithFunction
- * description: endswith(expr, endExpr)
- * Returns whether expr ends with endExpr.
+ * description: Returns whether expr ends with endExpr.
  */
 @TransformFunction(names = {"endswith"})
 public class EndsWithFunction implements ValueParser {
@@ -66,4 +82,3 @@ public class EndsWithFunction implements ValueParser {
         return (a instanceof String && b instanceof String) || (a instanceof byte[] && b instanceof byte[]);
     }
 }
-

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/EndsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/EndsWithFunction.java
@@ -1,0 +1,69 @@
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.util.List;
+
+/**
+ * EndsWithFunction
+ * description: endswith(expr, endExpr)
+ * Returns whether expr ends with endExpr.
+ */
+@TransformFunction(names = {"endswith"})
+public class EndsWithFunction implements ValueParser {
+
+    private ValueParser exprParser;
+    private ValueParser endExprParser;
+
+    public EndsWithFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        if (expressions != null && expressions.size() == 2) {
+            exprParser = OperatorTools.buildParser(expressions.get(0));
+            endExprParser = OperatorTools.buildParser(expressions.get(1));
+        }
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object exprObj = exprParser.parse(sourceData, rowIndex, context);
+        Object endExprObj = endExprParser.parse(sourceData, rowIndex, context);
+
+        if (exprObj == null || endExprObj == null) {
+            return null;
+        }
+
+        if (!isSameType(exprObj, endExprObj)) {
+            throw new IllegalArgumentException("Both arguments must be of the same type.");
+        }
+
+        if (exprObj instanceof byte[] && endExprObj instanceof byte[]) {
+            String exprString = new String((byte[]) exprObj);
+            String endExprString = new String((byte[]) endExprObj);
+            if (endExprString.isEmpty()) {
+                return true;
+            }
+
+            return exprString.endsWith(endExprString);
+        }
+
+        String exprString = OperatorTools.parseString(exprObj);
+        String endExprString = OperatorTools.parseString(endExprObj);
+
+        if (endExprString.isEmpty()) {
+            return true;
+        }
+
+        return exprString.endsWith(endExprString);
+    }
+
+    private boolean isSameType(Object a, Object b) {
+        return (a instanceof String && b instanceof String) || (a instanceof byte[] && b instanceof byte[]);
+    }
+}
+

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/StartsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/StartsWithFunction.java
@@ -1,8 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sdk.transform.process.function;
 
 import org.apache.inlong.sdk.transform.decode.SourceData;
 import org.apache.inlong.sdk.transform.process.Context;
-import org.apache.inlong.sdk.transform.process.function.TransformFunction;
 import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
 import org.apache.inlong.sdk.transform.process.parser.ValueParser;
 
@@ -13,8 +29,7 @@ import java.util.List;
 
 /**
  * StartsWithFunction
- * description: startswith(expr, startExpr)
- * Returns whether expr starts with startExpr.
+ * description: Returns whether expr starts with startExpr.
  */
 @TransformFunction(names = {"startswith"})
 public class StartsWithFunction implements ValueParser {

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/StartsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/StartsWithFunction.java
@@ -1,0 +1,69 @@
+package org.apache.inlong.sdk.transform.process.function;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.function.TransformFunction;
+import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.Expression;
+import net.sf.jsqlparser.expression.Function;
+
+import java.util.List;
+
+/**
+ * StartsWithFunction
+ * description: startswith(expr, startExpr)
+ * Returns whether expr starts with startExpr.
+ */
+@TransformFunction(names = {"startswith"})
+public class StartsWithFunction implements ValueParser {
+
+    private ValueParser exprParser;
+    private ValueParser startExprParser;
+
+    public StartsWithFunction(Function expr) {
+        List<Expression> expressions = expr.getParameters().getExpressions();
+        if (expressions != null && expressions.size() == 2) {
+            exprParser = OperatorTools.buildParser(expressions.get(0));
+            startExprParser = OperatorTools.buildParser(expressions.get(1));
+        }
+    }
+
+    @Override
+    public Object parse(SourceData sourceData, int rowIndex, Context context) {
+        Object exprObj = exprParser.parse(sourceData, rowIndex, context);
+        Object startExprObj = startExprParser.parse(sourceData, rowIndex, context);
+
+        if (exprObj == null || startExprObj == null) {
+            return null;
+        }
+
+        if (!isSameType(exprObj, startExprObj)) {
+            throw new IllegalArgumentException("Both arguments must be of the same type.");
+        }
+
+        if (exprObj instanceof byte[] && startExprObj instanceof byte[]) {
+            String exprString = new String((byte[]) exprObj);
+            String startExprString = new String((byte[]) startExprObj);
+            if (startExprString.isEmpty()) {
+                return true;
+            }
+
+            return exprString.startsWith(startExprString);
+        }
+
+        String exprString = OperatorTools.parseString(exprObj);
+        String startExprString = OperatorTools.parseString(startExprObj);
+
+        if (startExprString.isEmpty()) {
+            return true;
+        }
+
+        return exprString.startsWith(startExprString);
+    }
+
+    private boolean isSameType(Object a, Object b) {
+        return (a instanceof String && b instanceof String) || (a instanceof byte[] && b instanceof byte[]);
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestEndsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestEndsWithFunction.java
@@ -1,0 +1,86 @@
+package org.apache.inlong.sdk.transform.process.function.string;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+public class TestEndsWithFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testEndsWithFunction() throws Exception {
+        String transformSql1 = "select endswith(encode(string1, string2), encode(string3, string2)) from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+
+        // case1: endswith(encode('Hello','UTF-8'), encode('lo','UTF-8'))
+        List<String> output1 = processor1.transform("Hello|UTF-8|lo|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=true");
+
+        // case2: endswith(encode('Hello','UTF-8'), encode('H','UTF-8'))
+        List<String> output2 = processor1.transform("Hello|UTF-8|H|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output2.size());
+        Assert.assertEquals(output2.get(0), "result=false");
+
+        // case3: endswith(encode('Hello','UTF-8'), encode('LO','UTF-8'))
+        List<String> output3 = processor1.transform("Hello|UTF-8|LO|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals(output3.get(0), "result=false");
+
+        // below are tests for String params; while upper are tests for byte[] params
+        String transformSql2 = "select endswith(string1, stringX) from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: endswith('Apache InLong', null)
+        List<String> output4 = processor2.transform("Apache InLong|UTF-16BE|UTF-16BE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "result=");
+
+        String transformSql3 = "select endswith(stringX, string2) from source";
+        TransformConfig config3 = new TransformConfig(transformSql3);
+        TransformProcessor<String, String> processor3 = TransformProcessor
+                .create(config3, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case5: endswith(null, 'Apache InLong')
+        List<String> output5 = processor2.transform("Apache InLong|Apache InLong|UTF-16BE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "result=");
+
+        String transformSql4 = "select endswith(string1, string2) from source";
+        TransformConfig config4 = new TransformConfig(transformSql4);
+        TransformProcessor<String, String> processor4 = TransformProcessor
+                .create(config4, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+
+        // case6: endswith('Apache InLong', 'Apache InLong')
+        List<String> output6 = processor4.transform("Apache InLong|Apache InLong|UtF-16|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output6.size());
+        Assert.assertEquals(output6.get(0), "result=true");
+
+        // case7: endswith('Apache InLong', 'Apache')
+        List<String> output7 = processor4.transform("Apache InLong|Apache|UTF-16--|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output7.size());
+        Assert.assertEquals(output7.get(0), "result=false");
+
+        // case8: endswith('Apache InLong', 'Long')
+        List<String> output8 = processor4.transform("Apache InLong|Long|UTf-16LE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output8.size());
+        Assert.assertEquals(output8.get(0), "result=true");
+
+        // case6: endswith('Apache InLong', '')
+        List<String> output9 = processor4.transform("Apache InLong||UtF-16|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output9.size());
+        Assert.assertEquals(output9.get(0), "result=true");
+
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestEndsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestEndsWithFunction.java
@@ -1,9 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sdk.transform.process.function.string;
 
 import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
 import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
 import org.apache.inlong.sdk.transform.pojo.TransformConfig;
 import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestStartsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestStartsWithFunction.java
@@ -1,15 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.inlong.sdk.transform.process.function.string;
+
 import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
 import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
 import org.apache.inlong.sdk.transform.pojo.TransformConfig;
-import org.apache.inlong.sdk.transform.process.Context;
-import org.apache.inlong.sdk.transform.decode.SourceData;
 import org.apache.inlong.sdk.transform.process.TransformProcessor;
-import org.apache.inlong.sdk.transform.process.function.StartsWithFunction;
+
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 
@@ -86,4 +101,3 @@ public class TestStartsWithFunction extends AbstractFunctionStringTestBase {
         Assert.assertEquals(output9.get(0), "result=true");
     }
 }
-

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestStartsWithFunction.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/function/string/TestStartsWithFunction.java
@@ -1,0 +1,89 @@
+package org.apache.inlong.sdk.transform.process.function.string;
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+import org.apache.inlong.sdk.transform.process.function.StartsWithFunction;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+
+public class TestStartsWithFunction extends AbstractFunctionStringTestBase {
+
+    @Test
+    public void testStartsWithFunction() throws Exception {
+        String transformSql1 = "select startswith(encode(string1, string2), encode(string3, string2)) from source";
+        TransformConfig config1 = new TransformConfig(transformSql1);
+        TransformProcessor<String, String> processor1 = TransformProcessor
+                .create(config1, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+
+        // case1: startswith(encode('Hello','UTF-8'), encode('lo','UTF-8'))
+        List<String> output1 = processor1.transform("Hello|UTF-8|Hel|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=true");
+
+        // case2: startswith(encode('Hello','UTF-8'), encode('o','UTF-8'))
+        List<String> output2 = processor1.transform("Hello|UTF-8|o|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output2.size());
+        Assert.assertEquals(output2.get(0), "result=false");
+
+        // case3: startswith(encode('Hello','UTF-8'), encode('','UTF-8'))
+        List<String> output3 = processor1.transform("Hello|UTF-8||cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output3.size());
+        Assert.assertEquals(output3.get(0), "result=true");
+
+        // below are tests for String params; while upper are tests for byte[] params
+        String transformSql2 = "select startswith(string1, stringX) from source";
+        TransformConfig config2 = new TransformConfig(transformSql2);
+        TransformProcessor<String, String> processor2 = TransformProcessor
+                .create(config2, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case4: startswith('Apache InLong', null)
+        List<String> output4 = processor2.transform("Apache InLong|UTF-16BE|UTF-16BE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "result=");
+
+        String transformSql3 = "select startswith(stringX, string2) from source";
+        TransformConfig config3 = new TransformConfig(transformSql3);
+        TransformProcessor<String, String> processor3 = TransformProcessor
+                .create(config3, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        // case5: startswith(null, 'Apache InLong')
+        List<String> output5 = processor2.transform("Apache InLong|Apache InLong|UTF-16BE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output4.size());
+        Assert.assertEquals(output4.get(0), "result=");
+
+        String transformSql4 = "select startswith(string1, string2) from source";
+        TransformConfig config4 = new TransformConfig(transformSql4);
+        TransformProcessor<String, String> processor4 = TransformProcessor
+                .create(config4, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+
+        // case6: startswith('Apache InLong', 'Apache InLong')
+        List<String> output6 = processor4.transform("Apache InLong|Apache InLong|UtF-16|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output6.size());
+        Assert.assertEquals(output6.get(0), "result=true");
+
+        // case7: startswith('Apache InLong', ' [')
+        List<String> output7 = processor4.transform("Apache InLong| [|UTF-16--|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output7.size());
+        Assert.assertEquals(output7.get(0), "result=false");
+
+        // case8: startswith('Apache InLong', 'A')
+        List<String> output8 = processor4.transform("Apache InLong|A|UTf-16LE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output8.size());
+        Assert.assertEquals(output8.get(0), "result=true");
+
+        // case8: startswith('Apache InLong', '')
+        List<String> output9 = processor4.transform("Apache InLong||UTf-16LE|cloud|1", new HashMap<>());
+        Assert.assertEquals(1, output9.size());
+        Assert.assertEquals(output9.get(0), "result=true");
+    }
+}
+


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11029

### Motivation
Add two function classes: StartsWith & EndsWith functions and their unit tests.

- STARTSWITH(expr, startExpr):
Returns whether expr starts with startExpr. If startExpr is empty, the result is true.

- ENDSWITH(expr, endExpr):
Returns whether expr ends with endExpr. If endExpr is empty, the result is true.
<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
