### PR TITLE
[INLONG-11760][Agent] Increase the number of global instances control

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/AgentConstants.java
@@ -81,6 +81,8 @@ public class AgentConstants {
     public static final String DEFAULT_AGENT_SCAN_RANGE_DAY = "-2";
     public static final String DEFAULT_AGENT_SCAN_RANGE_HOUR = "-10";
     public static final String DEFAULT_AGENT_SCAN_RANGE_MINUTE = "-600";
+    public static final String AGENT_INSTANCE_LIMIT = "agent.instance.limit";
+    public static final int DEFAULT_AGENT_INSTANCE_LIMIT = 100;
 
     // pulsar sink config
     public static final String PULSAR_CLIENT_IO_TREHAD_NUM = "agent.sink.pulsar.client.io.thread.num";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -29,7 +29,7 @@ public class CommonConstants {
     public static final String DEFAULT_PROXY_INLONG_STREAM_ID = "default_inlong_stream_id";
 
     public static final String PROXY_TOTAL_ASYNC_PROXY_SIZE = "proxy.total.async.proxy.size";
-    public static final int DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE = 200 * 1024 * 1024;
+    public static final int DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE_KB = 200 * 1024;
 
     public static final String PROXY_ALIVE_CONNECTION_NUM = "proxy.alive.connection.num";
     public static final int DEFAULT_PROXY_ALIVE_CONNECTION_NUM = 10;

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Task.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/plugin/file/Task.java
@@ -54,4 +54,6 @@ public abstract class Task extends AbstractStateWrapper {
      * is profile valid
      */
     public abstract boolean isProfileValid(TaskProfile profile);
+
+    public abstract int getInstanceNum();
 }

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -202,7 +202,7 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
             proxyClientConfig = new TcpMsgSenderConfig(managerAddr,
                     INLONG_AGENT_SYSTEM, authSecretId, authSecretKey);
             proxyClientConfig.setMaxInFlightSizeInKb(
-                    CommonConstants.DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE / 1024);
+                    CommonConstants.DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE_KB);
             proxyClientConfig.setAliveConnections(CommonConstants.DEFAULT_PROXY_ALIVE_CONNECTION_NUM);
             proxyClientConfig.setNettyWorkerThreadNum(CommonConstants.DEFAULT_PROXY_CLIENT_IO_THREAD_NUM);
             proxyClientConfig.setRequestTimeoutMs(30000L);

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -527,6 +527,14 @@ public class TaskManager extends AbstractDaemon {
         return taskMap.get(taskId);
     }
 
+    public int getInstanceNum() {
+        int num = 0;
+        for (Task task : taskMap.values()) {
+            num += task.getInstanceNum();
+        }
+        return num;
+    }
+
     public TaskProfile getTaskProfile(String taskId) {
         return taskStore.getTask(taskId);
     }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -275,8 +275,8 @@ public class ProxySink extends AbstractSink {
         }
         MemoryManager.getInstance().release(AGENT_GLOBAL_WRITER_PERMIT, lenToRelease);
         if (info != null) {
-            LOGGER.info("save offset {} taskId {} instanceId {}", info.getOffset(), profile.getTaskId(),
-                    profile.getInstanceId());
+            LOGGER.info("save offset {} taskId {} instanceId {} ackInfoList {}", info.getOffset(), profile.getTaskId(),
+                    profile.getInstanceId(), ackInfoList.size());
             OffsetProfile offsetProfile = new OffsetProfile(profile.getTaskId(), profile.getInstanceId(),
                     info.getOffset(), profile.get(INODE_INFO));
             offsetManager.setOffset(offsetProfile);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/Sender.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/Sender.java
@@ -120,7 +120,7 @@ public class Sender {
         totalAsyncBufSize = profile
                 .getInt(
                         CommonConstants.PROXY_TOTAL_ASYNC_PROXY_SIZE,
-                        CommonConstants.DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE);
+                        CommonConstants.DEFAULT_PROXY_TOTAL_ASYNC_PROXY_SIZE_KB);
         aliveConnectionNum = profile
                 .getInt(
                         CommonConstants.PROXY_ALIVE_CONNECTION_NUM, CommonConstants.DEFAULT_PROXY_ALIVE_CONNECTION_NUM);
@@ -203,7 +203,7 @@ public class Sender {
     private void createMessageSender() throws Exception {
         TcpMsgSenderConfig proxyClientConfig = new TcpMsgSenderConfig(
                 managerAddr, inlongGroupId, authSecretId, authSecretKey);
-        proxyClientConfig.setMaxInFlightSizeInKb(totalAsyncBufSize / 1024);
+        proxyClientConfig.setMaxInFlightSizeInKb(totalAsyncBufSize);
         proxyClientConfig.setAliveConnections(aliveConnectionNum);
         proxyClientConfig.setRequestTimeoutMs(maxSenderTimeout * 1000L);
         proxyClientConfig.setNettyWorkerThreadNum(ioThreadNum);

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/AbstractTask.java
@@ -60,7 +60,7 @@ public abstract class AbstractTask extends Task {
         this.taskProfile = taskProfile;
         this.basicStore = basicStore;
         auditVersion = Long.parseLong(taskProfile.get(TASK_AUDIT_VERSION));
-        instanceManager = new InstanceManager(taskProfile.getTaskId(), getInstanceLimit(),
+        instanceManager = new InstanceManager(taskManager, taskProfile.getTaskId(), getInstanceLimit(),
                 basicStore, taskManager.getTaskStore());
         try {
             instanceManager.start();
@@ -162,5 +162,10 @@ public abstract class AbstractTask extends Task {
 
     protected boolean isFull() {
         return instanceManager.isFull();
+    }
+
+    @Override
+    public int getInstanceNum() {
+        return instanceManager.getInstanceNum();
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/CronTask.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/task/CronTask.java
@@ -57,6 +57,11 @@ public class CronTask extends Task {
     }
 
     @Override
+    public int getInstanceNum() {
+        return 0;
+    }
+
+    @Override
     public void addCallbacks() {
 
     }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/instance/TestInstanceManager.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/instance/TestInstanceManager.java
@@ -83,7 +83,7 @@ public class TestInstanceManager {
         Store taskBasicStore = TaskManager.initStore(AgentConstants.AGENT_STORE_PATH_TASK);
         TaskStore taskStore = new TaskStore(taskBasicStore);
         taskStore.storeTask(taskProfile);
-        manager = new InstanceManager("1", 20, basicInstanceStore, taskStore);
+        manager = new InstanceManager(null, "1", 20, basicInstanceStore, taskStore);
         manager.CORE_THREAD_SLEEP_TIME_MS = 100;
     }
 

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/MockTask.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/task/MockTask.java
@@ -63,6 +63,11 @@ public class MockTask extends Task {
     }
 
     @Override
+    public int getInstanceNum() {
+        return 0;
+    }
+
+    @Override
     public void addCallbacks() {
 
     }


### PR DESCRIPTION
Fixes #11760 

### Motivation

Prevent multiple collection tasks from executing simultaneously, which can lead to too many instances

### Modifications

Increase the number of global instances control

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
