### PR TITLE
[INLONG-11929][SDK] Dataproxy GO SDK supports HTTP reporting

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_client.go
@@ -1,0 +1,182 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/discoverer"
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/logger"
+)
+
+// HTTPClient HTTP客户端
+type HTTPClient struct {
+	client           *http.Client
+	endpoints        []discoverer.Endpoint
+	mutex            sync.RWMutex
+	groupID          string
+	timeout          time.Duration
+	maxRetries       int
+	log              logger.Logger
+	metrics          *metrics
+	endpointSelector atomic.Uint64
+}
+
+// NewHTTPClient Create a new HTTP client with the given options
+func NewHTTPClient(options *Options, log logger.Logger, metrics *metrics) *HTTPClient {
+	transport := &http.Transport{
+		MaxIdleConns:        options.HTTPMaxConns,
+		MaxIdleConnsPerHost: options.HTTPMaxConns / 4,
+		IdleConnTimeout:     30 * time.Second,
+		DialContext: (&net.Dialer{
+			Timeout:   options.ConnTimeout,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		DisableKeepAlives:  false,
+		DisableCompression: false,
+	}
+
+	return &HTTPClient{
+		client: &http.Client{
+			Transport: transport,
+			Timeout:   options.HTTPTimeout,
+		},
+		groupID:    options.GroupID,
+		timeout:    options.HTTPTimeout,
+		maxRetries: options.MaxRetries,
+		log:        log,
+		metrics:    metrics,
+		endpoints:  make([]discoverer.Endpoint, 0),
+	}
+}
+
+// SendBatch Send a batch of messages to the DataProxy server
+func (c *HTTPClient) SendBatch(ctx context.Context, batch *HTTPBatchReq) error {
+	endpoints := c.getEndpoints()
+	if len(endpoints) == 0 {
+		return fmt.Errorf("no available endpoints")
+	}
+
+	// select an endpoint using a simple round-robin strategy
+	endpoint := c.selectEndpoint(endpoints)
+
+	req, err := c.buildRequest(ctx, endpoint, batch)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return c.handleResponse(resp, batch)
+}
+
+// buildRequest builds the HTTP request for sending a batch of messages
+func (c *HTTPClient) buildRequest(ctx context.Context, endpoint discoverer.Endpoint, batch *HTTPBatchReq) (*http.Request, error) {
+	requestURL := fmt.Sprintf("http://%s/dataproxy/message", endpoint.Addr)
+
+	params := url.Values{}
+	params.Set("groupId", batch.GroupID)
+	params.Set("streamId", batch.StreamID)
+	params.Set("dt", strconv.FormatInt(batch.DataTime, 10))
+	params.Set("body", strings.Join(batch.Bodies, "\n"))
+	params.Set("cnt", strconv.Itoa(len(batch.Bodies)))
+
+	req, err := http.NewRequestWithContext(ctx, "POST", requestURL,
+		strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Connection", "keep-alive")
+
+	return req, nil
+}
+
+// handleResponse handles the HTTP response from the DataProxy server
+func (c *HTTPClient) handleResponse(resp *http.Response, batch *HTTPBatchReq) error {
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP error: %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body failed: %w", err)
+	}
+
+	var result struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+
+	err = json.Unmarshal(body, &result)
+	if err != nil {
+		if code, parseErr := strconv.Atoi(strings.TrimSpace(string(body))); parseErr == nil {
+			if code == 0 {
+				return nil
+			}
+			return fmt.Errorf("send failed with code: %d", code)
+		}
+		return fmt.Errorf("parse response failed: %w", err)
+	}
+
+	if result.Code == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("send failed: %s (code: %d)", result.Msg, result.Code)
+}
+
+// selectEndpoint selects an endpoint from the available endpoints.
+func (c *HTTPClient) selectEndpoint(endpoints []discoverer.Endpoint) discoverer.Endpoint {
+	if len(endpoints) == 1 {
+		return endpoints[0]
+	}
+
+	index := c.endpointSelector.Add(1) % uint64(len(endpoints))
+	return endpoints[index]
+}
+
+// UpdateEndpoints updates the list of endpoints for the HTTP client.
+func (c *HTTPClient) UpdateEndpoints(endpoints []discoverer.Endpoint) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.endpoints = endpoints
+	c.log.Infof("HTTP client updated endpoints: %d nodes", len(endpoints))
+}
+
+// getEndpoints returns the current list of endpoints.
+func (c *HTTPClient) getEndpoints() []discoverer.Endpoint {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return c.endpoints
+}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_client.go
@@ -34,7 +34,6 @@ import (
 	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/logger"
 )
 
-// HTTPClient HTTP客户端
 type HTTPClient struct {
 	client           *http.Client
 	endpoints        []discoverer.Endpoint

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_worker.go
@@ -276,7 +276,6 @@ func (w *HTTPWorker) backoffRetry(batch *HTTPBatchReq) {
 				w.finishBatch(batch, errSendQueueIsFull)
 			}
 		case <-w.stop:
-			// 工作线程关闭，终止重试
 			w.finishBatch(batch, errProducerClosed)
 		}
 	}()

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/http_worker.go
@@ -1,0 +1,341 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataproxy
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/logger"
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/syncx"
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util"
+	"go.uber.org/atomic"
+)
+
+type HTTPBatchReq struct {
+	GroupID   string
+	StreamID  string
+	Bodies    []string
+	DataTime  int64
+	DataReqs  []*sendDataReq
+	BatchTime time.Time
+	Retries   int
+}
+
+type HTTPWorker struct {
+	client         *HTTPClient
+	index          int
+	indexStr       string
+	options        *Options
+	log            logger.Logger
+	metrics        *metrics
+	state          atomic.Int32
+	dataChan       chan *sendDataReq
+	dataSemaphore  syncx.Semaphore
+	pendingBatches map[string]*HTTPBatchReq
+	retryBatches   chan *HTTPBatchReq
+	batchTicker    *time.Ticker
+	stop           chan struct{}
+	closeOnce      sync.Once
+}
+
+// NewHTTPWorker creates a new HTTPWorker instance
+func NewHTTPWorker(client *HTTPClient, index int, options *Options, log logger.Logger, metrics *metrics) *HTTPWorker {
+	w := &HTTPWorker{
+		client:         client,
+		index:          index,
+		indexStr:       strconv.Itoa(index),
+		options:        options,
+		log:            log,
+		metrics:        metrics,
+		dataChan:       make(chan *sendDataReq, options.MaxPendingMessages),
+		dataSemaphore:  syncx.NewSemaphore(int32(options.MaxPendingMessages)),
+		pendingBatches: make(map[string]*HTTPBatchReq),
+		retryBatches:   make(chan *HTTPBatchReq, options.MaxPendingMessages),
+		batchTicker:    time.NewTicker(options.BatchingMaxPublishDelay),
+		stop:           make(chan struct{}),
+	}
+
+	w.state.Store(int32(stateReady))
+	go w.run()
+	return w
+}
+
+// Send a message synchronously
+func (w *HTTPWorker) Send(ctx context.Context, msg Message) error {
+	var err error
+	isDone := atomic.NewBool(false)
+	doneCh := make(chan struct{})
+
+	w.SendAsync(ctx, msg, func(msg Message, e error) {
+		if isDone.CompareAndSwap(false, true) {
+			err = e
+			close(doneCh)
+		}
+	})
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-doneCh:
+		return err
+	}
+}
+
+// SendAsync sends a message asynchronously
+func (w *HTTPWorker) SendAsync(ctx context.Context, msg Message, callback Callback) {
+	req := &sendDataReq{
+		ctx:              ctx,
+		msg:              msg,
+		callback:         callback,
+		flushImmediately: false,
+		publishTime:      time.Now(),
+		metrics:          w.metrics,
+		workerID:         w.indexStr,
+	}
+
+	if len(msg.Payload) == 0 {
+		if callback != nil {
+			callback(msg, errBadLog)
+		}
+		return
+	}
+
+	// worker has been closed
+	if workerState(w.state.Load()) != stateReady {
+		if callback != nil {
+			callback(msg, errProducerClosed)
+		}
+		return
+	}
+
+	if w.options.BlockIfQueueIsFull {
+		if !w.dataSemaphore.Acquire(ctx) {
+			if callback != nil {
+				callback(msg, errContextExpired)
+			}
+			return
+		}
+	} else {
+		if !w.dataSemaphore.TryAcquire() {
+			if callback != nil {
+				callback(msg, errSendQueueIsFull)
+			}
+			return
+		}
+	}
+
+	req.semaphore = w.dataSemaphore
+
+	select {
+	case w.dataChan <- req:
+		w.metrics.incPending(w.indexStr)
+	case <-ctx.Done():
+		w.dataSemaphore.Release()
+		if callback != nil {
+			callback(msg, ctx.Err())
+		}
+	}
+}
+
+// run main loop for the HTTP worker
+func (w *HTTPWorker) run() {
+	defer func() {
+		w.batchTicker.Stop()
+		close(w.dataChan)
+		close(w.retryBatches)
+	}()
+
+	for {
+		select {
+		case <-w.stop:
+			w.flushAllPendingBatches()
+			return
+		case req, ok := <-w.dataChan:
+			if !ok {
+				return
+			}
+			w.handleSendData(req)
+		case batch, ok := <-w.retryBatches:
+			if !ok {
+				return
+			}
+			w.handleRetry(batch)
+		case <-w.batchTicker.C:
+			w.handleBatchTimeout()
+		}
+	}
+}
+
+func (w *HTTPWorker) handleRetry(batch *HTTPBatchReq) {
+	w.log.Debugf("Retrying HTTP batch %s, attempt %d", batch.StreamID, batch.Retries)
+	w.sendBatch(batch)
+}
+
+// handleSendData handles sending data requests
+func (w *HTTPWorker) handleSendData(req *sendDataReq) {
+	batch, ok := w.pendingBatches[req.msg.StreamID]
+	if !ok {
+		batch = &HTTPBatchReq{
+			GroupID:   w.options.GroupID,
+			StreamID:  req.msg.StreamID,
+			Bodies:    make([]string, 0, w.options.BatchingMaxMessages),
+			DataTime:  time.Now().UnixMilli(),
+			DataReqs:  make([]*sendDataReq, 0, w.options.BatchingMaxMessages),
+			BatchTime: time.Now(),
+			Retries:   0,
+		}
+		w.pendingBatches[req.msg.StreamID] = batch
+	}
+
+	batch.Bodies = append(batch.Bodies, string(req.msg.Payload))
+	batch.DataReqs = append(batch.DataReqs, req)
+
+	if req.flushImmediately ||
+		len(batch.Bodies) >= w.options.BatchingMaxMessages ||
+		w.calculateBatchSize(batch) >= w.options.BatchingMaxSize {
+		w.sendBatch(batch)
+		delete(w.pendingBatches, batch.StreamID)
+	}
+}
+
+// sendBatch send a batch of messages to the HTTP server
+func (w *HTTPWorker) sendBatch(batch *HTTPBatchReq) {
+	if batch.Retries > w.options.MaxRetries {
+		w.finishBatch(batch, errSendTimeout)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), w.options.HTTPTimeout)
+	defer cancel()
+
+	err := w.client.SendBatch(ctx, batch)
+	if err == nil {
+		w.finishBatch(batch, nil)
+		return
+	}
+
+	w.log.Warnf("HTTP send failed: %v", err)
+	batch.Retries++
+	w.backoffRetry(batch)
+}
+
+func (w *HTTPWorker) backoffRetry(batch *HTTPBatchReq) {
+	if batch.Retries > w.options.MaxRetries {
+		w.finishBatch(batch, errSendTimeout)
+		return
+	}
+
+	// check if the worker is still ready to process
+	if workerState(w.state.Load()) != stateReady {
+		w.finishBatch(batch, errProducerClosed)
+		return
+	}
+
+	go func() {
+		// use exponential backoff for retry
+		backoff := util.ExponentialBackoff{
+			InitialInterval: 100 * time.Millisecond,
+			MaxInterval:     5 * time.Second,
+			Multiplier:      2.0,
+			Randomization:   0.1,
+		}
+
+		waitTime := backoff.Next(batch.Retries)
+		w.log.Debugf("HTTP retry %d after %v for batch %s", batch.Retries, waitTime, batch.StreamID)
+
+		select {
+		case <-time.After(waitTime):
+			// check if the worker is still ready to process
+			if workerState(w.state.Load()) != stateReady {
+				w.finishBatch(batch, errProducerClosed)
+				return
+			}
+
+			// let the worker handle the retry
+			select {
+			case w.retryBatches <- batch:
+				w.metrics.incRetry(w.indexStr)
+			default:
+				w.finishBatch(batch, errSendQueueIsFull)
+			}
+		case <-w.stop:
+			// 工作线程关闭，终止重试
+			w.finishBatch(batch, errProducerClosed)
+		}
+	}()
+}
+
+// finishBatch finishes the batch processing
+func (w *HTTPWorker) finishBatch(batch *HTTPBatchReq, err error) {
+	for _, req := range batch.DataReqs {
+		if req.callback != nil {
+			req.callback(req.msg, err)
+		}
+		if req.semaphore != nil {
+			req.semaphore.Release()
+		}
+		w.metrics.decPending(req.workerID)
+		if err == nil {
+			w.metrics.incMessage(errOK.strCode)
+		} else {
+			w.metrics.incError(getErrorCode(err))
+		}
+	}
+}
+
+// handleBatchTimeout handles timeout for pending batches
+func (w *HTTPWorker) handleBatchTimeout() {
+	for streamID, batch := range w.pendingBatches {
+		if time.Since(batch.BatchTime) > w.options.BatchingMaxPublishDelay {
+			w.sendBatch(batch)
+			delete(w.pendingBatches, streamID)
+		}
+	}
+}
+
+// calculateBatchSize calculates the size of a batch
+func (w *HTTPWorker) calculateBatchSize(batch *HTTPBatchReq) int {
+	size := 0
+	for _, body := range batch.Bodies {
+		size += len(body)
+	}
+	return size
+}
+
+// flushAllPendingBatches flushes all pending batches
+func (w *HTTPWorker) flushAllPendingBatches() {
+	for streamID, batch := range w.pendingBatches {
+		w.sendBatch(batch)
+		delete(w.pendingBatches, streamID)
+	}
+}
+
+// Available checks if the worker is available to send data
+func (w *HTTPWorker) Available() bool {
+	return w.dataSemaphore.Available() > 0 && workerState(w.state.Load()) == stateReady
+}
+
+// Close closes the HTTP worker, stopping it from processing any further requests
+func (w *HTTPWorker) Close() {
+	w.closeOnce.Do(func() {
+		w.state.Store(int32(stateClosing))
+		close(w.stop)
+	})
+}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
@@ -77,6 +77,9 @@ type Options struct {
 	addColumnStr            string                // the string format of the AddColumns, just a cache, used internal
 	Auth                    Auth                  // dataproxy authentication interface
 	MaxConnLifetime         time.Duration         // connection max lifetime, default: 0, set to 5m/10m when the servers provide service though CLBs (Cloud Load Balancers)
+	Protocol                Protocol              // protocol type for data transmission, default: ProtocolTCP
+	HTTPTimeout             time.Duration         // HTTP request timeout, default: 30s
+	HTTPMaxConns            int                   // HTTP max connections per host, default: 100
 }
 
 // ValidateAndSetDefault validates an options and set up the default values
@@ -173,6 +176,14 @@ func (options *Options) ValidateAndSetDefault() error {
 
 	if options.SocketRecvBufferSize <= 0 {
 		options.SocketRecvBufferSize = 1 * 1024 * 1024
+	}
+
+	if options.HTTPTimeout <= 0 {
+		options.HTTPTimeout = 30 * time.Second
+	}
+
+	if options.HTTPMaxConns <= 0 {
+		options.HTTPMaxConns = 100
 	}
 
 	sb := strings.Builder{}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_basic.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_basic.go
@@ -189,3 +189,30 @@ func WithMaxConnLifetime(lifetime time.Duration) Option {
 		o.MaxConnLifetime = lifetime
 	}
 }
+
+// WithProtocol sets Protocol
+func WithProtocol(protocol Protocol) Option {
+	return func(o *Options) {
+		o.Protocol = protocol
+	}
+}
+
+// WithHTTPTimeout sets HTTPTimeout
+func WithHTTPTimeout(timeout time.Duration) Option {
+	return func(o *Options) {
+		if timeout <= 0 {
+			return
+		}
+		o.HTTPTimeout = timeout
+	}
+}
+
+// WithHTTPMaxConns sets HTTPMaxConns
+func WithHTTPMaxConns(n int) Option {
+	return func(o *Options) {
+		if n <= 0 {
+			return
+		}
+		o.HTTPMaxConns = n
+	}
+}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/protocol.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/protocol.go
@@ -1,0 +1,39 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataproxy
+
+// Protocol represents the communication protocol type
+type Protocol int
+
+const (
+	// ProtocolTCP uses TCP protocol (default)
+	ProtocolTCP Protocol = iota
+	// ProtocolHTTP uses HTTP protocol
+	ProtocolHTTP
+)
+
+// String returns the string representation of the protocol
+func (p Protocol) String() string {
+	switch p {
+	case ProtocolTCP:
+		return "tcp"
+	case ProtocolHTTP:
+		return "http"
+	default:
+		return "tcp"
+	}
+}


### PR DESCRIPTION
Fixes [#11929](https://github.com/apache/inlong/issues/11929)

### Motivation

As described in issue #11929, the InLong DataProxy Go SDK currently only supports TCP for data reporting. While the DataProxy server provides a public HTTP API for this purpose, it is not yet integrated into the Go SDK. This requires users to write their own HTTP client logic, which is inconvenient and leads to inconsistent implementations.

This pull request addresses this gap by integrating a native HTTP reporting mechanism into the Go SDK, providing users with a more flexible choice of protocols. This is particularly useful in environments where TCP traffic is restricted or when HTTP is preferred for its simplicity and firewall-friendliness.

### Modifications

This pull request introduces HTTP reporting capabilities with the following key changes:

1.  **Added `Protocol` Enum and `WithProtocol` Option**:
    -   A new `Protocol` enum (`ProtocolTCP`, `ProtocolHTTP`) has been added to allow protocol selection.
    -   The `WithProtocol(protocol Protocol)` option enables users to easily switch to HTTP during client initialization. The default remains TCP to ensure backward compatibility.

2.  **Implemented a `HTTPClient`**:
    -   A new `http_client.go` file encapsulates the `HTTPClient`, which manages a pooled `http.Client`.
    -   It handles the construction of HTTP requests according to the [DataProxy HTTP API specification](https://inlong.apache.org/docs/sdk/dataproxy-sdk/http/) and processes server responses.
    -   To ensure balanced load distribution across DataProxy nodes, it uses an atomic counter for round-robin endpoint selection.

3.  **Implemented a `HTTPWorker`**:
    -   A new `http_worker.go` file contains the `HTTPWorker`, which batches messages and sends them asynchronously.
    -   To maximize performance and resilience, the worker is fully non-blocking. When a send operation fails, it triggers an **asynchronous exponential backoff** retry mechanism, allowing it to continue processing new messages without delay.

4.  **Seamless Integration into the Main `Client`**:
    -   The main `client.go` has been updated to act as a dispatcher. Key methods like `initAll`, `Send`, `SendAsync`, and `Close` now delegate to the appropriate TCP or HTTP implementation based on the configured protocol.

### Verifying this change

- [x] This change added tests and can be verified as follows:

  - Added `ExampleClient_Send_http` and `ExampleClient_SendAsync_http` in `dataproxy/example_test.go`. These examples demonstrate how to initialize the client with the HTTP protocol and use both synchronous (`Send`) and asynchronous (`SendAsync`) methods.
  - These examples can be executed via `go test`. They serve as both a verification of the implementation and as live documentation for users.

### Documentation

- Does this pull request introduce a new feature? **yes**
- If yes, how is the feature documented? **docs**
- This PR introduces a new feature that will be documented on the official InLong website. A follow-up issue will be created to track this documentation update. The new options (`WithProtocol`, `WithHTTPTimeout`, `WithHTTPMaxConns`) and a usage example for the HTTP protocol will be added.