### PR TITLE
[INLONG-11457][SDK] Optimize SequentialID class implementation

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SequentialID.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SequentialID.java
@@ -17,32 +17,25 @@
 
 package org.apache.inlong.sdk.dataproxy.network;
 
-import java.util.concurrent.atomic.AtomicLong;
+import java.security.SecureRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class SequentialID {
-
-    private static final long maxId = 2000000000;
-    private String ip = null;
-    private AtomicLong id = new AtomicLong(0);
+    private static final SecureRandom sRandom = new SecureRandom(
+            Long.toString(System.nanoTime()).getBytes());
+    private final String ip;
+    private final AtomicInteger id = new AtomicInteger(sRandom.nextInt());
 
     public SequentialID(String theIp) {
         ip = theIp;
     }
 
-    public synchronized String getNextId() {
-        if (id.get() > maxId) {
-            id.set(0);
-        }
-        id.incrementAndGet();
-        return ip + "#" + id.toString() + "#" + System.currentTimeMillis();
+    public String getNextId() {
+        return ip + "#" + id.incrementAndGet() + "#" + System.currentTimeMillis();
     }
 
-    public synchronized long getNextInt() {
-        if (id.get() > maxId) {
-            id.set(0);
-        }
-        id.incrementAndGet();
-        return id.get();
+    public int getNextInt() {
+        return id.incrementAndGet();
     }
 
 }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SequentialID.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SequentialID.java
@@ -21,6 +21,7 @@ import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SequentialID {
+
     private static final SecureRandom sRandom = new SecureRandom(
             Long.toString(System.nanoTime()).getBytes());
     private final String ip;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/network/TcpChannel.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/network/TcpChannel.java
@@ -159,7 +159,7 @@ public class TcpChannel {
      * acquireUninterruptibly
      */
     public void acquireUninterruptibly() {
-        packToken.acquireUninterruptibly();;
+        packToken.acquireUninterruptibly();
     }
 
     /**


### PR DESCRIPTION
Fixes #11457

1. Remove the synchronized modifier from the SeqId method
2. Save the id field as AtomicInteger to avoid out-of-bounds judgment every call;
3. Initialize the id value to a random value to avoid duplicate IDs generated on the virtual machine