### PR TITLE
[INLONG-11546][SDK] Support async and sync report dirty data

### DIFF
--- a/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
+++ b/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
@@ -77,10 +77,12 @@ public class InlongSdkDirtySender {
         dirtyDataQueue.put(messageWrapper);
     }
 
-    public void sendDirtyMessageAsync(DirtyMessageWrapper messageWrapper) throws InterruptedException {
-        if(!dirtyDataQueue.offer(messageWrapper)) {
-            log.warn("the dirty data queue is full, you can increase the size of queue by configure maxCallbackSize");
+    public boolean sendDirtyMessageAsync(DirtyMessageWrapper messageWrapper) {
+        boolean result = dirtyDataQueue.offer(messageWrapper);
+        if (!result) {
+            log.warn("send dirty message async queue is full, you can increase maxCallbackSize");
         }
+        return result;
     }
 
     private void doSendDirtyMessage() {

--- a/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
+++ b/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
@@ -74,8 +74,14 @@ public class InlongSdkDirtySender {
         log.info("init InlongSdkDirtySink successfully, target group={}, stream={}", inlongGroupId, inlongStreamId);
     }
 
-    public void sendDirtyMessage(DirtyMessageWrapper messageWrapper) throws InterruptedException {
-        dirtyDataQueue.offer(messageWrapper, 10, TimeUnit.SECONDS);
+    public void sendDirtyMessageSync(DirtyMessageWrapper messageWrapper) throws InterruptedException {
+        dirtyDataQueue.put(messageWrapper);
+    }
+
+    public void sendDirtyMessageAsync(DirtyMessageWrapper messageWrapper) throws InterruptedException {
+        if(!dirtyDataQueue.offer(messageWrapper)) {
+            log.warn("the dirty data queue is full, you can increase the size of queue by configure maxCallbackSize");
+        }
     }
 
     private void doSendDirtyMessage() {

--- a/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
+++ b/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
@@ -78,11 +78,7 @@ public class InlongSdkDirtySender {
     }
 
     public boolean sendDirtyMessageAsync(DirtyMessageWrapper messageWrapper) {
-        boolean result = dirtyDataQueue.offer(messageWrapper);
-        if (!result) {
-            log.warn("send dirty message async queue is full, you can increase maxCallbackSize");
-        }
-        return result;
+        return dirtyDataQueue.offer(messageWrapper);
     }
 
     private void doSendDirtyMessage() {

--- a/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
+++ b/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
@@ -73,7 +73,7 @@ public class InlongSdkDirtySender {
         log.info("init InlongSdkDirtySink successfully, target group={}, stream={}", inlongGroupId, inlongStreamId);
     }
 
-    public void sendDirtyMessageSync(DirtyMessageWrapper messageWrapper) throws InterruptedException {
+    public void sendDirtyMessage(DirtyMessageWrapper messageWrapper) throws InterruptedException {
         dirtyDataQueue.put(messageWrapper);
     }
 

--- a/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
+++ b/inlong-sdk/dirty-data-sdk/src/main/java/org/apache/inlong/sdk/dirtydata/InlongSdkDirtySender.java
@@ -31,7 +31,6 @@ import java.net.InetAddress;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Builder

--- a/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/sdk/InlongSdkDirtySink.java
+++ b/inlong-sort/sort-flink/base/src/main/java/org/apache/inlong/sort/base/dirty/sink/sdk/InlongSdkDirtySink.java
@@ -74,7 +74,7 @@ public class InlongSdkDirtySink<T> implements DirtySink<T> {
                     .data(dirtyMessage)
                     .build();
 
-            dirtySender.sendDirtyMessage(wrapper);
+            dirtySender.sendDirtyMessageAsync(wrapper);
         } catch (Throwable t) {
             log.error("failed to send dirty message to inlong sdk", t);
             if (!options.isIgnoreSideOutputErrors()) {


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11546 

### Motivation

Provide async and sync way to report dirty data

### Modifications

Add sendDirtyMessage and sendDirtyMessageAsync method

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
