### PR TITLE
[INLONG-11819][Sort] Sort kv/csv format support keep escape, using line delimiter and call back when parse field has exception

### DIFF
--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/base/TableFormatUtils.java
@@ -58,6 +58,7 @@ import org.apache.inlong.common.pojo.sort.dataflow.field.format.TimestampTypeInf
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.TypeInfo;
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.VarBinaryFormatInfo;
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.VarCharFormatInfo;
+import org.apache.inlong.sort.formats.inlongmsg.FailureHandler;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -547,7 +548,8 @@ public class TableFormatUtils {
             String fieldName,
             FormatInfo fieldFormatInfo,
             String fieldText,
-            String nullLiteral) {
+            String nullLiteral,
+            FailureHandler failureHandler) throws Exception {
         checkState(fieldFormatInfo instanceof BasicFormatInfo);
 
         if (fieldText == null) {
@@ -573,6 +575,9 @@ public class TableFormatUtils {
         } catch (Exception e) {
             LOG.warn("Could not properly deserialize the " + "text "
                     + fieldText + " for field " + fieldName + ".", e);
+            if (failureHandler != null) {
+                failureHandler.onConvertingFieldFailure(fieldName, fieldText, fieldFormatInfo, e);
+            }
         }
         return null;
     }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/base/TextFormatBuilder.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/base/TextFormatBuilder.java
@@ -18,6 +18,7 @@
 package org.apache.inlong.sort.formats.base;
 
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.RowFormatInfo;
+import org.apache.inlong.sort.formats.inlongmsg.FailureHandler;
 
 import org.apache.flink.table.descriptors.DescriptorProperties;
 
@@ -44,6 +45,7 @@ public abstract class TextFormatBuilder<T extends TextFormatBuilder> {
     protected Character quoteChar = DEFAULT_QUOTE_CHARACTER;
     protected String nullLiteral = DEFAULT_NULL_LITERAL;
     protected boolean ignoreErrors = DEFAULT_IGNORE_ERRORS;
+    protected FailureHandler failureHandler;
 
     protected TextFormatBuilder(RowFormatInfo rowFormatInfo) {
         this.rowFormatInfo = rowFormatInfo;
@@ -76,6 +78,11 @@ public abstract class TextFormatBuilder<T extends TextFormatBuilder> {
     @SuppressWarnings("unchecked")
     public T setIgnoreErrors(boolean ignoreErrors) {
         this.ignoreErrors = ignoreErrors;
+        return (T) this;
+    }
+
+    public T setFailureHandler(FailureHandler failureHandler) {
+        this.failureHandler = failureHandler;
         return (T) this;
     }
 

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.FormatInfo;
+
 import java.io.Serializable;
 
 /**
@@ -70,5 +72,17 @@ public interface FailureHandler extends Serializable {
      * @throws Exception the exception
      */
     void onConvertingRowFailure(InLongMsgHead head, InLongMsgBody body, Exception exception) throws Exception;
+
+    /**
+     * This method is called when there is a failure occurred while converting any field to row.
+     *
+     * @param fieldName the filed name
+     * @param fieldText the filed test
+     * @param formatInfo the filed target type info
+     * @param exception the thrown exception
+     * @throws Exception the exception
+     */
+    void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+            Exception exception) throws Exception;
 
 }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/IgnoreFailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/IgnoreFailureHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.FormatInfo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +47,13 @@ public class IgnoreFailureHandler implements FailureHandler {
     @Override
     public void onConvertingRowFailure(InLongMsgHead head, InLongMsgBody body, Exception exception) {
         LOG.warn("Cannot properly convert the InLongMsg ({}, {})", head, body, exception);
+    }
+
+    @Override
+    public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+            Exception exception) throws Exception {
+        LOG.warn("Cannot convert the InLongMsg Filed (fieldName = {}, formatInfo = {}, fieldText = {}),",
+                fieldName, formatInfo, fieldText, exception);
     }
 
     @Override

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/NoOpFailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/NoOpFailureHandler.java
@@ -17,6 +17,8 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.FormatInfo;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,6 +51,13 @@ public class NoOpFailureHandler implements FailureHandler {
     public void onConvertingRowFailure(InLongMsgHead head, InLongMsgBody body, Exception exception) throws Exception {
         LOG.error("Cannot properly convert the InLongMsg ({}, {})", head, body, exception);
         throw exception;
+    }
+
+    @Override
+    public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+            Exception exception) throws Exception {
+        LOG.warn("Cannot convert the InLongMsg Filed (fieldName = {}, formatInfo = {}, fieldText = {}),",
+                fieldName, formatInfo, fieldText, exception);
     }
 
     @Override

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/util/StringUtils.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/util/StringUtils.java
@@ -39,7 +39,7 @@ public class StringUtils {
     private static final int STATE_QUOTING = 16;
 
     /**
-     * @see StringUtils#splitKv(String, Character, Character, Character,Character, Character)
+     * @see StringUtils#splitKv(String, Character, Character, Character,Character)
      */
     public static Map<String, String> splitKv(
             @Nonnull String text,
@@ -48,7 +48,8 @@ public class StringUtils {
             @Nullable Character escapeChar,
             @Nullable Character quoteChar) {
         List<Map<String, String>> lines =
-                splitKv(text, entryDelimiter, kvDelimiter, escapeChar, quoteChar, null);
+                splitKv(text, entryDelimiter, kvDelimiter, escapeChar, quoteChar, null,
+                        true);
         if (lines.size() == 0) {
             return new HashMap<>();
         }
@@ -77,7 +78,8 @@ public class StringUtils {
             @Nonnull Character kvDelimiter,
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
-            @Nullable Character lineDelimiter) {
+            @Nullable Character lineDelimiter,
+            @Nullable boolean isDeleteEscapeChar) {
         Map<String, String> fields = new HashMap<>();
         List<Map<String, String>> lines = new ArrayList<>();
 
@@ -158,6 +160,9 @@ public class StringUtils {
                     case STATE_VALUE:
                         kvState = state;
                         state = STATE_ESCAPING;
+                        if (!isDeleteEscapeChar) {
+                            stringBuilder.append(ch);
+                        }
                         break;
                     case STATE_ESCAPING:
                         stringBuilder.append(ch);
@@ -369,7 +374,7 @@ public class StringUtils {
     /**
      * Splits a single line of csv text.
      *
-     * @see StringUtils#splitCsv(String, Character, Character, Character, Character, boolean)
+     * @see StringUtils#splitCsv(String, Character, Character, Character, Character)
      */
     public static String[] splitCsv(
             @Nonnull String text,
@@ -384,7 +389,7 @@ public class StringUtils {
     }
 
     /**
-     * @see StringUtils#splitCsv(String, Character, Character, Character, Character, boolean)
+     * @see StringUtils#splitCsv(String, Character, Character, Character, Character)
      */
     public static String[][] splitCsv(
             @Nonnull String text,
@@ -392,11 +397,12 @@ public class StringUtils {
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
             @Nullable Character lineDelimiter) {
-        return splitCsv(text, delimiter, escapeChar, quoteChar, lineDelimiter, false);
+        return splitCsv(text, delimiter, escapeChar, quoteChar, lineDelimiter,
+                false, true);
     }
 
     /**
-     * @see StringUtils#splitCsv(String, Character, Character, Character, Character, boolean, Integer)
+     * @see StringUtils#splitCsv(String, Character, Character, Character, Character, boolean, boolean)
      */
     public static String[][] splitCsv(
             @Nonnull String text,
@@ -404,8 +410,10 @@ public class StringUtils {
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
             @Nullable Character lineDelimiter,
-            boolean deleteHeadDelimiter) {
-        return splitCsv(text, delimiter, escapeChar, quoteChar, lineDelimiter, deleteHeadDelimiter, null);
+            boolean deleteHeadDelimiter,
+            boolean isDeleteEscapeChar) {
+        return splitCsv(text, delimiter, escapeChar, quoteChar, lineDelimiter,
+                deleteHeadDelimiter, isDeleteEscapeChar, null);
     }
 
     /**
@@ -434,6 +442,7 @@ public class StringUtils {
             @Nullable Character quoteChar,
             @Nullable Character lineDelimiter,
             boolean deleteHeadDelimiter,
+            boolean isDeleteEscapeChar,
             @Nullable Integer maxFieldSize) {
         if (maxFieldSize != null && maxFieldSize <= 0) {
             return new String[0][];
@@ -481,6 +490,9 @@ public class StringUtils {
                 switch (state) {
                     case STATE_NORMAL:
                         state = STATE_ESCAPING;
+                        if (!isDeleteEscapeChar) {
+                            stringBuilder.append(ch);
+                        }
                         break;
                     case STATE_ESCAPING:
                         stringBuilder.append(ch);

--- a/inlong-sort/sort-formats/format-common/src/test/java/org/apache/inlong/sort/formats/common/StringUtilsTest.java
+++ b/inlong-sort/sort-formats/format-common/src/test/java/org/apache/inlong/sort/formats/common/StringUtilsTest.java
@@ -34,27 +34,27 @@ public class StringUtilsTest {
     public void testSplitKvString() {
 
         String kvString1 = "name=n&age=10";
-        Map<String, String> map1 = StringUtils.splitKv(kvString1, '&',
-                '=', '\\', '\'');
-        assertEquals("n", map1.get("name"));
-        assertEquals("10", map1.get("age"));
+        List<Map<String, String>> listMap1 = StringUtils.splitKv(kvString1, '&',
+                '=', '\\', '\'', '\n', true);
+        assertEquals("n", listMap1.get(0).get("name"));
+        assertEquals("10", listMap1.get(0).get("age"));
 
         String kvString2 = "name=&age=20&";
-        Map<String, String> map2 = StringUtils.splitKv(kvString2, '&',
-                '=', '\\', '\'');
-        assertEquals("", map2.get("name"));
-        assertEquals("20&", map2.get("age"));
+        List<Map<String, String>> listMap2 = StringUtils.splitKv(kvString2, '&',
+                '=', '\\', '\'', '\n', true);
+        assertEquals("", listMap2.get(0).get("name"));
+        assertEquals("20&", listMap2.get(0).get("age"));
 
         String kvString3 = "name==&age=20&&&value=aaa&dddd&";
-        Map<String, String> map3 = StringUtils.splitKv(kvString3, '&',
-                '=', '\\', '\'');
-        assertEquals("=", map3.get("name"));
-        assertEquals("20&&", map3.get("age"));
-        assertEquals("aaa&dddd&", map3.get("value"));
+        List<Map<String, String>> listMap3 = StringUtils.splitKv(kvString3, '&',
+                '=', '\\', '\'', '\n', true);
+        assertEquals("=", listMap3.get(0).get("name"));
+        assertEquals("20&&", listMap3.get(0).get("age"));
+        assertEquals("aaa&dddd&", listMap3.get(0).get("value"));
 
         String kvString4 = "name==&age=20&&\nname1==&age1=20&&";
         List<Map<String, String>> map4 = StringUtils.splitKv(kvString4, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map4.get(0).get("name"));
         assertEquals("20&&", map4.get(0).get("age"));
         assertEquals("=", map4.get(1).get("name1"));
@@ -62,7 +62,7 @@ public class StringUtilsTest {
 
         String kvString5 = "name==&age=20&&\nname1==&age1=20&&&value=aaa&dddd&";
         List<Map<String, String>> map5 = StringUtils.splitKv(kvString5, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map5.get(0).get("name"));
         assertEquals("20&&", map5.get(0).get("age"));
         assertEquals("=", map5.get(1).get("name1"));
@@ -71,25 +71,25 @@ public class StringUtilsTest {
 
         String kvString6 = "name==&age=20&&\\";
         List<Map<String, String>> map6 = StringUtils.splitKv(kvString6, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map6.get(0).get("name"));
         assertEquals("20&&", map6.get(0).get("age"));
 
         String kvString7 = "name==&age=20&&'";
         List<Map<String, String>> map7 = StringUtils.splitKv(kvString7, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map7.get(0).get("name"));
         assertEquals("20&&", map7.get(0).get("age"));
 
         String kvString8 = "name=\\=&age=20&a&'";
         List<Map<String, String>> map8 = StringUtils.splitKv(kvString8, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map8.get(0).get("name"));
         assertEquals("20&a&", map8.get(0).get("age"));
 
         String kvString9 = "name=\\=&age=20&a\\&'";
         List<Map<String, String>> map9 = StringUtils.splitKv(kvString9, '&',
-                '=', '\\', '\'', '\n');
+                '=', '\\', '\'', '\n', true);
         assertEquals("=", map8.get(0).get("name"));
         assertEquals("20&a&", map8.get(0).get("age"));
     }
@@ -116,21 +116,45 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testSplitCsvStringWhiteEscape() {
+        String csvString1 = "name|age=20\\||&'";
+        String[][] csv1Array1 = StringUtils.splitCsv(csvString1, '|',
+                '\\', '\'', '\n', false, false);
+
+        assertEquals("age=20\\|", csv1Array1[0][1]);
+        assertEquals("&", csv1Array1[0][2]);
+
+        String csvString2 = "name|age=20\\||&'\n\name|age=20\\||&'\n\n|home|\\home\\";
+        String[][] csv1Array2 = StringUtils.splitCsv(csvString2, '|',
+                '\\', '\'', '\n', false, false);
+
+        assertEquals("name", csv1Array2[0][0]);
+        assertEquals("age=20\\|", csv1Array2[0][1]);
+        assertEquals("&\n\name|age=20\\||&", csv1Array2[0][2]);
+        assertEquals("", csv1Array2[2][0]);
+        assertEquals("home", csv1Array2[2][1]);
+        assertEquals("\\home\\", csv1Array2[2][2]);
+    }
+
+    @Test
     public void testSplitCsvStringWithMaxFields() {
 
         String csvString = "name|age=20\\||&'\n\name|age=20\\||&'\n\n|home|\\home\\";
         String[][] csv1Array0 = StringUtils.splitCsv(csvString, '|',
-                '\\', '\'', '\n', false, 0);
+                '\\', '\'', '\n', false, true,
+                0);
         assertEquals(0, csv1Array0.length);
 
         String[][] csv1Array1 = StringUtils.splitCsv(csvString, '|',
-                '\\', '\'', '\n', false, 1);
+                '\\', '\'', '\n', false, true,
+                1);
         assertEquals("name|age=20\\||&'\n\name|age=20\\||&'", csv1Array1[0][0]);
         assertEquals("", csv1Array1[1][0]);
         assertEquals("|home|\\home\\", csv1Array1[2][0]);
 
         String[][] csv1Array2 = StringUtils.splitCsv(csvString, '|',
-                '\\', '\'', '\n', false, 2);
+                '\\', '\'', '\n', false, true,
+                2);
         assertEquals("name", csv1Array2[0][0]);
         assertEquals("age=20\\||&'\n\name|age=20\\||&'", csv1Array2[0][1]);
         assertEquals("", csv1Array2[1][0]);
@@ -138,7 +162,8 @@ public class StringUtilsTest {
         assertEquals("home|\\home\\", csv1Array2[2][1]);
 
         String[][] csv1Array3 = StringUtils.splitCsv(csvString, '|',
-                '\\', '\'', '\n', false, 3);
+                '\\', '\'', '\n', false, true,
+                3);
         assertEquals("name", csv1Array3[0][0]);
         assertEquals("age=20|", csv1Array3[0][1]);
         assertEquals("&\n\name|age=20\\||&", csv1Array3[0][2]);
@@ -147,7 +172,8 @@ public class StringUtilsTest {
         assertEquals("home", csv1Array3[2][2]);
 
         String[][] csv1Array4 = StringUtils.splitCsv(csvString, '|',
-                '\\', '\'', '\n', false, 4);
+                '\\', '\'', '\n', false, true,
+                4);
         assertEquals("name", csv1Array4[0][0]);
         assertEquals("age=20|", csv1Array4[0][1]);
         assertEquals("&\n\name|age=20\\||&", csv1Array4[0][2]);
@@ -159,9 +185,11 @@ public class StringUtilsTest {
     @Test
     public void testKvScapeCharSplit() {
         String text = "k1=v1&\nk\\2=v2\\&&k3=v3";
-        Map<String, String> kvMap = splitKv(text, '&', '=', '\\', null);
-        Assert.assertTrue(kvMap != null && kvMap.size() == 3);
-        Assert.assertTrue(kvMap.get("k3") != null);
-        Assert.assertTrue(kvMap.get("\nk2") != null);
+        List<Map<String, String>> kvMapList = splitKv(text, '&', '=', '\\',
+                null, '\n', false);
+        Assert.assertTrue(kvMapList != null && kvMapList.size() == 2);
+        Assert.assertTrue(kvMapList.get(0).get("k3") == null);
+        Assert.assertTrue(kvMapList.get(1).get("\nk2") == null);
+        Assert.assertTrue(kvMapList.get(1).get("k\\2") != null);
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-base/src/test/java/org/apache/inlong/sort/formats/base/TableFormatUtilsTest.java
+++ b/inlong-sort/sort-formats/format-row/format-base/src/test/java/org/apache/inlong/sort/formats/base/TableFormatUtilsTest.java
@@ -34,13 +34,13 @@ import static org.junit.Assert.assertNull;
 public class TableFormatUtilsTest {
 
     @Test
-    public void testDeserializeStringWithoutNullLiteral() {
+    public void testDeserializeStringWithoutNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         StringFormatInfo.INSTANCE,
                         "data",
-                        null);
+                        null, null);
         assertEquals("data", result1);
 
         Object result2 =
@@ -48,7 +48,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "",
-                        null);
+                        null, null);
         assertEquals("", result2);
     }
 
@@ -72,13 +72,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeStringWithNullLiteral() {
+    public void testDeserializeStringWithNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         StringFormatInfo.INSTANCE,
                         "data",
-                        "n/a");
+                        "n/a", null);
         assertEquals("data", result1);
 
         Object result2 =
@@ -86,7 +86,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "",
-                        "n/a");
+                        "n/a", null);
         assertEquals("", result2);
 
         Object result3 =
@@ -94,7 +94,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "n/a",
-                        "n/a");
+                        "n/a", null);
         assertNull(result3);
     }
 
@@ -126,13 +126,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeNumberWithoutNullLiteral() {
+    public void testDeserializeNumberWithoutNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         IntFormatInfo.INSTANCE,
                         "1",
-                        null);
+                        null, null);
         assertEquals(1, result1);
 
         Object result2 =
@@ -140,7 +140,7 @@ public class TableFormatUtilsTest {
                         "f",
                         IntFormatInfo.INSTANCE,
                         "",
-                        null);
+                        null, null);
         assertNull(result2);
     }
 
@@ -164,13 +164,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeNumberWithNullLiteral() {
+    public void testDeserializeNumberWithNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         IntFormatInfo.INSTANCE,
                         "1",
-                        "n/a");
+                        "n/a", null);
         assertEquals(1, result1);
 
         try {
@@ -178,7 +178,7 @@ public class TableFormatUtilsTest {
                     "f",
                     IntFormatInfo.INSTANCE,
                     "",
-                    "n/a");
+                    "n/a", null);
             Assert.assertEquals(null, result2);
         } catch (Exception e) {
             // ignored
@@ -189,7 +189,7 @@ public class TableFormatUtilsTest {
                         "f",
                         IntFormatInfo.INSTANCE,
                         "n/a",
-                        "n/a");
+                        "n/a", null);
         assertNull(result3);
     }
 

--- a/inlong-sort/sort-formats/format-row/format-csv/src/main/java/org/apache/inlong/sort/formats/csv/CsvDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-row/format-csv/src/main/java/org/apache/inlong/sort/formats/csv/CsvDeserializationSchema.java
@@ -160,7 +160,7 @@ public final class CsvDeserializationSchema extends DefaultDeserializationSchema
                                     fieldNames[i],
                                     fieldFormatInfos[i],
                                     fieldTexts[i],
-                                    nullLiteral);
+                                    nullLiteral, null);
 
                     row.setField(i, field);
                 }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/row/InLongMsgUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/row/InLongMsgUtils.java
@@ -79,10 +79,12 @@ public class InLongMsgUtils {
     public static final String FORMAT_TIME_FIELD_NAME = "format.time-field-name";
     public static final String FORMAT_ATTRIBUTES_FIELD_NAME = "format.attributes-field-name";
     public static final String FORMAT_RETAIN_PREDEFINED_FIELD = "format.retain-predefined-field";
+    public static final String FORMAT_APPEND_ESCAPE_FIELD = "format.append-escape";
 
     public static final String DEFAULT_TIME_FIELD_NAME = "inlongmsg_time";
     public static final String DEFAULT_ATTRIBUTES_FIELD_NAME = "inlongmsg_attributes";
     public static final boolean DEFAULT_PREDEFINED_FIELD = true;
+    public static final boolean DEFAULT_APPEND_ESCAPE = false;
 
     public static final TypeInformation<Row> MIXED_ROW_TYPE =
             Types.ROW_NAMED(

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
@@ -30,7 +30,6 @@ import org.apache.flink.types.Row;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -152,7 +151,7 @@ public final class InLongMsgBinlogFormatDeserializer extends AbstractInLongMsgFo
     }
 
     @Override
-    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) throws IOException {
+    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) throws Exception {
         return InLongMsgBinlogUtils.getRows(
                 rowFormatInfo,
                 timeFieldName,

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
@@ -29,7 +29,6 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.types.Row;
 
-import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -186,7 +185,7 @@ public class InLongMsgBinlogUtils {
             String metadataFieldName,
             Map<String, String> attributes,
             byte[] bytes,
-            boolean includeUpdateBefore) throws IOException {
+            boolean includeUpdateBefore) throws Exception {
 
         InLongBinlog.RowData rowData = InLongBinlog.RowData.parseFrom(bytes);
 
@@ -256,7 +255,7 @@ public class InLongMsgBinlogUtils {
             Map<String, String> attributes,
             InLongBinlog.RowData rowData,
             String operation,
-            List<InLongBinlog.Column> columns) {
+            List<InLongBinlog.Column> columns) throws Exception {
         List<Object> headFields = new ArrayList<>();
 
         if (timeFieldName != null) {
@@ -311,7 +310,7 @@ public class InLongMsgBinlogUtils {
                                 fieldName,
                                 dataFieldFormatInfos[i],
                                 fieldText,
-                                null);
+                                null, null);
                 row.setField(i + headFields.size(), field);
             }
         }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializer.java
@@ -40,9 +40,11 @@ import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_D
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_LINE_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_LINE_DELIMITER;
+import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.DEFAULT_APPEND_ESCAPE;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.DEFAULT_ATTRIBUTES_FIELD_NAME;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.DEFAULT_PREDEFINED_FIELD;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.DEFAULT_TIME_FIELD_NAME;
+import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.FORMAT_APPEND_ESCAPE_FIELD;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.FORMAT_ATTRIBUTES_FIELD_NAME;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.FORMAT_RETAIN_PREDEFINED_FIELD;
 import static org.apache.inlong.sort.formats.inlongmsg.row.InLongMsgUtils.FORMAT_TIME_FIELD_NAME;
@@ -119,6 +121,11 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
      * True if the predefinedField existed, default true.
      */
     private boolean retainPredefinedField = true;
+
+    /**
+     * True if the append configed escape char, default false.
+     */
+    private boolean appendEscapeChar = false;
 
     public InLongMsgCsvFormatDeserializer(
             @Nonnull RowFormatInfo rowFormatInfo,
@@ -223,7 +230,7 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
     }
 
     @Override
-    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) {
+    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) throws Exception {
         Row dataRow =
                 InLongMsgCsvUtils.deserializeRow(
                         rowFormatInfo,
@@ -252,6 +259,7 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
         private Character lineDelimiter = DEFAULT_LINE_DELIMITER;
         private Boolean deleteHeadDelimiter = DEFAULT_DELETE_HEAD_DELIMITER;
         private Boolean retainPredefinedField = DEFAULT_PREDEFINED_FIELD;
+        private Boolean appendEscapeChar = DEFAULT_APPEND_ESCAPE;
 
         public Builder(RowFormatInfo rowFormatInfo) {
             super(rowFormatInfo);
@@ -287,6 +295,11 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
             return this;
         }
 
+        public Builder setAppendEscapeChar(Boolean appendEscapeChar) {
+            this.appendEscapeChar = appendEscapeChar;
+            return this;
+        }
+
         @Override
         public Builder configure(DescriptorProperties descriptorProperties) {
             super.configure(descriptorProperties);
@@ -303,6 +316,8 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
                     .ifPresent(this::setDeleteHeadDelimiter);
             descriptorProperties.getOptionalBoolean(FORMAT_RETAIN_PREDEFINED_FIELD)
                     .ifPresent(this::setRetainPredefinedField);
+            descriptorProperties.getOptionalBoolean(FORMAT_APPEND_ESCAPE_FIELD)
+                    .ifPresent(this::setAppendEscapeChar);
             return this;
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvMixedFormatConverter.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvMixedFormatConverter.java
@@ -96,7 +96,7 @@ public class InLongMsgCsvMixedFormatConverter extends AbstractInLongMsgMixedForm
             Timestamp time,
             List<String> predefinedFields,
             List<String> fields,
-            Map<String, String> entries) {
+            Map<String, String> entries) throws Exception {
         Row dataRow =
                 InLongMsgCsvUtils.deserializeRow(
                         rowFormatInfo,

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
@@ -108,7 +108,8 @@ public class InLongMsgCsvUtils {
         String bodyStr = new String(bytes, Charset.forName(charset));
 
         String[][] split =
-                splitCsv(bodyStr, delimiter, escapeChar, quoteChar, lineDelimiter, deleteHeadDelimiter);
+                splitCsv(bodyStr, delimiter, escapeChar, quoteChar, lineDelimiter, deleteHeadDelimiter,
+                        true);
 
         return Arrays.stream(split)
                 .map((line) -> {
@@ -135,7 +136,7 @@ public class InLongMsgCsvUtils {
             RowFormatInfo rowFormatInfo,
             String nullLiteral,
             List<String> predefinedFields,
-            List<String> fields) {
+            List<String> fields) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -164,7 +165,7 @@ public class InLongMsgCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 
@@ -184,7 +185,7 @@ public class InLongMsgCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i + predefinedFields.size(), field);
         }
         for (int i = predefinedFields.size() + fields.size(); i < fieldNames.length; ++i) {

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
@@ -744,5 +744,11 @@ public class InLongMsgCsvFormatDeserializerTest {
                 InLongMsgBody body, Exception exception) throws Exception {
             rowCount++;
         }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
+            rowCount++;
+        }
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
@@ -225,7 +225,7 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
     }
 
     @Override
-    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) {
+    protected List<Row> convertRows(InLongMsgHead head, InLongMsgBody body) throws Exception {
         Row dataRow =
                 InLongMsgKvUtils.deserializeRow(
                         rowFormatInfo,

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvMixedFormatConverter.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvMixedFormatConverter.java
@@ -95,7 +95,7 @@ public class InLongMsgKvMixedFormatConverter extends AbstractInLongMsgMixedForma
             Timestamp time,
             List<String> predefinedFields,
             List<String> fields,
-            Map<String, String> entries) {
+            Map<String, String> entries) throws Exception {
         Row dataRow =
                 InLongMsgKvUtils.deserializeRow(
                         rowFormatInfo,

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
@@ -101,7 +101,7 @@ public class InLongMsgKvUtils {
                         kvDelimiter,
                         escapeChar,
                         quoteChar,
-                        lineDelimiter);
+                        lineDelimiter, true);
 
         return list.stream().map((line) -> {
             return new InLongMsgBody(
@@ -125,7 +125,7 @@ public class InLongMsgKvUtils {
             RowFormatInfo rowFormatInfo,
             String nullLiteral,
             List<String> predefinedFields,
-            Map<String, String> entries) {
+            Map<String, String> entries) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -147,7 +147,7 @@ public class InLongMsgKvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 
@@ -163,7 +163,7 @@ public class InLongMsgKvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
@@ -329,5 +329,11 @@ public class InLongMsgKvFormatDeserializerTest {
                 Exception exception) throws Exception {
             rowCount++;
         }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
+            rowCount++;
+        }
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
@@ -110,7 +110,7 @@ public class InLongMsgTlogCsvUtils {
             RowFormatInfo rowFormatInfo,
             String nullLiteral,
             List<String> predefinedFields,
-            List<String> fields) {
+            List<String> fields) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -138,7 +138,7 @@ public class InLongMsgTlogCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 
@@ -158,7 +158,7 @@ public class InLongMsgTlogCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i + predefinedFields.size(), field);
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
@@ -285,5 +285,11 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
                 InLongMsgBody body, Exception exception) throws Exception {
             rowCount++;
         }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
+            rowCount++;
+        }
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvUtils.java
@@ -110,7 +110,7 @@ public class InLongMsgTlogKvUtils {
             RowFormatInfo rowFormatInfo,
             String nullLiteral,
             List<String> predefinedFields,
-            Map<String, String> entries) {
+            Map<String, String> entries) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -132,7 +132,7 @@ public class InLongMsgTlogKvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 
@@ -147,7 +147,7 @@ public class InLongMsgTlogKvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral);
+                            nullLiteral, null);
             row.setField(i, field);
         }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
@@ -209,5 +209,11 @@ public class InLongMsgTlogKvFormatDeserializerTest {
                 InLongMsgBody body, Exception exception) throws Exception {
             rowCount++;
         }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
+            rowCount++;
+        }
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-kv/src/main/java/org/apache/inlong/sort/formats/kv/KvDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-row/format-kv/src/main/java/org/apache/inlong/sort/formats/kv/KvDeserializationSchema.java
@@ -162,7 +162,7 @@ public final class KvDeserializationSchema extends DefaultDeserializationSchema<
                                 fieldName,
                                 fieldFormatInfo,
                                 fieldText,
-                                nullLiteral);
+                                nullLiteral, null);
                 row.setField(i, field);
             }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgUtils.java
@@ -76,6 +76,11 @@ public class InLongMsgUtils {
     public static final String DEFAULT_TIME_FIELD_NAME = "inlongmsg_time";
     public static final String DEFAULT_ATTRIBUTES_FIELD_NAME = "inlongmsg_attributes";
 
+    public static final boolean DEFAULT_IS_RETAIN_PREDEFINED_FIELD = false;
+    public static final boolean DEFAULT_IS_DELETE_ESCAPE_CHAR = true;
+    public static final boolean DEFAULT_IS_PATCH_ESCAPE_CHAR = false;
+    public static final boolean DEFAULT_IS_DELETE_HEAD_DELIMITER = false;
+
     private static final FieldToRowDataConverters.FieldToRowDataConverter TIME_FIELD_CONVERTER =
             FieldToRowDataConverters.createConverter(new TimestampType());
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
@@ -150,7 +150,8 @@ public final class InLongMsgBinlogFormatDeserializer extends AbstractInLongMsgFo
                 metadataFieldName,
                 head.getAttributes(),
                 body.getData(),
-                includeUpdateBefore);
+                includeUpdateBefore,
+                failureHandler);
     }
 
     @Override

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
@@ -21,6 +21,7 @@ import org.apache.inlong.common.pojo.sort.dataflow.field.format.FormatInfo;
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.RowFormatInfo;
 import org.apache.inlong.sort.formats.base.FieldToRowDataConverters;
 import org.apache.inlong.sort.formats.base.FieldToRowDataConverters.FieldToRowDataConverter;
+import org.apache.inlong.sort.formats.inlongmsg.FailureHandler;
 import org.apache.inlong.sort.formats.inlongmsg.InLongMsgBody;
 import org.apache.inlong.sort.formats.inlongmsg.InLongMsgHead;
 
@@ -109,11 +110,12 @@ public class InLongMsgCsvUtils {
             Character lineDelimiter,
             Character escapeChar,
             Character quoteChar,
-            boolean deleteHeadDelimiter) {
+            boolean deleteHeadDelimiter, boolean isDeleteEscapeChar) {
         String bodyStr = new String(bytes, Charset.forName(charset));
 
         String[][] split =
-                splitCsv(bodyStr, delimiter, escapeChar, quoteChar, lineDelimiter, deleteHeadDelimiter);
+                splitCsv(bodyStr, delimiter, escapeChar, quoteChar, lineDelimiter,
+                        deleteHeadDelimiter, isDeleteEscapeChar);
 
         return Arrays.stream(split)
                 .map((line) -> {
@@ -132,7 +134,8 @@ public class InLongMsgCsvUtils {
             String nullLiteral,
             List<String> predefinedFields,
             List<String> fields,
-            FieldToRowDataConverters.FieldToRowDataConverter[] converters) {
+            FieldToRowDataConverters.FieldToRowDataConverter[] converters,
+            FailureHandler failureHandler) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -160,7 +163,7 @@ public class InLongMsgCsvUtils {
                     fieldName,
                     fieldFormatInfo,
                     fieldText,
-                    nullLiteral));
+                    nullLiteral, failureHandler));
             rowData.setField(i, field);
         }
 
@@ -180,7 +183,7 @@ public class InLongMsgCsvUtils {
                     fieldName,
                     fieldFormatInfo,
                     fieldText,
-                    nullLiteral));
+                    nullLiteral, failureHandler));
             rowData.setField(i + predefinedFields.size(), field);
         }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/test/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializerTest.java
@@ -278,6 +278,8 @@ public class InLongMsgCsvFormatDeserializerTest {
                         null,
                         InLongMsgCsvUtils.DEFAULT_DELETE_HEAD_DELIMITER,
                         Collections.emptyList(),
+                        true,
+                        true,
                         errorHandler);
 
         InLongMsg inLongMsg = InLongMsg.newInLongMsg();
@@ -290,7 +292,7 @@ public class InLongMsgCsvFormatDeserializerTest {
         List<RowData> actualRows = new ArrayList<>();
         Collector<RowData> collector = new ListCollector<>(actualRows);
         deserializer.flatMap(inLongMsg.buildArray(), collector);
-        assertEquals(0, errorHandler.getRowCount());
+        assertEquals(1, errorHandler.getRowCount());
 
         InLongMsg inLongMsg1Head = InLongMsg.newInLongMsg();
         String abNormalAttrs = "m=0&streamId=testInterfaceId&__addcol1__=1&__addcol2__=2";
@@ -871,6 +873,12 @@ public class InLongMsgCsvFormatDeserializerTest {
 
         @Override
         public void onConvertingRowFailure(InLongMsgHead head, InLongMsgBody body,
+                Exception exception) throws Exception {
+            rowCount++;
+        }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
                 Exception exception) throws Exception {
             rowCount++;
         }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
@@ -44,6 +44,7 @@ import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_E
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_KV_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_LINE_DELIMITER;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_ATTRIBUTES_FIELD_NAME;
+import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_IS_DELETE_ESCAPE_CHAR;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_TIME_FIELD_NAME;
 
 /**
@@ -120,6 +121,11 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
      */
     private boolean retainPredefinedField = true;
 
+    /**
+     * True if delete escape char while parsing.
+     */
+    private boolean isDeleteEscapeChar = DEFAULT_IS_DELETE_ESCAPE_CHAR;
+
     public InLongMsgKvFormatDeserializer(
             @Nonnull RowFormatInfo rowFormatInfo,
             @Nullable String timeFieldName,
@@ -144,6 +150,7 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
                 escapeChar,
                 quoteChar,
                 nullLiteral,
+                DEFAULT_IS_DELETE_ESCAPE_CHAR,
                 InLongMsgUtils.getDefaultExceptionHandler(ignoreErrors));
         if (retainPredefinedField != null) {
             this.retainPredefinedField = retainPredefinedField;
@@ -173,6 +180,7 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
                 escapeChar,
                 quoteChar,
                 nullLiteral,
+                DEFAULT_IS_DELETE_ESCAPE_CHAR,
                 InLongMsgUtils.getDefaultExceptionHandler(ignoreErrors));
     }
 
@@ -187,6 +195,7 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
             @Nullable String nullLiteral,
+            @Nullable Boolean isDeleteEscapeChar,
             @Nonnull FailureHandler failureHandler) {
         super(failureHandler);
 
@@ -200,6 +209,7 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
         this.escapeChar = escapeChar;
         this.quoteChar = quoteChar;
         this.nullLiteral = nullLiteral;
+        this.isDeleteEscapeChar = isDeleteEscapeChar;
 
         converters = Arrays.stream(rowFormatInfo.getFieldFormatInfos())
                 .map(formatInfo -> FieldToRowDataConverters.createConverter(
@@ -231,17 +241,19 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
                 kvDelimiter,
                 lineDelimiter,
                 escapeChar,
-                quoteChar);
+                quoteChar,
+                isDeleteEscapeChar);
     }
 
     @Override
-    protected List<RowData> convertRowDataList(InLongMsgHead head, InLongMsgBody body) {
+    protected List<RowData> convertRowDataList(InLongMsgHead head, InLongMsgBody body) throws Exception {
         GenericRowData genericRowData = InLongMsgKvUtils.deserializeRowData(
                 rowFormatInfo,
                 nullLiteral,
                 retainPredefinedField ? head.getPredefinedFields() : Collections.emptyList(),
                 body.getEntries(),
-                converters);
+                converters,
+                failureHandler);
 
         // Decorate result with time and attributes fields if needed
         return Collections.singletonList(InLongMsgUtils.decorateRowDataWithNeededHeadFields(

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.formats.inlongmsgkv;
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.FormatInfo;
 import org.apache.inlong.common.pojo.sort.dataflow.field.format.RowFormatInfo;
 import org.apache.inlong.sort.formats.base.FieldToRowDataConverters.FieldToRowDataConverter;
+import org.apache.inlong.sort.formats.inlongmsg.FailureHandler;
 import org.apache.inlong.sort.formats.inlongmsg.InLongMsgBody;
 import org.apache.inlong.sort.formats.inlongmsg.InLongMsgHead;
 
@@ -91,7 +92,8 @@ public class InLongMsgKvUtils {
             char kvDelimiter,
             Character lineDelimiter,
             Character escapeChar,
-            Character quoteChar) {
+            Character quoteChar,
+            boolean isDeleteEscapeChar) {
         String text = new String(bytes, Charset.forName(charset));
 
         List<Map<String, String>> list =
@@ -101,7 +103,8 @@ public class InLongMsgKvUtils {
                         kvDelimiter,
                         escapeChar,
                         quoteChar,
-                        lineDelimiter);
+                        lineDelimiter,
+                        isDeleteEscapeChar);
 
         return list.stream().map((line) -> new InLongMsgBody(
                 bytes,
@@ -124,7 +127,8 @@ public class InLongMsgKvUtils {
             String nullLiteral,
             List<String> predefinedFields,
             Map<String, String> entries,
-            FieldToRowDataConverter[] converters) {
+            FieldToRowDataConverter[] converters,
+            FailureHandler failureHandler) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
 
@@ -146,7 +150,7 @@ public class InLongMsgKvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral));
+                            nullLiteral, failureHandler));
             row.setField(i, field);
         }
 
@@ -161,7 +165,8 @@ public class InLongMsgKvUtils {
                     fieldName,
                     fieldFormatInfo,
                     fieldText,
-                    nullLiteral));
+                    nullLiteral,
+                    failureHandler));
             row.setField(i, field);
         }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializerTest.java
@@ -84,6 +84,7 @@ public class InLongMsgKvFormatDeserializerTest {
                         null,
                         null,
                         null,
+                        true,
                         errorHandler);
 
         InLongMsg inLongMsg = InLongMsg.newInLongMsg();
@@ -96,7 +97,7 @@ public class InLongMsgKvFormatDeserializerTest {
         List<RowData> actualRows = new ArrayList<>();
         Collector<RowData> collector = new ListCollector<>(actualRows);
         deserializer.flatMap(inLongMsg.buildArray(), collector);
-        assertEquals(0, errorHandler.getRowCount());
+        assertEquals(1, errorHandler.getRowCount());
 
         InLongMsg inLongMsg1 = InLongMsg.newInLongMsg();
         String abNormalAttrs = "m=0&iname=testInterfaceId&__addcol1__=1&__addcol2__=2";
@@ -339,6 +340,12 @@ public class InLongMsgKvFormatDeserializerTest {
         @Override
         public void onConvertingRowFailure(InLongMsgHead head,
                 InLongMsgBody body, Exception exception) throws Exception {
+            rowCount++;
+        }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
             rowCount++;
         }
     }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializerTest.java
@@ -89,14 +89,16 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
                         DEFAULT_DELIMITER,
                         null,
                         null,
+                        '\n',
                         null,
                         Collections.emptyList(),
                         false,
+                        false,
+                        false,
                         errorHandler);
-
         InLongMsg inLongMsg1 = InLongMsg.newInLongMsg(true);
         String attrs = "m=0&dt=1584806400000&__addcol1_=1&__addcol2_=test";
-        String body1 = "interfaceId1,field1,field2,field3";
+        String body1 = "interfaceId1,field1,field2,field3\ninterfaceId1,field1,field2,field3";
         String body2 = "interfaceId2,field1,field2,field3";
         inLongMsg1.addMsg(attrs, body1.getBytes());
         inLongMsg1.addMsg(attrs, body2.getBytes());
@@ -104,7 +106,8 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
         List<RowData> actualRows = new ArrayList<>();
         Collector<RowData> collector = new ListCollector<>(actualRows);
         deserializer.flatMap(inLongMsg1.buildArray(), collector);
-        assertEquals(0, errorHandler.getRowCount());
+        assertEquals(3, errorHandler.getRowCount());
+        assertEquals(3, actualRows.size());
 
         InLongMsg inLongMsg1Head = InLongMsg.newInLongMsg();
         String abNormalAttrs = "m=0&__addcol1_=1&__addcol2_=test";
@@ -334,6 +337,12 @@ public class InLongMsgTlogCsvFormatDeserializerTest {
         @Override
         public void onConvertingRowFailure(InLongMsgHead head, InLongMsgBody body, Exception exception)
                 throws Exception {
+            rowCount++;
+        }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
             rowCount++;
         }
     }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializer.java
@@ -45,12 +45,15 @@ import java.util.Objects;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_ENTRY_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_KV_DELIMITER;
+import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_LINE_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_ATTRIBUTE_FIELD_NAME;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_ENTRY_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_KV_DELIMITER;
+import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_LINE_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.FORMAT_TIME_FIELD_NAME;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_ATTRIBUTES_FIELD_NAME;
+import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_IS_DELETE_ESCAPE_CHAR;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_TIME_FIELD_NAME;
 import static org.apache.inlong.sort.formats.inlongmsgtlogkv.InLongMsgTlogKvUtils.DEFAULT_INLONGMSG_TLOGKV_CHARSET;
 
@@ -115,11 +118,16 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
     @Nullable
     private final Character quoteChar;
 
+    @Nullable
+    private final Character lineDelimiter;
+
     /**
      * The literal represented null values, default "".
      */
     @Nullable
     private final String nullLiteral;
+
+    private boolean isDeleteEscapeChar = DEFAULT_IS_DELETE_ESCAPE_CHAR;
 
     private final FieldToRowDataConverter[] converters;
 
@@ -133,6 +141,7 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
             @Nonnull Character kvDelimiter,
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
+            @Nullable Character lineDelimiter,
             @Nullable String nullLiteral,
             @Nonnull Boolean ignoreErrors) {
         this(
@@ -145,7 +154,9 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                 kvDelimiter,
                 escapeChar,
                 quoteChar,
+                lineDelimiter,
                 nullLiteral,
+                DEFAULT_IS_DELETE_ESCAPE_CHAR,
                 InLongMsgUtils.getDefaultExceptionHandler(ignoreErrors));
     }
 
@@ -159,7 +170,9 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
             @Nonnull Character kvDelimiter,
             @Nullable Character escapeChar,
             @Nullable Character quoteChar,
+            @Nullable Character lineDelimiter,
             @Nullable String nullLiteral,
+            @Nullable Boolean isDeleteEscapeChar,
             @Nonnull FailureHandler failureHandler) {
         super(failureHandler);
 
@@ -172,7 +185,9 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
         this.kvDelimiter = kvDelimiter;
         this.escapeChar = escapeChar;
         this.quoteChar = quoteChar;
+        this.lineDelimiter = lineDelimiter;
         this.nullLiteral = nullLiteral;
+        this.isDeleteEscapeChar = isDeleteEscapeChar;
 
         this.converters = Arrays.stream(rowFormatInfo.getFieldFormatInfos())
                 .map(formatInfo -> FieldToRowDataConverters.createConverter(
@@ -193,15 +208,14 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
 
     @Override
     protected List<InLongMsgBody> parseBodyList(byte[] bytes) throws Exception {
-        return Collections.singletonList(
-                InLongMsgTlogKvUtils.parseBody(
-                        bytes,
-                        charset,
-                        delimiter,
-                        entryDelimiter,
-                        kvDelimiter,
-                        escapeChar,
-                        quoteChar));
+        return InLongMsgTlogKvUtils.parseBody(
+                bytes,
+                charset,
+                delimiter,
+                entryDelimiter,
+                kvDelimiter,
+                escapeChar,
+                quoteChar, lineDelimiter, isDeleteEscapeChar);
     }
 
     @Override
@@ -211,7 +225,7 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                         rowFormatInfo,
                         nullLiteral,
                         head.getPredefinedFields(),
-                        body.getEntries(), converters);
+                        body.getEntries(), converters, failureHandler);
 
         RowData rowData = InLongMsgUtils.decorateRowWithNeededHeadFields(
                 timeFieldName,
@@ -233,6 +247,8 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
         private Character delimiter = DEFAULT_DELIMITER;
         private Character entryDelimiter = DEFAULT_ENTRY_DELIMITER;
         private Character kvDelimiter = DEFAULT_KV_DELIMITER;
+        private Character lineDelimiter = DEFAULT_LINE_DELIMITER;
+        private boolean isDeleteEscapeChar = DEFAULT_IS_DELETE_ESCAPE_CHAR;
 
         public Builder(RowFormatInfo rowFormatInfo) {
             super(rowFormatInfo);
@@ -265,6 +281,16 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
             return this;
         }
 
+        public Builder setLineDelimiter(Character lineDelimiter) {
+            this.lineDelimiter = lineDelimiter;
+            return this;
+        }
+
+        public Builder setDeleteEscapeChar(boolean isDeleteEscapeChar) {
+            this.isDeleteEscapeChar = isDeleteEscapeChar;
+            return this;
+        }
+
         public Builder configure(DescriptorProperties descriptorProperties) {
             super.configure(descriptorProperties);
 
@@ -278,11 +304,29 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                     .ifPresent(this::setEntryDelimiter);
             descriptorProperties.getOptionalCharacter(FORMAT_KV_DELIMITER)
                     .ifPresent(this::setKvDelimiter);
+            descriptorProperties.getOptionalCharacter(FORMAT_LINE_DELIMITER)
+                    .ifPresent(this::setLineDelimiter);
 
             return this;
         }
 
         public InLongMsgTlogKvFormatDeserializer build() {
+            if (failureHandler != null) {
+                return new InLongMsgTlogKvFormatDeserializer(
+                        rowFormatInfo,
+                        timeFieldName,
+                        attributesFieldName,
+                        charset,
+                        delimiter,
+                        entryDelimiter,
+                        kvDelimiter,
+                        escapeChar,
+                        quoteChar,
+                        lineDelimiter,
+                        nullLiteral,
+                        isDeleteEscapeChar,
+                        failureHandler);
+            }
             return new InLongMsgTlogKvFormatDeserializer(
                     rowFormatInfo,
                     timeFieldName,
@@ -293,6 +337,7 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                     kvDelimiter,
                     escapeChar,
                     quoteChar,
+                    lineDelimiter,
                     nullLiteral,
                     ignoreErrors);
         }
@@ -322,13 +367,15 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                 kvDelimiter.equals(that.kvDelimiter) &&
                 Objects.equals(escapeChar, that.escapeChar) &&
                 Objects.equals(quoteChar, that.quoteChar) &&
-                Objects.equals(nullLiteral, that.nullLiteral);
+                Objects.equals(lineDelimiter, that.lineDelimiter) &&
+                Objects.equals(nullLiteral, that.nullLiteral) &&
+                Objects.equals(isDeleteEscapeChar, that.isDeleteEscapeChar);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), rowFormatInfo, timeFieldName,
                 attributesFieldName, charset, delimiter, entryDelimiter, kvDelimiter,
-                escapeChar, quoteChar, nullLiteral);
+                escapeChar, quoteChar, lineDelimiter, nullLiteral, isDeleteEscapeChar);
     }
 }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/test/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializerTest.java
@@ -47,7 +47,9 @@ import static org.apache.flink.table.api.DataTypes.STRING;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_ENTRY_DELIMITER;
 import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_KV_DELIMITER;
+import static org.apache.inlong.sort.formats.base.TableFormatConstants.DEFAULT_LINE_DELIMITER;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_ATTRIBUTES_FIELD_NAME;
+import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_IS_DELETE_ESCAPE_CHAR;
 import static org.apache.inlong.sort.formats.inlongmsg.InLongMsgUtils.DEFAULT_TIME_FIELD_NAME;
 import static org.apache.inlong.sort.formats.inlongmsgtlogkv.InLongMsgTlogKvUtils.DEFAULT_INLONGMSG_TLOGKV_CHARSET;
 import static org.junit.Assert.assertEquals;
@@ -85,7 +87,9 @@ public class InLongMsgTlogKvFormatDeserializerTest {
                         DEFAULT_KV_DELIMITER,
                         null,
                         null,
+                        DEFAULT_LINE_DELIMITER,
                         null,
+                        DEFAULT_IS_DELETE_ESCAPE_CHAR,
                         errorHandler);
 
         InLongMsg inLongMsg1 = InLongMsg.newInLongMsg(true);
@@ -98,7 +102,7 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         List<RowData> actualRowDatas = new ArrayList<>();
         Collector<RowData> collector = new ListCollector<>(actualRowDatas);
         deserializer.flatMap(inLongMsg1.buildArray(), collector);
-        assertEquals(0, errorHandler.getRowCount());
+        assertEquals(2, errorHandler.getRowCount());
 
         InLongMsg inLongMsg1Head = InLongMsg.newInLongMsg();
         String abNormalAttrs = "m=0&__addcol1_=1&__addcol2_=tes";
@@ -113,10 +117,10 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         InLongMsg inLongMsg1 = InLongMsg.newInLongMsg(true);
 
         String attrs = "m=0&t=20200322&__addcol1_=1&__addcol2_=2";
-        String body1 = "testInterfaceId1,f1=field1&f2=field2&f3=field3";
-        String body2 = "f1=field1&f2=field2&f3=field3";
-        String body3 = "f1=field1&f2=field2,f1=field1&f2=field2&f3=field3";
-        String body4 = ",testInterfaceId1,f1=field1&f2=field2&f3=field3";
+        String body1 = "testInterfaceId1,f1=field11&f2=field12&f3=field13";
+        String body2 = "f1=field21&f2=field22&f3=field23";
+        String body3 = "f1=field3&f2=field2,f1=field31&f2=field32&f3=field33";
+        String body4 = ",testInterfaceId1,f1=field41&f2=field42&f3=field43";
 
         inLongMsg1.addMsg(attrs, body1.getBytes());
         inLongMsg1.addMsg(attrs, body2.getBytes());
@@ -134,9 +138,9 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         expectRowData1.setField(1, mapConvert.convert(expectedAttributes));
         expectRowData1.setField(2, 1);
         expectRowData1.setField(3, 2);
-        expectRowData1.setField(4, StringData.fromString("field1"));
-        expectRowData1.setField(5, StringData.fromString("field2"));
-        expectRowData1.setField(6, StringData.fromString("field3"));
+        expectRowData1.setField(4, StringData.fromString("field11"));
+        expectRowData1.setField(5, StringData.fromString("field12"));
+        expectRowData1.setField(6, StringData.fromString("field13"));
 
         GenericRowData expectRowData2 = new GenericRowData(7);
         expectRowData2.setField(0, TimestampData.fromTimestamp(Timestamp.valueOf("2020-03-22 00:00:00")));
@@ -152,18 +156,18 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         expectRowData3.setField(1, mapConvert.convert(expectedAttributes));
         expectRowData3.setField(2, 1);
         expectRowData3.setField(3, 2);
-        expectRowData3.setField(4, StringData.fromString("field1"));
-        expectRowData3.setField(5, StringData.fromString("field2"));
-        expectRowData3.setField(6, StringData.fromString("field3"));
+        expectRowData3.setField(4, StringData.fromString("field31"));
+        expectRowData3.setField(5, StringData.fromString("field32"));
+        expectRowData3.setField(6, StringData.fromString("field33"));
 
         GenericRowData expectRowData4 = new GenericRowData(7);
         expectRowData4.setField(0, TimestampData.fromTimestamp(Timestamp.valueOf("2020-03-22 00:00:00")));
         expectRowData4.setField(1, mapConvert.convert(expectedAttributes));
         expectRowData4.setField(2, 1);
         expectRowData4.setField(3, 2);
-        expectRowData4.setField(4, StringData.fromString("field1"));
-        expectRowData4.setField(5, StringData.fromString("field2"));
-        expectRowData4.setField(6, StringData.fromString("field3"));
+        expectRowData4.setField(4, StringData.fromString("field41"));
+        expectRowData4.setField(5, StringData.fromString("field42"));
+        expectRowData4.setField(6, StringData.fromString("field43"));
 
         testRowDataDeserialization(inLongMsg1.buildArray(),
                 Arrays.asList(expectRowData1, expectRowData2, expectRowData3, expectRowData4));
@@ -217,6 +221,12 @@ public class InLongMsgTlogKvFormatDeserializerTest {
         @Override
         public void onConvertingRowFailure(InLongMsgHead head,
                 InLongMsgBody body, Exception exception) throws Exception {
+            rowCount++;
+        }
+
+        @Override
+        public void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+                Exception exception) throws Exception {
             rowCount++;
         }
     }

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/src/test/java/org/apache/inlong/sort/formats/base/TableFormatUtilsTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/src/test/java/org/apache/inlong/sort/formats/base/TableFormatUtilsTest.java
@@ -47,13 +47,13 @@ import static org.junit.Assert.assertNull;
 public class TableFormatUtilsTest {
 
     @Test
-    public void testDeserializeStringWithoutNullLiteral() {
+    public void testDeserializeStringWithoutNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         StringFormatInfo.INSTANCE,
                         "data",
-                        null);
+                        null, null);
         assertEquals("data", result1);
 
         Object result2 =
@@ -61,7 +61,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "",
-                        null);
+                        null, null);
         assertEquals("", result2);
     }
 
@@ -85,13 +85,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeStringWithNullLiteral() {
+    public void testDeserializeStringWithNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         StringFormatInfo.INSTANCE,
                         "data",
-                        "n/a");
+                        "n/a", null);
         assertEquals("data", result1);
 
         Object result2 =
@@ -99,7 +99,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "",
-                        "n/a");
+                        "n/a", null);
         assertEquals("", result2);
 
         Object result3 =
@@ -107,7 +107,7 @@ public class TableFormatUtilsTest {
                         "f",
                         StringFormatInfo.INSTANCE,
                         "n/a",
-                        "n/a");
+                        "n/a", null);
         assertNull(result3);
     }
 
@@ -139,13 +139,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeNumberWithoutNullLiteral() {
+    public void testDeserializeNumberWithoutNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         IntFormatInfo.INSTANCE,
                         "1",
-                        null);
+                        null, null);
         assertEquals(1, result1);
 
         Object result2 =
@@ -153,7 +153,7 @@ public class TableFormatUtilsTest {
                         "f",
                         IntFormatInfo.INSTANCE,
                         "",
-                        null);
+                        null, null);
         assertNull(result2);
     }
 
@@ -177,13 +177,13 @@ public class TableFormatUtilsTest {
     }
 
     @Test
-    public void testDeserializeNumberWithNullLiteral() {
+    public void testDeserializeNumberWithNullLiteral() throws Exception {
         Object result1 =
                 deserializeBasicField(
                         "f",
                         IntFormatInfo.INSTANCE,
                         "1",
-                        "n/a");
+                        "n/a", null);
         assertEquals(1, result1);
 
         try {
@@ -191,7 +191,7 @@ public class TableFormatUtilsTest {
                     "f",
                     IntFormatInfo.INSTANCE,
                     "",
-                    "n/a");
+                    "n/a", null);
 
             assertNull(result2);
         } catch (Exception e) {
@@ -203,7 +203,7 @@ public class TableFormatUtilsTest {
                         "f",
                         IntFormatInfo.INSTANCE,
                         "n/a",
-                        "n/a");
+                        "n/a", null);
         assertNull(result3);
     }
 

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/kv/KvUtilsTest.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/src/test/java/org/apache/inlong/sort/formats/kv/KvUtilsTest.java
@@ -37,7 +37,8 @@ public class KvUtilsTest {
     @Test
     public void testSplitNormal() {
         List<Map<String, String>> list =
-                splitKv("f1=a\nf1=b", '&', '=', '\\', '\"', '\n');
+                splitKv("f1=a\nf1=b", '&', '=', '\\', '\"',
+                        '\n', true);
         List<Map<String, String>> expectedList = new ArrayList<>();
         expectedList.add(new HashMap<String, String>() {
 
@@ -193,6 +194,103 @@ public class KvUtilsTest {
                     }
                 },
                 splitKv("=a&f=", '&', '=', '\\', '\"'));
+    }
+
+    @Test
+    public void testSplitNormalWithoutEscape() {
+        List<Map<String, String>> list =
+                splitKv("f1=a\nf1=b", '&', '=', '\\', '\"',
+                        '\n', false);
+        List<Map<String, String>> expectedList = new ArrayList<>();
+        expectedList.add(new HashMap<String, String>() {
+
+            {
+                put("f1", "a");
+            }
+        });
+        expectedList.add(new HashMap<String, String>() {
+
+            {
+                put("f1", "b");
+            }
+        });
+        assertEquals(list, expectedList);
+        ArrayList expectedListMap = new ArrayList<HashMap<String, String>>();
+        HashMap expectedMap = new HashMap<String, String>();
+        expectedMap.put("\\=f1", "a");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        expectedListMap.add(expectedMap);
+        assertEquals(expectedListMap,
+                splitKv("\\=f1=a&f2=b&f3=c", '&', '=', '\\',
+                        null, null, false));
+
+        expectedMap.clear();
+        expectedMap.put("\\&f1", "a");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        assertEquals(expectedListMap,
+                splitKv("\\&f1=a&f2=b&f3=c", '&', '=', '\\',
+                        null, null, false));
+
+        expectedMap.clear();
+        expectedMap.put("&f1", "a");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        assertEquals(expectedListMap,
+                splitKv("\"&f1\"=a&f2=b&f3=c", '&', '=', '\\',
+                        '\"', null, false));
+
+        expectedMap.clear();
+        expectedMap.put("f1", "a\\&");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        assertEquals(expectedListMap,
+                splitKv("f1=a\\&&f2=b&f3=c", '&', '=', '\\',
+                        null, null, false));
+
+        expectedMap.clear();
+        expectedMap.put("f1", "a\\\\");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        assertEquals(expectedListMap,
+                splitKv("f1=a\\\\&f2=b&f3=c", '&', '=',
+                        '\\', null, null, false));
+
+        expectedMap.clear();
+        expectedMap.put("f1", "a&f2=b");
+        expectedMap.put("f3", "c");
+        expectedMap.put("f4", "d");
+        assertEquals(expectedListMap,
+                splitKv("f1=a\"&f2=\"b&f3=c&f4=d", '&', '=',
+                        '\\', '\"', null, false));
+
+        expectedMap.clear();
+        expectedMap.put("f1", "atest\\test");
+        expectedMap.put("f2", "b");
+        expectedMap.put("f3", "c");
+        assertEquals(expectedListMap,
+                splitKv("f1=a\"test\\test\"&f2=b&f3=c", '&', '=', '\\',
+                        '\"', null, false));
+
+        expectedMap.clear();
+        expectedMap.put("f1", "a");
+        expectedMap.put("f2", "\\\"b");
+        expectedMap.put("f3", "c\\\"");
+        expectedMap.put("f4", "d");
+        assertEquals(expectedListMap,
+                splitKv("f1=a&f2=\\\"b&f3=c\\\"&f4=d", '&', '=', '\\',
+                        '\"', null, false));
+
+        expectedMap.clear();
+        expectedMap.put("", "a");
+        expectedMap.put("f", "");
+        HashMap expectedMap2 = new HashMap<String, String>();
+        expectedMap2.put("c", "dd");
+        expectedListMap.add(expectedMap2);
+        assertEquals(expectedListMap,
+                splitKv("=a&f=\nc=d\\d", '&', '=', '\\',
+                        '\"', '\n', true));
     }
 
     @Test


### PR DESCRIPTION
fix #11819
CSV and KC format case 

first support keep escape such as:
CSV : aaa|bbbb|dd\cc ,
when using keep escape configuration
result is "aaa bbbb dd\cc"
but default parse result is "aaa bbbb ddcc"

kv : a=b&c=\=d
when using keep escape configuration
result values are "b \=d"
but default parse result values are "b =d"

second using line delimiter such as:
CSV : aaa|bbbb|dd\n aaa|cc ,
when using line delimiter '\n' configuration
result is 
"aaa bbbb dd"
"aaa cc"
but default parse result is "aaa bbbb dd aaa cc"

kv : a=b&c=\nc=d
when using line delimiter '\n' configuration
result values are 
"b  "
"d"
but default parse result values are "b  d"
