### PR TITLE
[INLONG-11948][TubeMQ] Bump the base image zookeeper to 3.5 for building

### DIFF
--- a/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 # tubemq depend on zookeeper
-FROM zookeeper:3.4
+FROM zookeeper:3.5
 # install tools for debug
 RUN apt-get update \
     && apt-get install -y net-tools vim curl procps \


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11948

### Motivation

The zookeeper 3.5 works well for `apt update` during the image building.

<img width="1204" height="604" alt="image" src="https://github.com/user-attachments/assets/78be3aa2-80a9-4657-a5d8-40cca8aa0c87" />

