### PR TITLE
[INLONG-11685][Agent] Only use configuration files to provide IP address

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/AgentStatusManager.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_INSTALL_PLATFORM;
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_QUEUE_PERMIT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_READER_SOURCE_PERMIT;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_GLOBAL_WRITER_PERMIT;
@@ -221,7 +222,7 @@ public class AgentStatusManager {
 
     private AgentStatus getStatus() {
         AgentStatus data = new AgentStatus();
-        data.setAgentIp(AgentUtils.fetchLocalIp());
+        data.setAgentIp(conf.get(AGENT_LOCAL_IP));
         data.setTag(conf.get(AGENT_CLUSTER_TAG));
         data.setCluster(conf.get(AGENT_CLUSTER_NAME));
         data.setAgentVersion(TaskManager.class.getPackage().getImplementationVersion());

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/FileStaticManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/FileStaticManager.java
@@ -37,6 +37,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 
 /**
  * Collect various indicators of agent processes for backend problem analysis
@@ -109,7 +110,7 @@ public class FileStaticManager {
     }
 
     private void doPutStaticMsg(FileStatic data) {
-        data.setAgentIp(AgentUtils.fetchLocalIp());
+        data.setAgentIp(conf.get(AGENT_LOCAL_IP));
         data.setTag(conf.get(AGENT_CLUSTER_TAG));
         data.setCluster(conf.get(AGENT_CLUSTER_NAME));
         while (!queue.offer(data)) {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadFactory;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_IN_CHARGES;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_NODE_GROUP;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_ADDR;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_MANAGER_AUTH_SECRET_ID;
@@ -146,7 +147,7 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
      * build heartbeat message of agent
      */
     private HeartbeatMsg buildHeartbeatMsg() {
-        final String agentIp = AgentUtils.fetchLocalIp();
+        final String agentIp = conf.get(AGENT_LOCAL_IP);
         final String clusterName = conf.get(AGENT_CLUSTER_NAME);
         final String clusterTag = conf.get(AGENT_CLUSTER_TAG);
         final String inCharges = conf.get(AGENT_CLUSTER_IN_CHARGES);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/fetcher/ManagerFetcher.java
@@ -48,6 +48,7 @@ import java.util.List;
 
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_NAME;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_CLUSTER_TAG;
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
 import static org.apache.inlong.agent.constant.AgentConstants.AGENT_UNIQ_ID;
 import static org.apache.inlong.agent.constant.AgentConstants.DEFAULT_AGENT_UNIQ_ID;
 import static org.apache.inlong.agent.constant.FetcherConstants.AGENT_FETCHER_INTERVAL;
@@ -59,7 +60,6 @@ import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_FE
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_CONFIG_HTTP_PATH;
 import static org.apache.inlong.agent.constant.FetcherConstants.DEFAULT_AGENT_MANAGER_EXIST_TASK_HTTP_PATH;
 import static org.apache.inlong.agent.plugin.fetcher.ManagerResultFormatter.getResultData;
-import static org.apache.inlong.agent.utils.AgentUtils.fetchLocalIp;
 import static org.apache.inlong.agent.utils.AgentUtils.fetchLocalUuid;
 
 /**
@@ -259,7 +259,7 @@ public class ManagerFetcher extends AbstractDaemon implements ProfileFetcher {
     @Override
     public void start() throws Exception {
         // when agent start, check local ip and fetch manager ip list;
-        localIp = fetchLocalIp();
+        localIp = conf.get(AGENT_LOCAL_IP);
         uuid = fetchLocalUuid();
         submitWorker(configFetchThread());
     }


### PR DESCRIPTION
Fixes #11685 

### Motivation

Prevent agent IP uncertainty when the machine has multiple IPs

### Modifications

Only use configuration files to provide IP address

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No needed doc
