### PR TITLE
[INLONG-11939][Sort] Support that TaskConfig merge issue preventing configuration changes from taking effect

### DIFF
--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsSinkContext.java
@@ -51,6 +51,7 @@ import com.tencentcloudapi.cls.producer.errors.ProducerException;
 import com.tencentcloudapi.cls.producer.util.NetworkUtils;
 import lombok.Getter;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.slf4j.Logger;
@@ -118,8 +119,9 @@ public class ClsSinkContext extends SinkContext {
 
             TaskConfig newTaskConfig = SortConfigHolder.getTaskConfig(taskName);
             SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
-            if ((newTaskConfig == null || newTaskConfig.equals(taskConfig))
-                    && (newSortTaskConfig == null || newSortTaskConfig.equals(sortTaskConfig))) {
+            if ((newTaskConfig == null || StringUtils.equals(this.taskConfigJson, gson.toJson(newTaskConfig)))
+                    && (newSortTaskConfig == null
+                            || StringUtils.equals(this.sortTaskConfigJson, gson.toJson(newSortTaskConfig)))) {
                 return;
             }
             LOG.info("get new SortTaskConfig:taskName:{}", taskName);
@@ -130,8 +132,7 @@ public class ClsSinkContext extends SinkContext {
                 }
             }
 
-            this.taskConfig = newTaskConfig;
-            this.sortTaskConfig = newSortTaskConfig;
+            this.replaceConfig(newTaskConfig, newSortTaskConfig);
 
             Map<String, ClsIdConfig> fromTaskConfig = reloadIdParamsFromTaskConfig(taskConfig, clsNodeConfig);
             Map<String, ClsIdConfig> fromSortTaskConfig = reloadIdParamsFromSortTaskConfig(sortTaskConfig);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/elasticsearch/EsSinkContext.java
@@ -150,8 +150,9 @@ public class EsSinkContext extends SinkContext {
                     takeCounter.getAndSet(0), backCounter.getAndSet(0));
             TaskConfig newTaskConfig = SortConfigHolder.getTaskConfig(taskName);
             SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
-            if ((newTaskConfig == null || newTaskConfig.equals(taskConfig))
-                    && (newSortTaskConfig == null || newSortTaskConfig.equals(sortTaskConfig))) {
+            if ((newTaskConfig == null || StringUtils.equals(this.taskConfigJson, gson.toJson(newTaskConfig)))
+                    && (newSortTaskConfig == null
+                            || StringUtils.equals(this.sortTaskConfigJson, gson.toJson(newSortTaskConfig)))) {
                 return;
             }
             LOG.info("get new SortTaskConfig:taskName:{}", taskName);
@@ -163,9 +164,7 @@ public class EsSinkContext extends SinkContext {
                 }
             }
 
-            this.taskConfig = newTaskConfig;
-            this.sortTaskConfig = newSortTaskConfig;
-
+            this.replaceConfig(newTaskConfig, newSortTaskConfig);
             // change current config
             Map<String, EsIdConfig> fromTaskConfig = reloadIdParamsFromTaskConfig(taskConfig);
             Map<String, TransformProcessor<String, Map<String, Object>>> transformProcessor =

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/DefaultEvent2HttpRequestHandler.java
@@ -173,7 +173,8 @@ public class DefaultEvent2HttpRequestHandler implements IEvent2HttpRequestHandle
         List<Map<String, Object>> results = new ArrayList<>();
         for (Map<String, String> fieldMap : fieldMaps) {
             Map<String, Object> result = new ConcurrentHashMap<>();
-            result.putAll(fieldMap);
+            results.add(result);
+            fieldMap.forEach((k, v) -> result.put(k, String.valueOf(v)));
             if (!result.containsKey(KEY_FTIME)) {
                 result.put(KEY_FTIME, ftime);
             }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/http/HttpSinkContext.java
@@ -49,6 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.slf4j.Logger;
@@ -125,8 +126,9 @@ public class HttpSinkContext extends SinkContext {
                     takeCounter.getAndSet(0), backCounter.getAndSet(0));
             TaskConfig newTaskConfig = SortConfigHolder.getTaskConfig(taskName);
             SortTaskConfig newSortTaskConfig = SortClusterConfigHolder.getTaskConfig(taskName);
-            if ((newTaskConfig == null || newTaskConfig.equals(taskConfig))
-                    && (newSortTaskConfig == null || newSortTaskConfig.equals(sortTaskConfig))) {
+            if ((newTaskConfig == null || StringUtils.equals(this.taskConfigJson, gson.toJson(newTaskConfig)))
+                    && (newSortTaskConfig == null
+                            || StringUtils.equals(this.sortTaskConfigJson, gson.toJson(newSortTaskConfig)))) {
                 return;
             }
             LOG.info("get new SortTaskConfig:taskName:{}", taskName);
@@ -138,8 +140,7 @@ public class HttpSinkContext extends SinkContext {
                 }
             }
 
-            this.taskConfig = newTaskConfig;
-            this.sortTaskConfig = newSortTaskConfig;
+            this.replaceConfig(newTaskConfig, newSortTaskConfig);
 
             // change current config
             Map<String, HttpIdConfig> fromTaskConfig = reloadIdParamsFromTaskConfig(taskConfig);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/kafka/KafkaFederationSinkContext.java
@@ -89,7 +89,9 @@ public class KafkaFederationSinkContext extends SinkContext {
 
             CacheClusterConfig clusterConfig = new CacheClusterConfig();
             clusterConfig.setClusterName(this.taskName);
-            clusterConfig.setParams(this.sortTaskConfig.getSinkParams());
+            if (this.sortTaskConfig != null) {
+                clusterConfig.setParams(this.sortTaskConfig.getSinkParams());
+            }
             this.cacheClusterConfig = clusterConfig;
 
             Map<String, KafkaIdConfig> fromTaskConfig = fromTaskConfig(taskConfig);

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarFederationSinkContext.java
@@ -83,7 +83,9 @@ public class PulsarFederationSinkContext extends SinkContext {
 
             CacheClusterConfig clusterConfig = new CacheClusterConfig();
             clusterConfig.setClusterName(this.taskName);
-            clusterConfig.setParams(this.sortTaskConfig.getSinkParams());
+            if (this.sortTaskConfig != null) {
+                clusterConfig.setParams(this.sortTaskConfig.getSinkParams());
+            }
             this.cacheClusterConfig = clusterConfig;
 
             Map<String, PulsarIdConfig> fromTaskConfig = fromTaskConfig(taskConfig);


### PR DESCRIPTION
Fixes #11939 

### Motivation

Support that TaskConfig merge issue preventing configuration changes from taking effect

### Modifications

Support that TaskConfig merge issue preventing configuration changes from taking effect

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
