### PR TITLE
[INLONG-11855][Audit] Audit supports Audit reconciliation at the granularity of inlong group 

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/config/AuditColumn.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/config/AuditColumn.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.service.config;
+
+public class AuditColumn {
+
+    public static final String COLUMN_LOG_TS = "log_ts";
+    public static final String COLUMN_GROUP_ID = "inlong_group_id";
+    public static final String COLUMN_STREAM_ID = "inlong_stream_id";
+    public static final String COLUMN_AUDIT_ID = "audit_id";
+    public static final String COLUMN_AUDIT_TAG = "audit_tag";
+    public static final String COLUMN_CNT = "cnt";
+    public static final String COLUMN_SIZE = "size";
+    public static final String COLUMN_DELAY = "delay";
+    public static final String COLUMN_IP = "ip";
+    public static final String COLUMN_AUDIT_VERSION = "audit_version";
+}

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/config/SqlConstants.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/config/SqlConstants.java
@@ -143,7 +143,7 @@ public class SqlConstants {
 
     public static final String KEY_MYSQL_SOURCE_QUERY_DAY_SQL = "mysql.query.day.sql";
     public static final String DEFAULT_MYSQL_SOURCE_QUERY_DAY_SQL =
-            "select log_ts,inlong_group_id,inlong_stream_id,audit_id,audit_tag,count,size,delay " +
+            "select log_ts,inlong_group_id,inlong_stream_id,audit_id,audit_tag,count AS cnt,size,delay " +
                     "from audit_data_day where log_ts >= ? AND log_ts < ? AND inlong_group_id=? AND inlong_stream_id=? AND audit_id =? ";
 
     public static final String KEY_MYSQL_QUERY_AUDIT_ID_SQL = "mysql.query.audit.id.sql";
@@ -182,7 +182,7 @@ public class SqlConstants {
     public static final String KEY_RECONCILIATION_SQL = "audit.reconciliation.sql";
     public static final String DEFAULT_RECONCILIATION_SQL = "select\n" +
             "audit_version,\n" +
-            "sum(count) count\n" +
+            "sum(count) cnt\n" +
             "from\n" +
             "    audit_data\n" +
             "where\n" +
@@ -200,7 +200,7 @@ public class SqlConstants {
     public static final String KEY_RECONCILIATION_DISTINCT_SQL = "audit.reconciliation.distinct.sql";
     public static final String DEFAULT_RECONCILIATION_DISTINCT_SQL = "SELECT\n" +
             "    audit_version,\n" +
-            "    sum(count) AS count\n" +
+            "    sum(count) AS cnt\n" +
             "FROM\n" +
             "    (\n" +
             "        SELECT\n" +
@@ -251,4 +251,5 @@ public class SqlConstants {
             "    ) t_distinct\n" +
             "GROUP BY\n" +
             "    audit_version";
+    public static final String WILDCARD_STREAM_ID = "*";
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/entities/StatData.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/entities/StatData.java
@@ -18,10 +18,12 @@
 package org.apache.inlong.audit.service.entities;
 
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.sql.Timestamp;
 
 @Data
+@NoArgsConstructor
 public class StatData {
 
     private long auditVersion;
@@ -30,10 +32,50 @@ public class StatData {
     private String inlongStreamId;
     private String auditId;
     private String auditTag;
-    private Long count;
-    private Long size;
-    private Long delay;
+    private Long count = 0L;
+    private Long size = 0L;
+    private Long delay = 0L;
     private Timestamp updateTime;
     private String ip;
     private String sourceName;
+
+    /**
+     * Add values to statistics fields with null checks
+     * @param count message count to add
+     * @param size data size to add
+     * @param delay delay time to add
+     */
+    public void add(Long count, Long size, Long delay) {
+        if (count != null) {
+            this.count += count;
+        }
+        if (size != null) {
+            this.size += size;
+        }
+        if (delay != null) {
+            this.delay += delay;
+        }
+    }
+
+    /**
+     * Build composite key with format "logTs|inlongGroupId|auditId"
+     * @return composite key string
+     */
+    public String getCompositeKey() {
+        return String.join("|", logTs, inlongGroupId, auditId);
+    }
+
+    /**
+     * Constructor with essential fields
+     * @param logTs timestamp string
+     * @param inlongGroupId group ID
+     * @param inlongStreamId stream ID
+     * @param auditId audit ID
+     */
+    public StatData(String logTs, String inlongGroupId, String inlongStreamId, String auditId) {
+        this.logTs = logTs;
+        this.inlongGroupId = inlongGroupId;
+        this.inlongStreamId = inlongStreamId;
+        this.auditId = auditId;
+    }
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/utils/AuditUtils.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/utils/AuditUtils.java
@@ -24,11 +24,15 @@ import org.apache.inlong.audit.service.entities.StatData;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class AuditUtils {
 
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(ConfigConstants.DATE_FORMAT);
+    private static final String STREAM_ID_CONDITION_PATTERN = "(?i)\\band\\s+inlong_stream_id\\s*=\\s*\\?\\s*";
 
     public static double calculateDiffRatio(long srcCount, long destCount) {
         if (srcCount == 0 && destCount == 0) {
@@ -90,4 +94,58 @@ public class AuditUtils {
 
         return mergedStatData;
     }
+
+    /**
+     * Aggregates statistics data by composite key.
+     *
+     * @param data     List of StatData to be aggregated
+     * @param streamId Stream ID to use for aggregation
+     * @return List of aggregated StatData
+     */
+    public static List<StatData> aggregateStatData(List<StatData> data, String streamId) {
+        if (data == null || data.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        Map<String, StatData> aggregatedMap = new HashMap<>(data.size());
+        for (StatData stat : data) {
+            StatData aggregatedStatData = aggregatedMap.computeIfAbsent(
+                    stat.getCompositeKey(),
+                    k -> new StatData(stat.getLogTs(), stat.getInlongGroupId(), streamId, stat.getAuditId()));
+            aggregatedStatData.add(stat.getCount(), stat.getSize(), stat.getDelay());
+        }
+
+        return new ArrayList<>(aggregatedMap.values());
+    }
+
+    /**
+     * Removes stream ID condition from SQL query.
+     *
+     * @param sqlQuery Original SQL query string
+     * @return SQL query with stream ID condition removed
+     */
+    public static String removeStreamIdCondition(String sqlQuery) {
+        return sqlQuery == null ? null : sqlQuery.replaceAll(STREAM_ID_CONDITION_PATTERN, " ");
+    }
+
+    /**
+     * Remove 'inlong_stream_id' column from SQL SELECT statement.
+     * Handles cases where the column appears:
+     * 1. At the beginning/middle with optional comma and spaces
+     * 2. At the end with optional comma and spaces
+     *
+     * @param sql Original SQL string
+     * @return SQL string with 'inlong_stream_id' column removed
+     */
+    public static String removeStreamIdColumn(String sql) {
+        if (sql == null) {
+            return null;
+        }
+        // Remove inlong_stream_id when it appears at start/middle (with optional comma and spaces)
+        sql = sql.replaceAll("(?i)\\b(inlong_stream_id)\\b\\s*,?\\s*", "");
+        // Remove inlong_stream_id when it appears at end (with optional comma and spaces)
+        sql = sql.replaceAll(",?\\s*\\b(inlong_stream_id)\\b(?=\\s*$)", "");
+        return sql;
+    }
+
 }


### PR DESCRIPTION
- Fixes #11855

### Motivation
When there are many data streams under an inlong group, providing audit data at the group level allows you to view the data reconciliation status more intuitively.

### Modifications
Audit supports Audit reconciliation at the granularity of inlong group 


