### PR TITLE
[INLONG-11537][Sort] Optimize the session key generation of TubeMQ Source

### DIFF
--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/src/main/java/org/apache/inlong/sort/tubemq/FlinkTubeMQConsumer.java
@@ -221,7 +221,10 @@ public class FlinkTubeMQConsumer<T> extends RichParallelSourceFunction<T>
         messagePullConsumer = messageSessionFactory.createPullConsumer(consumerConfig);
         messagePullConsumer.subscribe(topic, streamIdSet);
         String jobId = getRuntimeContext().getJobId().toString();
-        messagePullConsumer.completeSubscribe(sessionKey.concat(jobId), numTasks, true, currentOffsets);
+        String attemptNumber = String.valueOf(getRuntimeContext().getAttemptNumber());
+        String startSessionKey = sessionKey.concat("_").concat(jobId).concat("_").concat(attemptNumber);
+        LOG.info("start to init tube mq consumer, session key={}", startSessionKey);
+        messagePullConsumer.completeSubscribe(startSessionKey, numTasks, true, currentOffsets);
 
         running = true;
     }


### PR DESCRIPTION


<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11537 

### Motivation

Optimize the session key generation of TubeMQ Source

### Modifications

The original way to generate a session key is to combine the job id with the base session key, which leads to data loss in the case of flink failover with only one task restart due to the reuse of the same session key.

The more reasonable way is to find a unique key different from the former one after each failover.

![image](https://github.com/user-attachments/assets/755c542b-93f0-471b-97a7-d1d53984426b)



### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
