### PR TITLE
[INLONG-11455][Sort] Only one OpenTelemetryAppender should be registered

### DIFF
--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
@@ -213,7 +213,7 @@ public class OpenTelemetryLogger {
             OpenTelemetryAppender.install(SDK);
             otelAppender.append(
                     new Log4jLogEvent.Builder()
-                            .setLevel(this.logLevel)
+                            .setLevel(Level.INFO)
                             .setMessage(new SimpleMessage("OpenTelemetryLogger installed"))
                             .build());
             return true;
@@ -240,7 +240,7 @@ public class OpenTelemetryLogger {
                 if (appender instanceof OpenTelemetryAppender) {
                     appender.append(
                             new Log4jLogEvent.Builder()
-                                    .setLevel(this.logLevel)
+                                    .setLevel(Level.INFO)
                                     .setMessage(new SimpleMessage("OpenTelemetryLogger uninstalled"))
                                     .build());
                     config.getRootLogger().removeAppender(appender.getName());

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
@@ -211,6 +211,7 @@ public class OpenTelemetryLogger {
             createOpenTelemetrySdk();
             // install OpenTelemetryAppender
             OpenTelemetryAppender.install(SDK);
+            LOG.info("OpenTelemetryLogger installed");
             otelAppender.append(
                     new Log4jLogEvent.Builder()
                             .setLevel(Level.INFO)
@@ -238,6 +239,7 @@ public class OpenTelemetryLogger {
             Configuration config = loggerContext.getConfiguration();
             config.getAppenders().values().forEach(appender -> {
                 if (appender instanceof OpenTelemetryAppender) {
+                    LOG.info("OpenTelemetryLogger uninstalled");
                     appender.append(
                             new Log4jLogEvent.Builder()
                                     .setLevel(Level.INFO)

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
@@ -33,7 +33,9 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.PatternLayout;
+import org.apache.logging.log4j.message.SimpleMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -209,7 +211,11 @@ public class OpenTelemetryLogger {
             createOpenTelemetrySdk();
             // install OpenTelemetryAppender
             OpenTelemetryAppender.install(SDK);
-            LOG.info("OpenTelemetryLogger installed");
+            otelAppender.append(
+                    new Log4jLogEvent.Builder()
+                            .setLevel(this.logLevel)
+                            .setMessage(new SimpleMessage("OpenTelemetryLogger installed"))
+                            .build());
             return true;
         }
     }
@@ -232,7 +238,11 @@ public class OpenTelemetryLogger {
             Configuration config = loggerContext.getConfiguration();
             config.getAppenders().values().forEach(appender -> {
                 if (appender instanceof OpenTelemetryAppender) {
-                    LOG.info("Uninstall OpenTelemetryLogger");
+                    appender.append(
+                            new Log4jLogEvent.Builder()
+                                    .setLevel(this.logLevel)
+                                    .setMessage(new SimpleMessage("OpenTelemetryLogger uninstalled"))
+                                    .build());
                     config.getRootLogger().removeAppender(appender.getName());
                     appender.stop();
                 }

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/util/OpenTelemetryLogger.java
@@ -182,7 +182,7 @@ public class OpenTelemetryLogger {
         synchronized (OpenTelemetryLogger.class) {
             org.apache.logging.log4j.spi.LoggerContext loggerContextSpi = LogManager.getContext(false);
             if (!(loggerContextSpi instanceof LoggerContext)) {
-                LOG.warn("LoggerContext is not instance of LoggerContext");
+                LOG.warn("LoggerContext is not instance of org.apache.logging.log4j.core.LoggerContext");
                 return false;
             }
             LoggerContext loggerContext = (LoggerContext) loggerContextSpi;
@@ -231,7 +231,7 @@ public class OpenTelemetryLogger {
             }
             org.apache.logging.log4j.spi.LoggerContext loggerContextSpi = LogManager.getContext(false);
             if (!(loggerContextSpi instanceof LoggerContext)) {
-                LOG.warn("LoggerContext is not instance of LoggerContext");
+                LOG.warn("LoggerContext is not instance of org.apache.logging.log4j.core.LoggerContext");
                 return false;
             }
             LoggerContext loggerContext = (LoggerContext) loggerContextSpi;


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11455 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

Only one OpenTelemetryAppender should be registered

### Modifications

<!--Describe the modifications you've done.-->

Added duplicate registration judgment to the install and uninstall functions, and use synchronized locks to ensure concurrency safety.

Furthermore, since users may set different logging levels, force log messages to be appended on successful installs and uninstalls to ensure successful reporting at any logging level. This also makes it easier to write unit tests to check that the logging reports are working.

```java
before:
LOG.info("OpenTelemetryLogger installed");

now:
otelAppender.append(
                    new Log4jLogEvent.Builder()
                        .setLevel(Level.INFO)
                        .setMessage(new SimpleMessage("OpenTelemetryLogger installed"))
                        .build());
```

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
