### PR TITLE
[INLONG-11588][Agent] Modify the default cluster tag of the configuration file

### DIFF
--- a/inlong-agent/agent-installer/conf/installer.properties
+++ b/inlong-agent/agent-installer/conf/installer.properties
@@ -31,7 +31,7 @@ agent.manager.auth.secretKey=
 ############################
 # cluster config for automatically report and register
 ############################
-agent.cluster.tag=default_cluster
+agent.cluster.tag=file_agent_common
 agent.cluster.name=default_agent
 
 ############################

--- a/inlong-agent/conf/agent.properties
+++ b/inlong-agent/conf/agent.properties
@@ -78,7 +78,7 @@ agent.manager.auth.secretKey=
 ############################
 # cluster config for automatically report and register
 ############################
-agent.cluster.tag=default_cluster
+agent.cluster.tag=file_agent_common
 agent.cluster.name=default_agent
 agent.cluster.inCharges=admin
 


### PR DESCRIPTION
Fixes #11558 

### Motivation

Modify the default cluster tag of the configuration file

### Modifications

Change the default cluster tag to file_agent_common

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
