### PR TITLE
[INLONG-11711][SDK] SortSDK shares the same PulsarClient among different SortTasks to avoid performance bottlenecks caused by too many PulsarClients

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
@@ -220,6 +220,7 @@ public class InlongMultiTopicManager extends TopicManager {
                     auth = AuthenticationFactory.token(token);
                 }
                 PulsarClient pulsarClient = PulsarClient.builder()
+                        .useNoopDnsResolver(true)
                         .serviceUrl(topic.getInLongCluster().getBootstraps())
                         .authentication(auth)
                         .build();

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongMultiTopicManager.java
@@ -220,7 +220,6 @@ public class InlongMultiTopicManager extends TopicManager {
                     auth = AuthenticationFactory.token(token);
                 }
                 PulsarClient pulsarClient = PulsarClient.builder()
-                        .useNoopDnsResolver(true)
                         .serviceUrl(topic.getInLongCluster().getBootstraps())
                         .authentication(auth)
                         .build();

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -370,7 +370,6 @@ public class InlongSingleTopicManager extends TopicManager {
                         auth = AuthenticationFactory.token(token);
                     }
                     PulsarClient pulsarClient = PulsarClient.builder()
-                            .useNoopDnsResolver(true)
                             .serviceUrl(topic.getInLongCluster().getBootstraps())
                             .authentication(auth)
                             .build();

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -199,7 +199,7 @@ public class InlongSingleTopicManager extends TopicManager {
             }
 
             closeFetcher();
-//            closePulsarClient();
+            // closePulsarClient();
             closeTubeSessionFactory();
             LOGGER.info("close finished {}", sortTaskId);
             return true;

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -199,7 +199,7 @@ public class InlongSingleTopicManager extends TopicManager {
             }
 
             closeFetcher();
-            closePulsarClient();
+//            closePulsarClient();
             closeTubeSessionFactory();
             LOGGER.info("close finished {}", sortTaskId);
             return true;

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongSingleTopicManager.java
@@ -66,7 +66,7 @@ public class InlongSingleTopicManager extends TopicManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(InlongSingleTopicManager.class);
 
     private final ConcurrentHashMap<String, TopicFetcher> fetchers = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, PulsarClient> pulsarClients = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, PulsarClient> pulsarClients = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, TubeConsumerCreator> tubeFactories = new ConcurrentHashMap<>();
 
     private final PeriodicTask updateMetaDataWorker;
@@ -370,6 +370,7 @@ public class InlongSingleTopicManager extends TopicManager {
                         auth = AuthenticationFactory.token(token);
                     }
                     PulsarClient pulsarClient = PulsarClient.builder()
+                            .useNoopDnsResolver(true)
                             .serviceUrl(topic.getInLongCluster().getBootstraps())
                             .authentication(auth)
                             .build();

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
@@ -88,7 +88,7 @@ public class InlongTopicManager extends TopicManager {
             LOGGER.info("start to clean topic manager, sortTaskId={}", sortTaskId);
             stopAssign = true;
             closeAllFetchers();
-//            closeAllPulsarClients();
+            // closeAllPulsarClients();
             closeAllTubeFactories();
             LOGGER.info("success to clean topic manager, sortTaskId={}", sortTaskId);
             return true;

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
@@ -65,7 +65,7 @@ public class InlongTopicManager extends TopicManager {
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
     private final Map<String, TopicFetcher> fetchers = new ConcurrentHashMap<>();
-    private final Map<String, PulsarClient> pulsarClients = new ConcurrentHashMap<>();
+    private static final Map<String, PulsarClient> pulsarClients = new ConcurrentHashMap<>();
     private final Map<String, TubeConsumerCreator> tubeFactories = new ConcurrentHashMap<>();
 
     protected final ForkJoinPool pool;
@@ -359,33 +359,39 @@ public class InlongTopicManager extends TopicManager {
 
     private void createPulsarClient(CacheZoneCluster cluster) {
         LOGGER.info("start to init pulsar client for cluster={}", cluster);
-        if (cluster.getBootstraps() != null) {
-            try {
-                String token = cluster.getToken();
-                Authentication auth = null;
-                if (StringUtils.isNoneBlank(token)) {
-                    auth = AuthenticationFactory.token(token);
-                }
-                PulsarClient pulsarClient = PulsarClient.builder()
-                        .serviceUrl(cluster.getBootstraps())
-                        .authentication(auth)
-                        .build();
-                LOGGER.info("create pulsar client succ cluster:{}, token:{}",
-                        cluster.getClusterId(),
-                        cluster.getToken());
-                PulsarClient oldClient = pulsarClients.putIfAbsent(cluster.getClusterId(), pulsarClient);
-                if (oldClient != null && !oldClient.isClosed()) {
-                    LOGGER.warn("close new pulsar client for cluster={}", cluster);
-                    pulsarClient.close();
-                }
-            } catch (Exception e) {
-                LOGGER.error("create pulsar client error for cluster={}", cluster, e);
-                return;
-            }
-            LOGGER.info("success to init pulsar client for cluster={}", cluster);
-        } else {
+        String clientKey = cluster.getBootstraps();
+        if (clientKey == null) {
             LOGGER.error("bootstrap is null for cluster={}", cluster);
+            return;
         }
+        if (pulsarClients.containsKey(clientKey)) {
+            LOGGER.info("Repeat to init pulsar client for cluster={}", cluster);
+            return;
+        }
+        try {
+            String token = cluster.getToken();
+            Authentication auth = null;
+            if (StringUtils.isNoneBlank(token)) {
+                auth = AuthenticationFactory.token(token);
+            }
+            PulsarClient pulsarClient = PulsarClient.builder()
+                    .useNoopDnsResolver(true)
+                    .serviceUrl(cluster.getBootstraps())
+                    .authentication(auth)
+                    .build();
+            LOGGER.info("create pulsar client succ cluster:{}, token:{}",
+                    cluster.getClusterId(),
+                    cluster.getToken());
+            PulsarClient oldClient = pulsarClients.putIfAbsent(cluster.getClusterId(), pulsarClient);
+            if (oldClient != null && !oldClient.isClosed()) {
+                LOGGER.warn("close new pulsar client for cluster={}", cluster);
+                pulsarClient.close();
+            }
+        } catch (Exception e) {
+            LOGGER.error("create pulsar client error for cluster={}", cluster, e);
+            return;
+        }
+        LOGGER.info("success to init pulsar client for cluster={}", cluster);
     }
 
     private List<CacheZoneCluster> getCacheZoneClusters(InlongTopicTypeEnum type) {

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
@@ -88,7 +88,7 @@ public class InlongTopicManager extends TopicManager {
             LOGGER.info("start to clean topic manager, sortTaskId={}", sortTaskId);
             stopAssign = true;
             closeAllFetchers();
-            closeAllPulsarClients();
+//            closeAllPulsarClients();
             closeAllTubeFactories();
             LOGGER.info("success to clean topic manager, sortTaskId={}", sortTaskId);
             return true;

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/manager/InlongTopicManager.java
@@ -375,7 +375,6 @@ public class InlongTopicManager extends TopicManager {
                 auth = AuthenticationFactory.token(token);
             }
             PulsarClient pulsarClient = PulsarClient.builder()
-                    .useNoopDnsResolver(true)
                     .serviceUrl(cluster.getBootstraps())
                     .authentication(auth)
                     .build();


### PR DESCRIPTION
[INLONG-11711][SDK] SortSDK shares the same PulsarClient among different SortTasks to avoid performance bottlenecks caused by too many PulsarClients

Fixes #11711 

### Motivation

SortSDK shares the same PulsarClient among different SortTasks to avoid performance bottlenecks caused by too many PulsarClients

### Modifications
Excessive PulsarClients lead to significant CPU consumption in waitForNextTick.
![image](https://github.com/user-attachments/assets/a9bdd639-2b79-4008-bb89-39df23849b0d)

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
