### PR TITLE
[INLONG-11531][Manager] Fix bug in DolphinScheduler engine

### DIFF
--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleConstants.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleConstants.java
@@ -22,6 +22,7 @@ public class DolphinScheduleConstants {
     // DS public constants
     public static final String DS_ID = "id";
     public static final String DS_CODE = "code";
+    public static final String DS_SUCCESS = "success";
     public static final String DS_TOKEN = "token";
     public static final String DS_PAGE_SIZE = "pageSize";
     public static final String DS_PAGE_NO = "pageNo";
@@ -29,6 +30,8 @@ public class DolphinScheduleConstants {
     public static final String DS_RESPONSE_DATA = "data";
     public static final String DS_RESPONSE_NAME = "name";
     public static final String DS_RESPONSE_TOTAL_LIST = "totalList";
+    public static final int DS_DEFAULT_RETRY_TIMES = 3;
+    public static final int DS_DEFAULT_WAIT_MILLS = 1000;
     public static final String DS_DEFAULT_PAGE_SIZE = "10";
     public static final String DS_DEFAULT_PAGE_NO = "1";
     public static final String DS_DEFAULT_TIMEZONE_ID = "Asia/Shanghai";

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngine.java
@@ -132,6 +132,7 @@ public class DolphinScheduleEngine implements ScheduleEngine {
     @Override
     @VisibleForTesting
     public boolean handleRegister(ScheduleInfo scheduleInfo) {
+        start();
         String processDefUrl = projectBaseUrl + "/" + projectCode + DS_PROCESS_URL;
         String scheduleUrl = projectBaseUrl + "/" + projectCode + DS_SCHEDULE_URL;
         String processName = scheduleInfo.getInlongGroupId() + DS_DEFAULT_PROCESS_NAME;
@@ -191,6 +192,7 @@ public class DolphinScheduleEngine implements ScheduleEngine {
     @Override
     @VisibleForTesting
     public boolean handleUnregister(String groupId) {
+        start();
         String processName = groupId + DS_DEFAULT_PROCESS_NAME;
         String processDefUrl = projectBaseUrl + "/" + projectCode + DS_PROCESS_URL;
 
@@ -224,6 +226,7 @@ public class DolphinScheduleEngine implements ScheduleEngine {
     @Override
     @VisibleForTesting
     public boolean handleUpdate(ScheduleInfo scheduleInfo) {
+        start();
         LOGGER.info("Update dolphin schedule info for {}", scheduleInfo.getInlongGroupId());
         try {
             return handleUnregister(scheduleInfo.getInlongGroupId()) && handleRegister(scheduleInfo);

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngine.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngine.java
@@ -226,7 +226,6 @@ public class DolphinScheduleEngine implements ScheduleEngine {
     @Override
     @VisibleForTesting
     public boolean handleUpdate(ScheduleInfo scheduleInfo) {
-        start();
         LOGGER.info("Update dolphin schedule info for {}", scheduleInfo.getInlongGroupId());
         try {
             return handleUnregister(scheduleInfo.getInlongGroupId()) && handleRegister(scheduleInfo);

--- a/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/exception/DolphinScheduleException.java
+++ b/inlong-manager/manager-schedule/src/main/java/org/apache/inlong/manager/schedule/exception/DolphinScheduleException.java
@@ -42,6 +42,7 @@ public class DolphinScheduleException extends RuntimeException {
     public static final String GEN_TASK_CODE_FAILED = "GEN_TASK_CODE_FAILED";
 
     // Process-related error codes
+    public static final int PROCESS_DEFINITION_IN_USED_ERROR = 10163;
     public static final String PROCESS_DEFINITION_QUERY_FAILED = "PROCESS_DEFINITION_QUERY_FAILED";
     public static final String PROCESS_DEFINITION_CREATION_FAILED = "PROCESS_DEFINITION_CREATION_FAILED";
     public static final String PROCESS_DEFINITION_RELEASE_FAILED = "PROCESS_DEFINITION_RELEASE_FAILED";

--- a/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngineTest.java
+++ b/inlong-manager/manager-schedule/src/test/java/org/apache/inlong/manager/schedule/dolphinscheduler/DolphinScheduleEngineTest.java
@@ -53,7 +53,6 @@ public class DolphinScheduleEngineTest extends DolphinScheduleContainerTestEnv {
 
         String token = accessToken();
         dolphinScheduleEngine.setToken(token);
-        dolphinScheduleEngine.start();
     }
 
     @AfterAll


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11531 

### Motivation
* A project in DS engine doesn't need to be created at bean initialize time, so it only needs to be called when a register-related-handle method is called, and this also allows data synchronization at each processing time
* delete operation need to add retry mechanism

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications
* add `start()` method in `handleRegister()`, `handleUnregister()` and `handleUpdate()`, before related operation be called
* because of situation below, deleting operation should add retry mechanism
![image](https://github.com/user-attachments/assets/b3b7283a-13e1-44d4-9a77-a44f9a79c6e0)


<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
