### PR TITLE
[INLONG-11606][Sort] When formatting string field values, the original value is not modified

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/StringFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/StringFormatInfo.java
@@ -38,7 +38,7 @@ public class StringFormatInfo implements BasicFormatInfo<String> {
 
     @Override
     public String deserialize(String text) {
-        return text.trim();
+        return text;
     }
 
     @Override

--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/VarCharFormatInfo.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/field/format/VarCharFormatInfo.java
@@ -52,7 +52,7 @@ public class VarCharFormatInfo implements BasicFormatInfo<String> {
 
     @Override
     public String deserialize(String text) {
-        return text.trim();
+        return text;
     }
 
     @Override


### PR DESCRIPTION
Fixes #11606 

### Motivation

When formatting string field values, the original value is not modified.

For example:
Raw data is aa|\tbb\tcc|dd, formatted data is [aa, bb\tcc, dd], the first char '\t' is missing.
Expect data is [aa, \tbb\tcc, dd].

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
