### PR TITLE
[INLONG-11386][TubeMQ] Use local files to save consumer group offset information

### DIFF
--- a/docker/kubernetes/templates/tubemq-broker-ini-configmap.yaml
+++ b/docker/kubernetes/templates/tubemq-broker-ini-configmap.yaml
@@ -38,12 +38,4 @@ data:
     loadMessageStoresInParallel=true
     consumerRegTimeoutMs=35000
 
-    [zookeeper]
-    zkNodeRoot=/tubemq
-    zkServerAddr={{ template "inlong.zookeeper.hostname" . }}:{{ .Values.zookeeper.ports.client }}
-    zkSessionTimeoutMs=30000
-    zkConnectionTimeoutMs=30000
-    zkSyncTimeMs=5000
-    zkCommitPeriodMs=5000
-    zkCommitFailRetries=10
 {{- end }}

--- a/inlong-tubemq/conf/broker.ini
+++ b/inlong-tubemq/conf/broker.ini
@@ -41,23 +41,6 @@ loadMessageStoresInParallel=true
 ; timeout of consumer heartbeat, optional; default is 30s
 consumerRegTimeoutMs=35000
 
-
-[zookeeper]
-; root path of TubeMQ znodes on ZK
-zkNodeRoot=/tubemq
-; connect string of ZK servers
-zkServerAddr=localhost:2181
-; timeout of ZK heartbeat; default is 30000ms
-zkSessionTimeoutMs=30000
-; timeout of ZK connection; default is 30000ms
-zkConnectionTimeoutMs=30000
-; sync time on ZK; default is 5000ms
-zkSyncTimeMs=5000
-; interval to commits data on ZK; default is 5000ms
-zkCommitPeriodMs=5000
-; maximum retry times when commits data on ZK fails
-zkCommitFailRetries=10
-
 [audit]
 ; whether to enable data report by audit sdk
 auditEnable=false

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
@@ -84,7 +84,6 @@ public class TBaseConstants {
     public static final long CFG_MIN_META_FORCE_UPDATE_PERIOD = 1 * 60 * 1000;
     public static final long CFG_STATS_MIN_SNAPSHOT_PERIOD_MS = 2000;
 
-    public static final int OFFSET_HISTORY_RECORD_VERSION = 1;
     public static final int OFFSET_HISTORY_RECORD_SHORT_VERSION = 2;
     public static final int OFFSET_HISTORY_RECORD_VERSION_3 = 3;
 

--- a/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
+++ b/inlong-tubemq/tubemq-core/src/main/java/org/apache/inlong/tubemq/corebase/TBaseConstants.java
@@ -84,4 +84,9 @@ public class TBaseConstants {
     public static final long CFG_MIN_META_FORCE_UPDATE_PERIOD = 1 * 60 * 1000;
     public static final long CFG_STATS_MIN_SNAPSHOT_PERIOD_MS = 2000;
 
+    public static final int OFFSET_HISTORY_RECORD_VERSION = 1;
+    public static final int OFFSET_HISTORY_RECORD_SHORT_VERSION = 2;
+    public static final int OFFSET_HISTORY_RECORD_VERSION_3 = 3;
+
+    public static final int OFFSET_TOPIC_PUBLISH_RECORD_VERSION_1 = 1;
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/BrokerServiceServer.java
@@ -54,7 +54,7 @@ import org.apache.inlong.tubemq.server.broker.msgstore.disk.GetMessageResult;
 import org.apache.inlong.tubemq.server.broker.nodeinfo.ConsumerNodeInfo;
 import org.apache.inlong.tubemq.server.broker.offset.OffsetHistoryInfo;
 import org.apache.inlong.tubemq.server.broker.offset.OffsetService;
-import org.apache.inlong.tubemq.server.broker.offset.offsetstorage.OffsetStorageInfo;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetStorageInfo;
 import org.apache.inlong.tubemq.server.broker.stats.BrokerSrvStatsHolder;
 import org.apache.inlong.tubemq.server.broker.stats.TrafficStatsService;
 import org.apache.inlong.tubemq.server.broker.stats.audit.AuditUtils;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerMetadataManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerMetadataManager.java
@@ -69,9 +69,11 @@ public class BrokerMetadataManager implements MetadataManager {
     private final Map<String/* topic */, TopicMetadata> removedTopicConfigMap =
             new ConcurrentHashMap<>();
     private long lastRptBrokerMetaConfId = 0;
+    // group offset storage expire ms
+    private final long grpOffsetStgExpMs;
 
-    public BrokerMetadataManager() {
-
+    public BrokerMetadataManager(long grpOffsetStgExpMs) {
+        this.grpOffsetStgExpMs = grpOffsetStgExpMs;
     }
 
     @Override
@@ -107,6 +109,11 @@ public class BrokerMetadataManager implements MetadataManager {
     @Override
     public List<String> getTopics() {
         return topics;
+    }
+
+    @Override
+    public boolean isTopicExisted(String topicName) {
+        return topics.contains(topicName);
     }
 
     @Override
@@ -171,6 +178,11 @@ public class BrokerMetadataManager implements MetadataManager {
     @Override
     public Map<String, TopicMetadata> getRemovedTopicConfigMap() {
         return removedTopicConfigMap;
+    }
+
+    @Override
+    public long getGrpOffsetsStgExpMs() {
+        return grpOffsetStgExpMs;
     }
 
     /**

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/MetadataManager.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/metadata/MetadataManager.java
@@ -46,6 +46,8 @@ public interface MetadataManager {
 
     List<String> getTopics();
 
+    boolean isTopicExisted(String topicName);
+
     TopicMetadata getTopicMetadata(String topic);
 
     BrokerDefMetadata getBrokerDefMetadata();
@@ -83,4 +85,6 @@ public interface MetadataManager {
     String getTopicDeletePolicy(String topic);
 
     Map<String, TopicMetadata> getTopicConfigMap();
+
+    long getGrpOffsetsStgExpMs();
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/StoreService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/msgstore/StoreService.java
@@ -17,11 +17,10 @@
 
 package org.apache.inlong.tubemq.server.broker.msgstore;
 
-import org.apache.inlong.tubemq.server.broker.offset.OffsetHistoryInfo;
+import org.apache.inlong.tubemq.server.broker.offset.topicpub.TopicPubInfo;
 import org.apache.inlong.tubemq.server.broker.utils.TopicPubStoreInfo;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,7 +33,7 @@ public interface StoreService {
 
     void close();
 
-    List<String> removeTopicStore();
+    Set<String> removeTopicStore();
 
     Collection<MessageStore> getMessageStoresByTopic(String topic);
 
@@ -46,5 +45,5 @@ public interface StoreService {
     // Add the current storage offset values to
     // the consumption partition records of the specified consumption group
     // include maximum and minimum, and consume lag
-    void getTopicPublishInfos(Map<String, OffsetHistoryInfo> groupOffsetMap);
+    Map<String, TopicPubInfo> getTopicPublishInfos();
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetCsmItem.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetCsmItem.java
@@ -24,24 +24,26 @@ public class OffsetCsmItem {
 
     protected int partitionId;
     // consume group confirmed offset
-    protected long offsetCfm = 0L;
+    protected long cfmOffset = 0L;
     // consume group fetched offset
-    protected long offsetFetch = 0L;
+    protected long inflightOffset = 0L;
+    // consumer clientRecId
+    protected int clientRecId = -1;
 
     public OffsetCsmItem(int partitionId) {
         this.partitionId = partitionId;
     }
 
     public void addCsmOffsets(long offsetCfm, long offsetFetch) {
-        this.offsetCfm = offsetCfm;
-        this.offsetFetch = offsetFetch;
+        this.cfmOffset = offsetCfm;
+        this.inflightOffset = offsetFetch;
     }
 
-    public void addCfmOffset(long offsetCfm) {
-        this.offsetCfm = offsetCfm;
+    public void addClientRecId(int clientRecId) {
+        this.clientRecId = clientRecId;
     }
 
-    public void addFetchOffset(long offsetFetch) {
-        this.offsetFetch = offsetFetch;
+    public long getCfmOffset() {
+        return cfmOffset;
     }
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetCsmRecord.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetCsmRecord.java
@@ -41,7 +41,7 @@ public class OffsetCsmRecord {
         this.storeId = storeId;
     }
 
-    public void addOffsetCfmInfo(int partitionId, long offsetCfm) {
+    public void addCsmOffsets(int partitionId, long offsetCfm, long tmpOffset) {
         OffsetCsmItem offsetCsmItem = partitionCsmMap.get(partitionId);
         if (offsetCsmItem == null) {
             OffsetCsmItem tmpItem = new OffsetCsmItem(partitionId);
@@ -50,10 +50,10 @@ public class OffsetCsmRecord {
                 offsetCsmItem = tmpItem;
             }
         }
-        offsetCsmItem.addCfmOffset(offsetCfm);
+        offsetCsmItem.addCsmOffsets(offsetCfm, tmpOffset);
     }
 
-    public void addOffsetFetchInfo(int partitionId, long offsetFetch) {
+    public void addClientRecId(int partitionId, int clientRecId) {
         OffsetCsmItem offsetCsmItem = partitionCsmMap.get(partitionId);
         if (offsetCsmItem == null) {
             OffsetCsmItem tmpItem = new OffsetCsmItem(partitionId);
@@ -62,7 +62,7 @@ public class OffsetCsmRecord {
                 offsetCsmItem = tmpItem;
             }
         }
-        offsetCsmItem.addFetchOffset(offsetFetch);
+        offsetCsmItem.addClientRecId(clientRecId);
     }
 
     public void addStoreInfo(long offsetMin, long offsetMax,

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetService.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetService.java
@@ -17,10 +17,11 @@
 
 package org.apache.inlong.tubemq.server.broker.offset;
 
+import org.apache.inlong.tubemq.corebase.rv.RetValue;
 import org.apache.inlong.tubemq.corebase.utils.Tuple2;
 import org.apache.inlong.tubemq.corebase.utils.Tuple3;
+import org.apache.inlong.tubemq.corebase.utils.Tuple4;
 import org.apache.inlong.tubemq.server.broker.msgstore.MessageStore;
-import org.apache.inlong.tubemq.server.broker.offset.offsetstorage.OffsetStorageInfo;
 
 import java.util.List;
 import java.util.Map;
@@ -31,12 +32,13 @@ import java.util.Set;
  */
 public interface OffsetService {
 
+    void start();
+
     void close(long waitTimeMs);
 
     OffsetStorageInfo loadOffset(MessageStore store, String group,
-            String topic, int partitionId,
-            int readStatus, long reqOffset,
-            StringBuilder sb);
+            String topic, int partitionId, int readStatus,
+            long reqOffset, StringBuilder sb);
 
     long getOffset(MessageStore msgStore, String group,
             String topic, int partitionId,
@@ -57,24 +59,34 @@ public interface OffsetService {
 
     long getTmpOffset(String group, String topic, int partitionId);
 
-    Set<String> getBookedGroups();
-
-    Set<String> getInMemoryGroups();
-
-    Set<String> getUnusedGroupInfo();
-
-    Set<String> getGroupSubInfo(String group);
-
     Map<String, Map<Integer, Tuple2<Long, Long>>> queryGroupOffset(
             String group, Map<String, Set<Integer>> topicPartMap);
 
     Map<String, OffsetHistoryInfo> getOnlineGroupOffsetInfo();
 
+    Map<String, OffsetHistoryInfo> getOfflineGroupOffsetInfo();
+
     boolean modifyGroupOffset(Set<String> groups,
             List<Tuple3<String, Integer, Long>> topicPartOffsets,
+            String modifier);
+
+    boolean modifyGroupOffset2(Set<String> groups,
+            List<Tuple4<Long, String, Integer, Long>> topicPartOffsets,
             String modifier);
 
     void deleteGroupOffset(boolean onlyMemory,
             Map<String, Map<String, Set<Integer>>> groupTopicPartMap,
             String modifier);
+
+    Set<String> getAllBookedGroups();
+
+    Set<String> getOnlineGroups();
+
+    Set<String> getOfflineGroups();
+
+    Set<String> getGroupSubInfo(String group);
+
+    void cleanRmvTopicInfo(Set<String> rmvTopics);
+
+    RetValue backupGroupOffsets(String backupFilePath);
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetStorage.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetStorage.java
@@ -15,29 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.tubemq.server.broker.offset.offsetstorage;
+package org.apache.inlong.tubemq.server.broker.offset;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface OffsetStorage {
 
     void close();
 
+    ConcurrentHashMap<String, OffsetStorageInfo> loadGroupStgInfo(String group);
+
     OffsetStorageInfo loadOffset(String group, String topic, int partitionId);
 
-    void commitOffset(String group,
-            Collection<OffsetStorageInfo> offsetInfoList,
-            boolean isFailRetry);
+    boolean commitOffset(String group, Collection<OffsetStorageInfo> offsetInfoList, boolean isFailRetry);
 
-    Map<String, Set<String>> queryZkAllGroupTopicInfos();
-
-    Map<String, Set<String>> queryZKGroupTopicInfo(List<String> groupSet);
+    Map<String, Set<String>> queryGroupTopicInfo(Set<String> groups);
 
     Map<Integer, Long> queryGroupOffsetInfo(String group, String topic,
             Set<Integer> partitionIds);
 
     void deleteGroupOffsetInfo(Map<String, Map<String, Set<Integer>>> groupTopicPartMap);
+
+    Set<String> cleanExpiredGroupInfo(long checkTime, long expiredDurMs);
+
+    Set<String> cleanRmvTopicInfo(Set<String> rmvTopics);
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetStorageInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/OffsetStorageInfo.java
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.inlong.tubemq.server.broker.offset.offsetstorage;
+package org.apache.inlong.tubemq.server.broker.offset;
 
+import org.apache.inlong.tubemq.corebase.TBaseConstants;
 import org.apache.inlong.tubemq.corebase.TokenConstants;
 import org.apache.inlong.tubemq.server.broker.utils.DataStoreUtils;
 
@@ -31,8 +32,12 @@ public class OffsetStorageInfo implements Serializable {
     private final int partitionId;
     private final AtomicLong offset = new AtomicLong(0);
     private long messageId;
+    private long lstRstTerm;
     private boolean firstCreate = false;
+    private long firstOffset = TBaseConstants.META_VALUE_UNDEFINED;
+    private long createTime = TBaseConstants.META_VALUE_UNDEFINED;
     private boolean modified = false;
+    private final AtomicLong lstUpdateTime = new AtomicLong(0);
 
     /**
      * Initial offset storage information
@@ -40,12 +45,13 @@ public class OffsetStorageInfo implements Serializable {
      * @param topic          the topic name
      * @param brokerId       the broker id
      * @param partitionId    the partition id
+     * @param lstRstTerm     the last reset term
      * @param offset         the offset
      * @param messageId      the message id
      */
     public OffsetStorageInfo(String topic, int brokerId, int partitionId,
-            long offset, long messageId) {
-        this(topic, brokerId, partitionId, offset, messageId, true);
+            long lstRstTerm, long offset, long messageId) {
+        this(topic, brokerId, partitionId, lstRstTerm, offset, messageId, true, System.currentTimeMillis());
     }
 
     /**
@@ -54,21 +60,28 @@ public class OffsetStorageInfo implements Serializable {
      * @param topic          the topic name
      * @param brokerId       the broker id
      * @param partitionId    the partition id
+     * @param lstRstTerm     the last reset term
      * @param offset         the offset
      * @param messageId      the message id
      * @param firstCreate    whether is the first record creation
+     * @param lstUpdateTime  the last update time
      */
     public OffsetStorageInfo(String topic, int brokerId, int partitionId,
-            long offset, long messageId, boolean firstCreate) {
+            long lstRstTerm, long offset, long messageId,
+            boolean firstCreate, long lstUpdateTime) {
         this.topic = topic;
         this.brokerId = brokerId;
         this.partitionId = partitionId;
+        this.lstRstTerm = lstRstTerm;
         this.offset.set(offset - offset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
         this.messageId = messageId;
         this.firstCreate = firstCreate;
         if (firstCreate) {
-            modified = true;
+            this.modified = true;
+            this.firstOffset = this.offset.get();
+            this.createTime = lstUpdateTime;
         }
+        this.lstUpdateTime.set(lstUpdateTime);
     }
 
     public boolean isFirstCreate() {
@@ -87,6 +100,10 @@ public class OffsetStorageInfo implements Serializable {
         return partitionId;
     }
 
+    public long getLstRstTerm() {
+        return lstRstTerm;
+    }
+
     public long getOffset() {
         return offset.get();
     }
@@ -95,12 +112,20 @@ public class OffsetStorageInfo implements Serializable {
         return messageId;
     }
 
-    public void setMessageId(long messageId) {
-        this.messageId = messageId;
+    public long getLstUpdateTime() {
+        return lstUpdateTime.get();
     }
 
     public boolean isModified() {
         return modified;
+    }
+
+    public long getFirstOffset() {
+        return firstOffset;
+    }
+
+    public long getCreateTime() {
+        return createTime;
     }
 
     public void setModified(boolean modified) {
@@ -108,15 +133,17 @@ public class OffsetStorageInfo implements Serializable {
     }
 
     public long addAndGetOffset(long tmpOffset) {
-        firstCreate = false;
-        modified = true;
-        return offset.addAndGet(tmpOffset - tmpOffset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
+        this.firstCreate = false;
+        this.modified = true;
+        this.lstUpdateTime.set(System.currentTimeMillis());
+        return this.offset.addAndGet(tmpOffset - tmpOffset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
     }
 
     public long getAndSetOffset(long absOffset) {
-        firstCreate = false;
-        modified = true;
-        return offset.getAndSet(absOffset - absOffset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
+        this.firstCreate = false;
+        this.modified = true;
+        this.lstUpdateTime.set(System.currentTimeMillis());
+        return this.offset.getAndSet(absOffset - absOffset % DataStoreUtils.STORE_INDEX_HEAD_LEN);
     }
 
     @Override
@@ -143,6 +170,12 @@ public class OffsetStorageInfo implements Serializable {
         if (modified != that.modified) {
             return false;
         }
+        if (lstRstTerm != that.lstRstTerm) {
+            return false;
+        }
+        if (lstUpdateTime.get() != that.lstUpdateTime.get()) {
+            return false;
+        }
         if (!topic.equals(that.topic)) {
             return false;
         }
@@ -150,13 +183,14 @@ public class OffsetStorageInfo implements Serializable {
 
     }
 
-    @Override
     public int hashCode() {
         int result = topic.hashCode();
         result = 31 * result + brokerId;
         result = 31 * result + partitionId;
         result = 31 * result + offset.hashCode();
-        result = 31 * result + (int) (messageId ^ (messageId >>> 32));
+        result = 31 * result + Long.hashCode(messageId);
+        result = 31 * result + Long.hashCode(lstUpdateTime.get());
+        result = 31 * result + Long.hashCode(lstRstTerm);
         result = 31 * result + (firstCreate ? 1 : 0);
         result = 31 * result + (modified ? 1 : 0);
         return result;
@@ -171,6 +205,10 @@ public class OffsetStorageInfo implements Serializable {
                 .append(", messageId=").append(messageId)
                 .append(", modified=").append(modified)
                 .append(", firstCreate=").append(firstCreate)
+                .append(", firstOffset=").append(firstOffset)
+                .append(", createTime=").append(createTime)
+                .append(", lstUpdateTime=").append(lstUpdateTime.get())
+                .append(", lstRstTerm=").append(lstRstTerm)
                 .append("]").toString();
     }
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/FileOffsetStorage.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/FileOffsetStorage.java
@@ -1,0 +1,676 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.offsetfile;
+
+import org.apache.inlong.tubemq.corebase.daemon.AbstractDaemonService;
+import org.apache.inlong.tubemq.corebase.rv.RetValue;
+import org.apache.inlong.tubemq.corebase.utils.ConcurrentHashSet;
+import org.apache.inlong.tubemq.corebase.utils.ServiceStatusHolder;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetHistoryInfo;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetStorage;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetStorageInfo;
+import org.apache.inlong.tubemq.server.broker.stats.BrokerSrvStatsHolder;
+
+import com.google.gson.Gson;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class FileOffsetStorage extends AbstractDaemonService implements OffsetStorage {
+
+    private static final Logger logger = LoggerFactory.getLogger(FileOffsetStorage.class);
+    private static final Gson GSON = new Gson();
+    private static final String offsetSubDir = "offsetDir";
+    private static final String OFFSET_FILENAME = "offsets";
+    private static final String OFFSET_FILENAME_SUFFIX_FORMAL = ".meta";
+    private static final String OFFSET_FILENAME_SUFFIX_TMP = ".tmp";
+    private static final String OFFSET_FILENAME_SUFFIX_MID = ".mid";
+    private static final String OFFSET_FILENAME_SUFFIX_OLD = ".old";
+    private final int brokerId;
+    private final String offsetsDirBase;
+    private final String offsetsFileBase;
+    private final long syncDurWarnMs;
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    private final AtomicBoolean isUpdated = new AtomicBoolean(false);
+    private GroupOffsetStgInfo groupOffsetInfo;
+    private final ConcurrentHashMap<String, ConcurrentHashSet<String>> groupTopicsInfo = new ConcurrentHashMap<>();
+
+    public FileOffsetStorage(int brokerId, String offsetFilePath, long syncIntMs, long syncDurWarnMs) {
+        super("Offset-File", syncIntMs);
+        this.brokerId = brokerId;
+        this.syncDurWarnMs = syncDurWarnMs;
+        this.offsetsDirBase = offsetFilePath + File.separator + offsetSubDir;
+        this.offsetsFileBase = this.offsetsDirBase + File.separator + OFFSET_FILENAME;
+    }
+
+    @Override
+    public void start() {
+        if (!this.isStarted.compareAndSet(false, true)) {
+            return;
+        }
+        logger.info("[File offsets] initial File offsets starting...");
+        super.start();
+        if (!initialFileInfo()) {
+            logger.error("[File offsets] initial File offsets failure!");
+            System.exit(2);
+            return;
+        }
+        this.isStarted.set(true);
+        logger.info("[File offsets] initial File offsets started!");
+    }
+
+    @Override
+    protected void loopProcess(StringBuilder strBuff) {
+        if (!this.isStarted.get()) {
+            return;
+        }
+        if (!this.isUpdated.compareAndSet(true, false)) {
+            return;
+        }
+        long curStartTime = System.currentTimeMillis();
+        storeOffsetStgInfoToFile(this.groupOffsetInfo, this.offsetsFileBase);
+        long wastMs = System.currentTimeMillis() - curStartTime;
+        if (wastMs > syncDurWarnMs) {
+            logger.warn("[File offsets] sync offsets to file over warn value, wast={}ms, warnMs={}",
+                    wastMs, syncDurWarnMs);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!this.isStarted.compareAndSet(true, false)) {
+            return;
+        }
+        super.stop();
+        logger.info("[File offsets] begin sync content to file, begin");
+        long curStartTime = System.currentTimeMillis();
+        storeOffsetStgInfoToFile(this.groupOffsetInfo, this.offsetsFileBase);
+        long wastMs = System.currentTimeMillis() - curStartTime;
+        if (wastMs > syncDurWarnMs) {
+            logger.warn("[File offsets] close and sync offsets to file, wast={}ms, warnMs={}",
+                    wastMs, syncDurWarnMs);
+        }
+    }
+
+    @Override
+    public ConcurrentHashMap<String, OffsetStorageInfo> loadGroupStgInfo(String group) {
+        ConcurrentHashMap<String, OffsetStorageInfo> result = new ConcurrentHashMap<>();
+        if (!this.isStarted.get()) {
+            return result;
+        }
+        Map<String, PartStgInfo> partStgInfos = this.groupOffsetInfo.getOffsetStgInfos(group);
+        if (partStgInfos == null) {
+            return result;
+        }
+        for (Map.Entry<String, PartStgInfo> entry : partStgInfos.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            PartStgInfo partStgInfo = entry.getValue();
+            result.put(entry.getKey(), new OffsetStorageInfo(partStgInfo.getTopic(),
+                    brokerId, partStgInfo.getPartId(), partStgInfo.getLstRstTerm(),
+                    partStgInfo.getLstOffset(), partStgInfo.getMsgId(), false,
+                    partStgInfo.getLstUpdTime()));
+        }
+        return result;
+    }
+
+    @Override
+    public OffsetStorageInfo loadOffset(String group, String topic, int partitionId) {
+        if (!this.isStarted.get()) {
+            return null;
+        }
+        PartStgInfo partStgInfo =
+                this.groupOffsetInfo.getOffsetStgInfo(group, topic, partitionId);
+        if (partStgInfo == null) {
+            return null;
+        }
+        return new OffsetStorageInfo(topic, brokerId, partitionId,
+                partStgInfo.getLstRstTerm(), partStgInfo.getLstOffset(),
+                partStgInfo.getMsgId(), false, partStgInfo.getLstUpdTime());
+    }
+
+    @Override
+    public boolean commitOffset(String group, Collection<OffsetStorageInfo> offsetInfoList, boolean isFailRetry) {
+        if (offsetInfoList == null || offsetInfoList.isEmpty()) {
+            return false;
+        }
+        if (this.groupOffsetInfo.storeOffsetStgInfo(
+                group, offsetInfoList, this.groupTopicsInfo)) {
+            isUpdated.set(true);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Map<String, Set<String>> queryGroupTopicInfo(Set<String> groups) {
+        if (this.groupTopicsInfo.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Set<String> tmpTopics;
+        Map<String, Set<String>> groupTopicMap;
+        if (groups == null) {
+            groupTopicMap = new HashMap<>();
+            for (Map.Entry<String, ConcurrentHashSet<String>> entry : this.groupTopicsInfo.entrySet()) {
+                if (entry == null
+                        || entry.getKey() == null
+                        || entry.getValue() == null
+                        || entry.getValue().isEmpty()) {
+                    continue;
+                }
+                tmpTopics = groupTopicMap.computeIfAbsent(entry.getKey(), k -> new HashSet<>());
+                tmpTopics.addAll(entry.getValue());
+            }
+            return groupTopicMap;
+        } else {
+            if (groups.isEmpty()) {
+                return Collections.emptyMap();
+            }
+            groupTopicMap = new HashMap<>();
+            for (Map.Entry<String, ConcurrentHashSet<String>> entry : this.groupTopicsInfo.entrySet()) {
+                if (entry == null
+                        || entry.getKey() == null
+                        || entry.getValue() == null
+                        || entry.getValue().isEmpty()) {
+                    continue;
+                }
+                if (groups.contains(entry.getKey())) {
+                    tmpTopics = groupTopicMap.computeIfAbsent(entry.getKey(), k -> new HashSet<>());
+                    tmpTopics.addAll(entry.getValue());
+                }
+            }
+            return groupTopicMap;
+        }
+    }
+
+    @Override
+    public Map<Integer, Long> queryGroupOffsetInfo(String group, String topic, Set<Integer> partitionIds) {
+        return this.groupOffsetInfo.queryGroupOffsetInfo(group, topic, partitionIds);
+    }
+
+    @Override
+    public void deleteGroupOffsetInfo(Map<String, Map<String, Set<Integer>>> groupTopicPartMap) {
+        if (groupTopicPartMap == null || groupTopicPartMap.isEmpty()) {
+            return;
+        }
+        boolean isUpdated = false;
+        ConcurrentHashSet<String> curTopics;
+        Set<String> rmvTopics = new HashSet<>();
+        for (Map.Entry<String, Map<String, Set<Integer>>> entry : groupTopicPartMap.entrySet()) {
+            if (entry == null
+                    || entry.getKey() == null
+                    || entry.getValue() == null
+                    || entry.getValue().isEmpty()) {
+                continue;
+            }
+            if (this.groupOffsetInfo.rmvGroupOffsetInfo(entry.getKey(), entry.getValue())) {
+                isUpdated = true;
+            }
+            // clean cache
+            curTopics = groupTopicsInfo.get(entry.getKey());
+            if (curTopics == null) {
+                continue;
+            }
+            for (String topic : curTopics) {
+                if (topic == null) {
+                    continue;
+                }
+                if (this.groupOffsetInfo.includedTopic(entry.getKey(), topic)) {
+                    rmvTopics.add(topic);
+                }
+            }
+            if (!rmvTopics.isEmpty()) {
+                for (String topic : rmvTopics) {
+                    curTopics.remove(topic);
+                }
+                if (curTopics.isEmpty()) {
+                    groupTopicsInfo.remove(entry.getKey());
+                }
+            }
+        }
+        if (isUpdated) {
+            this.isUpdated.set(true);
+        }
+    }
+
+    @Override
+    public Set<String> cleanExpiredGroupInfo(long checkTime, long expiredDurMs) {
+        Set<String> rmvGroups =
+                this.groupOffsetInfo.rmvExpiredGroupOffsetInfo(checkTime, expiredDurMs);
+        if (!rmvGroups.isEmpty()) {
+            for (String rmvGroup : rmvGroups) {
+                this.groupTopicsInfo.remove(rmvGroup);
+            }
+            this.isUpdated.set(true);
+        }
+        return rmvGroups;
+    }
+
+    @Override
+    public Set<String> cleanRmvTopicInfo(Set<String> rmvTopics) {
+        Set<String> groups = new HashSet<>();
+        for (String topic : rmvTopics) {
+            if (topic == null) {
+                continue;
+            }
+            for (Map.Entry<String, ConcurrentHashSet<String>> entry : this.groupTopicsInfo.entrySet()) {
+                if (entry == null
+                        || entry.getKey() == null
+                        || entry.getValue() == null
+                        || entry.getValue().isEmpty()) {
+                    continue;
+                }
+                if (entry.getValue().contains(topic)) {
+                    groups.add(entry.getKey());
+                }
+            }
+        }
+        if (groups.isEmpty()) {
+            return groups;
+        }
+        ConcurrentHashSet<String> curTopics;
+        for (String group : groups) {
+            this.groupOffsetInfo.rmvGroupOffsetInfo(group, rmvTopics);
+            curTopics = groupTopicsInfo.get(group);
+            if (curTopics == null) {
+                continue;
+            }
+            curTopics.addAll(rmvTopics);
+            if (curTopics.isEmpty()) {
+                groupTopicsInfo.remove(group);
+            }
+        }
+        this.isUpdated.set(true);
+        return groups;
+    }
+
+    public String getOffsetsFileBase() {
+        return offsetsFileBase;
+    }
+
+    public Map<String, OffsetHistoryInfo> getOffsetHistoryInfo(Set<String> groups) {
+        if (groups == null || groups.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        OffsetStgInfo curStgInfo;
+        OffsetHistoryInfo tmpHisInfo;
+        ConcurrentHashMap<String, PartStgInfo> curPartStgInfoMap;
+        Map<String, OffsetHistoryInfo> result = new HashMap<>();
+        ConcurrentHashMap<String, OffsetStgInfo> offsetStgInfoMap =
+                this.groupOffsetInfo.getGroupOffsetStgInfo();
+        for (String group : groups) {
+            curStgInfo = offsetStgInfoMap.get(group);
+            if (curStgInfo == null || curStgInfo.getPartOffsetInfo().isEmpty()) {
+                continue;
+            }
+            tmpHisInfo = new OffsetHistoryInfo(brokerId, group);
+            curPartStgInfoMap = curStgInfo.getPartOffsetInfo();
+            for (PartStgInfo partStgInfo : curPartStgInfoMap.values()) {
+                if (partStgInfo == null) {
+                    continue;
+                }
+                tmpHisInfo.addCsmOffsets(partStgInfo.getTopic(),
+                        partStgInfo.getPartId(), partStgInfo.getLstOffset(), 0L);
+            }
+            result.put(group, tmpHisInfo);
+        }
+        return result;
+    }
+
+    public boolean isFistUseFileStg() {
+        boolean isFistUseFileStg = false;
+        File baseDir = new File(this.offsetsDirBase);
+        if (!baseDir.exists()) {
+            if (!baseDir.mkdirs()) {
+                logger.error("[File offsets] could not make File offset directory {}",
+                        baseDir.getAbsolutePath());
+                System.exit(2);
+            }
+            isFistUseFileStg = true;
+        }
+        if (!baseDir.isDirectory() || !baseDir.canRead()) {
+            logger.error("[File offsets] File offset path {} is not a readable directory",
+                    baseDir.getAbsolutePath());
+            System.exit(2);
+        }
+        final File[] listFiles = baseDir.listFiles();
+        if (listFiles != null) {
+            isFistUseFileStg = true;
+            for (File file : listFiles) {
+                if (file.isFile()) {
+                    if (file.getName().endsWith(OFFSET_FILENAME_SUFFIX_MID)
+                            || file.getName().endsWith(OFFSET_FILENAME_SUFFIX_FORMAL)
+                            || file.getName().endsWith(OFFSET_FILENAME_SUFFIX_OLD)) {
+                        isFistUseFileStg = false;
+                        break;
+                    }
+                }
+            }
+        }
+        return isFistUseFileStg;
+    }
+
+    private boolean initialFileInfo() {
+        if (!checkAndRecoverStgFiles()) {
+            return false;
+        }
+        GroupOffsetStgInfo tmpOffsetInfoMap;
+        File dstFile = new File(this.offsetsFileBase + OFFSET_FILENAME_SUFFIX_FORMAL);
+        if (dstFile.exists()) {
+            String offsetsContent = getConfigFromFile(dstFile);
+            if (offsetsContent == null) {
+                logger.error("[File offsets] initial load storage file {} failure!",
+                        dstFile.getAbsoluteFile());
+                return false;
+            }
+            try {
+                tmpOffsetInfoMap = GSON.fromJson(offsetsContent, GroupOffsetStgInfo.class);
+            } catch (Throwable ex) {
+                logger.error("[File offsets] parse loaded json config failure", ex);
+                return false;
+            }
+            if (tmpOffsetInfoMap == null) {
+                logger.error("[File offsets] LOADED configure is null");
+                return false;
+            }
+        } else {
+            if (!isFistUseFileStg()) {
+                logger.error("[File offsets] storage file {} is required!",
+                        dstFile.getAbsoluteFile());
+                return false;
+            }
+            tmpOffsetInfoMap = new GroupOffsetStgInfo(this.brokerId);
+            RetValue retValue = storeOffsetStgInfoToFile(tmpOffsetInfoMap, this.offsetsFileBase);
+            if (!retValue.isSuccess()) {
+                return false;
+            }
+        }
+        this.groupOffsetInfo = tmpOffsetInfoMap;
+        Map<String, OffsetStgInfo> offsetStgInfos = tmpOffsetInfoMap.getGroupOffsetStgInfo();
+        if (offsetStgInfos == null || offsetStgInfos.isEmpty()) {
+            return true;
+        }
+        ConcurrentHashSet<String> tmpSet;
+        ConcurrentHashSet<String> topicSet;
+        for (Map.Entry<String, OffsetStgInfo> entry : offsetStgInfos.entrySet()) {
+            if (entry == null
+                    || entry.getKey() == null
+                    || entry.getValue() == null) {
+                continue;
+            }
+            Map<String, PartStgInfo> partStgInfoMap = entry.getValue().getPartOffsetInfo();
+            if (partStgInfoMap == null || partStgInfoMap.isEmpty()) {
+                continue;
+            }
+            for (Map.Entry<String, PartStgInfo> partEntry : partStgInfoMap.entrySet()) {
+                if (partEntry == null || partEntry.getValue() == null) {
+                    continue;
+                }
+                topicSet = groupTopicsInfo.get(entry.getKey());
+                if (topicSet == null) {
+                    tmpSet = new ConcurrentHashSet<>();
+                    topicSet = groupTopicsInfo.putIfAbsent(entry.getKey(), tmpSet);
+                    if (topicSet == null) {
+                        topicSet = tmpSet;
+                    }
+                }
+                topicSet.add(partEntry.getValue().getTopic());
+            }
+        }
+        return true;
+    }
+
+    private boolean checkAndRecoverStgFiles() {
+        String fileContent;
+        GroupOffsetStgInfo tmpGroupStgInfo;
+        File midFile = new File(this.offsetsFileBase + OFFSET_FILENAME_SUFFIX_MID);
+        File dstFile = new File(this.offsetsFileBase + OFFSET_FILENAME_SUFFIX_FORMAL);
+        File oldFile = new File(this.offsetsFileBase + OFFSET_FILENAME_SUFFIX_OLD);
+        // delete tmp file
+        FileUtils.deleteQuietly(new File(this.offsetsFileBase + OFFSET_FILENAME_SUFFIX_TMP));
+        try {
+            if (midFile.exists()) {
+                fileContent = getConfigFromFile(midFile);
+                if (fileContent == null) {
+                    logger.error("[File offsets] load mid file {} failure!", midFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo = getOffsetStgInfoFromConfig(fileContent);
+                if (tmpGroupStgInfo == null) {
+                    logger.error("[File offsets] parse loaded mid file {} failure!", midFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo.clear();
+                if (dstFile.exists()) {
+                    if (!dstFile.delete()) {
+                        logger.error("[File offsets] delete residual file1 {} failed!", dstFile.getAbsoluteFile());
+                        return false;
+                    }
+                }
+                if (oldFile.exists()) {
+                    if (!oldFile.delete()) {
+                        logger.error("[File offsets] delete residual file2 {} failed!", oldFile.getAbsoluteFile());
+                        return false;
+                    }
+                }
+                if (!storeConfigToFile(fileContent, oldFile)) {
+                    logger.error("[File offsets] backup content to file {} failed!", oldFile.getAbsoluteFile());
+                    return false;
+                }
+                if (!oldFile.exists()) {
+                    logger.error("[File offsets] backup file {} not found!", oldFile.getAbsoluteFile());
+                    return false;
+                }
+                FileUtils.moveFile(midFile, dstFile);
+                if (!dstFile.exists()) {
+                    logger.error("[File offsets] moved formal file {} not found!", dstFile.getAbsoluteFile());
+                    return false;
+                }
+                if (!oldFile.delete()) {
+                    logger.error("[File offsets] delete backup file {} failure!", oldFile.getAbsoluteFile());
+                    return false;
+                }
+                return true;
+            }
+            if (dstFile.exists()) {
+                fileContent = getConfigFromFile(dstFile);
+                if (fileContent == null) {
+                    logger.error("[File offsets] load formal file {} failure!", dstFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo = getOffsetStgInfoFromConfig(fileContent);
+                if (tmpGroupStgInfo == null) {
+                    logger.error("[File offsets] parse loaded formal file {} failure!", dstFile.getAbsoluteFile());
+                    return false;
+                }
+                if (oldFile.exists()) {
+                    if (!oldFile.delete()) {
+                        logger.error("[File offsets] delete residual file {} failed!", oldFile.getAbsoluteFile());
+                        return false;
+                    }
+                }
+                return true;
+            }
+            if (oldFile.exists()) {
+                fileContent = getConfigFromFile(oldFile);
+                if (fileContent == null) {
+                    logger.error("[File offsets] load backup file {} failure!",
+                            oldFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo = getOffsetStgInfoFromConfig(fileContent);
+                if (tmpGroupStgInfo == null) {
+                    logger.error("[File offsets] parse loaded backup content {} failure!",
+                            oldFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo.clear();
+                if (!storeConfigToFile(fileContent, dstFile)) {
+                    logger.error("[File offsets] recover formal file {} failed!",
+                            dstFile.getAbsoluteFile());
+                    return false;
+                }
+                if (!dstFile.exists()) {
+                    logger.error("[File offsets] recovered formal file {} not found!",
+                            dstFile.getAbsoluteFile());
+                    return false;
+                }
+                fileContent = getConfigFromFile(dstFile);
+                if (fileContent == null) {
+                    logger.error("[File offsets] load recovered file {} failure!",
+                            dstFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo = getOffsetStgInfoFromConfig(fileContent);
+                if (tmpGroupStgInfo == null) {
+                    logger.error("[File offsets] parse recovered file content {} failure!",
+                            dstFile.getAbsoluteFile());
+                    return false;
+                }
+                tmpGroupStgInfo.clear();
+                if (!oldFile.delete()) {
+                    logger.error("[File offsets] delete backup file {} failed!",
+                            oldFile.getAbsoluteFile());
+                    return false;
+                }
+            }
+            return true;
+        } catch (Throwable ex) {
+            if (ex instanceof IOException || ex instanceof SecurityException) {
+                ServiceStatusHolder.addWriteIOErrCnt();
+                BrokerSrvStatsHolder.incDiskIOExcCnt();
+            }
+            logger.error("[File offsets] recover offset storage files failed!", ex);
+            return false;
+        }
+    }
+
+    public RetValue backupGroupOffsets(String backupPath) {
+        String fileNameBase = backupPath + File.separator + OFFSET_FILENAME;
+        return storeOffsetStgInfoToFile(this.groupOffsetInfo, fileNameBase);
+    }
+
+    public static RetValue storeOffsetStgInfoToFile(GroupOffsetStgInfo offsetStgInfo, String fileNameBase) {
+        RetValue result = new RetValue();
+        String configStr;
+        try {
+            offsetStgInfo.setLstStoreTime();
+            configStr = GSON.toJson(offsetStgInfo, GroupOffsetStgInfo.class);
+        } catch (Throwable ex) {
+            logger.error("[File offsets] serial offset configure to json failure", ex);
+            result.setFailResult("serial offset configure to json failure: " + ex.getMessage());
+            return result;
+        }
+        File tmpFile = new File(fileNameBase + OFFSET_FILENAME_SUFFIX_TMP);
+        if (!storeConfigToFile(configStr, tmpFile)) {
+            logger.error("[File offsets] store json config to file {} failure", tmpFile.getAbsoluteFile());
+            result.setFailResult("store json config failure to file: " + tmpFile.getAbsoluteFile());
+            return result;
+        }
+        String readConfigStr = getConfigFromFile(tmpFile);
+        if (!configStr.equals(readConfigStr)) {
+            result.setFailResult("read stored offset json not equal!");
+            return result;
+        }
+        File midFile = new File(fileNameBase + OFFSET_FILENAME_SUFFIX_MID);
+        File dstFile = new File(fileNameBase + OFFSET_FILENAME_SUFFIX_FORMAL);
+        File oldFile = new File(fileNameBase + OFFSET_FILENAME_SUFFIX_OLD);
+        try {
+            FileUtils.moveFile(tmpFile, midFile);
+            if (!midFile.exists()) {
+                throw new Exception("Mid File " + midFile + " not found!");
+            }
+            if (dstFile.exists()) {
+                FileUtils.moveFile(dstFile, oldFile);
+                if (!oldFile.exists()) {
+                    throw new Exception("Backup File " + oldFile + " not found!");
+                }
+            }
+            FileUtils.moveFile(midFile, dstFile);
+            if (!dstFile.exists()) {
+                throw new Exception("Formal File " + dstFile + " not found!");
+            }
+            if (oldFile.exists()) {
+                if (!oldFile.delete()) {
+                    throw new Exception("Backup file " + oldFile + " delete failed!");
+                }
+            }
+            result.setSuccResult();
+        } catch (Throwable ex) {
+            if (ex instanceof IOException || ex instanceof SecurityException) {
+                ServiceStatusHolder.addWriteIOErrCnt();
+                BrokerSrvStatsHolder.incDiskIOExcCnt();
+            }
+            logger.error("[File offsets] exception thrown while adjust file name", ex);
+            result.setFailResult("Exception while store to file: " + ex.getMessage());
+        }
+        return result;
+    }
+
+    public static GroupOffsetStgInfo getOffsetStgInfoFromConfig(String metaJsonStr) {
+        try {
+            return GSON.fromJson(metaJsonStr, GroupOffsetStgInfo.class);
+        } catch (Throwable ex) {
+            logger.error("[File offsets] parse offsets json failure, contents={}", metaJsonStr, ex);
+            return null;
+        }
+    }
+
+    public static boolean storeConfigToFile(String metaJsonStr, File tgtFile) {
+        boolean isSuccess = false;
+        try {
+            FileUtils.writeStringToFile(tgtFile, metaJsonStr, StandardCharsets.UTF_8);
+            isSuccess = true;
+        } catch (Throwable ex) {
+            if (ex instanceof IOException) {
+                ServiceStatusHolder.addWriteIOErrCnt();
+                BrokerSrvStatsHolder.incDiskIOExcCnt();
+            }
+            logger.error("[File offsets] exception thrown while writing to file {}",
+                    tgtFile.getAbsoluteFile(), ex);
+        }
+        return isSuccess;
+    }
+
+    public static String getConfigFromFile(File tgtFile) {
+        try {
+            return FileUtils.readFileToString(tgtFile, StandardCharsets.UTF_8);
+        } catch (Throwable ex) {
+            if (ex instanceof IOException) {
+                ServiceStatusHolder.addReadIOErrCnt();
+                BrokerSrvStatsHolder.incDiskIOExcCnt();
+            }
+            logger.error("[File offsets] exception thrown while load from file {}",
+                    tgtFile.getAbsoluteFile(), ex);
+            return null;
+        }
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/GroupOffsetStgInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/GroupOffsetStgInfo.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.offsetfile;
+
+import org.apache.inlong.tubemq.corebase.utils.ConcurrentHashSet;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetStorageInfo;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class GroupOffsetStgInfo {
+
+    private final AtomicLong lstStoreTime = new AtomicLong(0);
+    private final int brokerId;
+    private final ConcurrentHashMap<String, OffsetStgInfo> groupOffsetStgInfo = new ConcurrentHashMap<>();
+
+    public GroupOffsetStgInfo(int brokerId) {
+        this.brokerId = brokerId;
+    }
+
+    public boolean isStgInfoEmpty() {
+        return groupOffsetStgInfo.isEmpty();
+    }
+
+    public boolean storeOffsetStgInfo(String group, Collection<OffsetStorageInfo> offsetInfoList,
+            ConcurrentHashMap<String, ConcurrentHashSet<String>> groupTopicsInfo) {
+        OffsetStgInfo curOffsetStgInfo = groupOffsetStgInfo.get(group);
+        if (curOffsetStgInfo == null) {
+            OffsetStgInfo tmpOffsetStgInfo = new OffsetStgInfo();
+            curOffsetStgInfo = groupOffsetStgInfo.putIfAbsent(group, tmpOffsetStgInfo);
+            if (curOffsetStgInfo == null) {
+                curOffsetStgInfo = tmpOffsetStgInfo;
+            }
+        }
+        boolean updated = false;
+        ConcurrentHashSet<String> tmpSet;
+        ConcurrentHashSet<String> topicSet;
+        for (OffsetStorageInfo info : offsetInfoList) {
+            if (info == null || !info.isModified()) {
+                continue;
+            }
+            if (curOffsetStgInfo.updOffsetInfo(info)) {
+                topicSet = groupTopicsInfo.get(group);
+                if (topicSet == null) {
+                    tmpSet = new ConcurrentHashSet<>();
+                    topicSet = groupTopicsInfo.putIfAbsent(group, tmpSet);
+                    if (topicSet == null) {
+                        topicSet = tmpSet;
+                    }
+                }
+                topicSet.add(info.getTopic());
+            }
+            updated = true;
+            info.setModified(false);
+        }
+        return updated;
+    }
+
+    public boolean addOffsetStgInfo(String group, String topic, int partId, long offset, long msgId) {
+        OffsetStgInfo curOffsetStgInfo = groupOffsetStgInfo.get(group);
+        if (curOffsetStgInfo == null) {
+            OffsetStgInfo tmpOffsetStgInfo = new OffsetStgInfo();
+            curOffsetStgInfo = groupOffsetStgInfo.putIfAbsent(group, tmpOffsetStgInfo);
+            if (curOffsetStgInfo == null) {
+                curOffsetStgInfo = tmpOffsetStgInfo;
+            }
+        }
+        return curOffsetStgInfo.updOffsetInfo(topic, partId, 0, msgId, offset, System.currentTimeMillis());
+    }
+
+    public Map<Integer, Long> queryGroupOffsetInfo(String group, String topic, Set<Integer> partIds) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            Map<Integer, Long> offsetMap = new HashMap<>(partIds.size());
+            for (Integer partId : partIds) {
+                offsetMap.put(partId, null);
+            }
+            return offsetMap;
+        }
+        return offsetStgInfo.getPartOffsetInfo(topic, partIds);
+    }
+
+    public boolean rmvGroupOffsetInfo(String group, Map<String, Set<Integer>> topicParts) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            return false;
+        }
+        for (Map.Entry<String, Set<Integer>> entry : topicParts.entrySet()) {
+            if (entry == null
+                    || entry.getKey() == null
+                    || entry.getValue() == null
+                    || entry.getValue().isEmpty()) {
+                continue;
+            }
+            offsetStgInfo.rmvPartOffsetInfo(entry.getKey(), entry.getValue());
+        }
+        if (offsetStgInfo.isOffsetStgInfoEmpty()) {
+            groupOffsetStgInfo.remove(group);
+        }
+        return true;
+    }
+
+    public void rmvGroupOffsetInfo(String group, Set<String> rmvTopics) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            return;
+        }
+        if (offsetStgInfo.rmvPartOffsetInfo(rmvTopics)) {
+            groupOffsetStgInfo.remove(group);
+        }
+    }
+
+    public ConcurrentHashMap<String, OffsetStgInfo> getGroupOffsetStgInfo() {
+        return groupOffsetStgInfo;
+    }
+
+    public boolean includedTopic(String group, String topic) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            return false;
+        }
+        return offsetStgInfo.includedTopic(topic);
+    }
+
+    public Map<String, PartStgInfo> getOffsetStgInfos(String group) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            return null;
+        }
+        return offsetStgInfo.getPartOffsetInfo();
+    }
+
+    public PartStgInfo getOffsetStgInfo(String group, String topic, int partId) {
+        OffsetStgInfo offsetStgInfo = groupOffsetStgInfo.get(group);
+        if (offsetStgInfo == null) {
+            return null;
+        }
+        return offsetStgInfo.getPartOffsetInfo(topic, partId);
+    }
+
+    public Set<String> rmvExpiredGroupOffsetInfo(long chkTime, long expireDurMs) {
+        Set<String> rmvGroups = new HashSet<>();
+        for (Map.Entry<String, OffsetStgInfo> entry : groupOffsetStgInfo.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            if (chkTime - entry.getValue().getLstCommitTime() > expireDurMs) {
+                rmvGroups.add(entry.getKey());
+            }
+        }
+        if (!rmvGroups.isEmpty()) {
+            for (String group : rmvGroups) {
+                if (group == null) {
+                    continue;
+                }
+                groupOffsetStgInfo.remove(group);
+            }
+        }
+        return rmvGroups;
+    }
+
+    public void setLstStoreTime() {
+        lstStoreTime.set(System.currentTimeMillis());
+    }
+
+    public void clear() {
+        this.groupOffsetStgInfo.clear();
+    }
+
+    @Override
+    public String toString() {
+        return "GroupOffsetStgInfo{" +
+                "lstStoreTime=" + lstStoreTime +
+                ", brokerId=" + brokerId +
+                ", groupOffsetStgInfo=" + groupOffsetStgInfo +
+                '}';
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/OffsetStgInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/OffsetStgInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.offsetfile;
+
+import org.apache.inlong.tubemq.corebase.TokenConstants;
+import org.apache.inlong.tubemq.server.broker.offset.OffsetStorageInfo;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class OffsetStgInfo {
+
+    private long lstCommitTime;
+    private final ConcurrentHashMap<String, PartStgInfo> partOffsetInfo = new ConcurrentHashMap<>();
+
+    public OffsetStgInfo() {
+    }
+
+    public boolean updOffsetInfo(String topic, int partId, long lstTerm,
+            long msgId, long offset, long lstUpdateTime) {
+        boolean isAdded = false;
+        String key = buildOffsetKey(topic, partId);
+        PartStgInfo partInfo = partOffsetInfo.get(key);
+        if (partInfo == null) {
+            PartStgInfo tmpPartInfo = new PartStgInfo(topic, partId);
+            partInfo = partOffsetInfo.putIfAbsent(key, tmpPartInfo);
+            if (partInfo == null) {
+                isAdded = true;
+                partInfo = tmpPartInfo;
+            }
+        }
+        partInfo.updateOffset(lstTerm, msgId, isAdded,
+                offset, lstUpdateTime, offset, lstUpdateTime);
+        this.lstCommitTime = lstUpdateTime;
+        return isAdded;
+    }
+
+    public boolean updOffsetInfo(OffsetStorageInfo info) {
+        boolean isAdded = false;
+        String key = buildOffsetKey(info.getTopic(), info.getPartitionId());
+        PartStgInfo partInfo = this.partOffsetInfo.get(key);
+        if (partInfo == null) {
+            PartStgInfo tmpPartInfo = new PartStgInfo(info.getTopic(), info.getPartitionId());
+            partInfo = this.partOffsetInfo.putIfAbsent(key, tmpPartInfo);
+            if (partInfo == null) {
+                isAdded = true;
+                partInfo = tmpPartInfo;
+            }
+        }
+        partInfo.updateOffset(info.getLstRstTerm(), info.getMessageId(), isAdded,
+                info.getFirstOffset(), info.getCreateTime(), info.getOffset(), info.getLstUpdateTime());
+        this.lstCommitTime = info.getLstUpdateTime();
+        return isAdded;
+    }
+
+    public boolean resetOffsetInfo(String topic, int partId, long resetTerm, long offset, long lstUpdateTime) {
+        boolean isAdded = false;
+        String key = buildOffsetKey(topic, partId);
+        PartStgInfo partInfo = this.partOffsetInfo.get(key);
+        if (partInfo == null) {
+            PartStgInfo tmpPartInfo = new PartStgInfo(topic, partId);
+            partInfo = this.partOffsetInfo.putIfAbsent(key, tmpPartInfo);
+            if (partInfo == null) {
+                isAdded = true;
+                partInfo = tmpPartInfo;
+            }
+        }
+        partInfo.resetOffset(resetTerm, isAdded, offset, lstUpdateTime);
+        this.lstCommitTime = lstUpdateTime;
+        return isAdded;
+    }
+
+    public long getLstCommitTime() {
+        return lstCommitTime;
+    }
+
+    public boolean isOffsetStgInfoEmpty() {
+        return partOffsetInfo.isEmpty();
+    }
+
+    public boolean includedTopic(String topic) {
+        if (partOffsetInfo.isEmpty()) {
+            return false;
+        }
+        for (PartStgInfo partStgInfo : partOffsetInfo.values()) {
+            if (partStgInfo == null) {
+                continue;
+            }
+            if (topic.equals(partStgInfo.getTopic())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public PartStgInfo getPartOffsetInfo(String topic, int partId) {
+        return partOffsetInfo.get(buildOffsetKey(topic, partId));
+    }
+
+    public ConcurrentHashMap<String, PartStgInfo> getPartOffsetInfo() {
+        return partOffsetInfo;
+    }
+
+    public Map<Integer, Long> getPartOffsetInfo(String topic, Set<Integer> partIds) {
+        Map<Integer, Long> offsetMap = new HashMap<>(partIds.size());
+        for (Integer partId : partIds) {
+            PartStgInfo partInfo = partOffsetInfo.get(buildOffsetKey(topic, partId));
+            if (partInfo == null) {
+                offsetMap.put(partId, null);
+            } else {
+                offsetMap.put(partId, partInfo.getLstOffset());
+            }
+        }
+        return offsetMap;
+    }
+
+    public boolean rmvPartOffsetInfo(String topic, Set<Integer> partIds) {
+        for (Integer partId : partIds) {
+            partOffsetInfo.remove(buildOffsetKey(topic, partId));
+        }
+        return partOffsetInfo.isEmpty();
+    }
+
+    public boolean rmvPartOffsetInfo(Set<String> rmvTopics) {
+        Set<String> rmvItems = new HashSet<>();
+        for (Map.Entry<String, PartStgInfo> entry : partOffsetInfo.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            if (rmvTopics.contains(entry.getValue().getTopic())) {
+                rmvItems.add(buildOffsetKey(entry.getValue().getTopic(), entry.getValue().getPartId()));
+            }
+        }
+        for (String rmvItem : rmvItems) {
+            partOffsetInfo.remove(rmvItem);
+        }
+        return partOffsetInfo.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetStgInfo{" +
+                "lstCommitTime=" + lstCommitTime +
+                ", partOffsetInfo=" + partOffsetInfo +
+                '}';
+    }
+
+    public static String buildOffsetKey(String topic, int partId) {
+        return topic + TokenConstants.HYPHEN + partId;
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/PartStgInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/offsetfile/PartStgInfo.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.offsetfile;
+
+import org.apache.inlong.tubemq.corebase.TBaseConstants;
+
+public class PartStgInfo {
+
+    private final String topic;
+    private final int partId;
+    private long lstRstTerm = 0;
+    private long lstOffset = TBaseConstants.META_VALUE_UNDEFINED;
+    private long msgId = 0;
+    private long lstUpdTime = 0;
+    private long createOffset = TBaseConstants.META_VALUE_UNDEFINED;
+    private long createTime = 0;
+
+    public PartStgInfo(String topicName, int partitionId) {
+        this.topic = topicName;
+        this.partId = partitionId;
+    }
+
+    public void updateOffset(long lstRstTerm, long msgId, boolean isFstCreate,
+            long fstOffset, long fstUpdTime, long lstOffset, long lstUpdTime) {
+        this.lstRstTerm = lstRstTerm;
+        this.msgId = msgId;
+        if (isFstCreate) {
+            this.createOffset = fstOffset;
+            this.createTime = fstUpdTime;
+        }
+        this.lstOffset = lstOffset;
+        this.lstUpdTime = lstUpdTime;
+    }
+
+    public void resetOffset(long rstTerm, boolean isFstCreate, long offset, long resetTime) {
+        this.lstRstTerm = rstTerm;
+        if (isFstCreate) {
+            this.createOffset = offset;
+            this.createTime = resetTime;
+        }
+        this.lstOffset = offset;
+        this.lstUpdTime = resetTime;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public int getPartId() {
+        return partId;
+    }
+
+    public long getLstOffset() {
+        return lstOffset;
+    }
+
+    public long getLstRstTerm() {
+        return lstRstTerm;
+    }
+
+    public long getMsgId() {
+        return msgId;
+    }
+
+    public long getLstUpdTime() {
+        return lstUpdTime;
+    }
+
+    public long getCreateOffset() {
+        return createOffset;
+    }
+
+    public long getCreateTime() {
+        return createTime;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("PartStgInfo{");
+        sb.append("topic='").append(topic).append('\'');
+        sb.append(", partId=").append(partId);
+        sb.append(", lstRstTerm=").append(lstRstTerm);
+        sb.append(", lstOffset=").append(lstOffset);
+        sb.append(", msgId=").append(msgId);
+        sb.append(", lstUpdTime=").append(lstUpdTime);
+        sb.append(", createOffset=").append(createOffset);
+        sb.append(", createTime=").append(createTime);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/topicpub/OffsetPubItem.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/topicpub/OffsetPubItem.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.topicpub;
+
+/**
+ * The offset snapshot of the topic store.
+ */
+public class OffsetPubItem {
+
+    private int storeId;
+    // current number of partitions
+    private int numPart = 0;
+    // store min index offset
+    private long indexMin = 0L;
+    // store max index offset
+    private long indexMax = 0L;
+    // store min data offset
+    private long dataMin = 0L;
+    // store max data offset
+    private long dataMax = 0L;
+
+    public OffsetPubItem(int storeId, int numPart,
+            long indexMinOffset, long indexMaxOffset,
+            long dataMinOffset, long dataMaxOffset) {
+        this.storeId = storeId;
+        this.numPart = numPart;
+        this.indexMin = indexMinOffset;
+        this.indexMax = indexMaxOffset;
+        this.dataMin = dataMinOffset;
+        this.dataMax = dataMaxOffset;
+    }
+
+    public int getStoreId() {
+        return storeId;
+    }
+
+    public int getNumPart() {
+        return numPart;
+    }
+
+    public long getIndexMin() {
+        return indexMin;
+    }
+
+    public long getIndexMax() {
+        return indexMax;
+    }
+
+    public long getDataMin() {
+        return dataMin;
+    }
+
+    public long getDataMax() {
+        return dataMax;
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/topicpub/TopicPubInfo.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/offset/topicpub/TopicPubInfo.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.tubemq.server.broker.offset.topicpub;
+
+import org.apache.inlong.tubemq.corebase.TBaseConstants;
+import org.apache.inlong.tubemq.corebase.rv.ProcessResult;
+import org.apache.inlong.tubemq.corebase.utils.Tuple4;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The offset snapshot of the topic.
+ */
+public class TopicPubInfo {
+
+    private final String topicName;
+    Map<Integer, OffsetPubItem> storeOffsetMap = new HashMap<>();
+
+    public TopicPubInfo(String topicName) {
+        this.topicName = topicName;
+    }
+
+    public void addStorePubInfo(int storeId, int numPart,
+            long indexMinOffset, long indexMaxOffset,
+            long dataMinOffset, long dataMaxOffset) {
+        storeOffsetMap.put(storeId, new OffsetPubItem(storeId, numPart,
+                indexMinOffset, indexMaxOffset, dataMinOffset, dataMaxOffset));
+    }
+
+    public String getTopicName() {
+        return topicName;
+    }
+
+    public OffsetPubItem getTopicStorePubInfo(int storeId) {
+        return storeOffsetMap.get(storeId);
+    }
+
+    public Map<Integer, OffsetPubItem> getStoreOffsetMap() {
+        return storeOffsetMap;
+    }
+
+    /**
+     * Build brief topic produce offset information in string format
+     *
+     * @param brokerId    node id
+     * @param strBuff     string buffer
+     * @param dataTime    record build time
+     */
+    public void buildRecordInfo(int brokerId, StringBuilder strBuff, long dataTime) {
+        int itemCnt = 0;
+        strBuff.append("{\"dt\":").append(dataTime)
+                .append(",\"bId\":").append(brokerId)
+                .append(",\"ver\":").append(TBaseConstants.OFFSET_TOPIC_PUBLISH_RECORD_VERSION_1)
+                .append(",\"topic\":\"").append(topicName)
+                .append("\",\"offsets\":[");
+        for (Map.Entry<Integer, OffsetPubItem> entry : storeOffsetMap.entrySet()) {
+            if (entry == null || entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            if (itemCnt++ > 0) {
+                strBuff.append(",");
+            }
+            strBuff.append("{\"storeId\":").append(entry.getValue().getStoreId())
+                    .append(",\"numPart\":").append(entry.getValue().getNumPart())
+                    .append(",\"iMin\":").append(entry.getValue().getIndexMin())
+                    .append(",\"iMax\":").append(entry.getValue().getIndexMax())
+                    .append(",\"dMin\":").append(entry.getValue().getDataMin())
+                    .append(",\"dMax\":").append(entry.getValue().getDataMax())
+                    .append("}");
+        }
+        strBuff.append("]}");
+    }
+
+    /**
+     * Parse produce offset record info
+     *
+     * @param jsonData  string offset information
+     * @param result    process result
+     */
+    public static boolean parseRecordInfo(String topicName,
+            int curNumStores, int curNumParts,
+            String jsonData, ProcessResult result) {
+        JsonObject jsonObject;
+        // parse record
+        try {
+            jsonObject = JsonParser.parseString(jsonData).getAsJsonObject();
+        } catch (Throwable e1) {
+            result.setFailResult(String.format(
+                    "Parse topic %s offset value failure, reason is %s", topicName, e1.getMessage()));
+            return result.isSuccess();
+        }
+        // check record
+        if (jsonObject == null) {
+            result.setFailResult(String.format(
+                    "Parse error, topic %s offset value must be valid json format!", topicName));
+            return result.isSuccess();
+        }
+        if (!isFieldExist(jsonObject, topicName, "ver", result)
+                || !isFieldExist(jsonObject, topicName, "dt", result)
+                || !isFieldExist(jsonObject, topicName, "offsets", result)
+                || !isFieldExist(jsonObject, topicName, "topic", result)) {
+            return result.isSuccess();
+        }
+        int verValue = jsonObject.get("ver").getAsInt();
+        if (verValue != TBaseConstants.OFFSET_TOPIC_PUBLISH_RECORD_VERSION_1) {
+            result.setFailResult(String.format(
+                    "Un-support %d version in %s's offset value!", verValue, topicName));
+            return result.isSuccess();
+        }
+        long dataTime = jsonObject.get("dt").getAsLong();
+        String targetTopic = jsonObject.get("topic").getAsString();
+        if (!topicName.equals(targetTopic)) {
+            result.setFailResult(String.format(
+                    "FIELD topic value %s not equals required value %s!", targetTopic, topicName));
+            return result.isSuccess();
+        }
+        // get offsets
+        int storeId;
+        int baseValue;
+        long offsetVal;
+        JsonObject itemInfo;
+        JsonArray records = jsonObject.get("offsets").getAsJsonArray();
+        List<Tuple4<Long, String, Integer, Long>> resetOffsets = new ArrayList<>();
+        for (int i = 0; i < records.size(); i++) {
+            itemInfo = records.get(i).getAsJsonObject();
+            if (itemInfo == null) {
+                continue;
+            }
+            storeId = itemInfo.get("storeId").getAsInt();
+            offsetVal = itemInfo.get("iMax").getAsLong();
+            baseValue = storeId * TBaseConstants.META_STORE_INS_BASE;
+            for (int j = 0; j < curNumParts; j++) {
+                resetOffsets.add(new Tuple4<>(dataTime, topicName, baseValue + j, offsetVal));
+            }
+        }
+        for (int i = records.size(); i < curNumStores; i++) {
+            baseValue = i * TBaseConstants.META_STORE_INS_BASE;
+            for (int j = 0; j < curNumParts; j++) {
+                resetOffsets.add(new Tuple4<>(dataTime, topicName, baseValue + j, 0L));
+            }
+        }
+        result.setSuccResult(resetOffsets);
+        return result.isSuccess();
+    }
+
+    private static boolean isFieldExist(
+            JsonObject jsonObject, String topic, String key, ProcessResult result) {
+        if (!jsonObject.has(key)) {
+            result.setFailResult(String.format(
+                    "FIELD %s is required in %s's offset value!", key, topic));
+            return result.isSuccess();
+        }
+        return true;
+    }
+}

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/BrokerSrvStatsHolder.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/broker/stats/BrokerSrvStatsHolder.java
@@ -127,6 +127,14 @@ public class BrokerSrvStatsHolder {
         switchableSets[getIndex()].zkExcStats.incValue();
     }
 
+    public static void incOffsetFileExcCnt() {
+        switchableSets[getIndex()].offsetFileExcStats.incValue();
+    }
+
+    public static void updOffsetFileSyncDataDlt(long dltTime) {
+        switchableSets[getIndex()].offsetFileSyncDltStats.update(dltTime);
+    }
+
     public static void updDiskSyncDataDlt(long dltTime) {
         if (detailStatsClosed) {
             return;
@@ -192,6 +200,8 @@ public class BrokerSrvStatsHolder {
                     statsSet.fileIOExcStats.getAndResetValue());
             statsMap.put(statsSet.zkExcStats.getFullName(),
                     statsSet.zkExcStats.getAndResetValue());
+            statsMap.put(statsSet.offsetFileExcStats.getFullName(),
+                    statsSet.offsetFileExcStats.getAndResetValue());
             statsMap.put(statsSet.brokerTimeoutStats.getFullName(),
                     statsSet.brokerTimeoutStats.getAndResetValue());
             statsMap.put(statsSet.brokerHBExcStats.getFullName(),
@@ -203,6 +213,7 @@ public class BrokerSrvStatsHolder {
             statsMap.put(statsSet.errPubOverFlowStats.getFullName(),
                     statsSet.errPubOverFlowStats.getAndResetValue());
             statsSet.fileSyncDltStats.snapShort(statsMap, false);
+            statsSet.offsetFileSyncDltStats.snapShort(statsMap, false);
             statsSet.zkSyncDltStats.snapShort(statsMap, false);
             statsSet.msgPubLatencyStats.snapShort(statsMap, false);
             statsSet.msgSubLatencyStats.snapShort(statsMap, false);
@@ -212,6 +223,8 @@ public class BrokerSrvStatsHolder {
                     statsSet.fileIOExcStats.getValue());
             statsMap.put(statsSet.zkExcStats.getFullName(),
                     statsSet.zkExcStats.getValue());
+            statsMap.put(statsSet.offsetFileExcStats.getFullName(),
+                    statsSet.offsetFileExcStats.getValue());
             statsMap.put(statsSet.brokerTimeoutStats.getFullName(),
                     statsSet.brokerTimeoutStats.getValue());
             statsMap.put(statsSet.brokerHBExcStats.getFullName(),
@@ -223,6 +236,7 @@ public class BrokerSrvStatsHolder {
             statsMap.put(statsSet.errPubOverFlowStats.getFullName(),
                     statsSet.errPubOverFlowStats.getValue());
             statsSet.fileSyncDltStats.getValue(statsMap, false);
+            statsSet.offsetFileSyncDltStats.getValue(statsMap, false);
             statsSet.zkSyncDltStats.getValue(statsMap, false);
             statsSet.msgPubLatencyStats.getValue(statsMap, false);
             statsSet.msgSubLatencyStats.getValue(statsMap, false);
@@ -241,6 +255,8 @@ public class BrokerSrvStatsHolder {
                     .append("\":").append(statsSet.fileIOExcStats.getAndResetValue())
                     .append(",\"").append(statsSet.zkExcStats.getFullName())
                     .append("\":").append(statsSet.zkExcStats.getAndResetValue())
+                    .append(",\"").append(statsSet.offsetFileExcStats.getFullName())
+                    .append("\":").append(statsSet.offsetFileExcStats.getAndResetValue())
                     .append(",\"").append(statsSet.brokerTimeoutStats.getFullName())
                     .append("\":").append(statsSet.brokerTimeoutStats.getAndResetValue())
                     .append(",\"").append(statsSet.brokerHBExcStats.getFullName())
@@ -253,6 +269,8 @@ public class BrokerSrvStatsHolder {
                     .append("\":").append(statsSet.errPubOverFlowStats.getAndResetValue())
                     .append(",");
             statsSet.fileSyncDltStats.snapShort(strBuff, false);
+            strBuff.append(",");
+            statsSet.offsetFileSyncDltStats.snapShort(strBuff, false);
             strBuff.append(",");
             statsSet.zkSyncDltStats.snapShort(strBuff, false);
             strBuff.append(",");
@@ -267,6 +285,8 @@ public class BrokerSrvStatsHolder {
                     .append("\":").append(statsSet.fileIOExcStats.getValue())
                     .append(",\"").append(statsSet.zkExcStats.getFullName())
                     .append("\":").append(statsSet.zkExcStats.getValue())
+                    .append(",\"").append(statsSet.offsetFileExcStats.getFullName())
+                    .append("\":").append(statsSet.offsetFileExcStats.getAndResetValue())
                     .append(",\"").append(statsSet.brokerTimeoutStats.getFullName())
                     .append("\":").append(statsSet.brokerTimeoutStats.getValue())
                     .append(",\"").append(statsSet.brokerHBExcStats.getFullName())
@@ -279,6 +299,8 @@ public class BrokerSrvStatsHolder {
                     .append("\":").append(statsSet.errPubOverFlowStats.getValue())
                     .append(",");
             statsSet.fileSyncDltStats.getValue(strBuff, false);
+            strBuff.append(",");
+            statsSet.offsetFileSyncDltStats.getValue(strBuff, false);
             strBuff.append(",");
             statsSet.zkSyncDltStats.getValue(strBuff, false);
             strBuff.append(",");
@@ -331,6 +353,11 @@ public class BrokerSrvStatsHolder {
         // Zookeeper Exception statistics
         protected final LongStatsCounter zkExcStats =
                 new LongStatsCounter("zk_exc_cnt", null);
+        protected final LongStatsCounter offsetFileExcStats =
+                new LongStatsCounter("offset_file_exc_cnt", null);
+        // Delay statistics for syncing data to File offset
+        protected final ESTHistogram offsetFileSyncDltStats =
+                new ESTHistogram("offset_file_sync_dlt", null);
         // Broker 2 Master status statistics
         protected final LongStatsCounter brokerTimeoutStats =
                 new LongStatsCounter("broker_timeout_cnt", null);

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TServerConstants.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/TServerConstants.java
@@ -108,6 +108,9 @@ public final class TServerConstants {
     // max statistics token type length
     public static final int META_MAX_STATSTYPE_LENGTH = 256;
 
-    public static final int OFFSET_HISTORY_RECORD_VERSION = 1;
-    public static final int OFFSET_HISTORY_RECORD_SHORT_VERSION = 2;
+    public static final long CFG_DEF_GROUP_OFFSETS_STG_EXPIRED_DUR_MS = 20 * 24 * 60 * 60 * 1000L;
+    public static final long CFG_MIN_GROUP_OFFSETS_STG_EXPIRED_DUR_MS = 24 * 60 * 60 * 1000L;
+    public static final long CFG_GROUP_OFFSETS_STG_EXPIRED_CHECK_DUR_MS = 10 * 60 * 1000L;
+    public static final String CFG_DEF_BACKUP_PATH = "../conf";
+    public static final int CFG_MAX_BACKUP_PATH_LENGTH = 1024;
 }

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldDef.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fielddef/WebFieldDef.java
@@ -265,7 +265,11 @@ public enum WebFieldDef {
             "Reset value, default is false"),
     ENDTIME(96, "endTime", "et", WebFieldType.STRING,
             "The end record time of the historical offset of the consume group",
-            DateTimeConvertUtils.LENGTH_YYYYMMDDHHMMSS);
+            DateTimeConvertUtils.LENGTH_YYYYMMDDHHMMSS),
+    BACKUPPATH(97, "backupPath", "bPath",
+            WebFieldType.STRING, "Backup path", TServerConstants.CFG_MAX_BACKUP_PATH_LENGTH),
+    GROUPOFFSETSTORAGEEXPIREHR(98, "grpOffStgExpHr", "grpStgExp",
+            WebFieldType.INT, "Group offsets storage expired hours.", RegexDef.TMP_NUMBER);
 
     public final int id;
     public final String name;

--- a/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fileconfig/AbstractFileConfig.java
+++ b/inlong-tubemq/tubemq-server/src/main/java/org/apache/inlong/tubemq/server/common/fileconfig/AbstractFileConfig.java
@@ -251,8 +251,7 @@ public abstract class AbstractFileConfig {
     protected ZKConfig loadZKeeperSectConf(final Ini iniConf) {
         final Profile.Section zkeeperSect = iniConf.get(SECT_TOKEN_ZKEEPER);
         if (zkeeperSect == null) {
-            throw new IllegalArgumentException(new StringBuilder(256)
-                    .append(SECT_TOKEN_ZKEEPER).append(" configure section is required!").toString());
+            return null;
         }
         Set<String> configKeySet = zkeeperSect.keySet();
         if (configKeySet.isEmpty()) {

--- a/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerMetadataManagerTest.java
+++ b/inlong-tubemq/tubemq-server/src/test/java/org/apache/inlong/tubemq/server/broker/metadata/BrokerMetadataManagerTest.java
@@ -34,7 +34,7 @@ public class BrokerMetadataManagerTest {
 
     @Test
     public void updateBrokerTopicConfigMap() {
-        brokerMetadataManager = new BrokerMetadataManager();
+        brokerMetadataManager = new BrokerMetadataManager(2000L);
         // topic default config
         String newBrokerDefMetaConfInfo = "1:true:true:1000:10000:0,0,6:delete,168h:1:1000:1024:1000:1000";
         List<String> newTopicMetaConfInfoList = new LinkedList<>();
@@ -56,7 +56,8 @@ public class BrokerMetadataManagerTest {
 
     @Test
     public void updateBrokerRemoveTopicMap() {
-        brokerMetadataManager = new BrokerMetadataManager();
+        long grpOffsetExpMs = 1 * 60 * 60 * 1000L;
+        brokerMetadataManager = new BrokerMetadataManager(2000L);
         String newBrokerDefMetaConfInfo = "1:true:true:1000:10000:0,0,6:delete,168h:1:1000:1024:1000:1000";
         List<String> newTopicMetaConfInfoList = new LinkedList<>();
         // add topic custom config.


### PR DESCRIPTION

Fixes #11386

![image](https://github.com/user-attachments/assets/0aa0e7c5-644a-4f36-8e65-c01c3aeb8e26)

Optimize content:
1. Broker regularly refreshes the consumer group offset information in memory to the file Offset Cache according to the configured offsetStgCacheFlushMs value;
2. The consumer group offset information stored in the file Offset Cache is regularly written to the offsetStgFilePath/offsetDir directory according to the configured offsetStgFileSyncMs value. The file name successfully saved is offsets.meta. The persistence logic is as follows:
  - Persistently save the consumer group offset information to the file offsets.tmp. If the write fails, output the failure log, alarm and exit the persistence process;
  - Read the offsets.tmp file and compare it with the previously written information to see if it is consistent. If it is inconsistent, output the failure log and exit the persistence process;
  - Migrate the file from offsets.tmp to offsets.mid. If the offsets.meta file currently exists, change offsets.meta to offsets.old;
  - Migrate the file from offsets.mid to offsets.meta, and delete the offsets.old file at the same time.

3. Broker supports saving the current consumer group's Offset collection information to the backupPath path specified in the API interface through the HTTP API admin_backup_group_offsets. The saved file name is offsets.meta.
