### PR TITLE
[INLONG-11871][SDK] Fix init crashes when no IP available

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"log"
+	"sync"
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/google/uuid"
@@ -25,20 +26,22 @@ import (
 )
 
 var (
+	snowflakeOnce sync.Once
 	snowflakeNode *snowflake.Node
+	snowflakeErr  error
 )
 
-func init() {
+func newSnowFlakeNode() (*snowflake.Node, error) {
 	ip, err := GetOneIP()
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
-
 	id := IPtoUInt(ip)
-	snowflakeNode, err = snowflake.NewNode(int64(id % 1024))
+	node, err := snowflake.NewNode(int64(id % 1024))
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
+	return node, nil
 }
 
 // UInt64UUID generates an uint64 UUID
@@ -53,7 +56,23 @@ func UInt64UUID() (uint64, error) {
 	return cityhash.CityHash64WithSeeds(bytes, uint32(length), 13329145742295551469, 7926974186468552394), nil
 }
 
-// SnowFlakeID generates a snowflake ID
+// Deprecated: Use SafeSnowFlakeID instead.
+// SnowFlakeID generates a snowflake ID. If an error occurs, it logs it and exits.
 func SnowFlakeID() string {
-	return snowflakeNode.Generate().String()
+	id, err := SafeSnowFlakeID()
+	if err != nil {
+		log.Fatal(err)
+	}
+	return id
+}
+
+// SafeSnowFlakeID generates a snowflake ID. If an error occurs it returns it.
+func SafeSnowFlakeID() (string, error) {
+	snowflakeOnce.Do(func() {
+		snowflakeNode, snowflakeErr = newSnowFlakeNode()
+	})
+	if snowflakeErr != nil {
+		return "", snowflakeErr
+	}
+	return snowflakeNode.Generate().String(), nil
 }


### PR DESCRIPTION
If an IP is not available, we use id = 0 instead of crashing.

Fixes #11871

### Motivation

This PR allows programs which import the InLong DataProxy SDK to initialise properly even if no IP address is available on the system. Modular programs such as Telegraf may import the InLong SDK, but enable/disable its features in the configuration. Currently, such programs crash even if the configuration disables InLong. This PR fixes that.

### Modifications

Fairly trivial, please see the diff.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [X] This change is already covered by existing tests, such as:
  - happy path: all tests, because the change only impacts the init() function.
  - sad path: I manually verified this PR allows Telegraf to start in a Docker container with no network.

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? No
