### PR TITLE
[INLONG-11412][Agent] Do not report Agent status and file metrics

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
@@ -140,31 +140,24 @@ public class AgentStatusManager {
     private String processStartupTime = format.format(runtimeMXBean.getStartTime());
     private String systemStartupTime = ExcuteLinux.exeCmd("uptime -s").replaceAll("\r|\n", "");
 
-    private AgentStatusManager(AgentManager agentManager) {
-        this.agentManager = agentManager;
+    private AgentStatusManager() {
         this.conf = AgentConfiguration.getAgentConf();
         threadBean = ManagementFactory.getThreadMXBean();
     }
 
-    public static AgentStatusManager getInstance(AgentManager agentManager) {
-        if (manager == null) {
-            synchronized (AgentStatusManager.class) {
-                if (manager == null) {
-                    manager = new AgentStatusManager(agentManager);
-                }
+    public static void init() {
+        synchronized (AgentStatusManager.class) {
+            if (manager == null) {
+                manager = new AgentStatusManager();
             }
         }
+    }
+
+    private static AgentStatusManager getInstance() {
         return manager;
     }
 
-    public static AgentStatusManager getInstance() {
-        if (manager == null) {
-            throw new RuntimeException("HeartbeatManager has not been initialized by agentManager");
-        }
-        return manager;
-    }
-
-    public void sendStatusMsg(DefaultMessageSender sender) {
+    private void doSendStatusMsg(DefaultMessageSender sender) {
         AgentStatus data = AgentStatusManager.getInstance().getStatus();
         LOGGER.info("status detail: {}", data);
         if (sender == null) {
@@ -177,6 +170,12 @@ public class AgentStatusManager {
                 "", 30, TimeUnit.SECONDS);
         if (ret != SendResult.OK) {
             LOGGER.error("send status failed: ret {}", ret);
+        }
+    }
+
+    public static void sendStatusMsg(DefaultMessageSender sender) {
+        if (AgentStatusManager.getInstance() != null) {
+            AgentStatusManager.getInstance().doSendStatusMsg(sender);
         }
     }
 

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
@@ -140,15 +140,16 @@ public class AgentStatusManager {
     private String processStartupTime = format.format(runtimeMXBean.getStartTime());
     private String systemStartupTime = ExcuteLinux.exeCmd("uptime -s").replaceAll("\r|\n", "");
 
-    private AgentStatusManager() {
+    private AgentStatusManager(AgentManager agentManager) {
         this.conf = AgentConfiguration.getAgentConf();
         threadBean = ManagementFactory.getThreadMXBean();
+        this.agentManager = agentManager;
     }
 
-    public static void init() {
+    public static void init(AgentManager agentManager) {
         synchronized (AgentStatusManager.class) {
             if (manager == null) {
-                manager = new AgentStatusManager();
+                manager = new AgentStatusManager(agentManager);
             }
         }
     }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -75,8 +75,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
         baseManagerUrl = httpManager.getBaseUrl();
         reportHeartbeatUrl = buildReportHeartbeatUrl(baseManagerUrl);
         createMessageSender();
-        AgentStatusManager.getInstance(agentManager);
-        FileStaticManager.getInstance(agentManager);
     }
 
     public static HeartbeatManager getInstance(AgentManager agentManager) {
@@ -126,8 +124,8 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
                     if (sender == null) {
                         createMessageSender();
                     }
-                    AgentStatusManager.getInstance().sendStatusMsg(sender);
-                    FileStaticManager.getInstance().sendStaticMsg(sender);
+                    AgentStatusManager.sendStatusMsg(sender);
+                    FileStaticManager.sendStaticMsg(sender);
                 } catch (Throwable e) {
                     LOGGER.error("interrupted while report heartbeat", e);
                     ThreadUtils.threadThrowableHandler(Thread.currentThread(), e);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -323,9 +323,6 @@ public class LogFileSource extends AbstractSource {
     protected void releaseSource() {
         if (randomAccessFile != null) {
             try {
-                if (FileStaticManager.getInstance() == null) {
-                    return;
-                }
                 FileStatic data = new FileStatic();
                 data.setTaskId(taskId);
                 data.setRetry(String.valueOf(profile.isRetry()));
@@ -342,7 +339,7 @@ public class LogFileSource extends AbstractSource {
                     return;
                 }
                 data.setSendLines(offsetProfile.getOffset());
-                FileStaticManager.getInstance().putStaticMsg(data);
+                FileStaticManager.putStaticMsg(data);
                 randomAccessFile.close();
             } catch (IOException e) {
                 LOGGER.error("close randomAccessFile error", e);


### PR DESCRIPTION
Fixes #11412

### Motivation

Prevent printing too many error logs

### Modifications

Do not report Agent status and file metrics

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
