### PR TITLE
[INLONG-11815][Agent] Add a unified reporting point for events

### DIFF
--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/constant/CommonConstants.java
@@ -41,7 +41,7 @@ public class CommonConstants {
     public static final boolean DEFAULT_PROXY_IS_COMPRESS = true;
 
     public static final String PROXY_MAX_SENDER_PER_GROUP = "proxy.max.sender.per.group";
-    public static final int DEFAULT_PROXY_MAX_SENDER_PER_GROUP = 10;
+    public static final int DEFAULT_PROXY_MAX_SENDER_PER_GROUP = 3;
 
     // max size of message list
     public static final String PROXY_PACKAGE_MAX_SIZE = "proxy.package.maxSize";

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentEventMetricItem.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentEventMetricItem.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.metrics;
+
+import org.apache.inlong.common.metric.CountMetric;
+import org.apache.inlong.common.metric.Dimension;
+import org.apache.inlong.common.metric.MetricDomain;
+import org.apache.inlong.common.metric.MetricItem;
+
+import java.text.SimpleDateFormat;
+import java.util.concurrent.atomic.AtomicLong;
+
+@MetricDomain(name = "AgentEvent")
+public class AgentEventMetricItem extends MetricItem {
+
+    public final static SimpleDateFormat FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    public static final String KEY_INLONG_EVENT_TIME = "eventTime";
+    public static final String KEY_INLONG_GROUP_ID = "groupId";
+    public static final String KEY_INLONG_STREAM_ID = "streamId";
+    public static final String KEY_INLONG_COMPONENT_TYPE = "componentType";
+    public static final String KEY_INLONG_COMPONENT_NAME = "componentName";
+    public static final String KEY_INLONG_AGENT_IP = "agentIp";
+    public static final String KEY_INLONG_COMPONENT_VERSION = "componentVersion";
+    public static final String KEY_INLONG_EVENT_TYPE = "eventType";
+    public static final String KEY_INLONG_EVENT_LEVEL = "eventLevel";
+    public static final String KEY_INLONG_EVENT_CODE = "eventCode";
+    public static final String KEY_INLONG_EXT = "ext";
+    public static final String KEY_INLONG_EVENT_DESC = "eventDesc";
+
+    @Dimension
+    public String eventTime;
+    @Dimension
+    public String groupId;
+    @Dimension
+    public String streamId;
+    @Dimension
+    public String componentType;
+    @Dimension
+    public String componentName;
+    @Dimension
+    public String agentIp;
+    @Dimension
+    public String componentVersion;
+    @Dimension
+    public String eventType;
+    @Dimension
+    public String eventLevel;
+    @Dimension
+    public String eventCode;
+    @Dimension
+    public String ext;
+    @Dimension
+    public String eventDesc;
+
+    @CountMetric
+    public AtomicLong count = new AtomicLong(0);
+}

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentEventMetricItemSet.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/metrics/AgentEventMetricItemSet.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.metrics;
+
+import org.apache.inlong.common.metric.MetricDomain;
+import org.apache.inlong.common.metric.MetricItemSet;
+
+@MetricDomain(name = "AgentEvent")
+public class AgentEventMetricItemSet extends MetricItemSet<AgentEventMetricItem> {
+
+    /**
+     * Constructor
+     *
+     * @param name
+     */
+    public AgentEventMetricItemSet(String name) {
+        super(name);
+    }
+
+    @Override
+    protected AgentEventMetricItem createItem() {
+        return new AgentEventMetricItem();
+    }
+}

--- a/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/EventReportUtils.java
+++ b/inlong-agent/agent-common/src/main/java/org/apache/inlong/agent/utils/EventReportUtils.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.agent.utils;
+
+import org.apache.inlong.agent.conf.AgentConfiguration;
+import org.apache.inlong.agent.metrics.AgentEventMetricItem;
+import org.apache.inlong.agent.metrics.AgentEventMetricItemSet;
+import org.apache.inlong.common.metric.MetricRegister;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.inlong.agent.constant.AgentConstants.AGENT_LOCAL_IP;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_AGENT_IP;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_COMPONENT_NAME;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_COMPONENT_TYPE;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_COMPONENT_VERSION;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EVENT_CODE;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EVENT_DESC;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EVENT_LEVEL;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EVENT_TIME;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EVENT_TYPE;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_EXT;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_GROUP_ID;
+import static org.apache.inlong.agent.metrics.AgentEventMetricItem.KEY_INLONG_STREAM_ID;
+
+/**
+ * DiagUtils
+ */
+public class EventReportUtils {
+
+    public enum EvenCodeEnum {
+
+        CONFIG_UPDATE_SUC(0, "config update suc"),
+        CONFIG_NO_UPDATE(1, "config no update"),
+        CONFIG_UPDATE_VERSION_NO_CHANGE(2, "config update version no change"),
+        CONFIG_INVALID_RET_CODE(3, "config invalid ret code"),
+        CONFIG_INVALID_RESULT(4, "config invalid result maybe visit manager failed"),
+        TASK_ADD(5, "task add"),
+        TASK_DELETE(6, "task delete");
+
+        private final int code;
+        private final String message;
+
+        EvenCodeEnum(int code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    private final static String COMPONENT_TYPE_AGENT = "AGENT";
+    private final static String COMPONENT_NAME_AGENT = "AGENT";
+    public static final String EVENT_TYPE_CONFIG_UPDATE = "CONFIG_UPDATE";
+    public static final String EVENT_LEVEL_INFO = "INFO";
+    public static final String EVENT_LEVEL_WARN = "WARN";
+    public static final String EVENT_LEVEL_ERROR = "ERROR";
+    private static AgentEventMetricItemSet metricItemSet;
+
+    private EventReportUtils() {
+    }
+
+    public static void init() {
+        metricItemSet = new AgentEventMetricItemSet(COMPONENT_NAME_AGENT);
+        MetricRegister.register(metricItemSet);
+    }
+
+    public static void report(String groupId, String streamId, long eventTime, String eventType,
+            String eventLevel, EvenCodeEnum evenCode, String ext, String desc) {
+        Map<String, String> dims = new HashMap<>();
+        dims.put(KEY_INLONG_GROUP_ID, groupId);
+        dims.put(KEY_INLONG_STREAM_ID, streamId);
+        dims.put(KEY_INLONG_COMPONENT_TYPE, COMPONENT_TYPE_AGENT);
+        dims.put(KEY_INLONG_COMPONENT_NAME, COMPONENT_NAME_AGENT);
+        dims.put(KEY_INLONG_AGENT_IP, AgentConfiguration.getAgentConf().get(AGENT_LOCAL_IP));
+        dims.put(KEY_INLONG_COMPONENT_VERSION, EventReportUtils.class.getPackage().getImplementationVersion());
+        dims.put(KEY_INLONG_EVENT_TIME, AgentEventMetricItem.FORMAT.format(new Date(eventTime)));
+        dims.put(KEY_INLONG_EVENT_TYPE, eventType);
+        dims.put(KEY_INLONG_EVENT_LEVEL, eventLevel);
+        dims.put(KEY_INLONG_EVENT_CODE, String.valueOf(evenCode.getCode()));
+        dims.put(KEY_INLONG_EXT, ext.replaceAll("\\|", "-"));
+        dims.put(KEY_INLONG_EVENT_DESC, desc);
+        metricItemSet.findMetricItem(dims).count.addAndGet(1);
+    }
+}

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/HeartbeatManager.java
@@ -77,6 +77,9 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
         httpManager = new HttpManager(conf);
         baseManagerUrl = httpManager.getBaseUrl();
         reportHeartbeatUrl = buildReportHeartbeatUrl(baseManagerUrl);
+        createMessageSender();
+        AgentStatusManager.init(agentManager);
+        FileStaticManager.init();
     }
 
     public static HeartbeatManager getInstance(AgentManager agentManager) {
@@ -122,6 +125,9 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
                     reportHeartbeat(heartbeatMsg);
                     if (LOGGER.isDebugEnabled()) {
                         LOGGER.debug(" {} report heartbeat to manager", heartbeatMsg);
+                    }
+                    if (sender == null) {
+                        createMessageSender();
                     }
                     AgentStatusManager.sendStatusMsg(sender);
                     FileStaticManager.sendStaticMsg(sender);
@@ -212,6 +218,7 @@ public class HeartbeatManager extends AbstractDaemon implements AbstractHeartbea
             // start sender object
             ProcessResult procResult = new ProcessResult();
             if (!sender.start(procResult)) {
+                sender.close();
                 throw new ProxySdkException("Sender start failure, " + procResult);
             }
         } catch (Throwable ex) {

--- a/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
+++ b/inlong-agent/agent-core/src/main/java/org/apache/inlong/agent/core/task/TaskManager.java
@@ -27,6 +27,8 @@ import org.apache.inlong.agent.plugin.file.Task;
 import org.apache.inlong.agent.store.Store;
 import org.apache.inlong.agent.store.TaskStore;
 import org.apache.inlong.agent.utils.AgentUtils;
+import org.apache.inlong.agent.utils.EventReportUtils;
+import org.apache.inlong.agent.utils.EventReportUtils.EvenCodeEnum;
 import org.apache.inlong.agent.utils.ThreadUtils;
 import org.apache.inlong.common.enums.TaskStateEnum;
 
@@ -144,6 +146,7 @@ public class TaskManager extends AbstractDaemon {
         pendingTasks = new LinkedBlockingQueue<>(taskMaxLimit);
         configQueue = new LinkedBlockingQueue<>(CONFIG_QUEUE_CAPACITY);
         actionQueue = new LinkedBlockingQueue<>(ACTION_QUEUE_CAPACITY);
+        EventReportUtils.init();
     }
 
     public static TaskStore getTaskStore() {
@@ -299,6 +302,11 @@ public class TaskManager extends AbstractDaemon {
                         profileFromManager.getTaskId(),
                         profileFromManager.isRetry(), profileFromManager.getState());
                 addTask(profileFromManager);
+                EventReportUtils.report(profileFromManager.getInlongGroupId(),
+                        profileFromManager.getInlongStreamId(), AgentUtils.getCurrentTime(),
+                        EventReportUtils.EVENT_TYPE_CONFIG_UPDATE, EventReportUtils.EVENT_LEVEL_INFO,
+                        EvenCodeEnum.TASK_ADD, profileFromManager.toJsonStr(),
+                        EvenCodeEnum.TASK_ADD.getMessage());
             } else {
                 TaskStateEnum managerState = profileFromManager.getState();
                 TaskStateEnum storeState = taskFromStore.getState();
@@ -331,6 +339,11 @@ public class TaskManager extends AbstractDaemon {
         taskStore.getTasks().forEach((profileFromStore) -> {
             if (!tasksFromManager.containsKey(profileFromStore.getTaskId())) {
                 LOGGER.info("traverseStoreTasksToManager try to delete task {}", profileFromStore.getTaskId());
+                EventReportUtils.report(profileFromStore.getInlongGroupId(),
+                        profileFromStore.getInlongStreamId(), AgentUtils.getCurrentTime(),
+                        EventReportUtils.EVENT_TYPE_CONFIG_UPDATE, EventReportUtils.EVENT_LEVEL_INFO,
+                        EvenCodeEnum.TASK_DELETE, profileFromStore.toJsonStr(),
+                        EvenCodeEnum.TASK_DELETE.getMessage());
                 deleteTask(profileFromStore);
             }
         });

--- a/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/dataproxy/Sender.java
+++ b/inlong-agent/agent-plugins/src/main/java/org/apache/inlong/agent/plugin/sinks/dataproxy/Sender.java
@@ -218,6 +218,7 @@ public class Sender {
             InLongTcpMsgSender sender = new InLongTcpMsgSender(proxyClientConfig, SHARED_FACTORY);
             ProcessResult procResult = new ProcessResult();
             if (!sender.start(procResult)) {
+                sender.close();
                 throw new ProxySdkException("Start sender failure, " + procResult);
             }
             senders.add(sender);
@@ -376,7 +377,7 @@ public class Sender {
                 AgentStatusManager.sendPackageCount.addAndGet(message.getMsgCnt());
                 AgentStatusManager.sendDataLen.addAndGet(message.getTotalSize());
             } else {
-                LOGGER.warn("send groupId {}, streamId {}, taskId {}, instanceId {}, dataTime {} fail with times {}, "
+                LOGGER.error("send groupId {}, streamId {}, taskId {}, instanceId {}, dataTime {} fail with times {}, "
                         + "error {}", groupId, streamId, taskId, instanceId, dataTime, retry, result);
                 getMetricItem(groupId, streamId).pluginSendFailCount.addAndGet(msgCnt);
                 putInResendQueue(new AgentSenderCallback(message, retry));


### PR DESCRIPTION
Fixes #11815 

### Motivation

To be compatible with multiple different monitoring systems

### Modifications

Add a unified reporting point for events

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

No doc needed
