### PR TITLE
[INLONG-11321][CI] Fix the docker ci workflow failure when removing unnecessary packages

### DIFF
--- a/.github/workflows/ci_docker.yml
+++ b/.github/workflows/ci_docker.yml
@@ -63,8 +63,10 @@ jobs:
           dpkg-query -Wf '${Installed-Size}\t${Package}\n' | sort -n | tail -n 100
           df -h
           echo "Removing large packages"
-          sudo apt-get remove -y '^dotnet-.*'
+          echo "Removing mongodb-.* packages..."
           sudo apt-get remove -y '^mongodb-.*'
+          echo "Removed mongodb-.* packages..."
+          df -h
           sudo apt-get remove -y azure-cli google-chrome-stable google-cloud-cli microsoft-edge-stable firefox powershell mono-devel libgl1-mesa-dri
           df -h
           echo "Removing large directories"


### PR DESCRIPTION
Fixes #11321

### Motivation

Fix the docker ci workflow failure when removing unnecessary packages
### Modifications

In #11322 we fix the workflow failure partially which left the docker ci workflow not fixed, this pr fix the  docker ci workflow 

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)
  