### PR TITLE
[INLONG-11451][Agent] Prevent Installer from detecting process misjudgment

### DIFF
--- a/inlong-agent/agent-installer/src/test/java/installer/TestModuleManager.java
+++ b/inlong-agent/agent-installer/src/test/java/installer/TestModuleManager.java
@@ -138,7 +138,7 @@ public class TestModuleManager {
             PowerMockito.doAnswer(invocation -> {
                 ModuleConfig module = invocation.getArgument(0);
                 return true;
-            }).when(manager, "isProcessAllStarted", Mockito.any());
+            }).when(manager, "isProcessAllStarted", Mockito.any(), Mockito.anyInt());
 
             PowerMockito.doReturn(null).when(manager, "getHttpManager", Mockito.any());
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #11451 

### Motivation

The current Installer detection interval is too short, which can easily lead to misjudgment

### Modifications

When the Installer detects that the process does not exist, it increases the wait for retry to prevent misjudgment

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
