### PR TITLE
[INLONG-11489][Audit] Use Throwable instead of Exception to capture Java package conflicts

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/utils/HttpUtils.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/utils/HttpUtils.java
@@ -98,8 +98,9 @@ public class HttpUtils {
                     return responseStr;
                 }
             }
-        } catch (Exception e) {
-            LOGGER.error("Send get request has exception", e);
+        } catch (Throwable e) {
+            LOGGER.error("Http request url = {}, secretId = {}, secretKey = {}, component = {} has exception!", url,
+                    secretId, secretKey, component, e);
         }
         return null;
     }


### PR DESCRIPTION
- Fixes #11489

### Motivation

Use Throwable instead of Exception to capture Java package conflicts.

### Modifications

Use Throwable instead of Exception to capture Java package conflict issues and facilitate troubleshooting.
