### PR TITLE
[INLONG-11875][Manager] Fix the startup script in standalone deployment mode does not copy module dependencies

### DIFF
--- a/inlong-distribution/script/prepare_module_dependencies.sh
+++ b/inlong-distribution/script/prepare_module_dependencies.sh
@@ -20,12 +20,8 @@
 #
 cd "$(dirname "$0")"/../ || exit
 
-jar_file_num=`ls -l $1 |grep jar |wc -l`
-
-if [ $jar_file_num -eq 0 ]; then
-    if [ -e $1/dependencys.txt ]; then
-        for line in $(cat "$1/dependencys.txt"); do
-            cp "./lib/$line" $1/
-        done
-    fi
+if [ -e $1/dependencys.txt ]; then
+    for line in $(cat "$1/dependencys.txt"); do
+        cp -n "./lib/$line" $1/ 2>/dev/null
+    done
 fi


### PR DESCRIPTION


<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11875

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
When deploying InLong in standalone mode, if the user puts the MySQL connector jar package into the lib directory of the relevant module first, the copy operation of the dependency jar packages will not be triggered when the module is started, causing the module to fail to start normally due to the lack of relevant dependencies.

### Modifications

<!--Describe the modifications you've done.-->
Modify the script `prepare_module_dependencies.sh`

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
