### PR TITLE
[INLONG-11954][SDK] Fix potential data race in Golang SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util/id.go
@@ -56,8 +56,8 @@ func UInt64UUID() (uint64, error) {
 	return cityhash.CityHash64WithSeeds(bytes, uint32(length), 13329145742295551469, 7926974186468552394), nil
 }
 
-// Deprecated: Use SafeSnowFlakeID instead.
 // SnowFlakeID generates a snowflake ID. If an error occurs, it logs it and exits.
+// Deprecated: Use SafeSnowFlakeID instead.
 func SnowFlakeID() string {
 	id, err := SafeSnowFlakeID()
 	if err != nil {


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11954 

### Motivation

Fix potential data race in Golang SDK

### Modifications

1. Handle all the IO errors;
2. Disard connection's ring buffer after handling the response;
3. Fix lint error in id.go by the way.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
