### PR TITLE
[INLONG-11499][Agent] By default, use the locally configured audit address

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -68,7 +68,7 @@ public class AgentConstants {
 
     public static final String AUDIT_ENABLE = "audit.enable";
     public static final boolean DEFAULT_AUDIT_ENABLE = true;
-    public static final String AUDIT_PROXY_ADDRESS = "audit.proxy.address";
+    public static final String AUDIT_PROXY_ADDRESS = "audit.proxys";
 
     public static final String AGENT_HISTORY_PATH = "agent.history.path";
     public static final String DEFAULT_AGENT_HISTORY_PATH = ".history";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -68,6 +68,7 @@ public class AgentConstants {
 
     public static final String AUDIT_ENABLE = "audit.enable";
     public static final boolean DEFAULT_AUDIT_ENABLE = true;
+    public static final String AUDIT_PROXY_ADDRESS = "audit.proxy.address";
 
     public static final String AGENT_HISTORY_PATH = "agent.history.path";
     public static final String DEFAULT_AGENT_HISTORY_PATH = ".history";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/audit/AuditUtils.java
@@ -22,7 +22,10 @@ import org.apache.inlong.agent.constant.AgentConstants;
 import org.apache.inlong.audit.AuditOperator;
 import org.apache.inlong.audit.entity.AuditComponent;
 
+import java.util.HashSet;
+
 import static org.apache.inlong.agent.constant.AgentConstants.AUDIT_ENABLE;
+import static org.apache.inlong.agent.constant.AgentConstants.AUDIT_PROXY_ADDRESS;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AUDIT_ENABLE;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_ADDR;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_ID;
@@ -67,8 +70,14 @@ public class AuditUtils {
     public static void initAudit(AbstractConfiguration conf) {
         IS_AUDIT = conf.getBoolean(AUDIT_ENABLE, DEFAULT_AUDIT_ENABLE);
         if (IS_AUDIT) {
-            AuditOperator.getInstance().setAuditProxy(AuditComponent.AGENT, conf.get(AGENT_MANAGER_ADDR),
-                    conf.get(AGENT_MANAGER_AUTH_SECRET_ID), conf.get(AGENT_MANAGER_AUTH_SECRET_KEY));
+            if (conf.hasKey(AUDIT_PROXY_ADDRESS)) {
+                HashSet<String> address = new HashSet<>();
+                address.add(conf.get(AUDIT_PROXY_ADDRESS));
+                AuditOperator.getInstance().setAuditProxy(address);
+            } else {
+                AuditOperator.getInstance().setAuditProxy(AuditComponent.AGENT, conf.get(AGENT_MANAGER_ADDR),
+                        conf.get(AGENT_MANAGER_AUTH_SECRET_ID), conf.get(AGENT_MANAGER_AUTH_SECRET_KEY));
+            }
             AuditOperator.getInstance().setLocalIP(conf.get(AgentConstants.AGENT_LOCAL_IP));
         }
     }

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -98,3 +98,7 @@ agent.prometheus.exporter.port=9080
 ############################
 # whether to enable audit
 audit.enable=true
+# Audit proxy address
+# By default, the audit address is obtained from the manager, and only in special circumstances do
+# special addresses need to be specified through this configuration option
+# audit.proxys=


### PR DESCRIPTION
Fixes #11499 

### Motivation

Sometimes it is necessary to assign dedicated audit addresses to certain machines

### Modifications

By default, use the locally configured audit address

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
