### PR TITLE
[INLONG-11333][Agent] Retrieve IP from configuration file during audit reporting

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.agent.metrics.audit;
 
 import org.apache.inlong.agent.conf.AbstractConfiguration;
+import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.audit.AuditOperator;
 import org.apache.inlong.audit.entity.AuditComponent;
 
@@ -59,7 +60,6 @@ public class AuditUtils {
     public static int AUDIT_ID_AGENT_ADD_INSTANCE_MEM_FAILED = 1073741842;
     public static int AUDIT_ID_AGENT_DEL_INSTANCE_MEM_UNUSUAL = 1073741843;
     private static boolean IS_AUDIT = true;
-    private static AbstractConfiguration conf;
 
     /**
      * Init audit config
@@ -69,6 +69,7 @@ public class AuditUtils {
         if (IS_AUDIT) {
             AuditOperator.getInstance().setAuditProxy(AuditComponent.AGENT, conf.get(AGENT_MANAGER_ADDR),
                     conf.get(AGENT_MANAGER_AUTH_SECRET_ID), conf.get(AGENT_MANAGER_AUTH_SECRET_KEY));
+            AuditOperator.getInstance().setLocalIP(conf.get(AgentConstants.AGENT_LOCAL_IP));
         }
     }
 

--- a/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/AgentBaseTestsHelper.java
+++ b/inlong-agent/agent-common/src/test/java/org/apache/inlong/agent/AgentBaseTestsHelper.java
@@ -48,6 +48,7 @@ public class AgentBaseTestsHelper {
         boolean result = testRootDir.toFile().mkdirs();
         LOGGER.info("try to create {}, result is {}", testRootDir, result);
         AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_HOME, testRootDir.toString());
+        AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_LOCAL_IP, "127.0.0.1");
         return this;
     }
 

--- a/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/AgentBaseTestsHelper.java
+++ b/inlong-agent/agent-core/src/test/java/org/apache/inlong/agent/core/AgentBaseTestsHelper.java
@@ -57,6 +57,7 @@ public class AgentBaseTestsHelper {
         LOGGER.info("try to create {}, result is {}", testRootDir, result);
         AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_HOME, testRootDir.toString());
         AgentConfiguration.getAgentConf().set(FetcherConstants.AGENT_MANAGER_ADDR, "");
+        AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_LOCAL_IP, "127.0.0.1");
         return this;
     }
 

--- a/inlong-agent/agent-installer/src/test/java/installer/BaseTestsHelper.java
+++ b/inlong-agent/agent-installer/src/test/java/installer/BaseTestsHelper.java
@@ -52,6 +52,7 @@ public class BaseTestsHelper {
         LOGGER.info("try to create {}, result is {}", testRootDir, result);
         InstallerConfiguration.getInstallerConf().set(AgentConstants.AGENT_HOME, testRootDir.toString());
         InstallerConfiguration.getInstallerConf().set(FetcherConstants.AGENT_MANAGER_ADDR, "");
+        InstallerConfiguration.getInstallerConf().set(AgentConstants.AGENT_LOCAL_IP, "127.0.0.1");
         return this;
     }
 

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/AgentBaseTestsHelper.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/AgentBaseTestsHelper.java
@@ -60,6 +60,7 @@ public class AgentBaseTestsHelper {
         LOGGER.info("try to create {}, result is {}", testRootDir, result);
         AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_HOME, testRootDir.toString());
         AgentConfiguration.getAgentConf().set(FetcherConstants.AGENT_MANAGER_ADDR, "");
+        AgentConfiguration.getAgentConf().set(AgentConstants.AGENT_LOCAL_IP, "127.0.0.1");
         return this;
     }
 


### PR DESCRIPTION
Fixes #11333 

### Motivation

There are multiple IP addresses for public network machines, and a specific IP address needs to be specified for audit data

### Modifications

 Retrieve IP from configuration file during audit reporting

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
