### PR TITLE
[INLONG-11836][Sort] Provide SortStandalone flow control to prevent single-task blocking from affecting the normal sorting of other tasks

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatus.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatus.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.metrics.status;
+
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
+
+import lombok.Data;
+
+/**
+ * SortTaskStatus
+ */
+@Data
+public class SortTaskStatus {
+
+    private String taskName;
+    private boolean hasFirstSuccess = false;
+    private Semaphore firstSuccessPermit = new Semaphore(1);
+    private AtomicLong sendCount = new AtomicLong(0);
+    private AtomicLong sendFailCount = new AtomicLong(0);
+    private long previousPauseSortTaskTime = Long.MIN_VALUE;
+
+    public SortTaskStatus(String taskName) {
+        this.taskName = taskName;
+    }
+
+    public void tryFirstSend() throws InterruptedException {
+        firstSuccessPermit.acquire(1);
+    }
+
+    public void firstSuccess() {
+        hasFirstSuccess = true;
+        firstSuccessPermit.release(1);
+    }
+
+    public boolean needPauseSortTask(int failCountLimit, int failCountPercentLimit) {
+        long sendFail = this.sendFailCount.getAndSet(0);
+        long send = this.sendCount.getAndSet(0);
+        if (sendFail < failCountLimit) {
+            return false;
+        }
+        if (send <= 0) {
+            return false;
+        }
+        long rate = sendFail * 100 / send;
+        if (rate < failCountPercentLimit) {
+            return false;
+        }
+        this.previousPauseSortTaskTime = System.currentTimeMillis();
+        return true;
+    }
+
+    public boolean canResumeSortTask(long pauseIntervalMs) {
+        long currentTime = System.currentTimeMillis();
+        return currentTime > this.previousPauseSortTaskTime + pauseIntervalMs;
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatus.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -17,10 +17,10 @@
 
 package org.apache.inlong.sort.standalone.metrics.status;
 
+import lombok.Data;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicLong;
-
-import lombok.Data;
 
 /**
  * SortTaskStatus

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusMetricListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusMetricListener.java
@@ -1,10 +1,10 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
+ * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * the License. You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.standalone.metrics.status;
 import org.apache.inlong.common.metric.MetricItemValue;
 import org.apache.inlong.common.metric.MetricListener;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+
 import org.slf4j.Logger;
 
 import java.util.List;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusMetricListener.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusMetricListener.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.metrics.status;
+
+import org.apache.inlong.common.metric.MetricItemValue;
+import org.apache.inlong.common.metric.MetricListener;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.List;
+
+/**
+ * 
+ * SortTaskStatusMetricListener
+ */
+public class SortTaskStatusMetricListener implements MetricListener {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(SortTaskStatusMetricListener.class);
+
+    /**
+     * snapshot
+     * 
+     * @param domain
+     * @param itemValues
+     */
+    @Override
+    public void snapshot(String domain, List<MetricItemValue> itemValues) {
+        SortTaskStatusRepository.snapshot(itemValues);
+    }
+
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
@@ -122,6 +122,7 @@ public class SortTaskStatusRepository {
         if (!failPauseEnable) {
             return;
         }
+        LOG.info("start to SortTaskStatusRepository status:{}", statusMap);
         for (MetricItemValue itemValue : itemValues) {
             Map<String, String> dimensions = itemValue.getDimensions();
             String taskName = dimensions.get(SortMetricItem.KEY_TASK_NAME);
@@ -145,5 +146,6 @@ public class SortTaskStatusRepository {
                 }
             }
         }
+        LOG.info("end to SortTaskStatusRepository status:{}", statusMap);
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -17,12 +17,13 @@
 
 package org.apache.inlong.sort.standalone.metrics.status;
 
-import org.apache.flume.Context;
 import org.apache.inlong.common.metric.MetricItemValue;
 import org.apache.inlong.common.metric.MetricValue;
 import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+
+import org.apache.flume.Context;
 import org.slf4j.Logger;
 
 import java.util.List;

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/metrics/status/SortTaskStatusRepository.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.standalone.metrics.status;
+
+import org.apache.flume.Context;
+import org.apache.inlong.common.metric.MetricItemValue;
+import org.apache.inlong.common.metric.MetricValue;
+import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.metrics.SortMetricItem;
+import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
+import org.slf4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * SortTaskStatusRepository
+ * 
+ */
+public class SortTaskStatusRepository {
+
+    public static final Logger LOG = InlongLoggerFactory.getLogger(SortTaskStatusRepository.class);
+
+    public static final String KEY_FAIL_PAUSE_ENABLE = "sorttask.status.failPauseEnable";
+    public static final boolean DEFAULT_FAIL_PAUSE_ENABLE = false;
+    public static final String KEY_FAIL_COUNT_LIMIT = "sorttask.status.failCountLimit";
+    public static final int DEFAULT_FAIL_COUNT_LIMIT = 10;
+    public static final String KEY_FAIL_COUNT_PERCENT_LIMIT = "sorttask.status.failCountPercentLimit";
+    public static final int DEFAULT_FAIL_COUNT_PERCENT_LIMIT = 50;
+    public static final String KEY_PAUSE_INTERVAL_MS = "sorttask.status.pauseIntervalMs";
+    public static final long DEFAULT_PAUSE_INTERVAL_MS = 300000;
+
+    private static final AtomicBoolean hasInited = new AtomicBoolean(false);
+    private static Context context;
+    private static final ConcurrentHashMap<String, SortTaskStatus> statusMap = new ConcurrentHashMap<>();
+
+    private static boolean failPauseEnable;
+    private static int failCountLimit;
+    private static int failCountPercentLimit;
+    private static long pauseIntervalMs;
+
+    public static void init() {
+        LOG.info("start to init SortTaskStatusRepository");
+        if (!hasInited.compareAndSet(false, true)) {
+            return;
+        }
+        SortTaskStatusRepository.context = CommonPropertiesHolder.getContext();
+        SortTaskStatusRepository.failPauseEnable = context.getBoolean(KEY_FAIL_PAUSE_ENABLE, DEFAULT_FAIL_PAUSE_ENABLE);
+        SortTaskStatusRepository.failCountLimit = context.getInteger(KEY_FAIL_COUNT_LIMIT, DEFAULT_FAIL_COUNT_LIMIT);
+        SortTaskStatusRepository.failCountPercentLimit = context.getInteger(KEY_FAIL_COUNT_PERCENT_LIMIT,
+                DEFAULT_FAIL_COUNT_PERCENT_LIMIT);
+        SortTaskStatusRepository.pauseIntervalMs = context.getLong(KEY_PAUSE_INTERVAL_MS, DEFAULT_PAUSE_INTERVAL_MS);
+    }
+
+    public static void resetStatus(String taskName) {
+        statusMap.put(taskName, new SortTaskStatus(taskName));
+    }
+
+    public static void acquirePutChannel(String taskName) {
+        if (!hasInited.get()) {
+            init();
+        }
+        if (!failPauseEnable) {
+            return;
+        }
+        SortTaskStatus taskStatus = statusMap.computeIfAbsent(taskName, k -> new SortTaskStatus(k));
+        if (taskStatus.isHasFirstSuccess()) {
+            return;
+        }
+        try {
+            taskStatus.tryFirstSend();
+            return;
+        } catch (InterruptedException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+    public static boolean needPauseSortTask(String taskName) {
+        if (!hasInited.get()) {
+            init();
+        }
+        if (!failPauseEnable) {
+            return false;
+        }
+        SortTaskStatus taskStatus = statusMap.computeIfAbsent(taskName, k -> new SortTaskStatus(k));
+        return taskStatus.needPauseSortTask(failCountLimit, failCountPercentLimit);
+    }
+
+    public static boolean canResumeSortTask(String taskName) {
+        if (!hasInited.get()) {
+            init();
+        }
+        if (!failPauseEnable) {
+            return true;
+        }
+        SortTaskStatus taskStatus = statusMap.computeIfAbsent(taskName, k -> new SortTaskStatus(k));
+        return taskStatus.canResumeSortTask(pauseIntervalMs);
+    }
+
+    public static void snapshot(List<MetricItemValue> itemValues) {
+        if (!hasInited.get()) {
+            init();
+        }
+        if (!failPauseEnable) {
+            return;
+        }
+        for (MetricItemValue itemValue : itemValues) {
+            Map<String, String> dimensions = itemValue.getDimensions();
+            String taskName = dimensions.get(SortMetricItem.KEY_TASK_NAME);
+            if (taskName == null) {
+                continue;
+            }
+            SortTaskStatus taskStatus = statusMap.computeIfAbsent(taskName, k -> new SortTaskStatus(k));
+            Map<String, MetricValue> metrics = itemValue.getMetrics();
+            MetricValue sCount = metrics.get(SortMetricItem.M_SEND_COUNT);
+            if (sCount != null) {
+                taskStatus.getSendCount().addAndGet(sCount.value);
+            }
+            MetricValue sfCount = metrics.get(SortMetricItem.M_SEND_FAIL_COUNT);
+            if (sfCount != null) {
+                taskStatus.getSendFailCount().addAndGet(sfCount.value);
+            }
+            MetricValue ssCount = metrics.get(SortMetricItem.M_SEND_SUCCESS_COUNT);
+            if (ssCount != null) {
+                for (int i = 0; i < ssCount.value; i++) {
+                    taskStatus.firstSuccess();
+                }
+            }
+        }
+    }
+}

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaProducerCluster.java
@@ -126,7 +126,8 @@ public class KafkaProducerCluster implements LifecycleAware {
             props.putAll(nodeConfig.getProperties() == null ? new HashMap<>() : nodeConfig.getProperties());
             props.put(ProducerConfig.ACKS_CONFIG, nodeConfig.getAcks());
             props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, nodeConfig.getBootstrapServers());
-            props.put(ProducerConfig.CLIENT_ID_CONFIG, nodeConfig.getClientId() + "-" + workerName);
+            props.put(ProducerConfig.CLIENT_ID_CONFIG, nodeConfig.getClientId()
+                    + "-" + workerName + "-" + System.currentTimeMillis());
             LOG.info("init kafka client by node config info: " + props);
             configuredMaxPayloadSize = Long.parseLong(props.getProperty(ProducerConfig.MAX_REQUEST_SIZE_CONFIG));
             producer = new KafkaProducer<>(props, new StringSerializer(), new ByteArraySerializer());

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/source/sortsdk/FetchCallback.java
@@ -24,6 +24,7 @@ import org.apache.inlong.sdk.sort.entity.MessageRecord;
 import org.apache.inlong.sort.standalone.channel.CacheMessageRecord;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
+import org.apache.inlong.sort.standalone.metrics.status.SortTaskStatusRepository;
 
 import com.google.common.base.Preconditions;
 import org.apache.flume.channel.ChannelProcessor;
@@ -101,6 +102,7 @@ public class FetchCallback implements ReadCallback {
             CacheMessageRecord cacheRecord = new CacheMessageRecord(messageRecord, client,
                     CommonPropertiesHolder.getAckPolicy());
             for (InLongMessage inLongMessage : messageRecord.getMsgs()) {
+                SortTaskStatusRepository.acquirePutChannel(sortTaskName);
                 final ProfileEvent profileEvent = new ProfileEvent(inLongMessage, cacheRecord);
                 channelProcessor.processEvent(profileEvent);
                 context.reportToMetric(profileEvent, sortTaskName, "-", SortSdkSourceContext.FetchResult.SUCCESS);


### PR DESCRIPTION
Fixes #11836

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

1. ​​Implement flow control in SortStandalone first​​ to resolve current frequent alert issues.
​​2. Enable flow control at the SortTask granularity​​:
  1) Initial buffer size must be ​​1 data unit​​ upon deployment.
  2) After successful data transmission, the buffer size increases to ​​one-third of the default configuration value​​ (configurable).
  3) ​​Trigger SortTask deactivation in the container​​ if sending failure rate exceeds ​​50% capacity​​ (configurable), ​​and​
failures to scale up within the current minute exceed ​​10 data units​​ (configurable). Force shutdown via kafkaClient.closeTimeout (ensuring time-bound deactivation). Block SortTask reactivation for ​​5 minutes​​ (configurable).

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
