### PR TITLE
[INLONG-11774][Agent] Modify the lifecycle of the DataProxy SDK object

### DIFF
--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -61,13 +61,13 @@ public class TaskManager extends AbstractDaemon {
     private static final int ACTION_QUEUE_CAPACITY = 1000;
     private long lastPrintTime = 0;
     // task basic store
-    private final Store taskBasicStore;
+    private static Store taskBasicStore;
     // instance basic store
-    private final Store instanceBasicStore;
+    private static Store instanceBasicStore;
     // offset basic store
-    private final Store offsetBasicStore;
+    private static Store offsetBasicStore;
     // task in task store
-    private final TaskStore taskStore;
+    private static TaskStore taskStore;
     // task in memory
     private final ConcurrentHashMap<String, Task> taskMap;
     // task config from manager.
@@ -146,7 +146,7 @@ public class TaskManager extends AbstractDaemon {
         actionQueue = new LinkedBlockingQueue<>(ACTION_QUEUE_CAPACITY);
     }
 
-    public TaskStore getTaskStore() {
+    public static TaskStore getTaskStore() {
         return taskStore;
     }
 

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/ProxySink.java
@@ -29,6 +29,8 @@ import org.apache.inlong.agent.message.file.ProxyMessage;
 import org.apache.inlong.agent.message.file.SenderMessage;
 import org.apache.inlong.agent.plugin.Message;
 import org.apache.inlong.agent.plugin.MessageFilter;
+import org.apache.inlong.agent.plugin.sinks.dataproxy.Sender;
+import org.apache.inlong.agent.plugin.sinks.dataproxy.SenderManager;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.agent.utils.ThreadUtils;
 
@@ -177,9 +179,8 @@ public class ProxySink extends AbstractSink {
                 StandardCharsets.UTF_8);
         sourceName = profile.getInstanceId();
         offsetManager = OffsetManager.getInstance();
-        sender = new Sender(profile, inlongGroupId, sourceName);
+        sender = SenderManager.getInstance().getSender(profile.getTaskId(), profile);
         try {
-            sender.Start();
             EXECUTOR_SERVICE.execute(coreThread());
             EXECUTOR_SERVICE.execute(flushOffset());
             inited = true;
@@ -199,7 +200,6 @@ public class ProxySink extends AbstractSink {
         }
         Long start = AgentUtils.getCurrentTime();
         shutdown = true;
-        sender.Stop();
         LOGGER.info("destroy proxySink, wait for sender close {} ms instance {}", AgentUtils.getCurrentTime() - start,
                 profile.getInstanceId());
         start = AgentUtils.getCurrentTime();

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/dataproxy/SenderManager.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/dataproxy/SenderManager.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.plugin.sinks.dataproxy;
+
+import org.apache.inlong.agent.common.AbstractDaemon;
+import org.apache.inlong.agent.conf.InstanceProfile;
+import org.apache.inlong.agent.core.task.OffsetManager;
+import org.apache.inlong.agent.core.task.TaskManager;
+import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.ThreadUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SenderManager extends AbstractDaemon {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SenderManager.class);
+    public static final int CORE_THREAD_SLEEP_TIME_MS = 60 * 1000;
+    private static volatile SenderManager SenderManager = null;
+    private final ConcurrentHashMap<String, Sender> senderMap = new ConcurrentHashMap<>();
+
+    private SenderManager() {
+    }
+
+    public static SenderManager getInstance() {
+        if (SenderManager == null) {
+            synchronized (OffsetManager.class) {
+                if (SenderManager == null) {
+                    SenderManager = new SenderManager();
+                    try {
+                        SenderManager.start();
+                    } catch (Exception e) {
+                        LOGGER.error("start sender manager failed:", e);
+                    }
+                }
+            }
+        }
+        return SenderManager;
+    }
+
+    public Sender getSender(String taskId, InstanceProfile profile) {
+        Sender sender = senderMap.get(taskId);
+        if (sender == null) {
+            synchronized (OffsetManager.class) {
+                if (sender == null) {
+                    createSender(taskId, profile);
+                }
+                return senderMap.get(taskId);
+            }
+        } else {
+            return sender;
+        }
+    }
+
+    private void createSender(String taskId, InstanceProfile profile) {
+        Sender sender = new Sender(profile, profile.getInlongGroupId(), profile.getInstanceId());
+        try {
+            sender.Start();
+        } catch (Throwable ex) {
+            LOGGER.error("error while init sender for group id {}", profile.getInstanceId());
+            ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
+            throw new IllegalStateException(ex);
+        }
+        senderMap.put(taskId, sender);
+    }
+
+    private Runnable coreThread() {
+        return () -> {
+            Thread.currentThread().setName("sender-manager-core-thread");
+            while (isRunnable()) {
+                try {
+                    AgentUtils.silenceSleepInMs(CORE_THREAD_SLEEP_TIME_MS);
+                    senderMap.entrySet().forEach(entry -> {
+                        if (TaskManager.getTaskStore().getTask(entry.getKey()) == null) {
+                            Sender sender = senderMap.remove(entry.getKey());
+                            sender.Stop();
+                            LOGGER.info("task {} not exist, remove the related sender", entry.getKey());
+                        }
+                    });
+                } catch (Throwable ex) {
+                    LOGGER.error("sender-manager-core-thread: ", ex);
+                    ThreadUtils.threadThrowableHandler(Thread.currentThread(), ex);
+                }
+            }
+        };
+    }
+
+    @Override
+    public void start() throws Exception {
+        submitWorker(coreThread());
+    }
+
+    @Override
+    public void stop() throws Exception {
+
+    }
+}

--- a/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSender.java
+++ b/inlong-agent/agent-plugins/src/test/java/org/apache/inlong/agent/plugin/sinks/filecollect/TestSender.java
@@ -24,7 +24,7 @@ import org.apache.inlong.agent.constant.TaskConstants;
 import org.apache.inlong.agent.message.file.OffsetAckInfo;
 import org.apache.inlong.agent.message.file.SenderMessage;
 import org.apache.inlong.agent.plugin.AgentBaseTestsHelper;
-import org.apache.inlong.agent.plugin.sinks.Sender;
+import org.apache.inlong.agent.plugin.sinks.dataproxy.Sender;
 import org.apache.inlong.agent.plugin.task.logcollection.local.FileDataUtils;
 import org.apache.inlong.agent.utils.AgentUtils;
 import org.apache.inlong.common.enums.TaskStateEnum;


### PR DESCRIPTION
Fixes #11774 

### Motivation

Modify the lifecycle of the DataProxy SDK object

### Modifications

Modify the lifecycle of the dataproxy SDK object to match the task

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
