### PR TITLE
[INLONG-11340][Sort] Add new source metrics for sort-connector-pulsar-v1.15

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/metric/SourceExactlyMetric.java
@@ -372,6 +372,12 @@ public class SourceExactlyMetric implements MetricData, Serializable, SourceMetr
         }
     }
 
+    public void decNumDeserializeSuccess() {
+        if (numDeserializeSuccess != null) {
+            numDeserializeSuccess.dec();
+        }
+    }
+
     public void incNumDeserializeError() {
         if (numDeserializeError != null) {
             numDeserializeError.inc();


### PR DESCRIPTION
Fixes [[Feature][Sort] Added new source metrics for sort-connector-pulsar-v1.15 #11340](https://github.com/apache/inlong/issues/11340)

### Motivation

The purpose of this PR is to enhance observability for the sort-connector-pulsar-v1.15 by introducing new source metrics. These metrics will provide detailed insights into the deserialization process and checkpoint management, facilitating better monitoring, troubleshooting, and optimization for users.

### Modifications

Basically the same way of modifying as that of #11130 

**Deserialization Metrics:**
Added counters to track successful and failed deserialization attempts (`numDeserializeSuccess`, `numDeserializeError`).
Added latency gauge to measure time taken for deserialization (`deserializeTimeLag`).

**SnapshotState Metrics:**
Added counters for the number of snapshots created (`numSnapshotCreate`) and errors encountered during snapshot operations (`numSnapshotError`).

**NotifyComplete Metrics:**
Added a counter to track completed snapshots (`numCompletedSnapshots`).
Added latency gauge for the time between snapshot creation and checkpoint completion (`snapshotToCheckpointTimeLag`).

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

Can use the same way of verification as that in #11130, an simpler way, however, can be used in the following way.

Use an End-to-End test called `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Pulsar2StarRocksTest.java`.

Add a while loop after all the checks in `testPulsarToStarRocks`  to stop the testing container from being torn down. 
Add 
```
'inlong.metric.labels' = 'groupId=pulsarGroup&streamId=pulsarStream&nodeId=pulsarNode'
``` 
in the source connection option of `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/resources/flinkSql/pulsar_test.sql`.
Run the maven test.
Wait until all the tests down(should take a while), visit `localhost:8081`, which is the url for `Flink Web Dashboard`.

Click the operator, and check the `metrics` column.
The result should be like this:
<img width="1280" alt="PulsarSourceMetrics" src="https://github.com/user-attachments/assets/5c86b27d-55bd-40e0-83a1-3d144e05afb8">


### Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? docs. will be written under issue [[Feature][Doc] Add documentation for newly introduced source and sink metrics in inlong-sort #1057](https://github.com/apache/inlong-website/issues/1057)
