### PR TITLE
[INLONG-11355][Sort] Add new source metrics for sort-connector-mongodb-cdc-v1.15

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/DebeziumSourceFunction.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.sort.mongodb;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
+
 import com.ververica.cdc.debezium.Validator;
 import com.ververica.cdc.debezium.internal.DebeziumChangeConsumer;
 import com.ververica.cdc.debezium.internal.DebeziumOffset;
@@ -61,6 +64,8 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -197,17 +202,25 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
     /** Buffer the events from the source and record the errors from the debezium. */
     private transient Handover handover;
 
+    private transient SourceExactlyMetric sourceExactlyMetric;
+
+    private final MetricOption metricOption;
+
+    private transient Map<Long, Long> checkpointStartTimeMap;
+
     // ---------------------------------------------------------------------------------------
 
     public DebeziumSourceFunction(
             DebeziumDeserializationSchema<T> deserializer,
             Properties properties,
             @Nullable DebeziumOffset specificOffset,
-            Validator validator) {
+            Validator validator,
+            MetricOption metricOption) {
         this.deserializer = deserializer;
         this.properties = properties;
         this.specificOffset = specificOffset;
         this.validator = validator;
+        this.metricOption = metricOption;
     }
 
     @Override
@@ -220,6 +233,14 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
         this.executor = Executors.newSingleThreadExecutor(threadFactory);
         this.handover = new Handover();
         this.changeConsumer = new DebeziumChangeConsumer(handover);
+        if (metricOption != null) {
+            sourceExactlyMetric = new SourceExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
+        }
+        this.checkpointStartTimeMap = new HashMap<>();
+        // set sourceExactlyMetric for deserializer
+        if (deserializer instanceof MongoDBConnectorDeserializationSchema) {
+            ((MongoDBConnectorDeserializationSchema) deserializer).setSourceExactlyMetric(sourceExactlyMetric);
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -304,17 +325,32 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
 
     @Override
     public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
-        if (handover.hasError()) {
-            LOG.debug("snapshotState() called on closed source");
-            throw new FlinkRuntimeException(
-                    "Call snapshotState() on closed source, checkpoint failed.");
-        } else {
-            snapshotOffsetState(functionSnapshotContext.getCheckpointId());
-            snapshotHistoryRecordsState();
-        }
-        if (deserializer instanceof MongoDBConnectorDeserializationSchema) {
-            ((MongoDBConnectorDeserializationSchema) deserializer)
-                    .updateCurrentCheckpointId(functionSnapshotContext.getCheckpointId());
+        try {
+            if (handover.hasError()) {
+                LOG.debug("snapshotState() called on closed source");
+                throw new FlinkRuntimeException(
+                        "Call snapshotState() on closed source, checkpoint failed.");
+            } else {
+                snapshotOffsetState(functionSnapshotContext.getCheckpointId());
+                snapshotHistoryRecordsState();
+            }
+            if (deserializer instanceof MongoDBConnectorDeserializationSchema) {
+                ((MongoDBConnectorDeserializationSchema) deserializer)
+                        .updateCurrentCheckpointId(functionSnapshotContext.getCheckpointId());
+            }
+            if (checkpointStartTimeMap != null) {
+                checkpointStartTimeMap.put(functionSnapshotContext.getCheckpointId(), System.currentTimeMillis());
+            } else {
+                LOG.error("checkpointStartTimeMap is null, can't record the start time of checkpoint");
+            }
+            if (sourceExactlyMetric != null) {
+                sourceExactlyMetric.incNumSnapshotCreate();;
+            }
+        } catch (Exception e) {
+            if (sourceExactlyMetric != null) {
+                sourceExactlyMetric.incNumDeserializeError();
+            }
+            throw e;
         }
     }
 
@@ -495,6 +531,16 @@ public class DebeziumSourceFunction<T> extends RichSourceFunction<T>
                 MongoDBConnectorDeserializationSchema schema = (MongoDBConnectorDeserializationSchema) deserializer;
                 schema.flushAudit();
                 schema.updateLastCheckpointId(checkpointId);
+            }
+            if (checkpointStartTimeMap != null) {
+                Long snapShotStartTimeById = checkpointStartTimeMap.remove(checkpointId);
+                if (snapShotStartTimeById != null && sourceExactlyMetric != null) {
+                    sourceExactlyMetric.incNumSnapshotComplete();
+                    sourceExactlyMetric
+                            .recordSnapshotToCheckpointDelay(System.currentTimeMillis() - snapShotStartTimeById);
+                }
+            } else {
+                LOG.error("checkpointStartTimeMap is null, can't get the start time of checkpoint");
             }
         } catch (Exception e) {
             // ignore exception if we are no longer running

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBSource.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.mongodb;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+
 import com.mongodb.client.model.changestream.FullDocument;
 import com.mongodb.kafka.connect.source.MongoSourceConfig;
 import com.mongodb.kafka.connect.source.MongoSourceConfig.ErrorTolerance;
@@ -35,7 +37,11 @@ import static com.ververica.cdc.connectors.mongodb.internal.MongoDBConnectorSour
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBConnectorSourceTask.DATABASE_INCLUDE_LIST;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.HEARTBEAT_TOPIC_NAME;
 import static com.ververica.cdc.connectors.mongodb.internal.MongoDBEnvelope.OUTPUT_SCHEMA;
-import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.*;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.BATCH_SIZE;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.COPY_EXISTING;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.HEARTBEAT_INTERVAL_MILLIS;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_AWAIT_TIME_MILLIS;
+import static com.ververica.cdc.connectors.mongodb.source.config.MongoDBSourceOptions.POLL_MAX_BATCH_SIZE;
 import static com.ververica.cdc.connectors.mongodb.source.utils.MongoUtils.buildConnectionString;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -76,6 +82,7 @@ public class MongoDBSource {
         private String copyExistingPipeline;
         private Integer heartbeatIntervalMillis = HEARTBEAT_INTERVAL_MILLIS.defaultValue();
         private DebeziumDeserializationSchema<T> deserializer;
+        private MetricOption metricOption;
 
         /** The comma-separated list of hostname and port pairs of mongodb servers. */
         public Builder<T> hosts(String hosts) {
@@ -243,6 +250,11 @@ public class MongoDBSource {
             return this;
         }
 
+        public Builder<T> metricOption(MetricOption metricOption) {
+            this.metricOption = metricOption;
+            return this;
+        }
+
         /**
          * The properties of mongodb kafka connector.
          * https://docs.mongodb.com/kafka-connector/current/kafka-source
@@ -338,7 +350,7 @@ public class MongoDBSource {
                     MongoSourceConfig.ERRORS_TOLERANCE_CONFIG, ErrorTolerance.NONE.value());
 
             return new DebeziumSourceFunction<>(
-                    deserializer, props, null, Validator.getDefaultValidator());
+                    deserializer, props, null, Validator.getDefaultValidator(), metricOption);
         }
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/MongoDBTableSource.java
@@ -191,13 +191,15 @@ public class MongoDBTableSource implements ScanTableSource, SupportsReadingMetad
                     .ifPresent(builder::heartbeatIntervalMillis);
             Optional.ofNullable(splitMetaGroupSize).ifPresent(builder::splitMetaGroupSize);
             Optional.ofNullable(splitSizeMB).ifPresent(builder::splitSizeMB);
+            Optional.ofNullable(metricOption).ifPresent(builder::metricOption);
 
             return SourceProvider.of(builder.build());
         } else {
             org.apache.inlong.sort.mongodb.MongoDBSource.Builder<RowData> builder =
                     org.apache.inlong.sort.mongodb.MongoDBSource.<RowData>builder()
                             .hosts(hosts)
-                            .deserializer(deserializer);
+                            .deserializer(deserializer)
+                            .metricOption(metricOption);
 
             Optional.ofNullable(databaseList).ifPresent(builder::databaseList);
             Optional.ofNullable(collectionList).ifPresent(builder::collectionList);

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/source/MongoDBSourceBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/source/MongoDBSourceBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sort.mongodb.source;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
 import org.apache.inlong.sort.mongodb.DebeziumDeserializationSchema;
 
 import com.ververica.cdc.connectors.base.options.StartupOptions;
@@ -54,6 +55,7 @@ public class MongoDBSourceBuilder<T> {
 
     private final MongoDBSourceConfigFactory configFactory = new MongoDBSourceConfigFactory();
     private DebeziumDeserializationSchema<T> deserializer;
+    private MetricOption metricOption;
 
     /** The comma-separated list of hostname and port pairs of mongodb servers. */
     public MongoDBSourceBuilder<T> hosts(String hosts) {
@@ -186,6 +188,11 @@ public class MongoDBSourceBuilder<T> {
      */
     public MongoDBSourceBuilder<T> deserializer(DebeziumDeserializationSchema<T> deserializer) {
         this.deserializer = deserializer;
+        return this;
+    }
+
+    public MongoDBSourceBuilder<T> metricOption(MetricOption metricOption) {
+        this.metricOption = metricOption;
         return this;
     }
 

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/source/MongoDBSourceBuilder.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/src/main/java/org/apache/inlong/sort/mongodb/source/MongoDBSourceBuilder.java
@@ -191,6 +191,7 @@ public class MongoDBSourceBuilder<T> {
         return this;
     }
 
+    /** The metric option used to collect metrics when inlong.metric.labels is present in flink sql. */
     public MongoDBSourceBuilder<T> metricOption(MetricOption metricOption) {
         this.metricOption = metricOption;
         return this;


### PR DESCRIPTION
Fixes [[Feature][Sort] Add new source metrics for sort-connector-mongodb-cdc-v1.15 #11355](https://github.com/apache/inlong/issues/11355)

**Coauthored with [yangyang-12-wq](https://github.com/yangyang-12-wq)**

### Motivation

The purpose of this PR is to enhance observability for the `sort-connector-mongodb-cdc-v1.15` by introducing new source metrics. These metrics will provide detailed insights into the deserialization process and checkpoint management, facilitating better monitoring, troubleshooting, and optimization for users.

### Modifications

Basically the same way of modifying as that of #11130 

**Deserialization Metrics:**
Added counters to track successful and failed deserialization attempts (`numDeserializeSuccess`, `numDeserializeError`).
Added latency gauge to measure time taken for deserialization (`deserializeTimeLag`).

**SnapshotState Metrics:**
Added counters for the number of snapshots created (`numSnapshotCreate`) and errors encountered during snapshot operations (`numSnapshotError`).

**NotifyComplete Metrics:**
Added a counter to track completed snapshots (`numCompletedSnapshots`).
Added latency gauge for the time between snapshot creation and checkpoint completion (`snapshotToCheckpointTimeLag`).

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

Can use the same way of verification as that in #11130, an simpler way, however, can be used in the following way.

- Use an End-to-End test called `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Mongodb2StarRocksTest.java`.

- Add a while loop after all the checks in `testMongodbUpdateAndDelete`  to stop the testing container from being torn down. 
- Add 
```
'inlong.metric.labels' = 'groupId=mongoGroup&streamId=mongoStream&nodeId=mongoNode'
``` 
in the source connection option of `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/resources/flinkSql/pulsar_test.sql`.
- Run the maven test.
- Wait until all the tests down(should take a while), visit `localhost:8081`, which is the url for `Flink Web Dashboard`.

- Click the operator, and check the `metrics` column.
The result should be like this:
<img width="1280" alt="MongoDBMetrics1" src="https://github.com/user-attachments/assets/ffafe7d7-2b0a-487e-b01c-b969d0adc689">



### Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? Docs in `inlong-website` repo
