### PR TITLE
[INLONG-11410][DataProxy] Fixed the bug of excessive packet length when Go SDK receives DataProxy response

### DIFF
--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/consts/StatConstants.java
@@ -77,6 +77,7 @@ public class StatConstants {
     public static final java.lang.String EVENT_MSG_TXT_LEN_MALFORMED = "msg.txt.len.malformed";
     public static final java.lang.String EVENT_MSG_ITEM_LEN_MALFORMED = "msg.item.len.malformed";
     public static final java.lang.String EVENT_MSG_TYPE_5_LEN_MALFORMED = "msg.type5.len.malformed";
+    public static final java.lang.String EVENT_MSG_TYPE_5_CNT_UNEQUAL = "msg.type5.cnt.unequal";
     public static final java.lang.String EVENT_MSG_ATTR_INVALID = "msg.attr.invalid";
     public static final java.lang.String EVENT_MSG_ORDER_ACK_INVALID = "msg.attr.order.noack";
     public static final java.lang.String EVENT_MSG_PROXY_ACK_INVALID = "msg.attr.proxy.noack";

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/ServerMessageHandler.java
@@ -565,7 +565,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
             attrsLen = byTeAttrs.length;
         }
         // binTotalLen = mstType + uniq + attrsLen + attrs + magic
-        int binTotalLen = 1 + 4 + 2 + 2 + attrsLen;
+        int binTotalLen = 1 + 4 + 2 + attrsLen + 2;
         // allocate buffer and write fields
         ByteBuf binBuffer = ByteBufAllocator.DEFAULT.buffer(4 + binTotalLen);
         binBuffer.writeInt(binTotalLen);
@@ -673,7 +673,7 @@ public class ServerMessageHandler extends ChannelInboundHandlerAdapter {
             loadValue = 0xffff;
         }
         // binTotalLen = mstType + dataTime + version + bodyLen + body + attrsLen + attrs + magic
-        int binTotalLen = 1 + 4 + 1 + 4 + 2 + 2 + 2 + attrsLen;
+        int binTotalLen = 1 + 4 + 1 + 4 + 2 + 2 + attrsLen + 2;
         // allocate buffer and write fields
         ByteBuf binBuffer = ByteBufAllocator.DEFAULT.buffer(4 + binTotalLen);
         binBuffer.writeInt(binTotalLen);

--- a/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
+++ b/inlong-dataproxy/dataproxy-source/src/main/java/org/apache/inlong/dataproxy/source/v0msg/CodecTextMsg.java
@@ -259,8 +259,12 @@ public class CodecTextMsg extends AbsV0MsgCodec {
                 inLongMsg.addMsg(mapJoiner.join(attrMap), bodyBuffer);
                 calcCnt++;
             }
-            attrMap.put(AttributeConstants.MESSAGE_COUNT, String.valueOf(calcCnt));
-            this.msgCount = calcCnt;
+            if (calcCnt != this.msgCount) {
+                this.msgCount = calcCnt;
+                source.fileMetricIncWithDetailStats(
+                        StatConstants.EVENT_MSG_TYPE_5_CNT_UNEQUAL, groupId);
+            }
+            attrMap.put(AttributeConstants.MESSAGE_COUNT, String.valueOf(this.msgCount));
         } else if (MsgType.MSG_MULTI_BODY_ATTR.equals(MsgType.valueOf(msgType))) {
             attrMap.put(AttributeConstants.MESSAGE_COUNT, String.valueOf(1));
             inLongMsg.addMsg(mapJoiner.join(attrMap), bodyData);


### PR DESCRIPTION

Fixes #11410

Fill in the length of the corresponding package attribute according to the actual setting value
