### PR TITLE
[INLONG-11715][SDK] Optimize metric report content

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetaSyncInfo.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetaSyncInfo.java
@@ -51,7 +51,7 @@ public class MetaSyncInfo {
             strBuff.append("}");
         } else {
             long curCnt = 0;
-            strBuff.append("\"metaSync\":{\"errT\":{");
+            strBuff.append("\"mSync\":{\"errT\":{");
             for (Map.Entry<Integer, LongAdder> entry : syncErrInfo.entrySet()) {
                 if (curCnt++ > 0) {
                     strBuff.append(",");

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricDataHolder.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricDataHolder.java
@@ -327,10 +327,13 @@ public class MetricDataHolder implements Runnable {
             TcpMsgSenderConfig tcpConfig = (TcpMsgSenderConfig) sender.getConfigure();
             strBuff.append(",\"mT\":").append(tcpConfig.getSdkMsgType().getValue())
                     .append(",\"comp\":").append(tcpConfig.isEnableDataCompress())
+                    .append(",\"mCLen\":").append(tcpConfig.getMinCompEnableLength())
+                    .append(",\"lfSep\":").append(tcpConfig.isSeparateEventByLF())
                     .append(",\"nWk\":").append(tcpConfig.getNettyWorkerThreadNum())
                     .append(",\"sB\":").append(tcpConfig.getSendBufferSize())
-                    .append(",\"rTout\":").append(tcpConfig.getRequestTimeoutMs())
-                    .append(",\"reqOut\":").append(tcpConfig.getRequestTimeoutMs())
+                    .append(",\"rB\":").append(tcpConfig.getRcvBufferSize())
+                    .append(",\"cOut\":").append(tcpConfig.getConnectTimeoutMs())
+                    .append(",\"rOut\":").append(tcpConfig.getRequestTimeoutMs())
                     .append(",\"syncOut\":").append(tcpConfig.getMaxAllowedSyncMsgTimeoutCnt());
         } else {
             HttpMsgSenderConfig httpConfig = (HttpMsgSenderConfig) sender.getConfigure();

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/TimeCostInfo.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/TimeCostInfo.java
@@ -73,7 +73,7 @@ public class TimeCostInfo {
         long curTotalCnt = totalCnt.sumThenReset();
         if (curTotalCnt == 0) {
             strBuff.append("\"").append(name)
-                    .append("\":{\"bucketT\":{},\"min\":0,\"max\":0,\"avgT\":0,\"cnt\":0}");
+                    .append("\":{\"bucketT\":{},\"min\":0,\"max\":0,\"avgT\":0}");
         } else {
             long bucketCnt = 0;
             strBuff.append("\"").append(name).append("\":{\"bucketT\":{");

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/TrafficInfo.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/TrafficInfo.java
@@ -76,7 +76,7 @@ public class TrafficInfo {
         }
         strBuff.append("\",\"sPkg\":").append(sendPkgCount.sumThenReset())
                 .append(",\"sMsg\":").append(sendMsgCount.sumThenReset())
-                .append(",\"fMsg\":").append(failedPgkCount.sumThenReset())
+                .append(",\"fPkg\":").append(failedPgkCount.sumThenReset())
                 .append(",\"fMsg\":").append(failedMsgCount.sumThenReset())
                 .append(",");
         this.sendCostMs.getAndResetValue(strBuff);


### PR DESCRIPTION

Fixes #11715

1. Add TCP configure items;
2. Delete the redundant cnt field in bucketT;
3. Correct the incorrect field name metaSync
