### PR TITLE
[INLONG-11982][Sort] Fix Null Pointer Exception when changelogAuditKey is not set

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/util/AuditUtils.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/util/AuditUtils.java
@@ -19,6 +19,8 @@ package org.apache.inlong.sort.util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flink.types.RowKind;
 
 import java.util.Arrays;
@@ -56,6 +58,9 @@ public class AuditUtils {
     }
 
     public static Map<RowKind, Integer> extractChangelogAuditKeyMap(String changelogAuditKeys) {
+        if (StringUtils.isBlank(changelogAuditKeys)) {
+            return ImmutableMap.of();
+        }
         return Splitter.on("&").withKeyValueSeparator("=").split(changelogAuditKeys)
                 .entrySet()
                 .stream()


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11982 

### Motivation

Fix Null Point Exception when changelogAuditKey is not set.

Caused by: java.lang.NullPointerException
	at org.apache.inlong.sort.kafka.shaded.com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903) ~[?:?]
	at org.apache.inlong.sort.kafka.shaded.com.google.common.base.Splitter.split(Splitter.java:387) ~[?:?]
	at org.apache.inlong.sort.kafka.shaded.com.google.common.base.Splitter$MapSplitter.split(Splitter.java:518) ~[?:?]
	at org.apache.inlong.sort.kafka.shaded.org.apache.inlong.sort.util.AuditUtils.extractChangelogAuditKeyMap(AuditUtils.java:59) ~[?:?]
	at org.apache.inlong.sort.kafka.shaded.org.apache.inlong.sort.base.metric.MetricOption$Builder.build(MetricOption.java:262) ~[?:?]
	

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
