### PR TITLE
[INLONG-11556][Agent] Resolve exceptions when saving installation packages

### DIFF
--- a/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
+++ b/inlong-agent/agent-installer/src/main/java/org/apache/inlong/agent/installer/ModuleManager.java
@@ -601,6 +601,10 @@ public class ModuleManager extends AbstractDaemon {
 
     private String getRealPath(String originPath) {
         String homeDir = System.getProperty("user.home");
+        if (homeDir == null) {
+            LOGGER.warn("user.home should not be null");
+            return originPath;
+        }
         return originPath.replace("~", homeDir).replace("${HOME}", homeDir).replace("${home}", homeDir);
     }
 


### PR DESCRIPTION
Fixes #11556 

### Motivation

Resolve exceptions when saving installation packages

### Modifications

1. Create a non-existent folder
2. Identify the home directory

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
