### PR TITLE
[INLONG-11681][Agent] Fix bug of duplicate file collection

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/store/InstanceStore.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/store/InstanceStore.java
@@ -72,7 +72,7 @@ public class InstanceStore {
      * @return list of task
      */
     public List<InstanceProfile> getInstances(String taskId) {
-        List<KeyValueEntity> result = this.store.findAll(getKeyByTaskId(taskId));
+        List<KeyValueEntity> result = this.store.findAll(getKeyByTaskId(taskId) + store.getSplitter());
         List<InstanceProfile> instanceList = new ArrayList<>();
         for (KeyValueEntity entity : result) {
             instanceList.add(entity.getAsInstanceProfile());


### PR DESCRIPTION
Fixes #11681 

### Motivation

Fix bug of duplicate file collection

### Modifications

Add a delimiter after the task ID when querying multiple instances to prevent misjudgment.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
