### PR TITLE
[INLONG-11599][SDK] Optimize the configuration related content in the ProxyClientConfig class

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/filecollect/SenderManager.java
@@ -203,6 +203,7 @@ public class SenderManager {
                 authSecretKey);
         proxyClientConfig.setTotalAsyncCallbackSize(totalAsyncBufSize);
         proxyClientConfig.setAliveConnections(aliveConnectionNum);
+        proxyClientConfig.setRequestTimeoutMs(maxSenderTimeout * 1000L);
 
         proxyClientConfig.setIoThreadNum(ioThreadNum);
         proxyClientConfig.setEnableBusyWait(enableBusyWait);
@@ -242,7 +243,7 @@ public class SenderManager {
                         message.getTotalSize(), auditVersion);
                 asyncSendByMessageSender(cb, message.getDataList(), message.getGroupId(),
                         message.getStreamId(), message.getDataTime(), SEQUENTIAL_ID.getNextUuid(),
-                        maxSenderTimeout, TimeUnit.SECONDS, message.getExtraMap(), proxySend);
+                        message.getExtraMap(), proxySend);
                 getMetricItem(message.getGroupId(), message.getStreamId()).pluginSendCount.addAndGet(
                         message.getMsgCnt());
                 suc = true;
@@ -270,11 +271,9 @@ public class SenderManager {
 
     private void asyncSendByMessageSender(SendMessageCallback cb,
             List<byte[]> bodyList, String groupId, String streamId, long dataTime, String msgUUID,
-            long timeout, TimeUnit timeUnit,
             Map<String, String> extraAttrMap, boolean isProxySend) throws ProxysdkException {
         sender.asyncSendMessage(cb, bodyList, groupId,
-                streamId, dataTime, msgUUID,
-                timeout, timeUnit, extraAttrMap, isProxySend);
+                streamId, dataTime, msgUUID, extraAttrMap, isProxySend);
     }
 
     /**

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSenderManager.java
@@ -96,7 +96,6 @@ public class TestSenderManager {
                 return null;
             }).when(senderManager, "asyncSendByMessageSender", Mockito.any(),
                     Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyLong(), Mockito.any(),
-                    Mockito.anyLong(), Mockito.any(),
                     Mockito.any(), Mockito.anyBoolean());
             senderManager.Start();
             Long offset = 0L;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ConfigConstants.java
@@ -32,7 +32,8 @@ public class ConfigConstants {
     public static final String REMOTE_ENCRYPT_CACHE_FILE_SUFFIX = ".pubKey";
     // authorization key
     public static final String BASIC_AUTH_HEADER = "authorization";
-
+    // default region name
+    public static final String VAL_DEF_REGION_NAME = "";
     // config info sync interval in minutes
     public static final int VAL_DEF_CONFIG_SYNC_INTERVAL_MIN = 3;
     public static final int VAL_MIN_CONFIG_SYNC_INTERVAL_MIN = 1;
@@ -43,6 +44,10 @@ public class ConfigConstants {
     public static final int VAL_MAX_RETRY_IF_CONFIG_SYNC_FAIL = 5;
     // cache config expired time in ms
     public static final long VAL_DEF_CACHE_CONFIG_EXPIRED_MS = 20 * 60 * 1000L;
+    // cache config fail status expired time in ms
+    public static final long VAL_DEF_CONFIG_FAIL_STATUS_EXPIRED_MS = 1000L;
+    public static final long VAL_MAX_CONFIG_FAIL_STATUS_EXPIRED_MS = 3 * 60 * 1000L;
+
     // node force choose interval in ms
     public static final long VAL_DEF_FORCE_CHOOSE_INR_MS = 10 * 60 * 1000L;
     public static final long VAL_MIN_FORCE_CHOOSE_INR_MS = 30 * 1000L;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MessageSender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MessageSender.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 public interface MessageSender {
 
+    void close();
+
     /**
      * This method provides a synchronized  function which you want to send data  without packing
      *
@@ -137,5 +139,4 @@ public interface MessageSender {
     void asyncSendMessage(String inlongGroupId, String inlongStreamId, List<byte[]> bodyList,
             SendMessageCallback callback) throws ProxysdkException;
 
-    void close();
 }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/ProxyClientConfig.java
@@ -39,19 +39,24 @@ public class ProxyClientConfig {
     private String configStoreBasePath = System.getProperty("user.dir");
     // max expired time for config cache.
     private long configCacheExpiredMs = ConfigConstants.VAL_DEF_CACHE_CONFIG_EXPIRED_MS;
+    // max expired time for config query failure status
+    private long configFailStatusExpiredMs = ConfigConstants.VAL_DEF_CONFIG_FAIL_STATUS_EXPIRED_MS;
     // nodes force choose interval ms
     private long forceReChooseInrMs = ConfigConstants.VAL_DEF_FORCE_CHOOSE_INR_MS;
     private boolean enableAuthentication = false;
     private String authSecretId = "";
     private String authSecretKey = "";
     private String inlongGroupId;
+    private String regionName = ConfigConstants.VAL_DEF_REGION_NAME;
     private int aliveConnections = ConfigConstants.VAL_DEF_ALIVE_CONNECTIONS;
+    // data encrypt info
+    private boolean enableDataEncrypt = false;
+    private String rsaPubKeyUrl = "";
+    private String userName = "";
 
     private int syncThreadPoolSize;
     private int asyncCallbackSize;
 
-    private boolean isNeedDataEncry = false;
-    private String rsaPubKeyUrl = "";
     private String tlsServerCertFilePathAndName;
     private String tlsServerKey;
     private String tlsVersion = "TLSv1.2";
@@ -240,6 +245,15 @@ public class ProxyClientConfig {
         this.configCacheExpiredMs = configCacheExpiredMs;
     }
 
+    public long getConfigFailStatusExpiredMs() {
+        return configFailStatusExpiredMs;
+    }
+
+    public void setConfigFailStatusExpiredMs(long configFailStatusExpiredMs) {
+        this.configFailStatusExpiredMs =
+                Math.min(configFailStatusExpiredMs, ConfigConstants.VAL_MAX_CONFIG_FAIL_STATUS_EXPIRED_MS);
+    }
+
     public long getForceReChooseInrMs() {
         return forceReChooseInrMs;
     }
@@ -253,6 +267,16 @@ public class ProxyClientConfig {
         return inlongGroupId;
     }
 
+    public String getRegionName() {
+        return regionName;
+    }
+
+    public void setRegionName(String regionName) {
+        if (StringUtils.isNotBlank(regionName)) {
+            this.regionName = regionName.trim();
+        }
+    }
+
     public int getAliveConnections() {
         return this.aliveConnections;
     }
@@ -260,6 +284,33 @@ public class ProxyClientConfig {
     public void setAliveConnections(int aliveConnections) {
         this.aliveConnections =
                 Math.max(ConfigConstants.VAL_MIN_ALIVE_CONNECTIONS, aliveConnections);
+    }
+
+    public boolean isEnableDataEncrypt() {
+        return enableDataEncrypt;
+    }
+
+    public String getRsaPubKeyUrl() {
+        return rsaPubKeyUrl;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void enableDataEncrypt(boolean needDataEncrypt, String userName, String rsaPubKeyUrl) {
+        this.enableDataEncrypt = needDataEncrypt;
+        if (!this.enableDataEncrypt) {
+            return;
+        }
+        if (StringUtils.isBlank(userName)) {
+            throw new IllegalArgumentException("userName is Blank!");
+        }
+        if (StringUtils.isBlank(rsaPubKeyUrl)) {
+            throw new IllegalArgumentException("rsaPubKeyUrl is Blank!");
+        }
+        this.userName = userName.trim();
+        this.rsaPubKeyUrl = rsaPubKeyUrl.trim();
     }
 
     public String getTlsServerCertFilePathAndName() {
@@ -368,14 +419,6 @@ public class ProxyClientConfig {
 
     public void setMaxMsgInFlightPerConn(long maxMsgInFlightPerConn) {
         this.maxMsgInFlightPerConn = maxMsgInFlightPerConn;
-    }
-
-    public String getRsaPubKeyUrl() {
-        return rsaPubKeyUrl;
-    }
-
-    public boolean isNeedDataEncry() {
-        return isNeedDataEncry;
     }
 
     public void setHttpsInfo(String tlsServerCertFilePathAndName, String tlsServerKey) {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigEntry.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigEntry.java
@@ -62,6 +62,7 @@ public class ProxyConfigEntry implements java.io.Serializable {
     public void setHostMap(Map<String, HostInfo> hostMap) {
         this.hostMap = hostMap;
     }
+
     public boolean isNodesEmpty() {
         return this.hostMap.isEmpty();
     }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
@@ -345,7 +345,7 @@ public class ClientMgr {
                 if (!realHosts.isEmpty()) {
                     break;
                 }
-                Thread.sleep(1000);
+                Thread.sleep(1000L);
             } while (--maxCycleCnt > 0);
             // update active nodes
             if (realHosts.isEmpty()) {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/QueueObject.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/QueueObject.java
@@ -19,7 +19,6 @@ package org.apache.inlong.sdk.dataproxy.network;
 
 import org.apache.inlong.sdk.dataproxy.common.SendMessageCallback;
 
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class QueueObject {
@@ -32,11 +31,11 @@ public class QueueObject {
     private final int size;
 
     public QueueObject(NettyClient client, long sendTimeInMillis,
-            SendMessageCallback callback, int size, long timeout, TimeUnit timeUnit) {
+            SendMessageCallback callback, int size, long timeoutMs) {
         this.client = client;
         this.sendTimeInMillis = sendTimeInMillis;
         this.callback = callback;
-        this.timeoutInMillis = TimeUnit.MILLISECONDS.convert(timeout, timeUnit);
+        this.timeoutInMillis = timeoutMs;
         this.size = size;
     }
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SyncMessageCallable.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/SyncMessageCallable.java
@@ -37,17 +37,14 @@ public class SyncMessageCallable implements Callable<SendResult> {
     private final NettyClient client;
     private final CountDownLatch awaitLatch = new CountDownLatch(1);
     private final EncodeObject encodeObject;
-    private final long timeout;
-    private final TimeUnit timeUnit;
+    private final long timeoutMs;
 
     private SendResult message;
 
-    public SyncMessageCallable(NettyClient client, EncodeObject encodeObject,
-            long timeout, TimeUnit timeUnit) {
+    public SyncMessageCallable(NettyClient client, EncodeObject encodeObject, long timeoutMs) {
         this.client = client;
         this.encodeObject = encodeObject;
-        this.timeout = timeout;
-        this.timeUnit = timeUnit;
+        this.timeoutMs = timeoutMs;
     }
 
     public void update(SendResult message) {
@@ -61,7 +58,7 @@ public class SyncMessageCallable implements Callable<SendResult> {
                 return SendResult.WRITE_OVER_WATERMARK;
             }
             ChannelFuture channelFuture = client.write(encodeObject);
-            awaitLatch.await(timeout, timeUnit);
+            awaitLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (Throwable ex) {
             if (exptCnt.shouldPrint()) {
                 logger.warn("SyncMessageCallable write data throw exception", ex);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/MetricWorkerThread.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/MetricWorkerThread.java
@@ -193,8 +193,7 @@ public class MetricWorkerThread extends Thread implements Closeable {
         callBack.increaseRetry();
         try {
             if (callBack.getRetryCount() < 4) {
-                sender.asyncSendMessage(encodeObject, callBack,
-                        String.valueOf(System.currentTimeMillis()), 20, TimeUnit.SECONDS);
+                sender.asyncSendMessage(encodeObject, callBack, String.valueOf(System.currentTimeMillis()));
             } else {
                 logger.error("Send metric failure: {}", encodeObject.getBodylist());
             }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/TimeoutScanThread.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/threads/TimeoutScanThread.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Daemon threads to check timeout for asynchronous callback.
@@ -162,7 +161,6 @@ public class TimeoutScanThread extends Thread {
                     checkMessageIdBasedCallbacks(entry.getKey(), entry.getValue());
                 }
                 checkTimeoutChannel();
-                TimeUnit.SECONDS.sleep(1);
             } catch (Throwable ex) {
                 if (exptCnt.shouldPrint()) {
                     logger.warn("TimeoutScanThread({}) throw exception", sender.getInstanceId(), ex);
@@ -171,6 +169,14 @@ public class TimeoutScanThread extends Thread {
             if (printCount++ % 60 == 0) {
                 logger.info("TimeoutScanThread({}) scan, currentBufferSize={}",
                         sender.getInstanceId(), sender.getCurrentBufferSize().get());
+            }
+            if (bShutDown) {
+                break;
+            }
+            try {
+                Thread.sleep(1000L);
+            } catch (InterruptedException e) {
+                //
             }
         }
         logger.info("TimeoutScanThread({}) thread existed !", sender.getInstanceId());


### PR DESCRIPTION

Fixes #11599

1. When obtaining metadata, increase the frequency control of failed access to avoid repeated access causing access pressure on the Manager;
2. Use the request timeout setting configured in the ProxyClientConfig class, and no longer set the timeout value for each request one by one;
3. Remove unnecessary assignment operations on message objects when data encryption is not performed;
4. Add regionName configuration parameters in the DataProxy 