### PR TITLE
[INLONG-11720][SDK] Optimize MsgSenderSingleFactory implementation

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/BaseMsgSenderFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/BaseMsgSenderFactory.java
@@ -67,7 +67,6 @@ public class BaseMsgSenderFactory {
 
     public void close() {
         int totalSenderCnt;
-        int totalTDBankCnt;
         logger.info("MsgSenderFactory({}) is closing", this.factoryNo);
         senderCacheLock.writeLock().lock();
         try {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderFactory.java
@@ -37,7 +37,7 @@ public interface MsgSenderFactory {
      * Shutdown all senders at the factory
      *
      */
-    void shutdownAll() throws ProxySdkException;
+    void shutdownAll();
 
     /**
      * Remove the specified sender from the factory

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderMultiFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderMultiFactory.java
@@ -46,9 +46,9 @@ public class MsgSenderMultiFactory implements MsgSenderFactory {
     }
 
     @Override
-    public void shutdownAll() throws ProxySdkException {
-        if (!this.initialized.get()) {
-            throw new ProxySdkException("Please initialize the factory first!");
+    public void shutdownAll() {
+        if (!this.initialized.compareAndSet(true, false)) {
+            return;
         }
         this.baseMsgSenderFactory.close();
     }

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderSingleFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderSingleFactory.java
@@ -36,14 +36,18 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class MsgSenderSingleFactory implements MsgSenderFactory {
 
+    private static final AtomicLong refCounter = new AtomicLong(0);
     private static final AtomicBoolean initialized = new AtomicBoolean(false);
     private static final AtomicLong singletonRefCounter = new AtomicLong(0);
     private static BaseMsgSenderFactory baseMsgSenderFactory;
 
     public MsgSenderSingleFactory() {
-        if (singletonRefCounter.incrementAndGet() == 1) {
-            baseMsgSenderFactory = new BaseMsgSenderFactory(this, "iSingleFct");
-            initialized.set(true);
+        synchronized (singletonRefCounter) {
+            if (singletonRefCounter.incrementAndGet() == 1) {
+                baseMsgSenderFactory = new BaseMsgSenderFactory(
+                        this, "iSingleFct-" + refCounter.incrementAndGet());
+                initialized.set(true);
+            }
         }
         while (!initialized.get()) {
             ProxyUtils.sleepSomeTime(50L);
@@ -51,14 +55,20 @@ public class MsgSenderSingleFactory implements MsgSenderFactory {
     }
 
     @Override
-    public void shutdownAll() throws ProxySdkException {
+    public void shutdownAll() {
         if (!initialized.get()) {
-            throw new ProxySdkException("Please initialize the factory first!");
-        }
-        if (singletonRefCounter.decrementAndGet() > 0) {
             return;
         }
-        baseMsgSenderFactory.close();
+        BaseMsgSenderFactory tmpFactory;
+        synchronized (singletonRefCounter) {
+            if (singletonRefCounter.decrementAndGet() > 0) {
+                return;
+            }
+            tmpFactory = baseMsgSenderFactory;
+        }
+        if (tmpFactory != null) {
+            baseMsgSenderFactory.close();
+        }
     }
 
     @Override

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderSingleFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/MsgSenderSingleFactory.java
@@ -56,18 +56,18 @@ public class MsgSenderSingleFactory implements MsgSenderFactory {
 
     @Override
     public void shutdownAll() {
-        if (!initialized.get()) {
-            return;
-        }
         BaseMsgSenderFactory tmpFactory;
         synchronized (singletonRefCounter) {
-            if (singletonRefCounter.decrementAndGet() > 0) {
+            if (!initialized.get()
+                    || singletonRefCounter.decrementAndGet() > 0) {
                 return;
             }
             tmpFactory = baseMsgSenderFactory;
+            baseMsgSenderFactory = null;
+            initialized.set(false);
         }
         if (tmpFactory != null) {
-            baseMsgSenderFactory.close();
+            tmpFactory.close();
         }
     }
 


### PR DESCRIPTION

Fixes #11720

1. Lock when releasing and creating BaseMsgSenderFactory objects

2. Adjust the release interface to remove unnecessary exceptions

3. Remove useless code