### PR TITLE
[INLONG-11841][Sort] When the SortTask is closed, the BufferQueueChannel must be released along with synchronously releasing the GlobalBufferQueue's token

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/channel/BufferQueueChannel.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/channel/BufferQueueChannel.java
@@ -131,6 +131,16 @@ public class BufferQueueChannel extends AbstractChannel {
         }
     }
 
+    @Override
+    public synchronized void stop() {
+        super.stop();
+        ProfileEvent event = this.bufferQueue.pollRecord();
+        while (event != null) {
+            this.bufferQueue.release(event.getBody().length);
+            event = this.bufferQueue.pollRecord();
+        }
+    }
+
     /**
      * setReloadTimer
      */


### PR DESCRIPTION
Fixes #11841 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
