### PR TITLE
[INLONG-11597][SDK] Optimize the generation speed of UUIDv4

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 
 	"github.com/panjf2000/gnet/v2"
 	"go.uber.org/atomic"
@@ -329,7 +329,7 @@ func (w *worker) sendAsync(ctx context.Context, msg Message, callback Callback) 
 }
 
 func (w *worker) buildBatchID() string {
-	u, err := uuid.NewV4()
+	u, err := uuid.NewRandom()
 	if err != nil {
 		return w.indexStr + ":" + strconv.FormatInt(time.Now().UnixNano(), 10)
 	}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/go.mod
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/go.mod
@@ -23,7 +23,7 @@ toolchain go1.21.4
 require (
 	github.com/bwmarrin/snowflake v0.3.0
 	github.com/go-resty/resty/v2 v2.13.1
-	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
 	github.com/panjf2000/gnet/v2 v2.5.7
 	github.com/prometheus/client_golang v1.19.1

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/go.sum
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/go.sum
@@ -9,10 +9,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-resty/resty/v2 v2.13.1 h1:x+LHXBI2nMB1vqndymf26quycC4aggYJ7DECYbiz03g=
 github.com/go-resty/resty/v2 v2.13.1/go.mod h1:GznXlLxkq6Nh4sU59rPmUw3VtgpO3aS96ORAI6Q7d+0=
-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
@@ -20,7 +20,7 @@ import (
 	"log"
 
 	"github.com/bwmarrin/snowflake"
-	"github.com/gofrs/uuid"
+	"github.com/google/uuid"
 	"github.com/zentures/cityhash"
 )
 
@@ -43,12 +43,12 @@ func init() {
 
 // UInt64UUID generates an uint64 UUID
 func UInt64UUID() (uint64, error) {
-	guid, err := uuid.NewV4()
+	guid, err := uuid.NewRandom()
 	if err != nil {
 		return 0, err
 	}
 
-	bytes := guid.Bytes()
+	bytes := guid[:]
 	length := len(bytes)
 	return cityhash.CityHash64WithSeeds(bytes, uint32(length), 13329145742295551469, 7926974186468552394), nil
 }


### PR DESCRIPTION
Fixes #11597

### Motivation

Speed up UUIDv4 generation.

### Modifications

- Swap references from `github.com/gofrs/uuid` to `github.com/google/uuid` while preserve compatibility. Benchmark is listed in the original issue.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no) _no_
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) _not applicable_
  - If a feature is not applicable for documentation, explain why? _This is not really a feature_
  <!--
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
-->