### PR TITLE
[INLONG-11914][SDK] Dataproxy C++ SDK supports HTTP reporting

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/CMakeLists.txt
@@ -62,5 +62,5 @@ add_library(dataproxy_sdk STATIC ${UTILS} ${CONFIGS} ${CORE} ${MANAGER} ${GROUP}
 
 set_target_properties(dataproxy_sdk PROPERTIES OUTPUT_NAME "dataproxy_sdk" PREFIX "")
 
-target_link_libraries(dataproxy_sdk liblog4cplusS.a libsnappy.a libcurl.a libssl.a libcrypto.a)
+target_link_libraries(dataproxy_sdk liblog4cplusS.a libsnappy.a libcurl.a libssl.a libcrypto.a libzstd.a -lbrotlidec -lbrotlicommon)
 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/include/http_sender.h
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/include/http_sender.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <string>
+namespace inlong {
+class HttpSender {
+public:
+    HttpSender();
+    ~HttpSender();
+    int Send(const std::string& url, const std::string& body, int timeout = 5);
+};
+} 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/include/inlong_api.h
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/include/inlong_api.h
@@ -45,6 +45,8 @@ class InLongApi {
   int32_t Send(const char *inlong_group_id, const char *inlong_stream_id, const char *msg, int32_t msg_len,
                int64_t data_time, UserCallBack call_back = nullptr);
 
+  int32_t SendHttp(const char *url, const char *body, int timeout = 5);
+
   int32_t CloseApi(int32_t max_waitms);
 
  private:

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/release/demo/send_demo.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/release/demo/send_demo.cc
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include "inlong_api.h"
+#include "../../include/inlong_api.h"
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -72,6 +72,16 @@ int main(int argc, char const *argv[]) {
       cout << "tc_api_send error;"
            << " ";
     }
+  }
+
+  // HTTP report example
+  std::string http_url = "http://127.0.0.1:8080/inlong/dataproxy/send";
+  std::string http_body = R"({\"groupId\":\"test_cpp_sdk\",\"streamId\":\"stream1\",\"msg\":\"this is a http test\"})";
+  int http_ret = inlong_api.SendHttp(http_url.c_str(), http_body.c_str(), 5);
+  if (http_ret == 0) {
+    cout << "HTTP report succeeded" << endl;
+  } else {
+    cout << "HTTP report failed, code=" << http_ret << endl;
   }
 
   // step3. close

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/client/CMakeLists.txt
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/client/CMakeLists.txt
@@ -21,4 +21,4 @@ cmake_minimum_required(VERSION 3.1)
 
 aux_source_directory(. CLIENT_SRCS)
 
-add_library(inlong_client STATIC ${CLIENT_SRCS})
+add_library(client_objs OBJECT tcp_client.cc http_sender.cc)

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/client/http_sender.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/client/http_sender.cc
@@ -1,0 +1,21 @@
+#include "../../include/http_sender.h"
+#include <curl/curl.h>
+#include <iostream>
+namespace inlong {
+HttpSender::HttpSender() {}
+HttpSender::~HttpSender() {}
+int HttpSender::Send(const std::string& url, const std::string& body, int timeout) {
+    CURL* curl = curl_easy_init();
+    if (!curl) return -1;
+    struct curl_slist* headers = nullptr;
+    headers = curl_slist_append(headers, "Content-Type: application/json");
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+    int ret = curl_easy_perform(curl);
+    curl_slist_free_all(headers);
+    curl_easy_cleanup(curl);
+    return ret;
+}
+} 

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/api_imp.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/api_imp.cc
@@ -24,6 +24,7 @@
 #include "../utils/logger.h"
 #include "../utils/utils.h"
 #include "../core/api_code.h"
+#include "../../include/http_sender.h"
 
 namespace inlong {
 int32_t ApiImp::InitApi(const char *config_file_path) {
@@ -163,6 +164,11 @@ int32_t ApiImp::AddInLongGroupId(const std::vector<std::string> &group_ids) {
     ProxyManager::GetInstance()->CheckGroupIdConf(group_id, false);
   }
   return SdkCode::kSuccess;
+}
+int32_t ApiImp::SendHttp(const char *url, const char *body, int timeout) {
+  if (!url || !body) return -1;
+  inlong::HttpSender sender;
+  return sender.Send(url, body, timeout);
 }
 ApiImp::ApiImp() = default;
 ApiImp::~ApiImp() = default;

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/api_imp.h
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/api_imp.h
@@ -42,6 +42,7 @@ class ApiImp {
   int32_t CloseApi(int32_t max_waitms);
 
   int32_t AddInLongGroupId(const std::vector<std::string> &group_ids);
+  int32_t SendHttp(const char *url, const char *body, int timeout = 5);
 
  private:
   int32_t DoInit();

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/inlong_api.cc
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/src/core/inlong_api.cc
@@ -34,6 +34,8 @@ int32_t InLongApi::Send(const char *inlong_group_id, const char *inlong_stream_i
   return api_impl_->Send(inlong_group_id, inlong_stream_id, msg, msg_len, data_time, call_back);
 }
 
+int32_t InLongApi::SendHttp(const char *url, const char *body, int timeout) { return api_impl_->SendHttp(url, body, timeout); }
+
 int32_t InLongApi::CloseApi(int32_t max_waitms) { return api_impl_->CloseApi(max_waitms); }
 int32_t InLongApi::AddInLongGroupId(const std::vector<std::string> &bids) { return api_impl_->AddInLongGroupId(bids); }
 }  // namespace inlong


### PR DESCRIPTION
Fixes #11914

### Motivation

Currently, the Dataproxy C++ SDK only supports data reporting via TCP and UDP. Although the DataProxy server provides an API for HTTP reporting, this functionality is not integrated into the C++ SDK. This forces users to write their own HTTP client code, increasing complexity. This pull request aims to integrate HTTP reporting directly into the C++ SDK to provide a more comprehensive and user-friendly experience, as described in the official documentation.

### Modifications

- Integrated a new module within the C++ SDK to handle HTTP-based data reporting.
- Implemented the logic to send data records to the DataProxy via HTTP POST requests.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [x] This change added tests and can be verified as follows:

  *(example:)*
  - *Added demo for the new HTTP reporting client.*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
    **yes**
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
    **not documented**
  - If a feature is not applicable for documentation, explain why?
    **not documented**
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
    **Documentation will be updated as part of this PR.**