### PR TITLE
[INLONG-11944]​​[Sort] TransformFunction: parse_url supports parsing URL query strings​

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/string/ParseUrlFunction.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/function/string/ParseUrlFunction.java
@@ -85,36 +85,43 @@ public class ParseUrlFunction implements ValueParser {
             return null;
         }
 
-        try {
-            URL netUrl = new URL(url);
-            Map<String, String> queryPairs = splitQuery(netUrl.getQuery());
-            if ("QUERY".equals(part)) {
-                if (key != null && queryPairs.containsKey(key)) {
-                    return queryPairs.get(key);
-                }
-                return netUrl.getQuery();
-            } else {
+        if ("QUERY".equals(part)) {
+            String strQuery = null;
+            try {
+                URL netUrl = new URL(url);
+                strQuery = netUrl.getQuery();
+            } catch (MalformedURLException e) {
+                strQuery = url;
+            }
+            Map<String, String> queryPairs = splitQuery(strQuery);
+            if (key == null) {
+                return strQuery;
+            }
+            return queryPairs.getOrDefault(key, "");
+        } else {
+            try {
+                URL netUrl = new URL(url);
                 switch (part) {
-                    case "HOST":
+                    case "HOST" :
                         return netUrl.getHost();
-                    case "PATH":
+                    case "PATH" :
                         return netUrl.getPath();
-                    case "REF":
+                    case "REF" :
                         return netUrl.getRef();
-                    case "PROTOCOL":
+                    case "PROTOCOL" :
                         return netUrl.getProtocol();
-                    case "AUTHORITY":
+                    case "AUTHORITY" :
                         return netUrl.getAuthority();
-                    case "FILE":
+                    case "FILE" :
                         return netUrl.getFile();
-                    case "USERINFO":
+                    case "USERINFO" :
                         return netUrl.getUserInfo();
-                    default:
+                    default :
                         return null;
                 }
+            } catch (MalformedURLException e) {
+                return null;
             }
-        } catch (MalformedURLException e) {
-            return null;
         }
     }
 


### PR DESCRIPTION
Fixes #11944 

### Motivation

[Sort] TransformFunction: parse_url supports parsing URL query strings​
### Modifications

[Sort] TransformFunction: parse_url supports parsing URL query strings​
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
