### PR TITLE
[INLONG-11461][Agent] HeartbeatManager does not create a DefaultMessageSender

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -74,7 +74,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
         httpManager = new HttpManager(conf);
         baseManagerUrl = httpManager.getBaseUrl();
         reportHeartbeatUrl = buildReportHeartbeatUrl(baseManagerUrl);
-        createMessageSender();
     }
 
     public static HeartbeatManager getInstance(AgentManager agentManager) {
@@ -120,9 +119,6 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
                     reportHeartbeat(heartbeatMsg);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(" {} report heartbeat to manager", heartbeatMsg);
-                    }
-                    if (sender == null) {
-                        createMessageSender();
                     }
                     AgentStatusManager.sendStatusMsg(sender);
                     FileStaticManager.sendStaticMsg(sender);


### PR DESCRIPTION
Fixes #11461 

### Motivation

To prevent interference from error logs

### Modifications

HeartbeatManager does not create a DefaultMessageSender

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
