### PR TITLE
[INLONG-11907][SDK] Transform support IN operator

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/InOperator.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/operator/InOperator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.operator;
+
+import org.apache.inlong.sdk.transform.decode.SourceData;
+import org.apache.inlong.sdk.transform.process.Context;
+import org.apache.inlong.sdk.transform.process.parser.ValueParser;
+
+import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.InExpression;
+import net.sf.jsqlparser.expression.operators.relational.ItemsList;
+import net.sf.jsqlparser.expression.operators.relational.MultiExpressionList;
+import net.sf.jsqlparser.expression.operators.relational.NamedExpressionList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * InExpression
+ * 
+ */
+@TransformOperator(values = InExpression.class)
+public class InOperator implements ExpressionOperator {
+
+    private final ValueParser left;
+    private final List<ValueParser> right;
+
+    public InOperator(InExpression expr) {
+        this.left = OperatorTools.buildParser(expr.getLeftExpression());
+        ItemsList itemsList = expr.getRightItemsList();
+        this.right = new ArrayList<>();
+        if (itemsList instanceof ExpressionList) {
+            ((ExpressionList) itemsList).getExpressions().forEach(v -> this.right.add(OperatorTools.buildParser(v)));
+        } else if (itemsList instanceof MultiExpressionList) {
+            List<ExpressionList> exprListList = ((MultiExpressionList) itemsList).getExpressionLists();
+            for (ExpressionList exprList : exprListList) {
+                exprList.getExpressions().forEach(v -> this.right.add(OperatorTools.buildParser(v)));
+            }
+        } else if (itemsList instanceof NamedExpressionList) {
+            ((NamedExpressionList) itemsList).getExpressions()
+                    .forEach(v -> this.right.add(OperatorTools.buildParser(v)));
+        }
+    }
+
+    /**
+     * check
+     * @param sourceData
+     * @param rowIndex
+     * @return
+     */
+    @SuppressWarnings("rawtypes")
+    @Override
+    public boolean check(SourceData sourceData, int rowIndex, Context context) {
+        Comparable leftValue = (Comparable) this.left.parse(sourceData, rowIndex, context);
+        for (ValueParser parser : right) {
+            Comparable rightValue = (Comparable) parser.parse(sourceData, rowIndex, context);
+            if (OperatorTools.compareValue(leftValue, rightValue) == 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/operator/TestInOperator.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/operator/TestInOperator.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.operator;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestInOperator extends AbstractOperatorTestBase {
+
+    @Test
+    public void testAndOperator() throws Exception {
+        String transformSql = "select if(string2 IN ('3a','5'),1,0) from source";
+        TransformConfig config = new TransformConfig(transformSql);
+        // case1: "3.14159265358979323846|3a|4|4"
+        TransformProcessor<String, String> processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output1 = processor.transform("3.14159265358979323846|3a|4|4");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output1.get(0), "result=1");
+        // case2: "3.14159265358979323846|5|4|8"
+        List<String> output2 = processor.transform("3.14159265358979323846|5|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output2.get(0), "result=1");
+        // case3: "3.14159265358979323846|3|4|8"
+        List<String> output3 = processor.transform("3.14159265358979323846|3|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output3.get(0), "result=0");
+
+        transformSql = "select if(numeric3 IN (4,3.2),1,0) from source";
+        config = new TransformConfig(transformSql);
+        // case4: "3.14159265358979323846|4|4|8"
+        processor = TransformProcessor
+                .create(config, SourceDecoderFactory.createCsvDecoder(csvSource),
+                        SinkEncoderFactory.createKvEncoder(kvSink));
+        List<String> output4 = processor.transform("3.14159265358979323846|4|4|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output4.get(0), "result=1");
+        // case5: "3.14159265358979323846|4|3.2|4"
+        List<String> output5 = processor.transform("3.14159265358979323846|4|3.2|4");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output5.get(0), "result=1");
+        // case6: "3.14159265358979323846|4|3.2|8"
+        List<String> output6 = processor.transform("3.14159265358979323846|4|4.2|8");
+        Assert.assertEquals(1, output1.size());
+        Assert.assertEquals(output6.get(0), "result=0");
+    }
+}


### PR DESCRIPTION
Fixes #11907 

### Motivation

Transform support IN operator

### Modifications

#### Case 1
Source format : numeric1, string2, numeric3, numeric4
Transform : select if(string2 IN ('3a','5'),1,0) from source
Source data : 3.14159265358979323846|3a|4|4
Dest data : 1

#### Case 2
Source format : numeric1, string2, numeric3, numeric4
Transform : select if(string2 IN ('3a','5'),1,0) from source
Source data : 3.14159265358979323846|3|4|8
Dest data : 0

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
