### PR TITLE
[INLONG-11551][Manager] Add schedule engine to group info result

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/group/InlongGroupInfo.java
@@ -142,6 +142,10 @@ public abstract class InlongGroupInfo extends BaseInlongGroup {
     @ApiModelProperty("Schedule type")
     private Integer scheduleType;
 
+    // schedule engine type, support [Quartz, Airflow, DolphinScheduler]
+    @ApiModelProperty("Schedule engine")
+    private String scheduleEngine;
+
     // time unit for offline task schedule interval, support [month, week, day, hour, minute, oneround]
     // Y=year, M=month, W=week, D=day, H=hour, I=minute, O=oneround
     @ApiModelProperty("TimeUnit for schedule interval")


### PR DESCRIPTION
Fixes #11551 

### Motivation

The result for group info missed the schedule engine field. So this pull request add it.

### Modifications

Add schedule engine to group info result

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.


### Documentation

  - Does this pull request introduce a new feature? (no)
