### PR TITLE
[INLONG-11926][SDK] If SortSDK fails to retrieve GroupId and StreamId from the InLongMsgV0 protocol, it defaults to obtaining them from the unified metadata

### DIFF
--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/entity/InLongTopic.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/entity/InLongTopic.java
@@ -30,6 +30,9 @@ public class InLongTopic {
     private String startConsumeTime;
     private String stopConsumeTime;
     private Map<String, Object> properties;
+    private String groupId;
+    private String streamId;
+    private String dataFlowId;
 
     public void setStopConsumeTime(String stopConsumeTime) {
         this.stopConsumeTime = stopConsumeTime;
@@ -85,6 +88,54 @@ public class InLongTopic {
 
     public void setProperties(Map<String, Object> properties) {
         this.properties = properties;
+    }
+
+    /**
+     * get groupId
+     * @return the groupId
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * set groupId
+     * @param groupId the groupId to set
+     */
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    /**
+     * get streamId
+     * @return the streamId
+     */
+    public String getStreamId() {
+        return streamId;
+    }
+
+    /**
+     * set streamId
+     * @param streamId the streamId to set
+     */
+    public void setStreamId(String streamId) {
+        this.streamId = streamId;
+    }
+
+    /**
+     * get dataFlowId
+     * @return the dataFlowId
+     */
+    public String getDataFlowId() {
+        return dataFlowId;
+    }
+
+    /**
+     * set dataFlowId
+     * @param dataFlowId the dataFlowId to set
+     */
+    public void setDataFlowId(String dataFlowId) {
+        this.dataFlowId = dataFlowId;
     }
 
     @Override

--- a/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/decode/MessageDeserializer.java
+++ b/inlong-sdk/sort-sdk/src/main/java/org/apache/inlong/sdk/sort/impl/decode/MessageDeserializer.java
@@ -173,11 +173,13 @@ public class MessageDeserializer implements Deserializer {
             Map<String, String> attributes = StringUtil.splitKv(attr, INLONGMSG_ATTR_ENTRY_DELIMITER,
                     INLONGMSG_ATTR_KV_DELIMITER, null, null);
 
-            String groupId = Optional.ofNullable(attributes.get(INLONGMSG_ATTR_GROUP_ID))
+            String groupId = Optional.ofNullable(attributes.getOrDefault(INLONGMSG_ATTR_GROUP_ID,
+                    inLongTopic.getGroupId()))
                     .orElseThrow(() -> new IllegalArgumentException(String.format(PARSE_ATTR_ERROR_STRING,
                             INLONGMSG_ATTR_GROUP_ID)));
 
-            String streamId = Optional.ofNullable(attributes.get(INLONGMSG_ATTR_STREAM_ID))
+            String streamId = Optional.ofNullable(attributes.getOrDefault(INLONGMSG_ATTR_STREAM_ID,
+                    inLongTopic.getStreamId()))
                     .orElseThrow(() -> new IllegalArgumentException(String.format(PARSE_ATTR_ERROR_STRING,
                             INLONGMSG_ATTR_STREAM_ID)));
 


### PR DESCRIPTION
Fixes #11926 

### Motivation
If SortSDK fails to retrieve GroupId and StreamId from the InLongMsgV0 protocol, it defaults to obtaining them from the unified metadata

### Modifications

If SortSDK fails to retrieve GroupId and StreamId from the InLongMsgV0 protocol, it defaults to obtaining them from the unified metadata
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
