### PR TITLE
[INLONG-11762][Agent] Modify the logic for determining the end of the data source

### DIFF
--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/LogFileSource.java
@@ -30,6 +30,7 @@ import org.apache.inlong.agent.plugin.sources.extend.DefaultExtendedHandler;
 import org.apache.inlong.agent.plugin.sources.file.AbstractSource;
 import org.apache.inlong.agent.plugin.task.logcollection.local.FileDataUtils;
 import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.file.FileUtils;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -373,5 +374,10 @@ public class LogFileSource extends AbstractSource {
                 LOGGER.error("close randomAccessFile error", e);
             }
         }
+    }
+
+    @Override
+    public long getLastModifyTime() {
+        return FileUtils.getFileLastModifyTime(fileName);
     }
 }

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sources/file/AbstractSource.java
@@ -81,7 +81,7 @@ public abstract class AbstractSource implements Source {
     protected final Integer BATCH_READ_LINE_TOTAL_LEN = 1024 * 1024;
     protected final Integer CACHE_QUEUE_SIZE = 10 * BATCH_READ_LINE_COUNT;
     protected final Integer WAIT_TIMEOUT_MS = 10;
-    private final Integer EMPTY_CHECK_COUNT_AT_LEAST = 5 * 60 * 100;
+    private final Integer SOURCE_NO_UPDATE_INTERVAL_MS = 5 * 60 * 1000;
     private final Integer CORE_THREAD_PRINT_INTERVAL_MS = 1000;
     protected BlockingQueue<SourceData> queue;
 
@@ -429,6 +429,19 @@ public abstract class AbstractSource implements Source {
         if (isRealTime) {
             return false;
         }
-        return emptyCount > EMPTY_CHECK_COUNT_AT_LEAST;
+        if (emptyCount == 0) {
+            return false;
+        }
+        if (profile.isRetry()) {
+            return true;
+        }
+        if (AgentUtils.getCurrentTime() - getLastModifyTime() > SOURCE_NO_UPDATE_INTERVAL_MS) {
+            return true;
+        }
+        return false;
+    }
+
+    public long getLastModifyTime() {
+        return 0;
     }
 }

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sources/TestLogFileSource.java
@@ -95,7 +95,7 @@ public class TestLogFileSource {
             Whitebox.setInternalState(source, "BATCH_READ_LINE_TOTAL_LEN", 10);
             Whitebox.setInternalState(source, "CORE_THREAD_PRINT_INTERVAL_MS", 0);
             Whitebox.setInternalState(source, "SIZE_OF_BUFFER_TO_READ_FILE", 2);
-            Whitebox.setInternalState(source, "EMPTY_CHECK_COUNT_AT_LEAST", 3);
+            Whitebox.setInternalState(source, "SOURCE_NO_UPDATE_INTERVAL_MS", 1000);
             Whitebox.setInternalState(source, "WAIT_TIMEOUT_MS", 10);
             if (lineOffset > 0) {
                 String finalOffset = Long.toString(lineOffset);


### PR DESCRIPTION
Fixes #11762 

### Motivation

Reduce the waiting time after the collection of data sources that have not been updated for a long time

### Modifications

Modify the logic for determining the end of the data source

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
