### PR TITLE
[INLONG-11444][Distribution] Fix the merging modules jars failure

### DIFF
--- a/inlong-distribution/pom.xml
+++ b/inlong-distribution/pom.xml
@@ -33,32 +33,6 @@
         <inlong.root.dir>${project.parent.basedir}</inlong.root.dir>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec.maven.version}</version>
-                <configuration>
-                    <executable>bash</executable>
-                    <arguments>
-                        <argument>+x</argument>
-                        <argument>${basedir}/script/backup_module_dependencies.sh</argument>
-                    </arguments>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>uncompress</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>flink-all-version</id>
@@ -103,6 +77,27 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.maven.version}</version>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>${basedir}/script/backup_module_dependencies.sh</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>uncompress</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -141,6 +136,27 @@
                                         <descriptor>src/main/assemblies/sort-connectors-v1.13.xml</descriptor>
                                     </descriptors>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.maven.version}</version>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>${basedir}/script/backup_module_dependencies.sh</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>uncompress</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>
@@ -185,6 +201,27 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.maven.version}</version>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>${basedir}/script/backup_module_dependencies.sh</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>uncompress</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -223,6 +260,27 @@
                                         <descriptor>src/main/assemblies/sort-connectors-v1.18.xml</descriptor>
                                     </descriptors>
                                 </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${exec.maven.version}</version>
+                        <configuration>
+                            <executable>bash</executable>
+                            <arguments>
+                                <argument>+x</argument>
+                                <argument>${basedir}/script/backup_module_dependencies.sh</argument>
+                            </arguments>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>uncompress</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <phase>package</phase>
                             </execution>
                         </executions>
                     </plugin>

--- a/inlong-distribution/script/backup_module_dependencies.sh
+++ b/inlong-distribution/script/backup_module_dependencies.sh
@@ -34,11 +34,13 @@ filelist() {
 }
 
 # Get the current version for InLong
-find_gz_file=`ls -l ./target/*bin.tar.gz |awk '{print $9}'`
+prefix="apache-inlong-"
+suffix="-bin.tar.gz"
+find_gz_file=$(ls -l ./target/*bin.tar.gz |awk '{print $9}')
 gz_file=$(basename "$find_gz_file")
-name_length=`expr length $gz_file`
-version_length=$(expr $name_length \- 15 \- 10)
-project_version=`expr substr $gz_file 15 $version_length`
+version_with_suffix="${gz_file#$prefix}"
+project_version="${version_with_suffix%$suffix}"
+echo "The current version for InLong is: $project_version"
 projectpath="./target/apache-inlong-${project_version}-bin/apache-inlong-${project_version}"
 
 # Generate the file "dependencys.txt"


### PR DESCRIPTION

Fixes #11444 

### Motivation

Fix the merging modules jars failure, the reason is that the actions of `backup_module_dependencies` should be executed after the `apache-inlong-xxx-SNAPSHOT-bin.tar.gz` is created.

### Modifications

1.  move `backup_module_dependencies` to the place after assemble
2. improve the logic to find inlong version in backup_module_dependencies`

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

