### PR TITLE
[INLONG-11656][SDK] DataProxy Java SDK lacks a common-lang dependency

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/config/ProxyConfigManager.java
@@ -374,8 +374,8 @@ public class ProxyConfigManager extends Thread {
         }
         if (result.getF0() == null) {
             if (this.userEncryptConfigEntry != null) {
-                logger.warn("ConfigManager({}) connect manager({}) failure, using the last pubKey, secretId={}",
-                        this.callerId, this.encryptConfigVisitUrl, this.clientConfig.getAuthSecretId());
+                logger.warn("ConfigManager({}) connect manager({}) failure, using the last pubKey, userName={}",
+                        this.callerId, this.encryptConfigVisitUrl, this.clientConfig.getUserName());
                 return;
             }
             throw new Exception("Visit manager error:" + result.getF1());
@@ -570,8 +570,8 @@ public class ProxyConfigManager extends Thread {
             pubKeyConf = JsonParser.parseString(queryResult.getF1()).getAsJsonObject();
         } catch (Throwable ex) {
             if (parseCounter.shouldPrint()) {
-                logger.warn("ConfigManager({}) parse failure, secretId={}, config={}!",
-                        this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                logger.warn("ConfigManager({}) parse failure, userName={}, config={}!",
+                        this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
             }
             errorMsg = "parse pubkey failure:" + ex.getMessage();
             bookManagerQryFailStatus(false, errorMsg);
@@ -585,23 +585,23 @@ public class ProxyConfigManager extends Thread {
         try {
             if (!pubKeyConf.has("resultCode")) {
                 if (parseCounter.shouldPrint()) {
-                    logger.warn("ConfigManager({}) config failure: resultCode field not exist, secretId={}, config={}!",
-                            this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                    logger.warn("ConfigManager({}) config failure: resultCode field not exist, userName={}, config={}!",
+                            this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                 }
                 throw new Exception("resultCode field not exist");
             }
             int resultCode = pubKeyConf.get("resultCode").getAsInt();
             if (resultCode != 0) {
                 if (parseCounter.shouldPrint()) {
-                    logger.warn("ConfigManager({}) config failure: resultCode != 0, secretId={}, config={}!",
-                            this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                    logger.warn("ConfigManager({}) config failure: resultCode != 0, userName={}, config={}!",
+                            this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                 }
                 throw new Exception("resultCode != 0!");
             }
             if (!pubKeyConf.has("resultData")) {
                 if (parseCounter.shouldPrint()) {
-                    logger.warn("ConfigManager({}) config failure: resultData field not exist, secretId={}, config={}!",
-                            this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                    logger.warn("ConfigManager({}) config failure: resultData field not exist, userName={}, config={}!",
+                            this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                 }
                 throw new Exception("resultData field not exist");
             }
@@ -610,24 +610,24 @@ public class ProxyConfigManager extends Thread {
                 String publicKey = resultData.get("publicKey").getAsString();
                 if (StringUtils.isBlank(publicKey)) {
                     if (parseCounter.shouldPrint()) {
-                        logger.warn("ConfigManager({}) config failure: publicKey is blank, secretId={}, config={}!",
-                                this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                        logger.warn("ConfigManager({}) config failure: publicKey is blank, userName={}, config={}!",
+                                this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                     }
                     throw new Exception("publicKey is blank!");
                 }
                 String username = resultData.get("username").getAsString();
                 if (StringUtils.isBlank(username)) {
                     if (parseCounter.shouldPrint()) {
-                        logger.warn("ConfigManager({}) config failure: username is blank, secretId={}, config={}!",
-                                this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                        logger.warn("ConfigManager({}) config failure: username is blank, userName={}, config={}!",
+                                this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                     }
                     throw new Exception("username is blank!");
                 }
                 String versionStr = resultData.get("version").getAsString();
                 if (StringUtils.isBlank(versionStr)) {
                     if (parseCounter.shouldPrint()) {
-                        logger.warn("ConfigManager({}) config failure: version is blank, secretId={}, config={}!",
-                                this.callerId, this.clientConfig.getAuthSecretId(), queryResult.getF1());
+                        logger.warn("ConfigManager({}) config failure: version is blank, userName={}, config={}!",
+                                this.callerId, this.clientConfig.getUserName(), queryResult.getF1());
                     }
                     throw new Exception("version is blank!");
                 }
@@ -670,8 +670,8 @@ public class ProxyConfigManager extends Thread {
             }
         } catch (Throwable ex) {
             if (exptCounter.shouldPrint()) {
-                logger.warn("ConfigManager({}) read({}) file exception, secretId={}",
-                        callerId, encryptConfigCacheFile, clientConfig.getAuthSecretId(), ex);
+                logger.warn("ConfigManager({}) read({}) file exception, userName={}",
+                        callerId, encryptConfigCacheFile, clientConfig.getUserName(), ex);
             }
             return new Tuple2<>(null, "read PubKeyEntry file failure:" + ex.getMessage());
         } finally {
@@ -705,8 +705,8 @@ public class ProxyConfigManager extends Thread {
             // p.close();
         } catch (Throwable ex) {
             if (exptCounter.shouldPrint()) {
-                logger.warn("ConfigManager({}) write file({}) exception, secretId={}, content={}",
-                        callerId, encryptConfigCacheFile, clientConfig.getAuthSecretId(), entry.toString(), ex);
+                logger.warn("ConfigManager({}) write file({}) exception, userName={}, content={}",
+                        callerId, encryptConfigCacheFile, clientConfig.getUserName(), entry.toString(), ex);
             }
         } finally {
             if (fos != null) {
@@ -836,7 +836,7 @@ public class ProxyConfigManager extends Thread {
         this.encryptConfigCacheFile = strBuff
                 .append(clientConfig.getConfigStoreBasePath())
                 .append(ConfigConstants.META_STORE_SUB_DIR)
-                .append(clientConfig.getAuthSecretId())
+                .append(clientConfig.getUserName())
                 .append(ConfigConstants.REMOTE_ENCRYPT_CACHE_FILE_SUFFIX)
                 .toString();
         strBuff.delete(0, strBuff.length());

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricConfig.java
@@ -17,7 +17,7 @@
 
 package org.apache.inlong.sdk.dataproxy.metric;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class MetricConfig {
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sdk.dataproxy.network;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
 import org.apache.inlong.sdk.dataproxy.common.SendResult;
@@ -33,7 +34,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import org.apache.commons.lang.mutable.MutableBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -322,6 +322,9 @@ public class ClientMgr {
             do {
                 int selectCnt = 0;
                 for (HostInfo hostInfo : candidateNodes) {
+                    if (realHosts.contains(hostInfo.getReferenceName())) {
+                        continue;
+                    }
                     try {
                         client = new NettyClient(this.sender.getInstanceId(),
                                 this.bootstrap, hostInfo, this.configure);

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/ClientMgr.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sdk.dataproxy.network;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
 import org.apache.inlong.sdk.dataproxy.common.SendResult;
@@ -34,6 +33,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/Sender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/Sender.java
@@ -17,7 +17,6 @@
 
 package org.apache.inlong.sdk.dataproxy.network;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
 import org.apache.inlong.sdk.dataproxy.common.SendMessageCallback;
@@ -30,6 +29,7 @@ import org.apache.inlong.sdk.dataproxy.utils.Tuple2;
 
 import io.netty.channel.Channel;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/Sender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/network/Sender.java
@@ -17,6 +17,7 @@
 
 package org.apache.inlong.sdk.dataproxy.network;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.inlong.sdk.dataproxy.ProxyClientConfig;
 import org.apache.inlong.sdk.dataproxy.codec.EncodeObject;
 import org.apache.inlong.sdk.dataproxy.common.SendMessageCallback;
@@ -28,7 +29,6 @@ import org.apache.inlong.sdk.dataproxy.utils.LogCounter;
 import org.apache.inlong.sdk.dataproxy.utils.Tuple2;
 
 import io.netty.channel.Channel;
-import org.apache.commons.lang.mutable.MutableBoolean;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/config/ContextProxyClusterConfigLoader.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/config/ContextProxyClusterConfigLoader.java
@@ -17,13 +17,13 @@
 
 package org.apache.inlong.sdk.dataproxy.pb.config;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.GetProxyConfigBySdkResponse;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.InlongStreamConfig;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.ProxyClusterResult;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.ProxyInfo;
 
 import com.alibaba.fastjson.JSON;
-import org.apache.commons.lang.StringUtils;
 import org.apache.flume.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/config/ContextProxyClusterConfigLoader.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/pb/config/ContextProxyClusterConfigLoader.java
@@ -17,13 +17,13 @@
 
 package org.apache.inlong.sdk.dataproxy.pb.config;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.GetProxyConfigBySdkResponse;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.InlongStreamConfig;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.ProxyClusterResult;
 import org.apache.inlong.sdk.dataproxy.pb.config.pojo.ProxyInfo;
 
 import com.alibaba.fastjson.JSON;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Context;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION

Fixes #11656

1. Update all commons.lang references to commons.lang3;
2. Change the key of encryption information from authSecretId to userName
3. When reselecting a node, no connection will be established for the selected node