### PR TITLE
[INLONG-11357][Sort] Add new source metrics for sort-connector-sqlserver-cdc-v1.15

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/src/main/java/org/apache/inlong/sort/sqlserver/SqlServerSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/src/main/java/org/apache/inlong/sort/sqlserver/SqlServerSource.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.sqlserver;
 
+import org.apache.inlong.sort.base.metric.MetricOption;
+
 import com.ververica.cdc.connectors.sqlserver.SqlServerValidator;
 import com.ververica.cdc.connectors.sqlserver.table.StartupOptions;
 import io.debezium.connector.sqlserver.SqlServerConnector;
@@ -51,6 +53,7 @@ public class SqlServerSource {
         private Properties dbzProperties;
         private StartupOptions startupOptions = StartupOptions.initial();
         private DebeziumDeserializationSchema<T> deserializer;
+        private MetricOption metricOption;
 
         public Builder<T> hostname(String hostname) {
             this.hostname = hostname;
@@ -114,6 +117,12 @@ public class SqlServerSource {
             return this;
         }
 
+        /** metricOption used to instantiate SourceExactlyMetric when inlong.metric.labels is present in flink sql */
+        public Builder<T> metricOption(MetricOption metricOption) {
+            this.metricOption = metricOption;
+            return this;
+        }
+
         public DebeziumSourceFunction<T> build() {
             Properties props = new Properties();
             props.setProperty("connector.class", SqlServerConnector.class.getCanonicalName());
@@ -154,7 +163,7 @@ public class SqlServerSource {
             }
 
             return new DebeziumSourceFunction<>(
-                    deserializer, props, null, new SqlServerValidator(props));
+                    deserializer, props, null, new SqlServerValidator(props), metricOption);
         }
     }
 }

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/src/main/java/org/apache/inlong/sort/sqlserver/SqlServerTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/src/main/java/org/apache/inlong/sort/sqlserver/SqlServerTableSource.java
@@ -144,6 +144,7 @@ public class SqlServerTableSource implements ScanTableSource, SupportsReadingMet
                         .debeziumProperties(dbzProperties)
                         .startupOptions(startupOptions)
                         .deserializer(deserializer)
+                        .metricOption(metricOption)
                         .build();
         return SourceFunctionProvider.of(sourceFunction, false);
     }


### PR DESCRIPTION
Fixes [[Feature][Sort] Add new source metrics for sort-connector-sqlserver-cdc-v1.15 #11357](https://github.com/apache/inlong/issues/11357)

### Motivation

The purpose of this PR is to enhance observability for the `sort-connector-sqlserver-cdc-v1.15` by introducing new source metrics. These metrics will provide detailed insights into the deserialization process and checkpoint management, facilitating better monitoring, troubleshooting, and optimization for users.


### Modifications

Basically the same way of modifying as that of #11130 

**Deserialization Metrics:**
Added counters to track successful and failed deserialization attempts (`numDeserializeSuccess`, `numDeserializeError`).
Added latency gauge to measure time taken for deserialization (`deserializeTimeLag`).

**SnapshotState Metrics:**
Added counters for the number of snapshots created (`numSnapshotCreate`) and errors encountered during snapshot operations (`numSnapshotError`).

**NotifyComplete Metrics:**
Added a counter to track completed snapshots (`numCompletedSnapshots`).
Added latency gauge for the time between snapshot creation and checkpoint completion (`snapshotToCheckpointTimeLag`).


### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

Can use the same way of verification as that in #11130, an simpler way, however, can be used in the following way.

- Use an End-to-End test called `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/java/org/apache/inlong/sort/tests/Sqlserver2StarRocksTest.java`.

- Add a while loop after all the checks in `testSqlserverUpdateAndDelete`  to stop the testing container from being torn down. 
- Add 
```
'inlong.metric.labels' = 'groupId=sqlserverGroup&streamId=sqlserverStream&nodeId=sqlserverNode'
``` 
in the source connection option of `inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/src/test/resources/flinkSql/pulsar_test.sql`.
- Run the maven test.
- Wait until all the tests down(should take a while), visit `localhost:8081`, which is the url for `Flink Web Dashboard`.

- Click the operator, and check the `metrics` column.
The result should be like this:
<img width="1280" alt="SqlServerMetrics1" src="https://github.com/user-attachments/assets/191e7392-258d-47c5-93a5-a95eab2bf6f7">


### Documentation

  - Does this pull request introduce a new feature? Yes
  - If yes, how is the feature documented? Docs in `inlong-website` repo
