### PR TITLE
[INLONG-11643][Dashboard] The MySQL node password is not required

### DIFF
--- a/inlong-dashboard/src/plugins/nodes/defaults/MySQL.ts
+++ b/inlong-dashboard/src/plugins/nodes/defaults/MySQL.ts
@@ -35,7 +35,6 @@ export default class MySQLNode extends NodeInfo implements DataWithBackend, Rend
 
   @FieldDecorator({
     type: 'password',
-    rules: [{ required: true }],
   })
   @I18n('meta.Nodes.MySQL.Password')
   token: string;


### PR DESCRIPTION

Fixes #11643 

### Motivation
MySQL node password changed to optional


### Modifications

MySQL node password changed to optional

### Verifying this change
before：
![image](https://github.com/user-attachments/assets/292c41e5-f751-4138-877b-31b484613a28)

after：
![image](https://github.com/user-attachments/assets/2c43090a-ec86-4c43-80d1-dc048947807c)

