### PR TITLE
[INLONG-11734][SDK] Optimize SDK stop processing flow

### DIFF
--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/BaseMsgSenderFactory.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/BaseMsgSenderFactory.java
@@ -67,6 +67,7 @@ public class BaseMsgSenderFactory {
 
     public void close() {
         int totalSenderCnt;
+        long startTime = System.currentTimeMillis();
         logger.info("MsgSenderFactory({}) is closing", this.factoryNo);
         senderCacheLock.writeLock().lock();
         try {
@@ -77,8 +78,8 @@ public class BaseMsgSenderFactory {
         } finally {
             senderCacheLock.writeLock().unlock();
         }
-        logger.info("MsgSenderFactory({}) closed, release {} inlong senders",
-                this.factoryNo, totalSenderCnt);
+        logger.info("MsgSenderFactory({}) closed, release {} inlong senders, cost {} ms",
+                this.factoryNo, totalSenderCnt, System.currentTimeMillis() - startTime);
     }
 
     public void removeClient(BaseSender msgSender) {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/common/ProxyClientConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/common/ProxyClientConfig.java
@@ -379,11 +379,16 @@ public class ProxyClientConfig implements Cloneable {
         return metricConfig.isEnableMetric();
     }
 
-    public void setMetricConfig(MetricConfig metricConfig) {
-        if (metricConfig == null) {
-            throw new IllegalArgumentException("metricConfig is null");
-        }
-        this.metricConfig = metricConfig;
+    public void setEnableMetric(boolean enableMetric) {
+        this.metricConfig.setEnableMetric(enableMetric);
+    }
+
+    public void setMetricOutIntvlInfo(long metricOutIntvlMs, long metricOutWarnIntMs) {
+        this.metricConfig.setMetricOutIntvlInfo(metricOutIntvlMs, metricOutWarnIntMs);
+    }
+
+    public void setMetricKeyMaskInfos(boolean maskGroupId, boolean maskStreamId) {
+        this.metricConfig.setMetricKeyMaskInfos(maskGroupId, maskStreamId);
     }
 
     public MetricConfig getMetricConfig() {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricConfig.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/metric/MetricConfig.java
@@ -69,9 +69,16 @@ public class MetricConfig {
         return maskStreamId;
     }
 
-    public void setMetricOutIntvlMs(long metricOutIntvlMs) {
-        if (metricOutIntvlMs >= MIN_METRIC_OUTPUT_INTVL_MS) {
-            this.metricOutIntvlMs = metricOutIntvlMs;
+    public void setMetricOutIntvlInfo(Long metricOutIntvlMs, Long metricOutWarnIntMs) {
+        if (metricOutIntvlMs != null) {
+            if (metricOutIntvlMs >= MIN_METRIC_OUTPUT_INTVL_MS) {
+                this.metricOutIntvlMs = metricOutIntvlMs;
+            }
+        }
+        if (metricOutWarnIntMs != null) {
+            if (metricOutWarnIntMs >= MIN_METRIC_OUTPUT_INTVL_MS) {
+                this.metricOutWarnIntMs = metricOutWarnIntMs;
+            }
         }
     }
 
@@ -81,12 +88,6 @@ public class MetricConfig {
 
     public long getMetricOutWarnIntMs() {
         return metricOutWarnIntMs;
-    }
-
-    public void setMetricOutWarnIntMs(long metricOutWarnIntMs) {
-        if (metricOutWarnIntMs >= MIN_METRIC_OUTPUT_INTVL_MS) {
-            this.metricOutWarnIntMs = metricOutWarnIntMs;
-        }
     }
 
     public long getDateFormatIntvlMs() {

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/sender/BaseSender.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/sender/BaseSender.java
@@ -133,13 +133,16 @@ public abstract class BaseSender implements ConfigHolder {
         if (!senderStatus.compareAndSet(currentStatus, SENDER_STATUS_CLOSED)) {
             return;
         }
+        long startTime = System.currentTimeMillis();
+        logger.info("Sender({}) instance is stopping...", senderId);
         configManager.shutDown();
         clientMgr.stop();
         metricHolder.close();
         if (this.senderFactory != null) {
             this.senderFactory.removeClient(this);
         }
-        logger.info("Sender({}) instance stopped!", senderId);
+        logger.info("Sender({}) instance stopped, cost {} ms!",
+                senderId, System.currentTimeMillis() - startTime);
     }
 
     @Override

--- a/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ProxyUtils.java
+++ b/inlong-sdk/dataproxy-sdk/src/main/java/org/apache/inlong/sdk/dataproxy/utils/ProxyUtils.java
@@ -31,6 +31,7 @@ import java.lang.management.ManagementFactory;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -148,6 +149,38 @@ public class ProxyUtils {
 
     public static String buildGroupIdConfigKey(String protocol, String regionName, String groupId) {
         return protocol + ":" + regionName + ":" + groupId;
+    }
+
+    /**
+     * get valid attrs, remove invalid attrs
+     * @param attrsMap the input attrs
+     * @return valid attrs
+     */
+    public static Map<String, String> getValidAttrs(Map<String, String> attrsMap) {
+        if (attrsMap == null || attrsMap.isEmpty()) {
+            return attrsMap;
+        }
+        String tmpValue;
+        Map<String, String> validAttrsMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : attrsMap.entrySet()) {
+            if (StringUtils.isBlank(entry.getKey())
+                    || entry.getKey().contains(AttributeConstants.SEPARATOR)
+                    || entry.getKey().contains(AttributeConstants.KEY_VALUE_SEPARATOR)) {
+                continue;
+            }
+            tmpValue = entry.getKey().trim();
+            if (ProxyUtils.SdkReservedWords.contains(tmpValue)) {
+                continue;
+            }
+            if (entry.getValue() != null) {
+                if (entry.getValue().contains(AttributeConstants.SEPARATOR)
+                        || entry.getValue().contains(AttributeConstants.KEY_VALUE_SEPARATOR)) {
+                    continue;
+                }
+            }
+            validAttrsMap.put(tmpValue, entry.getValue());
+        }
+        return validAttrsMap;
     }
 
     public static boolean isAttrKeysValid(Map<String, String> attrsMap) {


### PR DESCRIPTION

Fixes #11734


1. Add statistics on the start and end time of stop to confirm the time-consuming point;

2. When stopping, the request waiting for response directly returns the SDK closed response;

3. No more indicator output when stopping;

4. Configure metric settings through ProxyClientConfig.java

5. Other optimizations that facilitate exit

