### PR TITLE
[INLONG-11905][SDK] TransformSDK calls the org.reflections library APIs ​​according to version 0.9.12, not version 0.10.2

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/FunctionTools.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/FunctionTools.java
@@ -27,7 +27,8 @@ import net.sf.jsqlparser.expression.Function;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.reflections.Reflections;
-import org.reflections.scanners.Scanners;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.lang.reflect.Constructor;
 import java.util.Collection;
@@ -48,7 +49,9 @@ public class FunctionTools {
     }
 
     private static void init() {
-        Reflections reflections = new Reflections(FUNCTION_PATH, Scanners.TypesAnnotated);
+        Reflections reflections = new Reflections(FUNCTION_PATH,
+                new TypeAnnotationsScanner(),
+                new SubTypesScanner());
         Set<Class<?>> clazzSet = reflections.getTypesAnnotatedWith(TransformFunction.class);
         for (Class<?> clazz : clazzSet) {
             TransformFunction annotation = clazz.getAnnotation(TransformFunction.class);

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/OperatorTools.java
@@ -28,7 +28,8 @@ import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.expression.Function;
 import org.apache.commons.lang.ObjectUtils;
 import org.reflections.Reflections;
-import org.reflections.scanners.Scanners;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.lang.reflect.Constructor;
 import java.math.BigDecimal;
@@ -58,7 +59,9 @@ public class OperatorTools {
     }
 
     private static void init() {
-        Reflections reflections = new Reflections(OPERATOR_PATH, Scanners.TypesAnnotated);
+        Reflections reflections = new Reflections(OPERATOR_PATH,
+                new TypeAnnotationsScanner(),
+                new SubTypesScanner());
         Set<Class<?>> clazzSet = reflections.getTypesAnnotatedWith(TransformOperator.class);
         for (Class<?> clazz : clazzSet) {
             if (ExpressionOperator.class.isAssignableFrom(clazz)) {

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/ParserTools.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/ParserTools.java
@@ -22,7 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.sf.jsqlparser.expression.Expression;
 import net.sf.jsqlparser.schema.Column;
 import org.reflections.Reflections;
-import org.reflections.scanners.Scanners;
+import org.reflections.scanners.SubTypesScanner;
+import org.reflections.scanners.TypeAnnotationsScanner;
 
 import java.lang.reflect.Constructor;
 import java.util.Map;
@@ -38,7 +39,9 @@ public class ParserTools {
         init();
     }
     private static void init() {
-        Reflections reflections = new Reflections(PARSER_PATH, Scanners.TypesAnnotated);
+        Reflections reflections = new Reflections(PARSER_PATH,
+                new TypeAnnotationsScanner(),
+                new SubTypesScanner());
         Set<Class<?>> clazzSet = reflections.getTypesAnnotatedWith(TransformParser.class);
         for (Class<?> clazz : clazzSet) {
             if (ValueParser.class.isAssignableFrom(clazz)) {


### PR DESCRIPTION
Fixes #11905 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
