### PR TITLE
[INLONG-11780][Dashboard] DataProxy node edit failed

### DIFF
--- a/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
@@ -244,6 +244,7 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
         name: 'isInstall',
         initialValue: false,
         hidden: type !== 'AGENT',
+        visible: () => form.getFieldValue('type') === 'AGENT',
         rules: [{ required: true }],
         props: {
           onChange: ({ target: { value } }) => {

--- a/inlong-dashboard/src/ui/pages/Clusters/NodeManage.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeManage.tsx
@@ -339,7 +339,7 @@ const Comp: React.FC = () => {
             title: i18n.t('basic.Operating'),
             dataIndex: 'action',
             key: 'operation',
-            width: isSmall ? 200 : 400,
+            width: 200,
             render: (text, record) => (
               <>
                 <Button type="link" onClick={() => onEdit(record)}>
@@ -367,7 +367,7 @@ const Comp: React.FC = () => {
             title: i18n.t('basic.Operating'),
             dataIndex: 'action',
             key: 'operation',
-            width: isSmall ? 200 : 400,
+            width: type !== 'AGENT' ? 200 : 400,
             render: (text, record) => (
               <>
                 <Button type="link" onClick={() => onEdit(record)}>
@@ -376,33 +376,43 @@ const Comp: React.FC = () => {
                 <Button type="link" onClick={() => onDelete(record)}>
                   {i18n.t('basic.Delete')}
                 </Button>
-                <Button
-                  type="link"
-                  onClick={() => getNodeData(record.id).then(() => setOperationType('onInstall'))}
-                >
-                  {i18n.t('pages.Cluster.Node.Install')}
-                </Button>
-                <Button
-                  type="link"
-                  onClick={() => getNodeData(record.id).then(() => setOperationType('onRestart'))}
-                >
-                  {i18n.t('pages.Nodes.Restart')}
-                </Button>
-                <Button
-                  type="link"
-                  onClick={() => getNodeData(record.id).then(() => setOperationType('onUnload'))}
-                >
-                  {i18n.t('pages.Cluster.Node.Unload')}
-                </Button>
-                <Button type="link" onClick={() => onLog(record)}>
-                  {i18n.t('pages.Cluster.Node.InstallLog')}
-                </Button>
-                <Button type="link" onClick={() => openHeartModal(record)}>
-                  {i18n.t('pages.Clusters.Node.Agent.HeartbeatDetection')}
-                </Button>
-                <Button type="link" onClick={() => openOperationLogModal(record)}>
-                  {i18n.t('pages.GroupDetail.OperationLog')}
-                </Button>
+                {type === 'AGENT' && (
+                  <>
+                    <Button
+                      type="link"
+                      onClick={() =>
+                        getNodeData(record.id).then(() => setOperationType('onInstall'))
+                      }
+                    >
+                      {i18n.t('pages.Cluster.Node.Install')}
+                    </Button>
+                    <Button
+                      type="link"
+                      onClick={() =>
+                        getNodeData(record.id).then(() => setOperationType('onRestart'))
+                      }
+                    >
+                      {i18n.t('pages.Nodes.Restart')}
+                    </Button>
+                    <Button
+                      type="link"
+                      onClick={() =>
+                        getNodeData(record.id).then(() => setOperationType('onUnload'))
+                      }
+                    >
+                      {i18n.t('pages.Cluster.Node.Unload')}
+                    </Button>
+                    <Button type="link" onClick={() => onLog(record)}>
+                      {i18n.t('pages.Cluster.Node.InstallLog')}
+                    </Button>
+                    <Button type="link" onClick={() => openHeartModal(record)}>
+                      {i18n.t('pages.Clusters.Node.Agent.HeartbeatDetection')}
+                    </Button>
+                    <Button type="link" onClick={() => openOperationLogModal(record)}>
+                      {i18n.t('pages.GroupDetail.OperationLog')}
+                    </Button>
+                  </>
+                )}
               </>
             ),
           },


### PR DESCRIPTION


Fixes #11780

### Motivation

 DataProxy node edit failed

### Modifications

 DataProxy node edit failed

### Verifying this change
before：
When updating, the validation fails, but the dataproxy node does not need this field for editing
![image](https://github.com/user-attachments/assets/783be582-8e81-4e01-9a46-95ac194d5427)
after：
![image](https://github.com/user-attachments/assets/01448bfc-5961-4899-ac60-893bb0d8c427)
![image](https://github.com/user-attachments/assets/f4dc86a3-8cc2-4847-a883-ab0c8c4203b9)

Page style changes
before:
Except for the delete and edit buttons, the other buttons belong to the agent node.
![image](https://github.com/user-attachments/assets/e104ad6e-3cce-4a44-a93a-8c0e71cd2b97)

after：
![image](https://github.com/user-attachments/assets/e9251873-14db-46b3-babd-519e1b88d5ec)
