### PR TITLE
[INLONG-11491][SDK] Fix the judgment error of onMessageAck function in MetricSendCallBack class

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/MetricWorkerThread.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/MetricWorkerThread.java
@@ -287,7 +287,7 @@ public class MetricWorkerThread extends Thread implements Closeable {
 
         @Override
         public void onMessageAck(SendResult result) {
-            if (!SendResult.OK.equals(result)) {
+            if (SendResult.OK.equals(result)) {
                 logger.debug("Send metric is ok!");
             } else {
                 tryToSendMetricToManager(encodeObject, this);


### PR DESCRIPTION

Fixes #11491 


