### PR TITLE
[INLONG-11900][Audit] In the case of no data, the Audit OpenAPI defaults to 0

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/auditor/Audit.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/auditor/Audit.java
@@ -75,6 +75,9 @@ public class Audit {
             validateRequest(request, auditCycle);
 
             ReconciliationData data = getAuditData(request, auditCycle);
+
+            checkReconciliationData(request, data);
+
             return createResponseJson(true, data, null);
 
         } catch (InvalidRequestException e) {
@@ -187,4 +190,29 @@ public class Audit {
                 return null;
         }
     }
+
+    /**
+     * Checks and initializes reconciliation data if source or destination data is null.
+     *
+     * @param request The request information containing audit parameters
+     * @param data The reconciliation data to be checked and initialized
+     */
+    private void checkReconciliationData(RequestInfo request, ReconciliationData data) {
+        // Extract basic parameters from request
+        String startTime = request.getStartTime();
+        String groupId = request.getInlongGroupId();
+        String streamId = request.getInlongStreamId();
+
+        // Initialize source data if null
+        if (data.srcData == null) {
+            data.srcData = new StatData(startTime, groupId, streamId,
+                    request.getSrcAuditId(), request.getSrcAuditTag());
+        }
+        // Initialize destination data if null
+        if (data.destData == null) {
+            data.destData = new StatData(startTime, groupId, streamId,
+                    request.getDestAuditId(), request.getDestAuditTag());
+        }
+    }
+
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/cache/RealTimeQuery.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/cache/RealTimeQuery.java
@@ -21,6 +21,7 @@ import org.apache.inlong.audit.service.config.ConfigConstants;
 import org.apache.inlong.audit.service.config.Configuration;
 import org.apache.inlong.audit.service.entities.JdbcConfig;
 import org.apache.inlong.audit.service.entities.StatData;
+import org.apache.inlong.audit.service.except.QueryAuditException;
 import org.apache.inlong.audit.service.node.ConfigService;
 import org.apache.inlong.audit.service.utils.AuditUtils;
 import org.apache.inlong.audit.service.utils.CacheUtils;
@@ -490,9 +491,11 @@ public class RealTimeQuery {
                 }
             } catch (SQLException sqlException) {
                 LOGGER.error("Query ips has SQL exception!, datasource={} ", dataSource, sqlException);
+                throw new QueryAuditException("Query audit data has SQL exception! ");
             }
         } catch (Exception exception) {
             LOGGER.error("Query audit data has exception! ", exception);
+            throw new QueryAuditException("Query audit data has exception! ");
         }
         return AuditUtils.getMaxAuditVersionAuditData(result);
     }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/entities/StatData.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/entities/StatData.java
@@ -78,4 +78,19 @@ public class StatData {
         this.inlongStreamId = inlongStreamId;
         this.auditId = auditId;
     }
+
+    /**
+     * @param logTs
+     * @param inlongGroupId
+     * @param inlongStreamId
+     * @param auditId
+     * @param auditTag
+     */
+    public StatData(String logTs, String inlongGroupId, String inlongStreamId, String auditId, String auditTag) {
+        this.logTs = logTs;
+        this.inlongGroupId = inlongGroupId;
+        this.inlongStreamId = inlongStreamId;
+        this.auditId = auditId;
+        this.auditTag = auditTag;
+    }
 }

--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/except/QueryAuditException.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/except/QueryAuditException.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.audit.service.except;
+
+public class QueryAuditException extends RuntimeException {
+
+    public QueryAuditException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
- Fixes #11900

### Motivation

In the case of no data, the Audit OpenAPI defaults to 0

### Modifications

When there is no data, fill it with 0