### PR TITLE
[INLONG-11799][Dashboard] The page will not refresh after the access groupId is switched

### DIFF
--- a/inlong-dashboard/src/ui/pages/GroupDetail/index.tsx
+++ b/inlong-dashboard/src/ui/pages/GroupDetail/index.tsx
@@ -54,6 +54,10 @@ const Comp: React.FC = () => {
     if (!hasOpened(current)) addOpened(current);
   }, [current, addOpened, hasOpened]);
 
+  useEffect(() => {
+    setId(groupId);
+  }, [groupId]);
+
   const { data } = useRequest(`/group/get/${id}`, {
     ready: !!id && !mqType,
     refreshDeps: [id],


### PR DESCRIPTION

Fixes #11799 

### Motivation
The page will not refresh after the access groupId is switched


### Modifications
Add a listener for groupId in index.tsx under the GroupDetail directory
### Verifying this change

