### PR TITLE
[INLONG-11988][Sort] Implement Weaviate Sort Connector based on Flink 1.15 with Audit reporting support

### DIFF
--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/ExtractNode.java
@@ -33,6 +33,7 @@ import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.RedisExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.SqlServerExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.TubeMQExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.WeaviateExtractNode;
 import org.apache.inlong.sort.protocol.transformation.WatermarkField;
 
 import com.google.common.base.Preconditions;
@@ -69,6 +70,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
         @JsonSubTypes.Type(value = OceanBaseExtractNode.class, name = "oceanbaseExtract"),
+        @JsonSubTypes.Type(value = WeaviateExtractNode.class, name = "weaviateExtract"),
 })
 @Data
 @NoArgsConstructor

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/LoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/LoadNode.java
@@ -37,6 +37,7 @@ import org.apache.inlong.sort.protocol.node.load.RedisLoadNode;
 import org.apache.inlong.sort.protocol.node.load.SqlServerLoadNode;
 import org.apache.inlong.sort.protocol.node.load.StarRocksLoadNode;
 import org.apache.inlong.sort.protocol.node.load.TDSQLPostgresLoadNode;
+import org.apache.inlong.sort.protocol.node.load.WeaviateLoadNode;
 import org.apache.inlong.sort.protocol.transformation.FieldRelation;
 import org.apache.inlong.sort.protocol.transformation.FilterFunction;
 
@@ -78,6 +79,7 @@ import java.util.Map;
         @JsonSubTypes.Type(value = HudiLoadNode.class, name = "hudiLoad"),
         @JsonSubTypes.Type(value = RedisLoadNode.class, name = "redisLoad"),
         @JsonSubTypes.Type(value = OceanBaseLoadNode.class, name = "oceanBaseLoad"),
+        @JsonSubTypes.Type(value = WeaviateLoadNode.class, name = "weaviateLoad"),
 })
 @NoArgsConstructor
 @Data

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/Node.java
@@ -32,6 +32,7 @@ import org.apache.inlong.sort.protocol.node.extract.PulsarExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.RedisExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.SqlServerExtractNode;
 import org.apache.inlong.sort.protocol.node.extract.TubeMQExtractNode;
+import org.apache.inlong.sort.protocol.node.extract.WeaviateExtractNode;
 import org.apache.inlong.sort.protocol.node.load.ClickHouseLoadNode;
 import org.apache.inlong.sort.protocol.node.load.DorisLoadNode;
 import org.apache.inlong.sort.protocol.node.load.ElasticsearchLoadNode;
@@ -51,6 +52,7 @@ import org.apache.inlong.sort.protocol.node.load.RedisLoadNode;
 import org.apache.inlong.sort.protocol.node.load.SqlServerLoadNode;
 import org.apache.inlong.sort.protocol.node.load.StarRocksLoadNode;
 import org.apache.inlong.sort.protocol.node.load.TDSQLPostgresLoadNode;
+import org.apache.inlong.sort.protocol.node.load.WeaviateLoadNode;
 import org.apache.inlong.sort.protocol.node.transform.DistinctNode;
 import org.apache.inlong.sort.protocol.node.transform.TransformNode;
 
@@ -83,6 +85,7 @@ import java.util.TreeMap;
         @JsonSubTypes.Type(value = HudiExtractNode.class, name = "hudiExtract"),
         @JsonSubTypes.Type(value = IcebergExtractNode.class, name = "icebergExtract"),
         @JsonSubTypes.Type(value = OceanBaseExtractNode.class, name = "oceanbaseExtract"),
+        @JsonSubTypes.Type(value = WeaviateExtractNode.class, name = "weaviateExtract"),
         @JsonSubTypes.Type(value = TransformNode.class, name = "baseTransform"),
         @JsonSubTypes.Type(value = DistinctNode.class, name = "distinct"),
         @JsonSubTypes.Type(value = KafkaLoadNode.class, name = "kafkaLoad"),
@@ -105,6 +108,7 @@ import java.util.TreeMap;
         @JsonSubTypes.Type(value = RedisLoadNode.class, name = "redisLoad"),
         @JsonSubTypes.Type(value = KuduLoadNode.class, name = "kuduLoad"),
         @JsonSubTypes.Type(value = OceanBaseLoadNode.class, name = "oceanBaseLoad"),
+        @JsonSubTypes.Type(value = WeaviateLoadNode.class, name = "weaviateLoad"),
 })
 public interface Node {
 

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/WeaviateExtractNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/extract/WeaviateExtractNode.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.extract;
+
+import org.apache.inlong.common.enums.MetaField;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InlongMetric;
+import org.apache.inlong.sort.protocol.Metadata;
+import org.apache.inlong.sort.protocol.node.ExtractNode;
+import org.apache.inlong.sort.protocol.transformation.WatermarkField;
+
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Weaviate extract node for reading data from Weaviate vector database with
+ * enhanced error handling
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("weaviateExtract")
+@JsonInclude(Include.NON_NULL)
+@Data
+@Slf4j
+public class WeaviateExtractNode extends ExtractNode implements InlongMetric, Metadata, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @JsonProperty("url")
+    @Nonnull
+    private String url;
+
+    @JsonProperty("apiKey")
+    @Nullable
+    private String apiKey;
+
+    @JsonProperty("className")
+    @Nonnull
+    private String className;
+
+    @JsonProperty("queryConditions")
+    @Nullable
+    private String queryConditions;
+
+    @JsonProperty("batchSize")
+    @Nullable
+    private Integer batchSize;
+
+    @JsonProperty("timeout")
+    @Nullable
+    private Integer timeout;
+
+    @JsonProperty("vectorField")
+    @Nullable
+    private String vectorField;
+
+    @JsonProperty("scheme")
+    @Nullable
+    private String scheme;
+
+    @JsonProperty("host")
+    @Nullable
+    private String host;
+
+    @JsonProperty("port")
+    @Nullable
+    private Integer port;
+
+    @JsonProperty("headers")
+    @Nullable
+    private Map<String, String> headers;
+
+    @JsonProperty("username")
+    @Nullable
+    private String username;
+
+    @JsonProperty("password")
+    @Nullable
+    private String password;
+
+    @JsonProperty("tenant")
+    @Nullable
+    private String tenant;
+
+    @JsonProperty("consistency")
+    @Nullable
+    private String consistency;
+
+    @JsonProperty("limit")
+    @Nullable
+    private Integer limit;
+
+    @JsonProperty("offset")
+    @Nullable
+    private Integer offset;
+
+    @JsonProperty("where")
+    @Nullable
+    private String where;
+
+    @JsonProperty("near")
+    @Nullable
+    private String near;
+
+    @JsonProperty("fieldsToSelect")
+    @Nullable
+    private String fieldsToSelect;
+
+    @JsonProperty("groupBy")
+    @Nullable
+    private String groupBy;
+
+    @JsonProperty("sort")
+    @Nullable
+    private String sort;
+
+    @JsonProperty("maxConnections")
+    @Nullable
+    private Integer maxConnections;
+
+    @JsonProperty("connectionTimeout")
+    @Nullable
+    private Integer connectionTimeout;
+
+    @JsonProperty("readTimeout")
+    @Nullable
+    private Integer readTimeout;
+
+    @JsonProperty("retryAttempts")
+    @Nullable
+    private Integer retryAttempts;
+
+    @JsonProperty("retryInterval")
+    @Nullable
+    private Integer retryInterval;
+
+    @JsonProperty("enableCache")
+    @Nullable
+    private Boolean enableCache;
+
+    @JsonProperty("cacheSize")
+    @Nullable
+    private Integer cacheSize;
+
+    @JsonProperty("cacheTtl")
+    @Nullable
+    private Integer cacheTtl;
+
+    @JsonCreator
+    public WeaviateExtractNode(@JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @Nullable @JsonProperty("watermarkField") WatermarkField watermarkField,
+            @Nullable @JsonProperty("properties") Map<String, String> properties,
+            @JsonProperty("url") @Nonnull String url,
+            @JsonProperty("apiKey") @Nullable String apiKey,
+            @JsonProperty("className") @Nonnull String className,
+            @JsonProperty("queryConditions") @Nullable String queryConditions,
+            @JsonProperty("batchSize") @Nullable Integer batchSize,
+            @JsonProperty("timeout") @Nullable Integer timeout,
+            @JsonProperty("vectorField") @Nullable String vectorField,
+            @JsonProperty("scheme") @Nullable String scheme,
+            @JsonProperty("host") @Nullable String host,
+            @JsonProperty("port") @Nullable Integer port,
+            @JsonProperty("headers") @Nullable Map<String, String> headers,
+            @JsonProperty("username") @Nullable String username,
+            @JsonProperty("password") @Nullable String password,
+            @JsonProperty("tenant") @Nullable String tenant,
+            @JsonProperty("consistency") @Nullable String consistency,
+            @JsonProperty("limit") @Nullable Integer limit,
+            @JsonProperty("offset") @Nullable Integer offset,
+            @JsonProperty("where") @Nullable String where,
+            @JsonProperty("near") @Nullable String near,
+            @JsonProperty("fieldsToSelect") @Nullable String fieldsToSelect,
+            @JsonProperty("groupBy") @Nullable String groupBy,
+            @JsonProperty("sort") @Nullable String sort,
+            @JsonProperty("maxConnections") @Nullable Integer maxConnections,
+            @JsonProperty("connectionTimeout") @Nullable Integer connectionTimeout,
+            @JsonProperty("readTimeout") @Nullable Integer readTimeout,
+            @JsonProperty("retryAttempts") @Nullable Integer retryAttempts,
+            @JsonProperty("retryInterval") @Nullable Integer retryInterval,
+            @JsonProperty("enableCache") @Nullable Boolean enableCache,
+            @JsonProperty("cacheSize") @Nullable Integer cacheSize,
+            @JsonProperty("cacheTtl") @Nullable Integer cacheTtl) {
+        super(id, name, fields, watermarkField, properties);
+
+        // Enhanced validation with detailed error messages
+        this.url = Preconditions.checkNotNull(url, "Weaviate URL cannot be null");
+        Preconditions.checkArgument(StringUtils.isNotBlank(url), "Weaviate URL cannot be blank");
+
+        // Validate URL format
+        try {
+            java.net.URL urlObj = new java.net.URL(url);
+            String urlScheme = urlObj.getProtocol();
+            if (!"http".equalsIgnoreCase(urlScheme) && !"https".equalsIgnoreCase(urlScheme)) {
+                throw new IllegalArgumentException("Weaviate URL must use http or https protocol, got: " + urlScheme);
+            }
+        } catch (java.net.MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid Weaviate URL format: " + url, e);
+        }
+
+        this.apiKey = apiKey;
+        this.className = Preconditions.checkNotNull(className, "Weaviate className cannot be null");
+        Preconditions.checkArgument(StringUtils.isNotBlank(className), "Weaviate className cannot be blank");
+
+        // Validate className format (basic validation)
+        if (!className.matches("^[A-Z][a-zA-Z0-9_]*$")) {
+            log.warn("Weaviate className '{}' may not follow naming conventions (should start with uppercase letter)",
+                    className);
+        }
+
+        this.queryConditions = queryConditions;
+        this.batchSize = batchSize != null ? batchSize : 100;
+
+        // Validate batch size
+        if (this.batchSize <= 0) {
+            throw new IllegalArgumentException("Batch size must be positive, got: " + this.batchSize);
+        }
+        if (this.batchSize > 10000) {
+            log.warn("Large batch size {} may cause performance issues", this.batchSize);
+        }
+
+        this.timeout = timeout != null ? timeout : 30000;
+
+        // Validate timeout
+        if (this.timeout <= 0) {
+            throw new IllegalArgumentException("Timeout must be positive, got: " + this.timeout);
+        }
+
+        this.vectorField = vectorField;
+
+        // Connection configuration
+        this.scheme = scheme;
+        this.host = host;
+        this.port = port;
+        this.headers = headers;
+
+        // Authentication configuration
+        this.username = username;
+        this.password = password;
+        this.tenant = tenant;
+
+        // Query configuration
+        this.consistency = consistency;
+        this.limit = limit;
+        this.offset = offset;
+        this.where = where;
+        this.near = near;
+        this.fieldsToSelect = fieldsToSelect;
+        this.groupBy = groupBy;
+        this.sort = sort;
+
+        // Connection pool and performance configuration with validation
+        this.maxConnections = maxConnections != null ? maxConnections : 10;
+        if (this.maxConnections <= 0) {
+            throw new IllegalArgumentException("Max connections must be positive, got: " + this.maxConnections);
+        }
+
+        this.connectionTimeout = connectionTimeout != null ? connectionTimeout : 10000;
+        if (this.connectionTimeout <= 0) {
+            throw new IllegalArgumentException("Connection timeout must be positive, got: " + this.connectionTimeout);
+        }
+
+        this.readTimeout = readTimeout != null ? readTimeout : 30000;
+        if (this.readTimeout <= 0) {
+            throw new IllegalArgumentException("Read timeout must be positive, got: " + this.readTimeout);
+        }
+
+        this.retryAttempts = retryAttempts != null ? retryAttempts : 3;
+        if (this.retryAttempts < 0) {
+            throw new IllegalArgumentException("Retry attempts cannot be negative, got: " + this.retryAttempts);
+        }
+        if (this.retryAttempts > 10) {
+            log.warn("High retry attempts {} may cause long delays on failures", this.retryAttempts);
+        }
+
+        this.retryInterval = retryInterval != null ? retryInterval : 1000;
+        if (this.retryInterval < 0) {
+            throw new IllegalArgumentException("Retry interval cannot be negative, got: " + this.retryInterval);
+        }
+
+        // Cache configuration with validation
+        this.enableCache = enableCache != null ? enableCache : false;
+        this.cacheSize = cacheSize != null ? cacheSize : 1000;
+        if (this.cacheSize <= 0) {
+            throw new IllegalArgumentException("Cache size must be positive, got: " + this.cacheSize);
+        }
+
+        this.cacheTtl = cacheTtl != null ? cacheTtl : 300;
+        if (this.cacheTtl <= 0) {
+            throw new IllegalArgumentException("Cache TTL must be positive, got: " + this.cacheTtl);
+        }
+
+        // Log configuration summary for debugging
+        log.info("WeaviateExtractNode configured: url={}, className={}, batchSize={}, timeout={}ms, " +
+                "maxConnections={}, retryAttempts={}, enableCache={}",
+                this.url, this.className, this.batchSize, this.timeout,
+                this.maxConnections, this.retryAttempts, this.enableCache);
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        options.put("connector", "weaviate-inlong");
+        options.put("url", url);
+        options.put("class-name", className);
+
+        // Authentication configuration
+        if (StringUtils.isNotBlank(apiKey)) {
+            options.put("api-key", apiKey);
+        }
+        if (StringUtils.isNotBlank(username)) {
+            options.put("username", username);
+        }
+        if (StringUtils.isNotBlank(password)) {
+            options.put("password", password);
+        }
+        if (StringUtils.isNotBlank(tenant)) {
+            options.put("tenant", tenant);
+        }
+
+        // Connection configuration
+        if (StringUtils.isNotBlank(scheme)) {
+            options.put("scheme", scheme);
+        }
+        if (StringUtils.isNotBlank(host)) {
+            options.put("host", host);
+        }
+        if (port != null) {
+            options.put("port", String.valueOf(port));
+        }
+        if (headers != null && !headers.isEmpty()) {
+            // Convert headers to string format, e.g.: "key1:value1,key2:value2"
+            StringBuilder headerStr = new StringBuilder();
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    if (headerStr.length() > 0) {
+                        headerStr.append(",");
+                    }
+                    headerStr.append(entry.getKey()).append(":").append(entry.getValue());
+                }
+            }
+            if (headerStr.length() > 0) {
+                options.put("headers", headerStr.toString());
+            }
+        }
+
+        // Query configuration
+        if (StringUtils.isNotBlank(queryConditions)) {
+            options.put("query-conditions", queryConditions);
+        }
+        if (StringUtils.isNotBlank(consistency)) {
+            options.put("consistency", consistency);
+        }
+        if (limit != null) {
+            options.put("limit", String.valueOf(limit));
+        }
+        if (offset != null) {
+            options.put("offset", String.valueOf(offset));
+        }
+        if (StringUtils.isNotBlank(where)) {
+            options.put("where", where);
+        }
+        if (StringUtils.isNotBlank(near)) {
+            options.put("near", near);
+        }
+        if (StringUtils.isNotBlank(fieldsToSelect)) {
+            options.put("fields", fieldsToSelect);
+        }
+        if (StringUtils.isNotBlank(groupBy)) {
+            options.put("group-by", groupBy);
+        }
+        if (StringUtils.isNotBlank(sort)) {
+            options.put("sort", sort);
+        }
+
+        // Performance configuration
+        if (batchSize != null) {
+            options.put("batch-size", String.valueOf(batchSize));
+        }
+        if (timeout != null) {
+            options.put("timeout", String.valueOf(timeout));
+        }
+        if (StringUtils.isNotBlank(vectorField)) {
+            options.put("vector-field", vectorField);
+        }
+
+        // Connection pool configuration
+        if (maxConnections != null) {
+            options.put("max-connections", String.valueOf(maxConnections));
+        }
+        if (connectionTimeout != null) {
+            options.put("connection-timeout", String.valueOf(connectionTimeout));
+        }
+        if (readTimeout != null) {
+            options.put("read-timeout", String.valueOf(readTimeout));
+        }
+        if (retryAttempts != null) {
+            options.put("retry-attempts", String.valueOf(retryAttempts));
+        }
+        if (retryInterval != null) {
+            options.put("retry-interval", String.valueOf(retryInterval));
+        }
+
+        // Cache configuration
+        if (enableCache != null) {
+            options.put("enable-cache", String.valueOf(enableCache));
+        }
+        if (cacheSize != null) {
+            options.put("cache-size", String.valueOf(cacheSize));
+        }
+        if (cacheTtl != null) {
+            options.put("cache-ttl", String.valueOf(cacheTtl));
+        }
+
+        return options;
+    }
+
+    @Override
+    public String getMetadataKey(MetaField metaField) {
+        String metadataKey;
+        switch (metaField) {
+            case TABLE_NAME:
+                metadataKey = "table_name";
+                break;
+            case DATABASE_NAME:
+                metadataKey = "database_name";
+                break;
+            case OP_TS:
+                metadataKey = "op_ts";
+                break;
+            case PROCESS_TIME:
+                metadataKey = "proc_time";
+                break;
+            default:
+                throw new UnsupportedOperationException(String.format("Unsupported meta field for %s: %s",
+                        this.getClass().getSimpleName(), metaField));
+        }
+        return metadataKey;
+    }
+
+    @Override
+    public boolean isVirtual(MetaField metaField) {
+        return true;
+    }
+
+    @Override
+    public Set<MetaField> supportedMetaFields() {
+        return EnumSet.of(MetaField.PROCESS_TIME, MetaField.TABLE_NAME,
+                MetaField.DATABASE_NAME, MetaField.OP_TS);
+    }
+}

--- a/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/WeaviateLoadNode.java
+++ b/inlong-sort/sort-common/src/main/java/org/apache/inlong/sort/protocol/node/load/WeaviateLoadNode.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.protocol.node.load;
+
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.InlongMetric;
+import org.apache.inlong.sort.protocol.enums.FilterStrategy;
+import org.apache.inlong.sort.protocol.node.LoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.FilterFunction;
+
+import com.google.common.base.Preconditions;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Weaviate load node can load data into Weaviate vector database with enhanced
+ * error handling
+ */
+@EqualsAndHashCode(callSuper = true)
+@JsonTypeName("weaviateLoad")
+@Data
+@NoArgsConstructor
+@Slf4j
+public class WeaviateLoadNode extends LoadNode implements InlongMetric, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Weaviate server URL (e.g., http://localhost:8080)
+     */
+    @JsonProperty("url")
+    private String url;
+
+    /**
+     * API key for authentication (optional)
+     */
+    @Nullable
+    @JsonProperty("apiKey")
+    private String apiKey;
+
+    /**
+     * Weaviate class name to load data into
+     */
+    @JsonProperty("className")
+    private String className;
+
+    /**
+     * Batch size for bulk operations
+     */
+    @JsonProperty("batchSize")
+    private Integer batchSize;
+
+    /**
+     * Vector field name for storing embeddings
+     */
+    @Nullable
+    @JsonProperty("vectorField")
+    private String vectorField;
+
+    /**
+     * Flush interval in milliseconds
+     */
+    @JsonProperty("flushInterval")
+    private Long flushInterval;
+
+    /**
+     * Connection timeout in milliseconds
+     */
+    @JsonProperty("timeout")
+    private Long timeout;
+
+    /**
+     * Maximum retry attempts for failed operations
+     */
+    @JsonProperty("maxRetries")
+    private Integer maxRetries;
+
+    @JsonCreator
+    public WeaviateLoadNode(
+            @JsonProperty("id") String id,
+            @JsonProperty("name") String name,
+            @JsonProperty("fields") List<FieldInfo> fields,
+            @JsonProperty("fieldRelations") List<FieldRelation> fieldRelations,
+            @JsonProperty("filters") List<FilterFunction> filters,
+            @JsonProperty("filterStrategy") FilterStrategy filterStrategy,
+            @JsonProperty("sinkParallelism") Integer sinkParallelism,
+            @JsonProperty("properties") Map<String, String> properties,
+            @JsonProperty("url") String url,
+            @JsonProperty("apiKey") String apiKey,
+            @JsonProperty("className") String className,
+            @JsonProperty("batchSize") Integer batchSize,
+            @JsonProperty("vectorField") String vectorField,
+            @JsonProperty("flushInterval") Long flushInterval,
+            @JsonProperty("timeout") Long timeout,
+            @JsonProperty("maxRetries") Integer maxRetries) {
+        super(id, name, fields, fieldRelations, filters, filterStrategy, sinkParallelism, properties);
+
+        // Enhanced validation with detailed error messages
+        this.url = Preconditions.checkNotNull(url, "Weaviate URL cannot be null");
+        Preconditions.checkArgument(url != null && !url.trim().isEmpty(), "Weaviate URL cannot be blank");
+
+        // Validate URL format
+        try {
+            java.net.URL urlObj = new java.net.URL(url);
+            String urlScheme = urlObj.getProtocol();
+            if (!"http".equalsIgnoreCase(urlScheme) && !"https".equalsIgnoreCase(urlScheme)) {
+                throw new IllegalArgumentException("Weaviate URL must use http or https protocol, got: " + urlScheme);
+            }
+        } catch (java.net.MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid Weaviate URL format: " + url, e);
+        }
+
+        this.className = Preconditions.checkNotNull(className, "Weaviate class name cannot be null");
+        Preconditions.checkArgument(className != null && !className.trim().isEmpty(),
+                "Weaviate class name cannot be blank");
+
+        // Validate className format (basic validation)
+        if (!className.matches("^[A-Z][a-zA-Z0-9_]*$")) {
+            log.warn("Weaviate className '{}' may not follow naming conventions (should start with uppercase letter)",
+                    className);
+        }
+
+        // Set optional parameters with defaults and validation
+        this.apiKey = apiKey;
+        this.batchSize = batchSize != null ? batchSize : 100;
+        this.vectorField = vectorField;
+        this.flushInterval = flushInterval != null ? flushInterval : 5000L;
+        this.timeout = timeout != null ? timeout : 30000L;
+        this.maxRetries = maxRetries != null ? maxRetries : 3;
+
+        // Enhanced validation with specific error messages
+        Preconditions.checkArgument(this.batchSize > 0,
+                "Batch size must be positive, got: %s", this.batchSize);
+        Preconditions.checkArgument(this.batchSize <= 10000,
+                "Batch size too large (max 10000), got: %s", this.batchSize);
+
+        Preconditions.checkArgument(this.flushInterval > 0,
+                "Flush interval must be positive, got: %s", this.flushInterval);
+        Preconditions.checkArgument(this.flushInterval <= 300000,
+                "Flush interval too large (max 5 minutes), got: %s", this.flushInterval);
+
+        Preconditions.checkArgument(this.timeout > 0,
+                "Timeout must be positive, got: %s", this.timeout);
+        Preconditions.checkArgument(this.timeout <= 600000,
+                "Timeout too large (max 10 minutes), got: %s", this.timeout);
+
+        Preconditions.checkArgument(this.maxRetries >= 0,
+                "Max retries must be non-negative, got: %s", this.maxRetries);
+        Preconditions.checkArgument(this.maxRetries <= 10,
+                "Max retries too large (max 10), got: %s", this.maxRetries);
+
+        // Log warnings for potentially problematic configurations
+        if (this.batchSize > 1000) {
+            log.warn("Large batch size {} may cause memory issues or timeouts", this.batchSize);
+        }
+        if (this.flushInterval < 1000) {
+            log.warn("Small flush interval {}ms may cause high CPU usage", this.flushInterval);
+        }
+        if (this.maxRetries > 5) {
+            log.warn("High retry count {} may cause long delays on failures", this.maxRetries);
+        }
+
+        // Log configuration summary for debugging
+        log.info("WeaviateLoadNode configured: url={}, className={}, batchSize={}, flushInterval={}ms, " +
+                "timeout={}ms, maxRetries={}, vectorField={}",
+                this.url, this.className, this.batchSize, this.flushInterval,
+                this.timeout, this.maxRetries, this.vectorField);
+    }
+
+    @Override
+    public Map<String, String> tableOptions() {
+        Map<String, String> options = super.tableOptions();
+        options.put("connector", "weaviate-inlong");
+        options.put("url", url);
+        options.put("class-name", className);
+        options.put("batch-size", String.valueOf(batchSize));
+        options.put("flush-interval", String.valueOf(flushInterval));
+        options.put("timeout", String.valueOf(timeout));
+        options.put("max-retries", String.valueOf(maxRetries));
+
+        if (apiKey != null) {
+            options.put("api-key", apiKey);
+        }
+        if (vectorField != null) {
+            options.put("vector-field", vectorField);
+        }
+
+        return options;
+    }
+
+    @Override
+    public String genTableName() {
+        return String.format("table_%s", super.getId());
+    }
+}

--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -260,6 +260,12 @@
                     <version>${project.version}</version>
                     <scope>test</scope>
                 </dependency>
+                <dependency>
+                    <groupId>org.apache.inlong</groupId>
+                    <artifactId>sort-connector-weaviate-v1.15</artifactId>
+                    <version>${project.version}</version>
+                    <scope>test</scope>
+                </dependency>
             </dependencies>
         </profile>
         <profile>

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractToWeaviateLoadTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/MySqlExtractToWeaviateLoadTest.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.ArrayFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.FloatFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.IntFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.LongFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.StringFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.MySqlExtractNode;
+import org.apache.inlong.sort.protocol.node.load.WeaviateLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Integration test for MySQL Extract Node to Weaviate Load Node ETL flow.
+ * Tests the complete data pipeline from MySQL database to Weaviate vector
+ * database.
+ */
+public class MySqlExtractToWeaviateLoadTest extends AbstractTestBase {
+
+    /**
+     * Build MySQL extract node for source data.
+     */
+    private MySqlExtractNode buildMySqlExtractNode(String id) {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category_id", new IntFormatInfo()),
+                new FieldInfo("embedding_vector", new StringFormatInfo()) // Vector as string initially
+        );
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("scan.incremental.snapshot.enabled", "false");
+
+        return new MySqlExtractNode(
+                id,
+                "mysql_source",
+                fields,
+                null, // watermarkField
+                properties,
+                "id", // primaryKey
+                Collections.singletonList("user"), // tableNames
+                "localhost", // hostname
+                "root", // username
+                "123456", // password
+                "test", // database
+                3306, // port
+                null, // serverId
+                false, // incrementalSnapshotEnabled
+                null // serverTimeZone
+        );
+    }
+
+    /**
+     * Build Weaviate load node for storing vectorized data.
+     */
+    private WeaviateLoadNode buildWeaviateLoadNode(String id) {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category_id", new IntFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())) // Convert to vector
+        );
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("category_id", new IntFormatInfo()),
+                        new FieldInfo("category_id", new IntFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding_vector", new StringFormatInfo()),
+                        new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo()))));
+
+        return new WeaviateLoadNode(
+                id,
+                "weaviate_sink",
+                fields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                null, // properties
+                "https://tcujllxnqksj7utgb8fy6w.c0.asia-southeast1.gcp.weaviate.cloud", // url
+                "RjZkdk9zeGV2YnNoMTJPUl9qZndoeTlSNnlsZS9lU0ZnVXJkSTZtNEowVDJZeFdXRXRQemJLWTB5cDRzPV92MjAw", // apiKey
+                "Article", // className
+                100, // batchSize
+                "embedding", // vectorField
+                5000L, // flushInterval
+                30000L, // timeout
+                3 // maxRetries
+        );
+    }
+
+    /**
+     * Build node relation between extract and load nodes.
+     */
+    private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    /**
+     * Test complete ETL flow from MySQL to Weaviate.
+     * This test verifies:
+     * 1. MySqlExtractNode can read data from MySQL database
+     * 2. WeaviateLoadNode can write data with vector conversion
+     * 3. FlinkSqlParser can generate correct SQL DDL for both nodes
+     * 4. The complete pipeline can be executed without errors
+     */
+    @Test
+    public void testMySqlToWeaviateETL() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build extract and load nodes
+        Node mysqlExtractNode = buildMySqlExtractNode("1");
+        Node weaviateLoadNode = buildWeaviateLoadNode("2");
+
+        // Create stream info with node relation
+        StreamInfo streamInfo = new StreamInfo(
+                "1L",
+                Arrays.asList(mysqlExtractNode, weaviateLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(mysqlExtractNode),
+                                Collections.singletonList(weaviateLoadNode))));
+
+        // Create group info
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        // Verify the parsing and execution succeeds
+        Assert.assertTrue("MySQL to Weaviate ETL pipeline should parse and execute successfully",
+                result.tryExecute());
+    }
+
+    /**
+     * Test MySQL extract with batch processing to Weaviate.
+     * This test verifies batch processing capabilities for large datasets.
+     */
+    @Test
+    public void testMySqlToWeaviateBatchProcessing() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build MySQL extract node with batch configuration
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("embedding_vector", new StringFormatInfo()));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("scan.incremental.snapshot.enabled", "false");
+        properties.put("scan.fetch.size", "1000");
+
+        MySqlExtractNode mysqlExtractNode = new MySqlExtractNode(
+                "1",
+                "mysql_batch_source",
+                fields,
+                null, // watermarkField
+                properties,
+                "id", // primaryKey
+                Collections.singletonList("large_articles"), // tableNames
+                "localhost", // hostname
+                "root", // username
+                "password", // password
+                "test_db", // database
+                3306, // port
+                10002, // serverId
+                false, // incrementalSnapshotEnabled
+                null // serverTimeZone
+        );
+
+        // Build Weaviate load node with larger batch size
+        List<FieldInfo> weaviateFields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding_vector", new StringFormatInfo()),
+                        new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo()))));
+
+        WeaviateLoadNode weaviateLoadNode = new WeaviateLoadNode(
+                "2",
+                "weaviate_batch_sink",
+                weaviateFields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                null, // properties
+                "http://localhost:8080", // url
+                "batch-test-key", // apiKey
+                "LargeArticle", // className
+                500, // batchSize (larger for batch processing)
+                "embedding", // vectorField
+                10000L, // flushInterval (longer for batch)
+                60000L, // timeout (longer for batch)
+                5 // maxRetries
+        );
+
+        // Create stream info
+        StreamInfo streamInfo = new StreamInfo(
+                "2L",
+                Arrays.asList(mysqlExtractNode, weaviateLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(mysqlExtractNode),
+                                Collections.singletonList(weaviateLoadNode))));
+
+        GroupInfo groupInfo = new GroupInfo("2", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        Assert.assertTrue("MySQL to Weaviate batch processing should work",
+                result.tryExecute());
+    }
+
+    /**
+     * Test MySQL CDC to Weaviate with real-time updates.
+     * This test verifies CDC (Change Data Capture) functionality.
+     */
+    @Test
+    public void testMySqlCDCToWeaviate() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build MySQL CDC extract node
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("updated_at", new StringFormatInfo()),
+                new FieldInfo("embedding_vector", new StringFormatInfo()));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("scan.incremental.snapshot.enabled", "true");
+        properties.put("scan.incremental.snapshot.chunk.size", "1000");
+
+        MySqlExtractNode mysqlCDCNode = new MySqlExtractNode(
+                "1",
+                "mysql_cdc_source",
+                fields,
+                null, // watermarkField
+                properties,
+                "id", // primaryKey
+                Collections.singletonList("articles"), // tableNames
+                "localhost", // hostname
+                "root", // username
+                "password", // password
+                "test_db", // database
+                3306, // port
+                10003, // serverId
+                true, // incrementalSnapshotEnabled
+                "UTC" // serverTimeZone
+        );
+
+        // Build Weaviate load node for CDC updates
+        List<FieldInfo> weaviateFields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("updated_at", new StringFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("updated_at", new StringFormatInfo()),
+                        new FieldInfo("updated_at", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding_vector", new StringFormatInfo()),
+                        new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo()))));
+
+        WeaviateLoadNode weaviateLoadNode = new WeaviateLoadNode(
+                "2",
+                "weaviate_cdc_sink",
+                weaviateFields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                null, // properties
+                "http://localhost:8080", // url
+                "cdc-test-key", // apiKey
+                "Article", // className
+                50, // batchSize (smaller for real-time)
+                "embedding", // vectorField
+                2000L, // flushInterval (shorter for real-time)
+                30000L, // timeout
+                3 // maxRetries
+        );
+
+        // Create stream info
+        StreamInfo streamInfo = new StreamInfo(
+                "3L",
+                Arrays.asList(mysqlCDCNode, weaviateLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(mysqlCDCNode),
+                                Collections.singletonList(weaviateLoadNode))));
+
+        GroupInfo groupInfo = new GroupInfo("3", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        Assert.assertTrue("MySQL CDC to Weaviate should work for real-time updates",
+                result.tryExecute());
+    }
+}

--- a/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/WeaviateExtractToMySqlLoadTest.java
+++ b/inlong-sort/sort-core/src/test/java/org/apache/inlong/sort/parser/WeaviateExtractToMySqlLoadTest.java
@@ -1,0 +1,560 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.parser;
+
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.ArrayFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.FloatFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.IntFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.LongFormatInfo;
+import org.apache.inlong.common.pojo.sort.dataflow.field.format.StringFormatInfo;
+import org.apache.inlong.sort.parser.impl.FlinkSqlParser;
+import org.apache.inlong.sort.parser.result.ParseResult;
+import org.apache.inlong.sort.protocol.FieldInfo;
+import org.apache.inlong.sort.protocol.GroupInfo;
+import org.apache.inlong.sort.protocol.StreamInfo;
+import org.apache.inlong.sort.protocol.node.Node;
+import org.apache.inlong.sort.protocol.node.extract.WeaviateExtractNode;
+import org.apache.inlong.sort.protocol.node.load.MySqlLoadNode;
+import org.apache.inlong.sort.protocol.transformation.FieldRelation;
+import org.apache.inlong.sort.protocol.transformation.relation.NodeRelation;
+
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.test.util.AbstractTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Integration test for Weaviate Extract Node to MySQL Load Node ETL flow.
+ * Tests the complete data pipeline from Weaviate vector database to MySQL
+ * database.
+ */
+public class WeaviateExtractToMySqlLoadTest extends AbstractTestBase {
+
+    /**
+     * Build Weaviate extract node for source data with vector fields.
+     */
+    private WeaviateExtractNode buildWeaviateExtractNode(String id) {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category_id", new IntFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())), // Vector field
+                new FieldInfo("similarity_score", new FloatFormatInfo()));
+
+        return new WeaviateExtractNode(
+                id,
+                "weaviate_source",
+                fields,
+                null, // watermarkField
+                null, // properties
+                "https://tcujllxnqksj7utgb8fy6w.c0.asia-southeast1.gcp.weaviate.cloud", // url
+                "RjZkdk9zeGV2YnNoMTJPUl9qZndoeTlSNnlsZS9lU0ZnVXJkSTZtNEowVDJZeFdXRXRQemJLWTB5cDRzPV92MjAw", // apiKey
+                "Article", // className
+                "limit: 1000", // queryConditions
+                100, // batchSize
+                30000, // timeout
+                "embedding", // vectorField
+                "http", // scheme
+                "localhost", // host
+                8080, // port
+                null, // headers
+                null, // username
+                null, // password
+                null, // tenant
+                null, // consistency
+                1000, // limit
+                null, // offset
+                null, // where
+                null, // near
+                null, // fieldsToSelect
+                null, // groupBy
+                null, // sort
+                null, // maxConnections
+                null, // connectionTimeout
+                null, // readTimeout
+                null, // retryAttempts
+                null, // retryInterval
+                null, // enableCache
+                null, // cacheSize
+                null // cacheTtl
+        );
+    }
+
+    /**
+     * Build MySQL load node for storing processed vector data.
+     */
+    private MySqlLoadNode buildMySqlLoadNode(String id) {
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category_id", new IntFormatInfo()),
+                new FieldInfo("embedding_text", new StringFormatInfo()), // Vector converted to text
+                new FieldInfo("similarity_score", new FloatFormatInfo()));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("category_id", new IntFormatInfo()),
+                        new FieldInfo("category_id", new IntFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())),
+                        new FieldInfo("embedding_text", new StringFormatInfo())), // Vector to text conversion
+                new FieldRelation(new FieldInfo("similarity_score", new FloatFormatInfo()),
+                        new FieldInfo("similarity_score", new FloatFormatInfo())));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("sink.buffer-flush.max-rows", "1000");
+        properties.put("sink.buffer-flush.interval", "5s");
+
+        return new MySqlLoadNode(
+                id,
+                "mysql_sink",
+                fields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                properties,
+                "jdbc:mysql://localhost:3306/test", // url
+                "root", // username
+                "123456", // password
+                "user", // tableName
+                "id" // primaryKey
+        );
+    }
+
+    /**
+     * Build node relation between extract and load nodes.
+     */
+    private NodeRelation buildNodeRelation(List<Node> inputs, List<Node> outputs) {
+        List<String> inputIds = inputs.stream().map(Node::getId).collect(Collectors.toList());
+        List<String> outputIds = outputs.stream().map(Node::getId).collect(Collectors.toList());
+        return new NodeRelation(inputIds, outputIds);
+    }
+
+    /**
+     * Test complete ETL flow from Weaviate to MySQL.
+     * This test verifies:
+     * 1. WeaviateExtractNode can read vector data from Weaviate
+     * 2. MySqlLoadNode can write data with vector-to-text conversion
+     * 3. FlinkSqlParser can generate correct SQL DDL for both nodes
+     * 4. The complete pipeline can be executed without errors
+     */
+    @Test
+    public void testWeaviateToMySqlETL() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build extract and load nodes
+        Node weaviateExtractNode = buildWeaviateExtractNode("1");
+        Node mysqlLoadNode = buildMySqlLoadNode("2");
+
+        // Create stream info with node relation
+        StreamInfo streamInfo = new StreamInfo(
+                "1L",
+                Arrays.asList(weaviateExtractNode, mysqlLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(weaviateExtractNode),
+                                Collections.singletonList(mysqlLoadNode))));
+
+        // Create group info
+        GroupInfo groupInfo = new GroupInfo("1", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        // Verify the parsing and execution succeeds
+        Assert.assertTrue("Weaviate to MySQL ETL pipeline should parse and execute successfully",
+                result.tryExecute());
+    }
+
+    /**
+     * Test Weaviate extract with similarity search to MySQL.
+     * This test verifies similarity search capabilities with vector processing.
+     */
+    @Test
+    public void testWeaviateSimilaritySearchToMySQL() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build Weaviate extract node with similarity search
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())),
+                new FieldInfo("similarity_score", new FloatFormatInfo()));
+
+        WeaviateExtractNode weaviateExtractNode = new WeaviateExtractNode(
+                "1",
+                "weaviate_similarity_source",
+                fields,
+                null, // watermarkField
+                null, // properties
+                "http://localhost:8080", // url
+                "similarity-test-key", // apiKey
+                "Document", // className
+                null, // queryConditions
+                50, // batchSize
+                60000, // timeout
+                "embedding", // vectorField
+                null, // scheme
+                null, // host
+                null, // port
+                null, // headers
+                null, // username
+                null, // password
+                null, // tenant
+                null, // consistency
+                100, // limit
+                null, // offset
+                null, // where
+                "nearVector: {vector: [0.1, 0.2, 0.3], distance: 0.8}", // near (similarity search)
+                null, // fieldsToSelect
+                null, // groupBy
+                null, // sort
+                null, // maxConnections
+                null, // connectionTimeout
+                null, // readTimeout
+                null, // retryAttempts
+                null, // retryInterval
+                null, // enableCache
+                null, // cacheSize
+                null // cacheTtl
+        );
+
+        // Build MySQL load node for similarity results
+        List<FieldInfo> mysqlFields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("embedding_text", new StringFormatInfo()),
+                new FieldInfo("similarity_score", new FloatFormatInfo()));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())),
+                        new FieldInfo("embedding_text", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("similarity_score", new FloatFormatInfo()),
+                        new FieldInfo("similarity_score", new FloatFormatInfo())));
+
+        MySqlLoadNode mysqlLoadNode = new MySqlLoadNode(
+                "2",
+                "mysql_similarity_sink",
+                mysqlFields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                null, // properties
+                "jdbc:mysql://localhost:3306/test_db", // url
+                "root", // username
+                "password", // password
+                "similarity_results", // tableName
+                "id" // primaryKey
+        );
+
+        // Create stream info
+        StreamInfo streamInfo = new StreamInfo(
+                "2L",
+                Arrays.asList(weaviateExtractNode, mysqlLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(weaviateExtractNode),
+                                Collections.singletonList(mysqlLoadNode))));
+
+        GroupInfo groupInfo = new GroupInfo("2", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        Assert.assertTrue("Weaviate similarity search to MySQL should work",
+                result.tryExecute());
+    }
+
+    /**
+     * Test Weaviate extract with filtering to MySQL batch processing.
+     * This test verifies filtered data extraction and batch processing.
+     */
+    @Test
+    public void testWeaviateFilteredToMySqlBatch() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build Weaviate extract node with filtering
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category", new StringFormatInfo()),
+                new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())),
+                new FieldInfo("created_at", new StringFormatInfo()));
+
+        WeaviateExtractNode weaviateExtractNode = new WeaviateExtractNode(
+                "1",
+                "weaviate_filtered_source",
+                fields,
+                null, // watermarkField
+                null, // properties
+                "http://localhost:8080", // url
+                "filter-test-key", // apiKey
+                "Article", // className
+                null, // queryConditions
+                200, // batchSize (larger for batch processing)
+                90000, // timeout (longer for batch)
+                "embedding", // vectorField
+                null, // scheme
+                null, // host
+                null, // port
+                null, // headers
+                null, // username
+                null, // password
+                null, // tenant
+                null, // consistency
+                500, // limit (larger batch)
+                null, // offset
+                "where: {path: [\"category\"], operator: Equal, valueText: \"technology\"}", // where filter
+                null, // near
+                null, // fieldsToSelect
+                null, // groupBy
+                "sort: [{path: [\"created_at\"], order: desc}]", // sort by creation date
+                null, // maxConnections
+                null, // connectionTimeout
+                null, // readTimeout
+                null, // retryAttempts
+                null, // retryInterval
+                null, // enableCache
+                null, // cacheSize
+                null // cacheTtl
+        );
+
+        // Build MySQL load node for batch processing
+        List<FieldInfo> mysqlFields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()),
+                new FieldInfo("category", new StringFormatInfo()),
+                new FieldInfo("embedding_text", new StringFormatInfo()),
+                new FieldInfo("created_at", new StringFormatInfo()));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("category", new StringFormatInfo()),
+                        new FieldInfo("category", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("embedding", new ArrayFormatInfo(new FloatFormatInfo())),
+                        new FieldInfo("embedding_text", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("created_at", new StringFormatInfo()),
+                        new FieldInfo("created_at", new StringFormatInfo())));
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put("sink.buffer-flush.max-rows", "2000"); // Larger batch for performance
+        properties.put("sink.buffer-flush.interval", "10s"); // Longer interval for batch
+        properties.put("sink.max-retries", "5");
+
+        MySqlLoadNode mysqlLoadNode = new MySqlLoadNode(
+                "2",
+                "mysql_batch_sink",
+                mysqlFields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                properties,
+                "jdbc:mysql://localhost:3306/test_db", // url
+                "root", // username
+                "password", // password
+                "filtered_articles", // tableName
+                "id" // primaryKey
+        );
+
+        // Create stream info
+        StreamInfo streamInfo = new StreamInfo(
+                "3L",
+                Arrays.asList(weaviateExtractNode, mysqlLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(weaviateExtractNode),
+                                Collections.singletonList(mysqlLoadNode))));
+
+        GroupInfo groupInfo = new GroupInfo("3", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        Assert.assertTrue("Weaviate filtered extraction to MySQL batch processing should work",
+                result.tryExecute());
+    }
+
+    /**
+     * Test Weaviate extract with minimal configuration to MySQL.
+     * This test verifies that the pipeline works with only required parameters.
+     */
+    @Test
+    public void testWeaviateMinimalToMySQL() throws Exception {
+        // Setup Flink environment
+        EnvironmentSettings settings = EnvironmentSettings
+                .newInstance()
+                .inStreamingMode()
+                .build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(10000);
+        StreamTableEnvironment tableEnv = StreamTableEnvironment.create(env, settings);
+
+        // Build minimal Weaviate extract node
+        List<FieldInfo> fields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()));
+
+        WeaviateExtractNode weaviateExtractNode = new WeaviateExtractNode(
+                "1",
+                "weaviate_minimal_source",
+                fields,
+                null, // watermarkField
+                null, // properties
+                "http://localhost:8080", // url
+                null, // apiKey (optional)
+                "SimpleArticle", // className
+                null, // queryConditions
+                null, // batchSize (will use default)
+                null, // timeout (will use default)
+                null, // vectorField
+                null, // scheme
+                null, // host
+                null, // port
+                null, // headers
+                null, // username
+                null, // password
+                null, // tenant
+                null, // consistency
+                null, // limit
+                null, // offset
+                null, // where
+                null, // near
+                null, // fieldsToSelect
+                null, // groupBy
+                null, // sort
+                null, // maxConnections
+                null, // connectionTimeout
+                null, // readTimeout
+                null, // retryAttempts
+                null, // retryInterval
+                null, // enableCache
+                null, // cacheSize
+                null // cacheTtl
+        );
+
+        // Build minimal MySQL load node
+        List<FieldInfo> mysqlFields = Arrays.asList(
+                new FieldInfo("id", new LongFormatInfo()),
+                new FieldInfo("title", new StringFormatInfo()),
+                new FieldInfo("content", new StringFormatInfo()));
+
+        List<FieldRelation> relations = Arrays.asList(
+                new FieldRelation(new FieldInfo("id", new LongFormatInfo()),
+                        new FieldInfo("id", new LongFormatInfo())),
+                new FieldRelation(new FieldInfo("title", new StringFormatInfo()),
+                        new FieldInfo("title", new StringFormatInfo())),
+                new FieldRelation(new FieldInfo("content", new StringFormatInfo()),
+                        new FieldInfo("content", new StringFormatInfo())));
+
+        MySqlLoadNode mysqlLoadNode = new MySqlLoadNode(
+                "2",
+                "mysql_minimal_sink",
+                mysqlFields,
+                relations,
+                null, // filters
+                null, // filterStrategy
+                null, // sinkParallelism
+                null, // properties
+                "jdbc:mysql://localhost:3306/test_db", // url
+                "root", // username
+                "password", // password
+                "simple_articles", // tableName
+                "id" // primaryKey
+        );
+
+        // Create stream info
+        StreamInfo streamInfo = new StreamInfo(
+                "4L",
+                Arrays.asList(weaviateExtractNode, mysqlLoadNode),
+                Collections.singletonList(
+                        buildNodeRelation(
+                                Collections.singletonList(weaviateExtractNode),
+                                Collections.singletonList(mysqlLoadNode))));
+
+        GroupInfo groupInfo = new GroupInfo("4", Collections.singletonList(streamInfo));
+
+        // Parse and execute
+        FlinkSqlParser parser = FlinkSqlParser.getInstance(tableEnv, groupInfo);
+        ParseResult result = parser.parse();
+
+        Assert.assertTrue("Minimal Weaviate to MySQL configuration should work",
+                result.tryExecute());
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
@@ -46,6 +46,7 @@
         <module>redis</module>
         <module>jdbc</module>
         <module>elasticsearch-base</module>
+        <module>weaviate</module>
     </modules>
 
     <properties>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/pom.xml
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.inlong</groupId>
+        <artifactId>sort-connectors-v1.15</artifactId>
+        <version>2.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>sort-connector-weaviate-v1.15</artifactId>
+    <packaging>jar</packaging>
+    <name>Apache InLong - Sort-connector-weaviate</name>
+
+    <properties>
+        <inlong.root.dir>${project.parent.parent.parent.parent.parent.basedir}</inlong.root.dir>
+    </properties>
+
+    <dependencies>
+        <!-- Weaviate Java Client -->
+        <dependency>
+            <groupId>io.weaviate</groupId>
+            <artifactId>client</artifactId>
+            <version>4.8.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-shaded-jackson</artifactId>
+            <version>${flink.shaded.jackson}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <!-- InLong Sort Base -->
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-connector-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+
+        <!-- InLong Sort Common -->
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>sort-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- InLong Audit SDK -->
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-sdk</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- InLong Audit Common -->
+        <dependency>
+            <groupId>org.apache.inlong</groupId>
+            <artifactId>audit-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Flink Table Common -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+        </dependency>
+
+        <!-- Flink Streaming Java -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Testcontainers for End-to-End Testing -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <version>1.19.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Embedded Kafka for Testing -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.12</artifactId>
+            <version>3.4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Flink Runtime for Integration Tests -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-runtime</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Awaitility for Async Testing -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.2.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>${plugin.shade.version}</version>
+                <executions>
+                    <execution>
+                        <id>shade-flink</id>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>with-dependencies</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>io.weaviate:*</include>
+                                    <include>org.apache.inlong:*</include>
+                                    <include>org.apache.httpcomponents:*</include>
+                                    <include>org.apache.commons:commons-lang3</include>
+                                    <include>com.google.protobuf:*</include>
+                                    <include>com.google.guava:*</include>
+                                    <include>com.fasterxml.jackson.core:*</include>
+                                    <include>commons-logging:commons-logging</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>org.apache.inlong:sort-connector-*</artifact>
+                                    <includes>
+                                        <include>org/apache/inlong/**</include>
+                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>
+                                    </includes>
+                                </filter>
+                                <!--                                <filter>-->
+                                <!--                                    <artifact>org.apache.inlong:sort-connector-*</artifact>-->
+                                <!--                                    <includes>-->
+                                <!--                                        <include>org/apache/inlong/**</include>-->
+                                <!--                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>-->
+                                <!--                                    </includes>-->
+                                <!--                                </filter>-->
+                                <!--                                &lt;!&ndash; 添加当前 weaviate 连接器的服务文件过滤器 &ndash;&gt;-->
+                                <!--                                <filter>-->
+                                <!--                                    <artifact>org.apache.inlong:sort-connector-weaviate-v1.15</artifact>-->
+                                <!--                                    <includes>-->
+                                <!--                                        <include>META-INF/services/org.apache.flink.table.factories.Factory</include>-->
+                                <!--                                    </includes>-->
+                                <!--                                </filter>-->
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons.logging</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.commons.logging</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.commons.lang3</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.commons.lang3</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.http</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.http</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.com.fasterxml.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.base</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.inlong.sort.base</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.configuration</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.inlong.sort.configuration</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.protocol</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.inlong.sort.protocol</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.schema</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.inlong.sort.schema</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.apache.inlong.sort.util</pattern>
+                                    <shadedPattern>org.apache.inlong.sort.weaviate.shaded.org.apache.inlong.sort.util</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/sink/WeaviateSinkFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/sink/WeaviateSinkFunction.java
@@ -1,0 +1,1023 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.sink;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.SinkExactlyMetric;
+import org.apache.inlong.sort.weaviate.table.WeaviateOptions;
+import org.apache.inlong.sort.weaviate.utils.WeaviateClientUtils;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateErrorCode;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateException;
+import org.apache.inlong.sort.weaviate.utils.WeaviateMonitoringUtils;
+import org.apache.inlong.sort.weaviate.utils.WeaviateTypeConverter;
+
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.base.Result;
+import io.weaviate.client.v1.batch.model.ObjectGetResponse;
+import io.weaviate.client.v1.data.model.WeaviateObject;
+import lombok.Data;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Enhanced Weaviate sink function with advanced performance optimizations.
+ * Features include:
+ * - Advanced batch processing with memory monitoring
+ * - Connection pool management
+ * - Backpressure handling
+ * - Concurrent batch processing
+ * - Memory pressure detection and auto-flush
+ * - Enhanced error handling and retry mechanisms
+ */
+@Data
+public class WeaviateSinkFunction extends RichSinkFunction<RowData> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateSinkFunction.class);
+
+    private final ReadableConfig config;
+    private final DataType physicalDataType;
+    private final MetricOption metricOption;
+
+    // Runtime state
+    private transient WeaviateClient client;
+    private transient WeaviateClientUtils.WeaviateConnectionPool connectionPool;
+    private transient SinkExactlyMetric sinkExactlyMetric;
+    private transient WeaviateTypeConverter typeConverter;
+    private transient List<Map<String, Object>> batchBuffer;
+    private transient ScheduledExecutorService flushExecutor;
+    private transient ScheduledExecutorService memoryMonitorExecutor;
+    private transient ThreadPoolExecutor batchProcessorExecutor;
+    private transient AtomicLong lastFlushTime;
+    private transient ReentrantLock batchLock;
+    private transient AtomicBoolean backpressureActive;
+    private transient MemoryMXBean memoryBean;
+    private transient Semaphore concurrentBatchSemaphore;
+
+    // Enhanced monitoring and error handling
+    private transient WeaviateMonitoringUtils.EnhancedMetrics enhancedMetrics;
+    private transient WeaviateMonitoringUtils.ConnectionHealthMonitor healthMonitor;
+
+    // Configuration
+    private String url;
+    private String apiKey;
+    private String className;
+    private String vectorField;
+    private Integer vectorDimension;
+    private Integer batchSize;
+    private Duration flushInterval;
+    private Integer maxRetries;
+    private Duration retryDelay;
+    private Boolean upsertEnabled;
+    private Boolean ignoreNullValues;
+    private String consistencyLevel;
+    private long maxBatchMemoryBytes;
+    private Boolean useConnectionPool;
+    private Integer connectionPoolSize;
+    private Double memoryPressureThreshold;
+    private Duration backpressureDelay;
+    private Integer maxConcurrentBatches;
+    private Duration memoryMonitorInterval;
+
+    // Enhanced metrics tracking
+    private transient AtomicLong totalRecordsProcessed;
+    private transient AtomicLong totalBytesProcessed;
+    private transient AtomicLong totalBatchesFlushed;
+    private transient AtomicLong totalFailedRecords;
+    private transient AtomicLong totalBackpressureEvents;
+    private transient AtomicLong totalMemoryFlushes;
+    private transient AtomicLong currentBatchMemoryUsage;
+    private transient AtomicLong totalConcurrentBatches;
+
+    public WeaviateSinkFunction(
+            ReadableConfig config,
+            DataType physicalDataType,
+            MetricOption metricOption) {
+        this.config = config;
+        this.physicalDataType = physicalDataType;
+        this.metricOption = metricOption;
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+
+        WeaviateMonitoringUtils.PerformanceTracker tracker = WeaviateMonitoringUtils
+                .startOperation("WeaviateSinkFunction.open", LOG);
+
+        try {
+            LOG.info("Opening WeaviateSinkFunction with enhanced error handling and monitoring");
+
+            // Initialize configuration with validation
+            initializeConfiguration();
+
+            // Initialize enhanced monitoring
+            initializeEnhancedMonitoring();
+
+            // Initialize Weaviate client with retry and health monitoring
+            initializeClient();
+
+            // Initialize type converter with validation
+            initializeTypeConverter();
+
+            // Initialize batch buffer and memory tracking
+            initializeBatchBuffer();
+
+            // Initialize metrics with enhanced reporting
+            initializeMetrics();
+
+            // Initialize flush executor for periodic flushing
+            initializeFlushExecutor();
+
+            // Log system resources for monitoring
+            WeaviateMonitoringUtils.logSystemResources(LOG);
+
+            tracker.recordSuccess(1, 0);
+            LOG.info("WeaviateSinkFunction opened successfully with enhanced monitoring");
+
+        } catch (Exception e) {
+            WeaviateException weaviateException = WeaviateErrorHandler.wrapException(e,
+                    "WeaviateSinkFunction.open failed");
+            tracker.recordFailure(weaviateException, 0);
+            throw weaviateException;
+        }
+    }
+
+    @Override
+    public void invoke(RowData value, Context context) throws Exception {
+        if (value == null) {
+            LOG.debug("Received null RowData, skipping");
+            return;
+        }
+
+        WeaviateMonitoringUtils.PerformanceTracker tracker = WeaviateMonitoringUtils
+                .startOperation("WeaviateSinkFunction.invoke", LOG);
+
+        // Check for backpressure before processing
+        if (backpressureActive.get()) {
+            totalBackpressureEvents.incrementAndGet();
+            LOG.debug("Backpressure active, applying delay of {}ms", backpressureDelay.toMillis());
+            Thread.sleep(backpressureDelay.toMillis());
+        }
+
+        try {
+            // Convert RowData to Weaviate object with enhanced error handling
+            Map<String, Object> weaviateObject;
+            try {
+                weaviateObject = typeConverter.convertRowDataToWeaviateObject(value);
+            } catch (WeaviateException e) {
+                totalFailedRecords.incrementAndGet();
+                WeaviateErrorHandler.logError(LOG, "RowData conversion", e,
+                        "rowData", value.toString());
+                if (enhancedMetrics != null) {
+                    enhancedMetrics.recordFailure(1, 0);
+                }
+                throw e;
+            }
+
+            // Skip null values if configured
+            if (ignoreNullValues && isObjectEmpty(weaviateObject)) {
+                LOG.debug("Skipping empty object due to ignore-null-values setting");
+                return;
+            }
+
+            // Add to batch buffer with enhanced synchronization and error handling
+            batchLock.lock();
+            try {
+                batchBuffer.add(weaviateObject);
+
+                // Update metrics
+                long dataSize = estimateObjectSize(weaviateObject);
+                totalRecordsProcessed.incrementAndGet();
+                totalBytesProcessed.addAndGet(dataSize);
+                currentBatchMemoryUsage.addAndGet(dataSize);
+
+                // Report enhanced metrics
+                reportMetrics(1, dataSize);
+                if (enhancedMetrics != null) {
+                    enhancedMetrics.recordSinkMetrics(1, dataSize, System.currentTimeMillis());
+                }
+
+                // Check if we need to flush based on batch size, memory usage, or pressure
+                if (shouldFlushBatch()) {
+                    // Use async batch processing to avoid blocking
+                    flushBatchAsync();
+                }
+
+                tracker.recordSuccess(1, dataSize);
+
+            } finally {
+                batchLock.unlock();
+            }
+
+        } catch (WeaviateException e) {
+            totalFailedRecords.incrementAndGet();
+            tracker.recordFailure(e, 0);
+            throw e;
+        } catch (Exception e) {
+            totalFailedRecords.incrementAndGet();
+            WeaviateException weaviateException = WeaviateErrorHandler.wrapException(e,
+                    "Failed to process RowData in WeaviateSinkFunction.invoke");
+            tracker.recordFailure(weaviateException, 0);
+            throw weaviateException;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.info("Closing WeaviateSinkFunction");
+
+        try {
+            // Flush any remaining data
+            batchLock.lock();
+            try {
+                if (batchBuffer != null && !batchBuffer.isEmpty()) {
+                    LOG.info("Flushing remaining {} records before closing", batchBuffer.size());
+                    flushBatchSync();
+                }
+            } finally {
+                batchLock.unlock();
+            }
+
+            // Shutdown executors gracefully
+            shutdownExecutors();
+
+            // Return client to pool or close
+            closeClient();
+
+            // Log final statistics
+            logFinalStatistics();
+
+        } finally {
+            super.close();
+        }
+
+        LOG.info("WeaviateSinkFunction closed");
+    }
+
+    /**
+     * Initialize enhanced monitoring and health tracking.
+     */
+    private void initializeEnhancedMonitoring() {
+        // Initialize enhanced metrics
+        enhancedMetrics = WeaviateMonitoringUtils.createMetrics(
+                "WeaviateSinkFunction", metricOption, getRuntimeContext().getMetricGroup(), false);
+
+        // Initialize connection health monitor
+        healthMonitor = WeaviateMonitoringUtils.createHealthMonitor(url);
+
+        LOG.info("Enhanced monitoring initialized for WeaviateSinkFunction");
+    }
+
+    /**
+     * Initialize configuration from ReadableConfig with enhanced validation.
+     */
+    private void initializeConfiguration() throws WeaviateException {
+        // Enhanced configuration validation
+        url = config.get(WeaviateOptions.URL);
+        WeaviateErrorHandler.validateConfig("url", url, "WeaviateSinkFunction");
+
+        apiKey = config.getOptional(WeaviateOptions.API_KEY).orElse(null);
+
+        className = config.get(WeaviateOptions.CLASS_NAME);
+        WeaviateErrorHandler.validateConfig("className", className, "WeaviateSinkFunction");
+
+        vectorField = config.getOptional(WeaviateOptions.VECTOR_FIELD).orElse(null);
+        vectorDimension = config.getOptional(WeaviateOptions.VECTOR_DIMENSION).orElse(null);
+
+        batchSize = config.get(WeaviateOptions.BATCH_SIZE);
+        if (batchSize <= 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_BATCH_SIZE,
+                    WeaviateErrorHandler.createContext("WeaviateSinkFunction", "batchSize", batchSize));
+        }
+
+        flushInterval = config.get(WeaviateOptions.FLUSH_INTERVAL);
+        maxRetries = config.get(WeaviateOptions.MAX_RETRIES);
+        retryDelay = config.get(WeaviateOptions.RETRY_DELAY);
+        upsertEnabled = config.get(WeaviateOptions.UPSERT_ENABLED);
+        ignoreNullValues = config.get(WeaviateOptions.IGNORE_NULL_VALUES);
+        consistencyLevel = config.get(WeaviateOptions.CONSISTENCY_LEVEL);
+
+        // Parse max batch memory
+        String maxBatchMemoryStr = config.get(WeaviateOptions.MAX_BATCH_MEMORY);
+        maxBatchMemoryBytes = parseMemorySize(maxBatchMemoryStr);
+
+        // Performance optimization settings
+        useConnectionPool = config.get(WeaviateOptions.USE_CONNECTION_POOL);
+        connectionPoolSize = config.get(WeaviateOptions.CONNECTION_POOL_SIZE);
+        memoryPressureThreshold = config.get(WeaviateOptions.MEMORY_PRESSURE_THRESHOLD);
+        backpressureDelay = config.get(WeaviateOptions.BACKPRESSURE_DELAY);
+        maxConcurrentBatches = config.get(WeaviateOptions.MAX_CONCURRENT_BATCHES);
+        memoryMonitorInterval = config.get(WeaviateOptions.MEMORY_MONITOR_INTERVAL);
+
+        LOG.info("Initialized configuration: url={}, className={}, batchSize={}, flushInterval={}, " +
+                "vectorField={}, upsertEnabled={}, maxBatchMemory={}, useConnectionPool={}, " +
+                "memoryPressureThreshold={}, maxConcurrentBatches={}",
+                url, className, batchSize, flushInterval, vectorField, upsertEnabled, maxBatchMemoryStr,
+                useConnectionPool, memoryPressureThreshold, maxConcurrentBatches);
+    }
+
+    /**
+     * Initialize Weaviate client with enhanced connection pooling and health
+     * monitoring.
+     */
+    private void initializeClient() throws WeaviateException {
+        String context = WeaviateErrorHandler.createContext("WeaviateSinkFunction.initializeClient",
+                "url", url, "useConnectionPool", useConnectionPool);
+        LOG.info("Initializing Weaviate client with enhanced monitoring: {}", context);
+
+        try {
+            if (useConnectionPool) {
+                // Use connection pool for better resource management
+                connectionPool = WeaviateClientUtils.getConnectionPool(url, apiKey, connectionPoolSize);
+                client = connectionPool.borrowClient();
+                LOG.info("Using connection pool with size: {} for URL: {}", connectionPoolSize, url);
+            } else {
+                // Use single client instance with enhanced retry
+                client = WeaviateClientUtils.createClientWithRetry(url, apiKey, maxRetries, retryDelay);
+            }
+
+            // Enhanced connection test with health monitoring
+            if (!WeaviateClientUtils.testConnectionWithHealthCheck(client, url)) {
+                healthMonitor.recordHealthCheck(false, "Initial connection test failed");
+                throw new WeaviateException(WeaviateErrorCode.CONNECTION_FAILED,
+                        context + " - Connection test failed");
+            }
+
+            // Record successful health check
+            healthMonitor.recordHealthCheck(true, null);
+
+            LOG.info("Weaviate client initialized successfully with health monitoring: {}", url);
+
+        } catch (WeaviateException e) {
+            WeaviateErrorHandler.logError(LOG, "client initialization", e, "url", url);
+            throw e;
+        } catch (Exception e) {
+            WeaviateException weaviateException = WeaviateErrorHandler.wrapException(e, context);
+            WeaviateErrorHandler.logError(LOG, "client initialization", weaviateException, "url", url);
+            throw weaviateException;
+        }
+    }
+
+    /**
+     * Initialize type converter with enhanced validation.
+     */
+    private void initializeTypeConverter() throws WeaviateException {
+        try {
+            RowType rowType = (RowType) physicalDataType.getLogicalType();
+            typeConverter = new WeaviateTypeConverter(rowType, vectorField, vectorDimension);
+            typeConverter.validate();
+
+            LOG.info("Type converter initialized and validated with vector field: {}, dimension: {}",
+                    vectorField, vectorDimension);
+
+        } catch (WeaviateException e) {
+            WeaviateErrorHandler.logError(LOG, "type converter initialization", e,
+                    "vectorField", vectorField, "vectorDimension", vectorDimension);
+            throw e;
+        } catch (Exception e) {
+            WeaviateException weaviateException = WeaviateErrorHandler.wrapException(e,
+                    "Type converter initialization failed");
+            WeaviateErrorHandler.logError(LOG, "type converter initialization", weaviateException);
+            throw weaviateException;
+        }
+    }
+
+    /**
+     * 
+     * Initialize batch buffer and synchronization primitives.
+     */
+    private void initializeBatchBuffer() {
+        batchBuffer = new ArrayList<>(batchSize);
+        lastFlushTime = new AtomicLong(System.currentTimeMillis());
+        batchLock = new ReentrantLock();
+        backpressureActive = new AtomicBoolean(false);
+        concurrentBatchSemaphore = new Semaphore(maxConcurrentBatches);
+        memoryBean = ManagementFactory.getMemoryMXBean();
+
+        // Initialize enhanced metrics tracking
+        totalRecordsProcessed = new AtomicLong(0);
+        totalBytesProcessed = new AtomicLong(0);
+        totalBatchesFlushed = new AtomicLong(0);
+        totalFailedRecords = new AtomicLong(0);
+        totalBackpressureEvents = new AtomicLong(0);
+        totalMemoryFlushes = new AtomicLong(0);
+        currentBatchMemoryUsage = new AtomicLong(0);
+        totalConcurrentBatches = new AtomicLong(0);
+
+        LOG.info("Batch buffer initialized with size: {}, max memory: {} bytes, concurrent batches: {}",
+                batchSize, maxBatchMemoryBytes, maxConcurrentBatches);
+    }
+
+    /**
+     * Initialize metrics for InLong audit.
+     */
+    private void initializeMetrics() {
+        if (metricOption != null) {
+            sinkExactlyMetric = new SinkExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
+            LOG.info("Sink metrics initialized");
+        } else {
+            LOG.warn("MetricOption is null, metrics will not be reported");
+        }
+    }
+
+    /**
+     * Initialize executors for async processing and memory monitoring.
+     */
+    private void initializeFlushExecutor() {
+        // Flush executor for periodic flushing
+        flushExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "weaviate-sink-flush-executor");
+            t.setDaemon(true);
+            return t;
+        });
+
+        // Schedule periodic flush
+        flushExecutor.scheduleAtFixedRate(
+                this::periodicFlush,
+                flushInterval.toMillis(),
+                flushInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
+
+        // Memory monitor executor
+        memoryMonitorExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "weaviate-memory-monitor");
+            t.setDaemon(true);
+            return t;
+        });
+
+        // Schedule memory monitoring
+        memoryMonitorExecutor.scheduleAtFixedRate(
+                this::monitorMemoryPressure,
+                memoryMonitorInterval.toMillis(),
+                memoryMonitorInterval.toMillis(),
+                TimeUnit.MILLISECONDS);
+
+        // Batch processor executor for concurrent batch processing
+        batchProcessorExecutor = new ThreadPoolExecutor(
+                1, // core pool size
+                maxConcurrentBatches, // maximum pool size
+                60L, TimeUnit.SECONDS, // keep alive time
+                new LinkedBlockingQueue<>(), // work queue
+                r -> {
+                    Thread t = new Thread(r, "weaviate-batch-processor");
+                    t.setDaemon(true);
+                    return t;
+                });
+
+        LOG.info(
+                "Executors initialized with flush interval: {}, memory monitor interval: {}, max concurrent batches: {}",
+                flushInterval, memoryMonitorInterval, maxConcurrentBatches);
+    }
+
+    /**
+     * Enhanced batch flush condition checking.
+     */
+    private boolean shouldFlushBatch() {
+        if (batchBuffer.isEmpty()) {
+            return false;
+        }
+
+        // Check batch size
+        if (batchBuffer.size() >= batchSize) {
+            LOG.debug("Batch size limit reached: {}/{}", batchBuffer.size(), batchSize);
+            return true;
+        }
+
+        // Check memory usage
+        long currentMemoryUsage = currentBatchMemoryUsage.get();
+        if (currentMemoryUsage >= maxBatchMemoryBytes) {
+            LOG.debug("Batch memory limit reached: {} bytes/{} bytes", currentMemoryUsage, maxBatchMemoryBytes);
+            return true;
+        }
+
+        // Check system memory pressure
+        if (isMemoryPressureHigh()) {
+            LOG.debug("System memory pressure detected, triggering flush");
+            totalMemoryFlushes.incrementAndGet();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Periodic flush triggered by executor.
+     */
+    private void periodicFlush() {
+        try {
+            synchronized (batchBuffer) {
+                if (!batchBuffer.isEmpty()) {
+                    long timeSinceLastFlush = System.currentTimeMillis() - lastFlushTime.get();
+                    if (timeSinceLastFlush >= flushInterval.toMillis()) {
+                        LOG.debug("Periodic flush triggered, {} records in buffer", batchBuffer.size());
+                        flushBatch();
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.error("Error during periodic flush", e);
+        }
+    }
+
+    /**
+     * Flush batch to Weaviate with retry mechanism.
+     */
+    private void flushBatch() throws Exception {
+        if (batchBuffer.isEmpty()) {
+            return;
+        }
+
+        List<Map<String, Object>> currentBatch = new ArrayList<>(batchBuffer);
+        batchBuffer.clear();
+        lastFlushTime.set(System.currentTimeMillis());
+
+        LOG.debug("Flushing batch with {} records", currentBatch.size());
+
+        Exception lastException = null;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                flushBatchWithRetry(currentBatch);
+                totalBatchesFlushed.incrementAndGet();
+                LOG.debug("Successfully flushed batch with {} records on attempt {}", currentBatch.size(), attempt);
+                return;
+
+            } catch (Exception e) {
+                lastException = e;
+                LOG.warn("Batch flush attempt {}/{} failed: {}", attempt, maxRetries, e.getMessage());
+
+                if (attempt < maxRetries) {
+                    try {
+                        // Exponential backoff with jitter
+                        long delayMs = retryDelay.toMillis() * (1L << (attempt - 1));
+                        delayMs += (long) (Math.random() * 1000); // Add jitter
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted during retry", ie);
+                    }
+                }
+            }
+        }
+
+        // All retries failed
+        totalFailedRecords.addAndGet(currentBatch.size());
+        throw new RuntimeException("Failed to flush batch after " + maxRetries + " attempts", lastException);
+    }
+
+    /**
+     * Execute batch write to Weaviate.
+     */
+    private void flushBatchWithRetry(List<Map<String, Object>> batch) throws Exception {
+        // Convert maps to WeaviateObject instances
+        WeaviateObject[] objects = new WeaviateObject[batch.size()];
+        for (int i = 0; i < batch.size(); i++) {
+            Map<String, Object> objectMap = batch.get(i);
+            WeaviateObject weaviateObject = WeaviateObject.builder()
+                    .className(className)
+                    .properties(objectMap)
+                    .build();
+            objects[i] = weaviateObject;
+        }
+
+        // Execute batch operation
+        Result<ObjectGetResponse[]> result;
+        if (upsertEnabled) {
+            // Use batch upsert if available
+            result = client.batch()
+                    .objectsBatcher()
+                    .withObjects(objects)
+                    .run();
+        } else {
+            // Use regular batch insert
+            result = client.batch()
+                    .objectsBatcher()
+                    .withObjects(objects)
+                    .run();
+        }
+
+        // Check for errors
+        if (result.hasErrors()) {
+            String errorMessage = "Batch operation failed: " + result.getError().getMessages();
+            LOG.error("Batch write failed: {}", errorMessage);
+            throw new RuntimeException(errorMessage);
+        }
+
+        // Check individual object results if available
+        ObjectGetResponse[] responses = result.getResult();
+        if (responses != null) {
+            int successCount = 0;
+            int errorCount = 0;
+
+            for (ObjectGetResponse response : responses) {
+                if (response != null) {
+                    // Check if response indicates success
+                    // Note: The exact success/error checking depends on Weaviate client version
+                    successCount++;
+                } else {
+                    errorCount++;
+                }
+            }
+
+            LOG.debug("Batch write completed: {} successful, {} errors", successCount, errorCount);
+
+            if (errorCount > 0) {
+                LOG.warn("Some objects in batch failed to write: {} errors out of {} objects",
+                        errorCount, batch.size());
+            }
+        }
+    }
+
+    /**
+     * 
+     * Asynchronous batch flush to avoid blocking the main thread.
+     */
+    private void flushBatchAsync() {
+        if (!concurrentBatchSemaphore.tryAcquire()) {
+            LOG.debug("Max concurrent batches reached, skipping async flush");
+            return;
+        }
+
+        List<Map<String, Object>> currentBatch;
+        batchLock.lock();
+        try {
+            if (batchBuffer.isEmpty()) {
+                concurrentBatchSemaphore.release();
+                return;
+            }
+
+            currentBatch = new ArrayList<>(batchBuffer);
+            batchBuffer.clear();
+            currentBatchMemoryUsage.set(0);
+            lastFlushTime.set(System.currentTimeMillis());
+        } finally {
+            batchLock.unlock();
+        }
+
+        // Submit batch processing task
+        CompletableFuture.runAsync(() -> {
+            try {
+                totalConcurrentBatches.incrementAndGet();
+                processBatch(currentBatch);
+                totalBatchesFlushed.incrementAndGet();
+                LOG.debug("Successfully flushed async batch with {} records", currentBatch.size());
+            } catch (Exception e) {
+                totalFailedRecords.addAndGet(currentBatch.size());
+                LOG.error("Failed to flush async batch with {} records", currentBatch.size(), e);
+            } finally {
+                totalConcurrentBatches.decrementAndGet();
+                concurrentBatchSemaphore.release();
+            }
+        }, batchProcessorExecutor);
+    }
+
+    /**
+     * Process a batch of records with enhanced error handling.
+     */
+    private void processBatch(List<Map<String, Object>> batch) throws Exception {
+        Exception lastException = null;
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                WeaviateClient batchClient = getBatchClient();
+                executeBatchWrite(batchClient, batch);
+                returnBatchClient(batchClient);
+                return;
+
+            } catch (Exception e) {
+                lastException = e;
+                LOG.warn("Batch processing attempt {}/{} failed: {}", attempt, maxRetries, e.getMessage());
+
+                if (attempt < maxRetries) {
+                    // Exponential backoff with jitter
+                    long delayMs = retryDelay.toMillis() * (1L << (attempt - 1));
+                    delayMs += (long) (Math.random() * 1000); // Add jitter
+                    Thread.sleep(delayMs);
+                }
+            }
+        }
+
+        throw new RuntimeException("Failed to process batch after " + maxRetries + " attempts", lastException);
+    }
+
+    /**
+     * Get a client for batch processing (from pool or main client).
+     */
+    private WeaviateClient getBatchClient() throws Exception {
+        if (useConnectionPool && connectionPool != null) {
+            return connectionPool.borrowClient();
+        }
+        return client;
+    }
+
+    /**
+     * Return a client after batch processing.
+     */
+    private void returnBatchClient(WeaviateClient batchClient) {
+        if (useConnectionPool && connectionPool != null && batchClient != client) {
+            connectionPool.returnClient(batchClient);
+        }
+    }
+
+    /**
+     * Execute batch write operation.
+     */
+    private void executeBatchWrite(WeaviateClient batchClient, List<Map<String, Object>> batch) throws Exception {
+        // Convert maps to WeaviateObject instances
+        WeaviateObject[] objects = new WeaviateObject[batch.size()];
+        for (int i = 0; i < batch.size(); i++) {
+            Map<String, Object> objectMap = batch.get(i);
+            WeaviateObject weaviateObject = WeaviateObject.builder()
+                    .className(className)
+                    .properties(objectMap)
+                    .build();
+            objects[i] = weaviateObject;
+        }
+
+        // Execute batch operation
+        Result<ObjectGetResponse[]> result;
+        if (upsertEnabled) {
+            result = batchClient.batch()
+                    .objectsBatcher()
+                    .withObjects(objects)
+                    .run();
+        } else {
+            result = batchClient.batch()
+                    .objectsBatcher()
+                    .withObjects(objects)
+                    .run();
+        }
+
+        // Check for errors
+        if (result.hasErrors()) {
+            String errorMessage = "Batch operation failed: " + result.getError().getMessages();
+            LOG.error("Batch write failed: {}", errorMessage);
+            throw new RuntimeException(errorMessage);
+        }
+    }
+
+    /**
+     * Synchronous batch flush for critical operations.
+     */
+    private void flushBatchSync() throws Exception {
+        List<Map<String, Object>> currentBatch;
+        if (batchBuffer.isEmpty()) {
+            return;
+        }
+
+        currentBatch = new ArrayList<>(batchBuffer);
+        batchBuffer.clear();
+        currentBatchMemoryUsage.set(0);
+        lastFlushTime.set(System.currentTimeMillis());
+
+        processBatch(currentBatch);
+        totalBatchesFlushed.incrementAndGet();
+        LOG.debug("Successfully flushed sync batch with {} records", currentBatch.size());
+    }
+
+    /**
+     * Shutdown all executors gracefully.
+     */
+    private void shutdownExecutors() {
+        // Shutdown flush executor
+        if (flushExecutor != null && !flushExecutor.isShutdown()) {
+            flushExecutor.shutdown();
+            try {
+                if (!flushExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
+                    flushExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                flushExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        // Shutdown memory monitor executor
+        if (memoryMonitorExecutor != null && !memoryMonitorExecutor.isShutdown()) {
+            memoryMonitorExecutor.shutdown();
+            try {
+                if (!memoryMonitorExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    memoryMonitorExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                memoryMonitorExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        // Shutdown batch processor executor
+        if (batchProcessorExecutor != null && !batchProcessorExecutor.isShutdown()) {
+            batchProcessorExecutor.shutdown();
+            try {
+                if (!batchProcessorExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                    batchProcessorExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                batchProcessorExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Close client resources.
+     */
+    private void closeClient() {
+        if (useConnectionPool && connectionPool != null && client != null) {
+            connectionPool.returnClient(client);
+        }
+        client = null;
+    }
+
+    /**
+     * Monitor memory pressure and activate backpressure if needed.
+     */
+    private void monitorMemoryPressure() {
+        try {
+            boolean highPressure = isMemoryPressureHigh();
+            boolean wasActive = backpressureActive.getAndSet(highPressure);
+
+            if (highPressure && !wasActive) {
+                LOG.warn("Memory pressure detected, activating backpressure");
+                // Trigger immediate flush if possible
+                if (batchLock.tryLock()) {
+                    try {
+                        if (!batchBuffer.isEmpty()) {
+                            flushBatchAsync();
+                        }
+                    } finally {
+                        batchLock.unlock();
+                    }
+                }
+            } else if (!highPressure && wasActive) {
+                LOG.info("Memory pressure relieved, deactivating backpressure");
+            }
+        } catch (Exception e) {
+            LOG.error("Error during memory pressure monitoring", e);
+        }
+    }
+
+    /**
+     * Check if system memory pressure is high.
+     */
+    private boolean isMemoryPressureHigh() {
+        try {
+            MemoryUsage heapMemory = memoryBean.getHeapMemoryUsage();
+            double usageRatio = (double) heapMemory.getUsed() / heapMemory.getMax();
+            return usageRatio > memoryPressureThreshold;
+        } catch (Exception e) {
+            LOG.debug("Failed to check memory pressure", e);
+            return false;
+        }
+    }
+
+    /**
+     * Report metrics for processed data.
+     */
+    private void reportMetrics(long recordCount, long dataSize) {
+        if (sinkExactlyMetric != null) {
+            try {
+                sinkExactlyMetric.invoke(recordCount, dataSize, System.currentTimeMillis());
+            } catch (Exception e) {
+                LOG.warn("Failed to report metrics", e);
+            }
+        }
+    }
+
+    /**
+     * Check if object is empty (all values are null).
+     */
+    private boolean isObjectEmpty(Map<String, Object> object) {
+        if (object == null || object.isEmpty()) {
+            return true;
+        }
+
+        return object.values().stream().allMatch(value -> value == null);
+    }
+
+    /**
+     * Estimate the size of a Weaviate object in bytes.
+     */
+    private long estimateObjectSize(Map<String, Object> object) {
+        if (object == null || object.isEmpty()) {
+            return 0;
+        }
+
+        long size = 0;
+        for (Map.Entry<String, Object> entry : object.entrySet()) {
+            // Estimate key size
+            size += entry.getKey().length() * 2; // Assuming UTF-16
+
+            // Estimate value size
+            Object value = entry.getValue();
+            if (value != null) {
+                if (value instanceof String) {
+                    size += ((String) value).length() * 2;
+                } else if (value instanceof float[]) {
+                    size += ((float[]) value).length * 4;
+                } else if (value instanceof List) {
+                    size += ((List<?>) value).size() * 8; // Rough estimate
+                } else {
+                    size += 8; // Default estimate for other types
+                }
+            }
+        }
+
+        return size;
+    }
+
+    /**
+     * Parse memory size string to bytes.
+     */
+    private long parseMemorySize(String memoryStr) {
+        if (memoryStr == null || memoryStr.trim().isEmpty()) {
+            return 64 * 1024 * 1024; // Default 64MB
+        }
+
+        String upperStr = memoryStr.trim().toUpperCase();
+        long multiplier = 1;
+
+        if (upperStr.endsWith("KB")) {
+            multiplier = 1024;
+            upperStr = upperStr.substring(0, upperStr.length() - 2);
+        } else if (upperStr.endsWith("MB")) {
+            multiplier = 1024 * 1024;
+            upperStr = upperStr.substring(0, upperStr.length() - 2);
+        } else if (upperStr.endsWith("GB")) {
+            multiplier = 1024 * 1024 * 1024;
+            upperStr = upperStr.substring(0, upperStr.length() - 2);
+        } else if (upperStr.endsWith("B")) {
+            upperStr = upperStr.substring(0, upperStr.length() - 1);
+        }
+
+        try {
+            return Long.parseLong(upperStr.trim()) * multiplier;
+        } catch (NumberFormatException e) {
+            LOG.warn("Invalid memory size format: {}, using default 64MB", memoryStr);
+            return 64 * 1024 * 1024;
+        }
+    }
+
+    /**
+     * Log comprehensive final statistics.
+     */
+    private void logFinalStatistics() {
+        LOG.info("WeaviateSinkFunction Performance Statistics:");
+        LOG.info("  Total records processed: {}", totalRecordsProcessed.get());
+        LOG.info("  Total bytes processed: {}", totalBytesProcessed.get());
+        LOG.info("  Total batches flushed: {}", totalBatchesFlushed.get());
+        LOG.info("  Total failed records: {}", totalFailedRecords.get());
+        LOG.info("  Total backpressure events: {}", totalBackpressureEvents.get());
+        LOG.info("  Total memory-triggered flushes: {}", totalMemoryFlushes.get());
+        LOG.info("  Peak concurrent batches: {}", totalConcurrentBatches.get());
+
+        long successRate = totalRecordsProcessed.get() > 0
+                ? ((totalRecordsProcessed.get() - totalFailedRecords.get()) * 100) / totalRecordsProcessed.get()
+                : 0;
+        LOG.info("  Success rate: {}%", successRate);
+
+        if (useConnectionPool && connectionPool != null) {
+            LOG.info("  Connection pool stats: current={}, available={}",
+                    connectionPool.getCurrentPoolSize(), connectionPool.getAvailableClients());
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/source/WeaviateSourceFunction.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/source/WeaviateSourceFunction.java
@@ -1,0 +1,618 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.source;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
+import org.apache.inlong.sort.weaviate.table.WeaviateOptions;
+import org.apache.inlong.sort.weaviate.utils.WeaviateClientUtils;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateErrorCode;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateException;
+import org.apache.inlong.sort.weaviate.utils.WeaviateMonitoringUtils;
+import org.apache.inlong.sort.weaviate.utils.WeaviateTypeConverter;
+
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.v1.graphql.model.GraphQLResponse;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Enhanced Weaviate source function with GraphQL query performance
+ * optimizations.
+ * Features include:
+ * - Optimized GraphQL query batching
+ * - Query result caching
+ * - Connection pool support
+ * - Enhanced error handling and retry mechanisms
+ * - Performance monitoring and metrics
+ */
+public class WeaviateSourceFunction extends RichSourceFunction<RowData> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateSourceFunction.class);
+
+    private final ReadableConfig config;
+    private final DataType physicalDataType;
+    private final MetricOption metricOption;
+
+    // Runtime state
+    private transient WeaviateClient client;
+    private transient WeaviateClientUtils.WeaviateConnectionPool connectionPool;
+    private transient SourceExactlyMetric sourceExactlyMetric;
+    private transient WeaviateTypeConverter typeConverter;
+    private transient volatile AtomicBoolean isRunning;
+    private transient ConcurrentHashMap<String, CachedQueryResult> queryCache;
+    private transient ScheduledExecutorService cacheCleanupExecutor;
+
+    // Enhanced monitoring and error handling
+    private transient WeaviateMonitoringUtils.EnhancedMetrics enhancedMetrics;
+    private transient WeaviateMonitoringUtils.ConnectionHealthMonitor healthMonitor;
+
+    // Configuration
+    private String url;
+    private String apiKey;
+    private String className;
+    private String queryConditions;
+    private Integer queryLimit;
+    private Integer queryOffset;
+    private String vectorField;
+    private Integer vectorDimension;
+    private Integer maxRetries;
+    private Duration retryDelay;
+
+    // Performance optimization settings
+    private Boolean useConnectionPool;
+    private Integer connectionPoolSize;
+    private Integer queryBatchSize;
+    private Boolean enableQueryCache;
+    private Duration queryCacheTtl;
+
+    public WeaviateSourceFunction(
+            ReadableConfig config,
+            DataType physicalDataType,
+            MetricOption metricOption) {
+        this.config = config;
+        this.physicalDataType = physicalDataType;
+        this.metricOption = metricOption;
+        this.isRunning = new AtomicBoolean(false);
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+        super.open(parameters);
+
+        WeaviateMonitoringUtils.PerformanceTracker tracker = WeaviateMonitoringUtils
+                .startOperation("WeaviateSourceFunction.open", LOG);
+
+        try {
+            LOG.info("Opening WeaviateSourceFunction with enhanced error handling and monitoring");
+
+            // Initialize configuration with validation
+            initializeConfiguration();
+
+            // Initialize enhanced monitoring
+            initializeEnhancedMonitoring();
+
+            // Initialize Weaviate client with retry and health monitoring
+            initializeClient();
+
+            // Initialize type converter with validation
+            initializeTypeConverter();
+
+            // Initialize metrics with enhanced reporting
+            initializeMetrics();
+
+            // Initialize query caching if enabled
+            initializeQueryCache();
+
+            // Log system resources for monitoring
+            WeaviateMonitoringUtils.logSystemResources(LOG);
+
+            tracker.recordSuccess(1, 0);
+            LOG.info("WeaviateSourceFunction opened successfully with enhanced monitoring and query cache: {}",
+                    enableQueryCache);
+
+        } catch (Exception e) {
+            WeaviateException weaviateException = WeaviateErrorHandler.wrapException(e,
+                    "WeaviateSourceFunction.open failed");
+            tracker.recordFailure(weaviateException, 0);
+            throw weaviateException;
+        }
+    }
+
+    @Override
+    public void run(SourceContext<RowData> ctx) throws Exception {
+        isRunning.set(true);
+
+        LOG.info("Starting WeaviateSourceFunction data reading");
+
+        try {
+            // Execute GraphQL query and process results
+            executeQueryAndEmitData(ctx);
+        } catch (Exception e) {
+            LOG.error("Error during data reading from Weaviate", e);
+            throw e;
+        } finally {
+            isRunning.set(false);
+        }
+
+        LOG.info("WeaviateSourceFunction data reading completed");
+    }
+
+    @Override
+    public void cancel() {
+        LOG.info("Cancelling WeaviateSourceFunction");
+        isRunning.set(false);
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.info("Closing WeaviateSourceFunction");
+
+        isRunning.set(false);
+
+        // Shutdown cache cleanup executor
+        if (cacheCleanupExecutor != null && !cacheCleanupExecutor.isShutdown()) {
+            cacheCleanupExecutor.shutdown();
+            try {
+                if (!cacheCleanupExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+                    cacheCleanupExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                cacheCleanupExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        // Return client to pool or close
+        if (useConnectionPool && connectionPool != null && client != null) {
+            connectionPool.returnClient(client);
+        }
+        client = null;
+
+        // Clear cache
+        if (queryCache != null) {
+            queryCache.clear();
+        }
+
+        super.close();
+        LOG.info("WeaviateSourceFunction closed");
+    }
+
+    /**
+     * 
+     * Initialize enhanced monitoring and health tracking.
+     */
+    private void initializeEnhancedMonitoring() {
+        // Initialize enhanced metrics
+        enhancedMetrics = WeaviateMonitoringUtils.createMetrics(
+                "WeaviateSourceFunction", metricOption, getRuntimeContext().getMetricGroup(), true);
+
+        // Initialize connection health monitor
+        healthMonitor = WeaviateMonitoringUtils.createHealthMonitor(url);
+
+        LOG.info("Enhanced monitoring initialized for WeaviateSourceFunction");
+    }
+
+    /**
+     * Initialize configuration from ReadableConfig with enhanced validation.
+     */
+    private void initializeConfiguration() throws WeaviateException {
+        // Enhanced configuration validation
+        url = config.get(WeaviateOptions.URL);
+        WeaviateErrorHandler.validateConfig("url", url, "WeaviateSourceFunction");
+
+        apiKey = config.getOptional(WeaviateOptions.API_KEY).orElse(null);
+
+        className = config.get(WeaviateOptions.CLASS_NAME);
+        WeaviateErrorHandler.validateConfig("className", className, "WeaviateSourceFunction");
+
+        queryConditions = config.get(WeaviateOptions.QUERY_CONDITIONS);
+        queryLimit = config.get(WeaviateOptions.QUERY_LIMIT);
+        queryOffset = config.get(WeaviateOptions.QUERY_OFFSET);
+
+        if (queryLimit <= 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    WeaviateErrorHandler.createContext("WeaviateSourceFunction", "queryLimit", queryLimit));
+        }
+        if (queryOffset < 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    WeaviateErrorHandler.createContext("WeaviateSourceFunction", "queryOffset", queryOffset));
+        }
+
+        vectorField = config.getOptional(WeaviateOptions.VECTOR_FIELD).orElse(null);
+        vectorDimension = config.getOptional(WeaviateOptions.VECTOR_DIMENSION).orElse(null);
+        maxRetries = config.get(WeaviateOptions.MAX_RETRIES);
+        retryDelay = config.get(WeaviateOptions.RETRY_DELAY);
+
+        // Performance optimization settings
+        useConnectionPool = config.get(WeaviateOptions.USE_CONNECTION_POOL);
+        connectionPoolSize = config.get(WeaviateOptions.CONNECTION_POOL_SIZE);
+        queryBatchSize = config.get(WeaviateOptions.QUERY_BATCH_SIZE);
+        enableQueryCache = config.get(WeaviateOptions.ENABLE_QUERY_CACHE);
+        queryCacheTtl = config.get(WeaviateOptions.QUERY_CACHE_TTL);
+
+        LOG.info("Initialized configuration: url={}, className={}, queryLimit={}, queryOffset={}, vectorField={}, " +
+                "useConnectionPool={}, queryBatchSize={}, enableQueryCache={}",
+                url, className, queryLimit, queryOffset, vectorField, useConnectionPool, queryBatchSize,
+                enableQueryCache);
+    }
+
+    /**
+     * Initialize Weaviate client with connection pooling support.
+     */
+    private void initializeClient() throws Exception {
+        LOG.info("Initializing Weaviate client with connection pool: {}", useConnectionPool);
+
+        try {
+            if (useConnectionPool) {
+                // Use connection pool for better resource management
+                connectionPool = WeaviateClientUtils.getConnectionPool(url, apiKey, connectionPoolSize);
+                client = connectionPool.borrowClient();
+                LOG.info("Using connection pool with size: {}", connectionPoolSize);
+            } else {
+                // Use single client instance
+                client = WeaviateClientUtils.createClientWithRetry(url, apiKey, maxRetries, retryDelay);
+            }
+
+            // Test connection
+            if (!WeaviateClientUtils.testConnection(client)) {
+                throw new RuntimeException("Failed to connect to Weaviate server: " + url);
+            }
+
+            LOG.info("Weaviate client initialized successfully");
+        } catch (Exception e) {
+            LOG.error("Failed to initialize Weaviate client", e);
+            throw new RuntimeException("Failed to initialize Weaviate client", e);
+        }
+    }
+
+    /**
+     * Initialize query caching if enabled.
+     */
+    private void initializeQueryCache() {
+        if (enableQueryCache) {
+            queryCache = new ConcurrentHashMap<>();
+
+            // Setup cache cleanup executor
+            cacheCleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+                Thread t = new Thread(r, "weaviate-cache-cleanup");
+                t.setDaemon(true);
+                return t;
+            });
+
+            // Schedule periodic cache cleanup
+            cacheCleanupExecutor.scheduleAtFixedRate(
+                    this::cleanupExpiredCacheEntries,
+                    queryCacheTtl.toMillis(),
+                    queryCacheTtl.toMillis(),
+                    TimeUnit.MILLISECONDS);
+
+            LOG.info("Query cache initialized with TTL: {}", queryCacheTtl);
+        }
+    }
+
+    /**
+     * Clean up expired cache entries.
+     */
+    private void cleanupExpiredCacheEntries() {
+        if (queryCache != null) {
+            int initialSize = queryCache.size();
+            queryCache.entrySet().removeIf(entry -> entry.getValue().isExpired());
+            int finalSize = queryCache.size();
+            if (initialSize != finalSize) {
+                LOG.debug("Cleaned up {} expired cache entries", initialSize - finalSize);
+            }
+        }
+    }
+
+    /**
+     * Initialize type converter.
+     */
+    private void initializeTypeConverter() {
+        RowType rowType = (RowType) physicalDataType.getLogicalType();
+        typeConverter = new WeaviateTypeConverter(rowType, vectorField, vectorDimension);
+        typeConverter.validate();
+
+        LOG.info("Type converter initialized with vector field: {}, dimension: {}", vectorField, vectorDimension);
+    }
+
+    /**
+     * Initialize metrics for InLong audit.
+     */
+    private void initializeMetrics() {
+        if (metricOption != null) {
+            sourceExactlyMetric = new SourceExactlyMetric(metricOption, getRuntimeContext().getMetricGroup());
+            LOG.info("Source metrics initialized");
+        } else {
+            LOG.warn("MetricOption is null, metrics will not be reported");
+        }
+    }
+
+    /**
+     * Execute GraphQL query and emit data to Flink context.
+     */
+    private void executeQueryAndEmitData(SourceContext<RowData> ctx) throws Exception {
+        int currentOffset = queryOffset;
+        int recordsProcessed = 0;
+
+        while (isRunning.get()) {
+            try {
+                // Build GraphQL query
+                String graphqlQuery = buildGraphQLQuery(currentOffset);
+                LOG.debug("Executing GraphQL query: {}", graphqlQuery);
+
+                // Try to get results from cache first
+                List<Map<String, Object>> results = getCachedResults(graphqlQuery);
+
+                if (results == null) {
+                    // Execute query with retry
+                    GraphQLResponse response = executeQueryWithRetry(graphqlQuery);
+
+                    // Process response
+                    results = extractResultsFromResponse(response);
+
+                    // Cache results if caching is enabled
+                    cacheResults(graphqlQuery, results);
+                }
+
+                if (results == null || results.isEmpty()) {
+                    LOG.info("No more data available, stopping source");
+                    break;
+                }
+
+                // Convert and emit data
+                for (Map<String, Object> weaviateObject : results) {
+                    if (!isRunning.get()) {
+                        break;
+                    }
+
+                    try {
+                        // Convert Weaviate object to RowData
+                        GenericRowData rowData = typeConverter.convertWeaviateObjectToRowData(weaviateObject);
+
+                        // Emit data
+                        synchronized (ctx.getCheckpointLock()) {
+                            ctx.collect(rowData);
+                        }
+
+                        // Report metrics
+                        reportMetrics(rowData);
+
+                        recordsProcessed++;
+
+                    } catch (Exception e) {
+                        LOG.error("Failed to convert and emit Weaviate object: {}", weaviateObject, e);
+                        // Continue processing other records
+                    }
+                }
+
+                LOG.info("Processed {} records in this batch, total processed: {}",
+                        results.size(), recordsProcessed);
+
+                // Update offset for next query
+                currentOffset += results.size();
+
+                // If we got fewer results than the limit, we've reached the end
+                if (results.size() < queryLimit) {
+                    LOG.info("Reached end of data, processed {} total records", recordsProcessed);
+                    break;
+                }
+
+            } catch (Exception e) {
+                LOG.error("Error during query execution at offset {}", currentOffset, e);
+                throw e;
+            }
+        }
+
+        LOG.info("Data reading completed, total records processed: {}", recordsProcessed);
+    }
+
+    /**
+     * Build GraphQL query string.
+     */
+    private String buildGraphQLQuery(int offset) {
+        RowType rowType = (RowType) physicalDataType.getLogicalType();
+        StringBuilder queryBuilder = new StringBuilder();
+
+        queryBuilder.append("{ Get { ").append(className).append("(");
+
+        // Add limit and offset
+        queryBuilder.append("limit: ").append(queryLimit);
+        queryBuilder.append(", offset: ").append(offset);
+
+        // Add additional query conditions if specified
+        if (queryConditions != null && !queryConditions.trim().isEmpty()
+                && !queryConditions.trim().equals("limit: 1000")) {
+            // Remove default limit from queryConditions if present
+            String cleanConditions = queryConditions.replaceAll("limit:\\s*\\d+", "").trim();
+            if (!cleanConditions.isEmpty()) {
+                queryBuilder.append(", ").append(cleanConditions);
+            }
+        }
+
+        queryBuilder.append(") { ");
+
+        // Add field selections
+        for (RowType.RowField field : rowType.getFields()) {
+            queryBuilder.append(field.getName()).append(" ");
+        }
+
+        // Add _additional fields for metadata
+        queryBuilder.append("_additional { id } ");
+
+        queryBuilder.append("} } }");
+
+        return queryBuilder.toString();
+    }
+
+    /**
+     * Execute GraphQL query with retry mechanism.
+     */
+    private GraphQLResponse executeQueryWithRetry(String query) throws Exception {
+        Exception lastException = null;
+
+        for (int attempt = 1; attempt <= maxRetries; attempt++) {
+            try {
+                // Use the raw GraphQL query approach
+                GraphQLResponse response = client.graphQL().raw().withQuery(query).run().getResult();
+
+                if (response.getErrors() != null && response.getErrors().length > 0) {
+                    throw new RuntimeException(
+                            "GraphQL query failed: " + java.util.Arrays.toString(response.getErrors()));
+                }
+
+                return response;
+
+            } catch (Exception e) {
+                lastException = e;
+                LOG.warn("Query attempt {}/{} failed: {}", attempt, maxRetries, e.getMessage());
+
+                if (attempt < maxRetries && isRunning.get()) {
+                    try {
+                        // Exponential backoff with jitter
+                        long delayMs = retryDelay.toMillis() * (1L << (attempt - 1));
+                        delayMs += (long) (Math.random() * 1000); // Add jitter
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted during retry", ie);
+                    }
+                }
+            }
+        }
+
+        throw new RuntimeException("Failed to execute query after " + maxRetries + " attempts", lastException);
+    }
+
+    /**
+     * Extract results from GraphQL response.
+     */
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> extractResultsFromResponse(GraphQLResponse response) {
+        try {
+            @SuppressWarnings("rawtypes")
+            Map data = (Map) response.getData();
+            if (data == null) {
+                return null;
+            }
+
+            Object getObj = data.get("Get");
+            if (getObj == null || !(getObj instanceof Map)) {
+                return null;
+            }
+
+            @SuppressWarnings("rawtypes")
+            Map get = (Map) getObj;
+            Object classObj = get.get(className);
+
+            if (classObj == null || !(classObj instanceof List)) {
+                return null;
+            }
+
+            @SuppressWarnings("rawtypes")
+            List result = (List) classObj;
+            return result;
+
+        } catch (Exception e) {
+            LOG.error("Failed to extract results from GraphQL response", e);
+            throw new RuntimeException("Failed to extract results from response", e);
+        }
+    }
+
+    /**
+     * Get cached query results if available and not expired.
+     */
+    private List<Map<String, Object>> getCachedResults(String query) {
+        if (!enableQueryCache || queryCache == null) {
+            return null;
+        }
+
+        CachedQueryResult cached = queryCache.get(query);
+        if (cached != null && !cached.isExpired()) {
+            LOG.debug("Using cached results for query");
+            return cached.getResults();
+        }
+
+        return null;
+    }
+
+    /**
+     * Cache query results if caching is enabled.
+     */
+    private void cacheResults(String query, List<Map<String, Object>> results) {
+        if (enableQueryCache && queryCache != null && results != null) {
+            queryCache.put(query, new CachedQueryResult(results, queryCacheTtl.toMillis()));
+            LOG.debug("Cached results for query, cache size: {}", queryCache.size());
+        }
+    }
+
+    /**
+     * Report metrics for processed data.
+     */
+    private void reportMetrics(RowData rowData) {
+        if (sourceExactlyMetric != null) {
+            try {
+                sourceExactlyMetric.outputMetrics(1, rowData.toString().getBytes().length, System.currentTimeMillis());
+            } catch (Exception e) {
+                LOG.warn("Failed to report metrics", e);
+            }
+        }
+    }
+
+    /**
+     * Cached query result for performance optimization.
+     */
+    private static class CachedQueryResult {
+
+        private final List<Map<String, Object>> results;
+        private final long timestamp;
+        private final long ttlMs;
+
+        public CachedQueryResult(List<Map<String, Object>> results, long ttlMs) {
+            this.results = results;
+            this.timestamp = System.currentTimeMillis();
+            this.ttlMs = ttlMs;
+        }
+
+        public boolean isExpired() {
+            return System.currentTimeMillis() - timestamp > ttlMs;
+        }
+
+        public List<Map<String, Object>> getResults() {
+            return results;
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableFactory.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableFactory.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.table;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.util.Preconditions.checkState;
+import static org.apache.inlong.sort.base.Constants.AUDIT_KEYS;
+import static org.apache.inlong.sort.base.Constants.INLONG_AUDIT;
+import static org.apache.inlong.sort.base.Constants.INLONG_METRIC;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.API_KEY;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.BATCH_SIZE;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.CLASS_NAME;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.CONNECTION_TIMEOUT;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.CONSISTENCY_LEVEL;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.FLUSH_INTERVAL;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.IGNORE_NULL_VALUES;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.MAX_BATCH_MEMORY;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.MAX_RETRIES;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.QUERY_CONDITIONS;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.QUERY_LIMIT;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.QUERY_OFFSET;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.READ_TIMEOUT;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.RETRY_DELAY;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.UPSERT_ENABLED;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.URL;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.VECTOR_DIMENSION;
+import static org.apache.inlong.sort.weaviate.table.WeaviateOptions.VECTOR_FIELD;
+
+/**
+ * Weaviate dynamic table factory for creating Weaviate table source and sink.
+ * This factory implements both DynamicTableSourceFactory and
+ * DynamicTableSinkFactory
+ * to support reading from and writing to Weaviate vector database with enhanced
+ * error handling.
+ */
+public class WeaviateDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateDynamicTableFactory.class);
+
+    /**
+     * The identifier of Weaviate Connector.
+     */
+    public static final String IDENTIFIER = "weaviate-inlong";
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        ReadableConfig config = helper.getOptions();
+
+        helper.validate();
+        validateConfigOptions(config);
+
+        // Build metric option for InLong audit
+        MetricOption metricOption = buildMetricOption(config);
+
+        return new WeaviateDynamicTableSource(
+                context.getCatalogTable().getResolvedSchema(),
+                config,
+                metricOption);
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        ReadableConfig config = helper.getOptions();
+
+        helper.validate();
+        validateConfigOptions(config);
+
+        // Build metric option for InLong audit
+        MetricOption metricOption = buildMetricOption(config);
+
+        return new WeaviateDynamicTableSink(
+                context.getCatalogTable().getResolvedSchema(),
+                config,
+                metricOption);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> requiredOptions = new HashSet<>();
+        requiredOptions.add(URL);
+        requiredOptions.add(CLASS_NAME);
+        return requiredOptions;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> optionalOptions = new HashSet<>();
+
+        // Connection options
+        optionalOptions.add(API_KEY);
+        optionalOptions.add(CONNECTION_TIMEOUT);
+        optionalOptions.add(READ_TIMEOUT);
+        optionalOptions.add(MAX_RETRIES);
+        optionalOptions.add(RETRY_DELAY);
+
+        // Batch processing options
+        optionalOptions.add(BATCH_SIZE);
+        optionalOptions.add(FLUSH_INTERVAL);
+        optionalOptions.add(MAX_BATCH_MEMORY);
+
+        // Vector field options
+        optionalOptions.add(VECTOR_FIELD);
+        optionalOptions.add(VECTOR_DIMENSION);
+
+        // Source specific options
+        optionalOptions.add(QUERY_CONDITIONS);
+        optionalOptions.add(QUERY_LIMIT);
+        optionalOptions.add(QUERY_OFFSET);
+
+        // Sink specific options
+        optionalOptions.add(UPSERT_ENABLED);
+        optionalOptions.add(IGNORE_NULL_VALUES);
+        optionalOptions.add(CONSISTENCY_LEVEL);
+
+        // InLong metric options
+        optionalOptions.add(INLONG_METRIC);
+        optionalOptions.add(INLONG_AUDIT);
+        optionalOptions.add(AUDIT_KEYS);
+
+        return optionalOptions;
+    }
+
+    /**
+     * Validates the configuration options with enha
+     *
+     * @param config the readable configuration
+     */
+    private void validateConfigOptions(ReadableConfig config) {
+        // Enhanced URL validation
+        String url = config.get(URL);
+        checkState(!StringUtils.isNullOrWhitespaceOnly(url),
+                "Weaviate URL cannot be empty or null");
+
+        // Validate URL format
+        try {
+            java.net.URL urlObj = new java.net.URL(url);
+            String scheme = urlObj.getProtocol();
+            checkState("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme),
+                    "Weaviate URL must use http or https protocol, but got: " + scheme);
+        } catch (java.net.MalformedURLException e) {
+            throw new IllegalStateException("Invalid Weaviate URL format: " + url, e);
+        }
+
+        // Enhanced class name validation
+        String className = config.get(CLASS_NAME);
+        checkState(!StringUtils.isNullOrWhitespaceOnly(className),
+                "Weaviate class name cannot be empty or null");
+        checkState(className.matches("^[A-Z][a-zA-Z0-9_]*$"),
+                "Weaviate class name should start with uppercase letter and contain only alphanumeric characters and underscores, but got: "
+                        + className);
+
+        // Enhanced batch size validation
+        Integer batchSize = config.get(BATCH_SIZE);
+        checkState(batchSize > 0,
+                "Batch size must be greater than 0, but got: " + batchSize);
+        checkState(batchSize <= 10000,
+                "Batch size too large (max 10000 for performance), but got: " + batchSize);
+
+        // Enhanced query limit validation for source
+        Integer queryLimit = config.get(QUERY_LIMIT);
+        checkState(queryLimit > 0,
+                "Query limit must be greater than 0, but got: " + queryLimit);
+        checkState(queryLimit <= 100000,
+                "Query limit too large (max 100000 for performance), but got: " + queryLimit);
+
+        // Enhanced query offset validation for source
+        Integer queryOffset = config.get(QUERY_OFFSET);
+        checkState(queryOffset >= 0,
+                "Query offset must be greater than or equal to 0, but got: " + queryOffset);
+
+        // Enhanced vector dimension validation
+        Integer vectorDimension = config.getOptional(VECTOR_DIMENSION).orElse(null);
+        if (vectorDimension != null) {
+            checkState(vectorDimension > 0,
+                    "Vector dimension must be greater than 0, but got: " + vectorDimension);
+            checkState(vectorDimension <= 4096,
+                    "Vector dimension too large (max 4096 for most models), but got: "
+                            + vectorDimension);
+        }
+
+        // Enhanced max retries validation
+        Integer maxRetries = config.get(MAX_RETRIES);
+        checkState(maxRetries >= 0,
+                "Max retries must be greater than or equal to 0, but got: " + maxRetries);
+        checkState(maxRetries <= 10,
+                "Max retries too large (max 10 to avoid long delays), but got: " + maxRetries);
+
+        // Enhanced consistency level validation
+        String consistencyLevel = config.get(CONSISTENCY_LEVEL);
+        if (!StringUtils.isNullOrWhitespaceOnly(consistencyLevel)) {
+            checkState(
+                    consistencyLevel.equals("ONE") || consistencyLevel.equals("QUORUM")
+                            || consistencyLevel.equals("ALL"),
+                    "Consistency level must be one of [ONE, QUORUM, ALL], but got: "
+                            + consistencyLevel);
+        }
+
+        // Validate timeout configurations
+        Duration connectionTimeout = config.get(CONNECTION_TIMEOUT);
+        checkState(!connectionTimeout.isNegative() && !connectionTimeout.isZero(),
+                "Connection timeout must be positive, but got: " + connectionTimeout);
+        checkState(connectionTimeout.toMillis() <= 300000,
+                "Connection timeout too large (max 5 minutes), but got: " + connectionTimeout);
+
+        Duration readTimeout = config.get(READ_TIMEOUT);
+        checkState(!readTimeout.isNegative() && !readTimeout.isZero(),
+                "Read timeout must be positive, but got: " + readTimeout);
+        checkState(readTimeout.toMillis() <= 600000,
+                "Read timeout too large (max 10 minutes), but got: " + readTimeout);
+
+        // Validate flush interval for sink
+        Duration flushInterval = config.get(FLUSH_INTERVAL);
+        checkState(!flushInterval.isNegative() && !flushInterval.isZero(),
+                "Flush interval must be positive, but got: " + flushInterval);
+        checkState(flushInterval.toMillis() <= 300000,
+                "Flush interval too large (max 5 minutes), but got: " + flushInterval);
+
+        // Log configuration summary for debugging
+        LOG.info("Weaviate connector configuration validated: url={}, className={}, batchSize={}, " +
+                "queryLimit={}, maxRetries={}, vectorDimension={}",
+                url, className, batchSize, queryLimit, maxRetries, vectorDimension);
+    }
+
+    /**
+     * Builds the metric option for InLong audit.
+     *
+     * @param config the readable configuration
+     * @return the metric option
+     */
+    private MetricOption buildMetricOption(ReadableConfig config) {
+        String inlongMetric = config.getOptional(INLONG_METRIC).orElse(null);
+        String auditHostAndPorts = config.getOptional(INLONG_AUDIT).orElse(null);
+        String auditKeys = config.getOptional(AUDIT_KEYS).orElse(null);
+
+        return MetricOption.builder()
+                .withInlongLabels(inlongMetric)
+                .withAuditAddress(auditHostAndPorts)
+                .withAuditKeys(auditKeys)
+                .build();
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableSink.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableSink.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.table;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.weaviate.sink.WeaviateSinkFunction;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+
+/**
+ * Weaviate dynamic table sink for writing data to Weaviate vector database.
+ * This class implements DynamicTableSink to provide table sink functionality
+ * for Flink SQL.
+ */
+public class WeaviateDynamicTableSink implements DynamicTableSink {
+
+    private final ResolvedSchema resolvedSchema;
+    private final ReadableConfig config;
+    private final MetricOption metricOption;
+
+    public WeaviateDynamicTableSink(
+            ResolvedSchema resolvedSchema,
+            ReadableConfig config,
+            MetricOption metricOption) {
+        this.resolvedSchema = resolvedSchema;
+        this.config = config;
+        this.metricOption = metricOption;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        // Check if upsert is enabled
+        boolean upsertEnabled = config.get(WeaviateOptions.UPSERT_ENABLED);
+
+        if (upsertEnabled) {
+            // Support INSERT, UPDATE, DELETE operations for upsert mode
+            return ChangelogMode.newBuilder()
+                    .addContainedKind(RowKind.INSERT)
+                    .addContainedKind(RowKind.UPDATE_AFTER)
+                    .addContainedKind(RowKind.DELETE)
+                    .build();
+        } else {
+            // Only support INSERT operations for append mode
+            return ChangelogMode.insertOnly();
+        }
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        DataType physicalDataType = resolvedSchema.toPhysicalRowDataType();
+
+        WeaviateSinkFunction sinkFunction = new WeaviateSinkFunction(
+                config,
+                physicalDataType,
+                metricOption);
+
+        return SinkFunctionProvider.of(sinkFunction);
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        return new WeaviateDynamicTableSink(resolvedSchema, config, metricOption);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("WeaviateSink(url=%s, className=%s, batchSize=%d)",
+                config.get(WeaviateOptions.URL),
+                config.get(WeaviateOptions.CLASS_NAME),
+                config.get(WeaviateOptions.BATCH_SIZE));
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableSource.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateDynamicTableSource.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.table;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.weaviate.source.WeaviateSourceFunction;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.types.DataType;
+
+/**
+ * Weaviate dynamic table source for reading data from Weaviate vector database.
+ * This class implements DynamicTableSource and ScanTableSource to provide
+ * table source functionality for Flink SQL.
+ */
+public class WeaviateDynamicTableSource implements DynamicTableSource, ScanTableSource {
+
+    private final ResolvedSchema resolvedSchema;
+    private final ReadableConfig config;
+    private final MetricOption metricOption;
+
+    public WeaviateDynamicTableSource(
+            ResolvedSchema resolvedSchema,
+            ReadableConfig config,
+            MetricOption metricOption) {
+        this.resolvedSchema = resolvedSchema;
+        this.config = config;
+        this.metricOption = metricOption;
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        // Weaviate source only supports INSERT mode for reading data
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        DataType physicalDataType = resolvedSchema.toPhysicalRowDataType();
+
+        WeaviateSourceFunction sourceFunction = new WeaviateSourceFunction(
+                config,
+                physicalDataType,
+                metricOption);
+
+        return SourceFunctionProvider.of(sourceFunction, false);
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new WeaviateDynamicTableSource(resolvedSchema, config, metricOption);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return String.format("WeaviateSource(url=%s, className=%s)",
+                config.get(WeaviateOptions.URL),
+                config.get(WeaviateOptions.CLASS_NAME));
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateOptions.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/table/WeaviateOptions.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.time.Duration;
+
+/**
+ * Option utils for Weaviate table source sink.
+ * Defines all configuration options for Weaviate connector.
+ */
+public class WeaviateOptions {
+
+    private WeaviateOptions() {
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Required options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Weaviate server URL.
+     */
+    public static final ConfigOption<String> URL = ConfigOptions
+            .key("url")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Weaviate server URL");
+
+    /**
+     * Weaviate class name.
+     */
+    public static final ConfigOption<String> CLASS_NAME = ConfigOptions
+            .key("class-name")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Weaviate class name");
+
+    // --------------------------------------------------------------------------------------------
+    // Optional options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Weaviate API key for authentication.
+     */
+    public static final ConfigOption<String> API_KEY = ConfigOptions
+            .key("api-key")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Weaviate API key for authentication");
+
+    /**
+     * Batch size for operations.
+     */
+    public static final ConfigOption<Integer> BATCH_SIZE = ConfigOptions
+            .key("batch-size")
+            .intType()
+            .defaultValue(100)
+            .withDescription("Number of records to batch before sending to Weaviate");
+
+    /**
+     * Maximum time to wait before flushing batch.
+     */
+    public static final ConfigOption<Duration> FLUSH_INTERVAL = ConfigOptions
+            .key("flush-interval")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(5))
+            .withDescription("Maximum time to wait before flushing batch");
+
+    /**
+     * Vector field name for vector operations.
+     */
+    public static final ConfigOption<String> VECTOR_FIELD = ConfigOptions
+            .key("vector-field")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Name of the vector field in Weaviate class");
+
+    /**
+     * Vector dimension for vector field validation.
+     */
+    public static final ConfigOption<Integer> VECTOR_DIMENSION = ConfigOptions
+            .key("vector-dimension")
+            .intType()
+            .noDefaultValue()
+            .withDescription("Dimension of the vector field");
+
+    /**
+     * Connection timeout for Weaviate client.
+     */
+    public static final ConfigOption<Duration> CONNECTION_TIMEOUT = ConfigOptions
+            .key("connection-timeout")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(30))
+            .withDescription("Connection timeout for Weaviate client");
+
+    /**
+     * Read timeout for Weaviate operations.
+     */
+    public static final ConfigOption<Duration> READ_TIMEOUT = ConfigOptions
+            .key("read-timeout")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(60))
+            .withDescription("Read timeout for Weaviate operations");
+
+    /**
+     * Maximum number of retries for failed operations.
+     */
+    public static final ConfigOption<Integer> MAX_RETRIES = ConfigOptions
+            .key("max-retries")
+            .intType()
+            .defaultValue(3)
+            .withDescription("Maximum number of retries for failed operations");
+
+    /**
+     * Retry delay for failed operations.
+     */
+    public static final ConfigOption<Duration> RETRY_DELAY = ConfigOptions
+            .key("retry-delay")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(1))
+            .withDescription("Delay between retries for failed operations");
+
+    // --------------------------------------------------------------------------------------------
+    // Source specific options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * GraphQL query conditions for source operations.
+     */
+    public static final ConfigOption<String> QUERY_CONDITIONS = ConfigOptions
+            .key("query-conditions")
+            .stringType()
+            .defaultValue("limit: 1000")
+            .withDescription("GraphQL query conditions for source operations");
+
+    /**
+     * Query limit for source operations.
+     */
+    public static final ConfigOption<Integer> QUERY_LIMIT = ConfigOptions
+            .key("query-limit")
+            .intType()
+            .defaultValue(1000)
+            .withDescription("Maximum number of records to fetch in a single query");
+
+    /**
+     * Query offset for source operations.
+     */
+    public static final ConfigOption<Integer> QUERY_OFFSET = ConfigOptions
+            .key("query-offset")
+            .intType()
+            .defaultValue(0)
+            .withDescription("Offset for source query operations");
+
+    // --------------------------------------------------------------------------------------------
+    // Sink specific options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Whether to enable upsert mode for sink operations.
+     */
+    public static final ConfigOption<Boolean> UPSERT_ENABLED = ConfigOptions
+            .key("upsert-enabled")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("Whether to enable upsert mode for sink operations");
+
+    /**
+     * Maximum memory usage for batch buffer.
+     */
+    public static final ConfigOption<String> MAX_BATCH_MEMORY = ConfigOptions
+            .key("max-batch-memory")
+            .stringType()
+            .defaultValue("64MB")
+            .withDescription("Maximum memory usage for batch buffer");
+
+    /**
+     * Whether to ignore null values in sink operations.
+     */
+    public static final ConfigOption<Boolean> IGNORE_NULL_VALUES = ConfigOptions
+            .key("ignore-null-values")
+            .booleanType()
+            .defaultValue(false)
+            .withDescription("Whether to ignore null values in sink operations");
+
+    /**
+     * Consistency level for write operations.
+     */
+    public static final ConfigOption<String> CONSISTENCY_LEVEL = ConfigOptions
+            .key("consistency-level")
+            .stringType()
+            .defaultValue("ONE")
+            .withDescription("Consistency level for write operations (ONE, QUORUM, ALL)");
+
+    // --------------------------------------------------------------------------------------------
+    // Performance optimization options
+    // --------------------------------------------------------------------------------------------
+
+    /**
+     * Whether to use connection pool for client management.
+     */
+    public static final ConfigOption<Boolean> USE_CONNECTION_POOL = ConfigOptions
+            .key("use-connection-pool")
+            .booleanType()
+            .defaultValue(true)
+            .withDescription("Whether to use connection pool for client management");
+
+    /**
+     * Connection pool size.
+     */
+    public static final ConfigOption<Integer> CONNECTION_POOL_SIZE = ConfigOptions
+            .key("connection-pool-size")
+            .intType()
+            .defaultValue(10)
+            .withDescription("Maximum number of connections in the pool");
+
+    /**
+     * Memory pressure threshold for triggering automatic flush.
+     */
+    public static final ConfigOption<Double> MEMORY_PRESSURE_THRESHOLD = ConfigOptions
+            .key("memory-pressure-threshold")
+            .doubleType()
+            .defaultValue(0.8)
+            .withDescription("Memory pressure threshold (0.0-1.0) for triggering automatic flush");
+
+    /**
+     * Backpressure delay when system is under pressure.
+     */
+    public static final ConfigOption<Duration> BACKPRESSURE_DELAY = ConfigOptions
+            .key("backpressure-delay")
+            .durationType()
+            .defaultValue(Duration.ofMillis(100))
+            .withDescription("Delay to apply when backpressure is detected");
+
+    /**
+     * Maximum number of concurrent batch operations.
+     */
+    public static final ConfigOption<Integer> MAX_CONCURRENT_BATCHES = ConfigOptions
+            .key("max-concurrent-batches")
+            .intType()
+            .defaultValue(3)
+            .withDescription("Maximum number of concurrent batch flush operations");
+
+    /**
+     * Memory monitoring interval.
+     */
+    public static final ConfigOption<Duration> MEMORY_MONITOR_INTERVAL = ConfigOptions
+            .key("memory-monitor-interval")
+            .durationType()
+            .defaultValue(Duration.ofSeconds(1))
+            .withDescription("Interval for memory usage monitoring");
+
+    /**
+     * Query batch size for source operations.
+     */
+    public static final ConfigOption<Integer> QUERY_BATCH_SIZE = ConfigOptions
+            .key("query-batch-size")
+            .intType()
+            .defaultValue(1000)
+            .withDescription("Batch size for GraphQL query operations");
+
+    /**
+     * Whether to enable query result caching.
+     */
+    public static final ConfigOption<Boolean> ENABLE_QUERY_CACHE = ConfigOptions
+            .key("enable-query-cache")
+            .booleanType()
+            .defaultValue(false)
+            .withDescription("Whether to enable query result caching for repeated queries");
+
+    /**
+     * Query cache TTL (time to live).
+     */
+    public static final ConfigOption<Duration> QUERY_CACHE_TTL = ConfigOptions
+            .key("query-cache-ttl")
+            .durationType()
+            .defaultValue(Duration.ofMinutes(5))
+            .withDescription("Time to live for cached query results");
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateClientUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateClientUtils.java
@@ -1,0 +1,644 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.utils;
+
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateErrorCode;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateException;
+import org.apache.inlong.sort.weaviate.utils.WeaviateMonitoringUtils.ConnectionHealthMonitor;
+
+import io.weaviate.client.Config;
+import io.weaviate.client.WeaviateClient;
+import io.weaviate.client.v1.misc.model.Meta;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utility class for creating and managing Weaviate clients.
+ * Provides methods for client creation, connection testing, health checks, and
+ * connection pooling.
+ */
+public class WeaviateClientUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateClientUtils.class);
+
+    // Connection pool management
+    private static final ConcurrentHashMap<String, WeaviateConnectionPool> CONNECTION_POOLS = new ConcurrentHashMap<>();
+
+    // Default configuration values
+    private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(60);
+    private static final int DEFAULT_MAX_RETRIES = 3;
+    private static final Duration DEFAULT_RETRY_DELAY = Duration.ofSeconds(1);
+    private static final int DEFAULT_POOL_SIZE = 10;
+
+    private WeaviateClientUtils() {
+        // Utility class, prevent instantiation
+    }
+
+    /**
+     * Creates a Weaviate client with the specified configuration.
+     *
+     * @param url    Weaviate server URL
+     * @param apiKey API key for authentication (can be null)
+     * @return WeaviateClient instance
+     * @throws WeaviateException if client creation fails
+     */
+    public static WeaviateClient createClient(String url, String apiKey) throws WeaviateException {
+        return createClient(url, apiKey, DEFAULT_CONNECTION_TIMEOUT, DEFAULT_READ_TIMEOUT);
+    }
+
+    /**
+     * Creates a Weaviate client with custom timeout settings and enhanced error
+     * handling.
+     *
+     * @param url               Weaviate server URL
+     * @param apiKey            API key for authentication (can be null)
+     * @param connectionTimeout Connection timeout duration
+     * @param readTimeout       Read timeout duration
+     * @return WeaviateClient instance
+     * @throws WeaviateException if client creation fails
+     */
+    public static WeaviateClient createClient(String url, String apiKey, Duration connectionTimeout,
+            Duration readTimeout) throws WeaviateException {
+
+        String context = WeaviateErrorHandler.createContext("WeaviateClientUtils.createClient",
+                "url", url, "hasApiKey", apiKey != null);
+
+        // Enhanced validation with proper error codes
+        WeaviateErrorHandler.validateConfig("url", url, "WeaviateClientUtils");
+        WeaviateErrorHandler.validateConfig("connectionTimeout", connectionTimeout, "WeaviateClientUtils");
+        WeaviateErrorHandler.validateConfig("readTimeout", readTimeout, "WeaviateClientUtils");
+
+        try {
+            URL parsedUrl = new URL(url);
+            String scheme = parsedUrl.getProtocol();
+            String host = parsedUrl.getHost();
+            int port = parsedUrl.getPort();
+
+            // Enhanced URL validation
+            if (scheme == null || scheme.trim().isEmpty()) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_URL,
+                        context + " - URL scheme cannot be null or empty");
+            }
+            if (host == null || host.trim().isEmpty()) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_URL,
+                        context + " - URL host cannot be null or empty");
+            }
+
+            // Ensure scheme is supported (http or https)
+            if (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https")) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_URL,
+                        context + " - Unsupported URL scheme: " + scheme + ". Only http and https are supported");
+            }
+
+            // Enhanced timeout validation
+            if (connectionTimeout.isNegative()) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                        context + " - connectionTimeout must be non-negative, got: " + connectionTimeout);
+            }
+            if (readTimeout.isNegative()) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                        context + " - readTimeout must be non-negative, got: " + readTimeout);
+            }
+
+            // Build the host string properly
+            String hostString = host;
+            if (port != -1) {
+                hostString = host + ":" + port;
+            }
+
+            // Set timeouts with proper bounds checking
+            long connectionTimeoutMs = connectionTimeout.toMillis();
+            long readTimeoutMs = readTimeout.toMillis();
+
+            // Ensure timeouts don't exceed Integer.MAX_VALUE
+            if (connectionTimeoutMs > Integer.MAX_VALUE) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                        context + " - connectionTimeout too large: " + connectionTimeoutMs + "ms");
+            }
+            if (readTimeoutMs > Integer.MAX_VALUE) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                        context + " - readTimeout too large: " + readTimeoutMs + "ms");
+            }
+
+            // Create Config with basic constructor
+            Config config = new Config(scheme, hostString);
+
+            // Try to set timeouts if the methods exist
+            try {
+                // Some versions of Config may have these methods
+                java.lang.reflect.Method setConnTimeout = config.getClass().getMethod("setConnectionTimeout",
+                        int.class);
+                java.lang.reflect.Method setReadTimeout = config.getClass().getMethod("setReadTimeout", int.class);
+
+                setConnTimeout.invoke(config, (int) connectionTimeoutMs);
+                setReadTimeout.invoke(config, (int) readTimeoutMs);
+
+                LOG.debug("Successfully set timeouts: connection={}ms, read={}ms",
+                        connectionTimeoutMs, readTimeoutMs);
+            } catch (Exception e) {
+                // Methods don't exist or failed to invoke - this is expected for some versions
+                LOG.debug("Timeout methods not available on Config class, using defaults. " +
+                        "Requested: connection={}ms, read={}ms", connectionTimeoutMs, readTimeoutMs);
+            }
+
+            // Add API key to headers if provided
+            if (apiKey != null && !apiKey.trim().isEmpty()) {
+                try {
+                    // Weaviate typically uses Authorization header with Bearer token
+                    config.getHeaders().put("Authorization", "Bearer " + apiKey);
+                    LOG.debug("API key configured for authentication");
+                } catch (Exception e) {
+                    LOG.warn("Failed to set API key in headers, authentication may fail", e);
+                }
+            }
+
+            // Create WeaviateClient using constructor
+            WeaviateClient client = new WeaviateClient(config);
+            LOG.info("Successfully created Weaviate client for URL: {} with timeouts: connection={}ms, read={}ms",
+                    url, connectionTimeoutMs, readTimeoutMs);
+            return client;
+
+        } catch (MalformedURLException e) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_URL, context + " - Malformed URL", e);
+        } catch (WeaviateException e) {
+            // Re-throw Weaviate exceptions as-is
+            throw e;
+        } catch (Exception e) {
+            LOG.error("Unexpected error creating Weaviate client for URL: {}", url, e);
+            throw WeaviateErrorHandler.wrapException(e, context);
+        }
+    }
+
+    /**
+     * Creates a Weaviate client with retry mechanism.
+     *
+     * @param url        Weaviate server URL
+     * @param apiKey     API key for authentication (can be null)
+     * @param maxRetries Maximum number of retry attempts
+     * @return WeaviateClient instance
+     * @throws WeaviateException if all retry attempts fail
+     */
+    public static WeaviateClient createClientWithRetry(String url, String apiKey, int maxRetries)
+            throws WeaviateException {
+        return createClientWithRetry(url, apiKey, maxRetries, DEFAULT_RETRY_DELAY);
+    }
+
+    /**
+     * Creates a Weaviate client with enhanced retry mechanism and monitoring.
+     *
+     * @param url        Weaviate server URL
+     * @param apiKey     API key for authentication (can be null)
+     * @param maxRetries Maximum number of retry attempts
+     * @param retryDelay Delay between retry attempts
+     * @return WeaviateClient instance
+     * @throws WeaviateException if all retry attempts fail
+     */
+    public static WeaviateClient createClientWithRetry(String url, String apiKey, int maxRetries, Duration retryDelay)
+            throws WeaviateException {
+
+        String context = WeaviateErrorHandler.createContext("WeaviateClientUtils.createClientWithRetry",
+                "url", url, "maxRetries", maxRetries);
+
+        // Enhanced validation
+        if (maxRetries <= 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    context + " - maxRetries must be positive, got: " + maxRetries);
+        }
+        if (retryDelay == null || retryDelay.isNegative()) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    context + " - retryDelay must be non-null and non-negative");
+        }
+
+        // Use enhanced retry mechanism
+        WeaviateErrorHandler.RetryConfig retryConfig = new WeaviateErrorHandler.RetryConfig(
+                maxRetries, retryDelay, Duration.ofMinutes(2), 2.0, true);
+
+        return WeaviateErrorHandler.executeWithRetry(
+                "createWeaviateClient",
+                () -> {
+                    WeaviateClient client = createClient(url, apiKey);
+
+                    // Enhanced connection test with health monitoring
+                    if (!testConnectionWithHealthCheck(client, url)) {
+                        throw new WeaviateException(WeaviateErrorCode.CONNECTION_FAILED,
+                                context + " - Connection test failed");
+                    }
+
+                    return client;
+                },
+                retryConfig,
+                LOG);
+    }
+
+    /**
+     * Tests the connection to Weaviate server with basic validation.
+     *
+     * @param client WeaviateClient instance
+     * @return true if connection is successful, false otherwise
+     */
+    public static boolean testConnection(WeaviateClient client) {
+        if (client == null) {
+            LOG.debug("Connection test failed: client is null");
+            return false;
+        }
+
+        try {
+            // Try to get server meta information
+            Meta meta = client.misc().metaGetter().run().getResult();
+            if (meta != null) {
+                LOG.debug("Connection test successful. Server version: {}", meta.getVersion());
+                return true;
+            }
+            return false;
+        } catch (Exception e) {
+            LOG.debug("Connection test failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Enhanced connection test with health monitoring and detailed logging.
+     *
+     * @param client WeaviateClient instance
+     * @param url    Server URL for context
+     * @return true if connection is successful, false otherwise
+     */
+    public static boolean testConnectionWithHealthCheck(WeaviateClient client, String url) {
+        if (client == null) {
+            LOG.warn("Connection test failed: client is null for URL: {}", url);
+            return false;
+        }
+
+        String context = WeaviateErrorHandler.createContext("testConnectionWithHealthCheck", "url", url);
+        ConnectionHealthMonitor healthMonitor = new ConnectionHealthMonitor(url);
+
+        try {
+            LOG.debug("Testing connection to Weaviate server: {}", url);
+
+            // Try to get server meta information with timeout
+            Meta meta = client.misc().metaGetter().run().getResult();
+
+            if (meta != null) {
+                String version = meta.getVersion();
+                LOG.info("Connection test successful for URL: {} - Server version: {}", url, version);
+
+                // Record successful health check
+                healthMonitor.recordHealthCheck(true, null);
+
+                // Additional validation - try to get server readiness
+                try {
+                    Boolean ready = client.misc().readyChecker().run().getResult();
+                    if (Boolean.TRUE.equals(ready)) {
+                        LOG.debug("Server readiness check passed for URL: {}", url);
+                    } else {
+                        LOG.warn("Server readiness check failed for URL: {} - server not ready", url);
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Server readiness check failed for URL: {} - {}", url, e.getMessage());
+                }
+
+                return true;
+            } else {
+                String errorMsg = "Server meta information is null";
+                LOG.warn("Connection test failed for URL: {} - {}", url, errorMsg);
+                healthMonitor.recordHealthCheck(false, errorMsg);
+                return false;
+            }
+
+        } catch (Exception e) {
+            String errorMsg = "Connection test exception: " + e.getMessage();
+            LOG.warn("Connection test failed for URL: {} - {}", url, errorMsg, e);
+            healthMonitor.recordHealthCheck(false, errorMsg);
+            return false;
+        }
+    }
+
+    /**
+     * Performs an enhanced health check on the Weaviate server with detailed
+     * monitoring.
+     *
+     * @param client WeaviateClient instance
+     * @param url    Server URL for context
+     * @return true if server is healthy, false otherwise
+     */
+    public static boolean healthCheck(WeaviateClient client, String url) {
+        if (client == null) {
+            LOG.warn("Health check failed: client is null for URL: {}", url);
+            return false;
+        }
+
+        String context = WeaviateErrorHandler.createContext("healthCheck", "url", url);
+        ConnectionHealthMonitor healthMonitor = new ConnectionHealthMonitor(url);
+
+        try {
+            LOG.debug("Performing health check for Weaviate server: {}", url);
+
+            // Get server readiness status
+            Boolean ready = client.misc().readyChecker().run().getResult();
+
+            if (Boolean.TRUE.equals(ready)) {
+                LOG.debug("Health check successful - server is ready for URL: {}", url);
+                healthMonitor.recordHealthCheck(true, null);
+
+                // Additional health checks
+                try {
+                    // Try to get server meta for additional validation
+                    Meta meta = client.misc().metaGetter().run().getResult();
+                    if (meta != null) {
+                        LOG.debug("Extended health check passed - server meta available for URL: {}", url);
+                    }
+                } catch (Exception e) {
+                    LOG.debug("Extended health check warning for URL: {} - {}", url, e.getMessage());
+                }
+
+                return true;
+            } else {
+                String errorMsg = "Server is not ready";
+                LOG.warn("Health check failed for URL: {} - {}", url, errorMsg);
+                healthMonitor.recordHealthCheck(false, errorMsg);
+                return false;
+            }
+
+        } catch (Exception e) {
+            String errorMsg = "Health check exception: " + e.getMessage();
+            LOG.warn("Health check failed for URL: {} - {}", url, errorMsg, e);
+            healthMonitor.recordHealthCheck(false, errorMsg);
+            return false;
+        }
+    }
+
+    /**
+     * Performs a health check on the Weaviate server (legacy method for backward
+     * compatibility).
+     *
+     * @param client WeaviateClient instance
+     * @return true if server is healthy, false otherwise
+     */
+    public static boolean healthCheck(WeaviateClient client) {
+        return healthCheck(client, "unknown");
+    }
+
+    /**
+     * Gets or creates a connection pool for the specified configuration.
+     *
+     * @param url      Weaviate server URL
+     * @param apiKey   API key for authentication (can be null)
+     * @param poolSize Maximum pool size
+     * @return WeaviateConnectionPool instance
+     */
+    public static WeaviateConnectionPool getConnectionPool(String url, String apiKey, int poolSize) {
+        if (poolSize <= 0) {
+            throw new IllegalArgumentException("poolSize must be positive, got: " + poolSize);
+        }
+
+        String poolKey = generatePoolKey(url, apiKey);
+        return CONNECTION_POOLS.computeIfAbsent(poolKey, k -> new WeaviateConnectionPool(url, apiKey, poolSize));
+    }
+
+    /**
+     * Gets or creates a connection pool with default size.
+     *
+     * @param url    Weaviate server URL
+     * @param apiKey API key for authentication (can be null)
+     * @return WeaviateConnectionPool instance
+     */
+    public static WeaviateConnectionPool getConnectionPool(String url, String apiKey) {
+        return getConnectionPool(url, apiKey, DEFAULT_POOL_SIZE);
+    }
+
+    /**
+     * Closes and removes a connection pool.
+     *
+     * @param url    Weaviate server URL
+     * @param apiKey API key for authentication (can be null)
+     */
+    public static void closeConnectionPool(String url, String apiKey) {
+        String poolKey = generatePoolKey(url, apiKey);
+        WeaviateConnectionPool pool = CONNECTION_POOLS.remove(poolKey);
+        if (pool != null) {
+            pool.close();
+            LOG.info("Closed connection pool for: {}", url);
+        }
+    }
+
+    /**
+     * Closes all connection pools.
+     */
+    public static void closeAllConnectionPools() {
+        CONNECTION_POOLS.values().forEach(WeaviateConnectionPool::close);
+        CONNECTION_POOLS.clear();
+        LOG.info("Closed all connection pools");
+    }
+
+    /**
+     * Generates a unique key for connection pool identification.
+     */
+    private static String generatePoolKey(String url, String apiKey) {
+        return url + "#" + (apiKey != null ? apiKey.hashCode() : "noauth");
+    }
+
+    /**
+     * Connection pool implementation for managing Weaviate client instances.
+     */
+    public static class WeaviateConnectionPool {
+
+        private final String url;
+        private final String apiKey;
+        private final int maxPoolSize;
+        private final BlockingQueue<WeaviateClient> availableClients;
+        private final AtomicInteger currentPoolSize;
+        private volatile boolean closed = false;
+
+        public WeaviateConnectionPool(String url, String apiKey, int maxPoolSize) {
+            if (url == null || url.trim().isEmpty()) {
+                throw new IllegalArgumentException("URL cannot be null or empty");
+            }
+            if (maxPoolSize <= 0) {
+                throw new IllegalArgumentException("maxPoolSize must be positive, got: " + maxPoolSize);
+            }
+
+            this.url = url;
+            this.apiKey = apiKey;
+            this.maxPoolSize = maxPoolSize;
+            this.availableClients = new LinkedBlockingQueue<>();
+            this.currentPoolSize = new AtomicInteger(0);
+        }
+
+        /**
+         * Borrows a client from the pool with enhanced error handling and monitoring.
+         *
+         * @return WeaviateClient instance
+         * @throws InterruptedException if interrupted while waiting
+         * @throws WeaviateException    if pool is closed or client creation fails
+         */
+        public WeaviateClient borrowClient() throws InterruptedException, WeaviateException {
+            if (closed) {
+                throw new WeaviateException(WeaviateErrorCode.CONNECTION_POOL_EXHAUSTED,
+                        WeaviateErrorHandler.createContext("WeaviateConnectionPool.borrowClient",
+                                "url", url, "reason", "pool is closed"));
+            }
+
+            String context = WeaviateErrorHandler.createContext("WeaviateConnectionPool.borrowClient",
+                    "url", url, "poolSize", currentPoolSize.get(),
+                    "maxPoolSize", maxPoolSize);
+
+            LOG.debug("Borrowing client from pool: {}", context);
+
+            WeaviateClient client = availableClients.poll();
+            if (client != null) {
+                // Test the client before returning with enhanced health check
+                if (testConnectionWithHealthCheck(client, url)) {
+                    LOG.debug("Reusing existing client from pool for URL: {}", url);
+                    return client;
+                } else {
+                    // Client is not healthy, discard it
+                    currentPoolSize.decrementAndGet();
+                    LOG.warn("Discarded unhealthy client from pool for URL: {}", url);
+                }
+            }
+
+            // Create new client if pool is not full
+            if (currentPoolSize.get() < maxPoolSize) {
+                try {
+                    LOG.debug("Creating new client for pool: {}", context);
+                    client = createClientWithRetry(url, apiKey, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_DELAY);
+                    currentPoolSize.incrementAndGet();
+                    LOG.info("Created new client for pool, current size: {}/{}", currentPoolSize.get(), maxPoolSize);
+                    return client;
+                } catch (WeaviateException e) {
+                    LOG.error("Failed to create new client for pool: {}", context, e);
+                    throw e;
+                } catch (Exception e) {
+                    LOG.error("Unexpected error creating new client for pool: {}", context, e);
+                    throw WeaviateErrorHandler.wrapException(e, context);
+                }
+            }
+
+            // Wait for available client with timeout
+            LOG.debug("Pool is full, waiting for available client: {}", context);
+            client = availableClients.poll(30, TimeUnit.SECONDS);
+            if (client == null) {
+                throw new WeaviateException(WeaviateErrorCode.CONNECTION_POOL_EXHAUSTED,
+                        context + " - Timeout waiting for available client");
+            }
+
+            // Test the borrowed client
+            if (!testConnectionWithHealthCheck(client, url)) {
+                currentPoolSize.decrementAndGet();
+                throw new WeaviateException(WeaviateErrorCode.CONNECTION_FAILED,
+                        context + " - Borrowed client failed health check");
+            }
+
+            LOG.debug("Successfully borrowed client from pool after waiting: {}", url);
+            return client;
+        }
+
+        /**
+         * Returns a client to the pool with enhanced health checking.
+         *
+         * @param client WeaviateClient to return
+         */
+        public void returnClient(WeaviateClient client) {
+            if (closed) {
+                LOG.debug("Pool is closed, not returning client for URL: {}", url);
+                return;
+            }
+
+            if (client == null) {
+                LOG.warn("Attempted to return null client to pool for URL: {}", url);
+                return;
+            }
+
+            String context = WeaviateErrorHandler.createContext("WeaviateConnectionPool.returnClient",
+                    "url", url, "poolSize", currentPoolSize.get());
+
+            // Enhanced health check before returning to pool
+            if (testConnectionWithHealthCheck(client, url)) {
+                boolean offered = availableClients.offer(client);
+                if (offered) {
+                    LOG.debug("Successfully returned healthy client to pool: {}", context);
+                } else {
+                    LOG.warn("Failed to return client to pool (queue full?): {}", context);
+                    currentPoolSize.decrementAndGet();
+                }
+            } else {
+                // Client is unhealthy, don't return to pool
+                currentPoolSize.decrementAndGet();
+                LOG.warn("Discarded unhealthy client instead of returning to pool: {}", context);
+            }
+        }
+
+        /**
+         * Gets the current pool size.
+         *
+         * @return current number of clients in the pool
+         */
+        public int getCurrentPoolSize() {
+            return currentPoolSize.get();
+        }
+
+        /**
+         * Gets the number of available clients.
+         *
+         * @return number of available clients
+         */
+        public int getAvailableClients() {
+            return availableClients.size();
+        }
+
+        /**
+         * Closes the connection pool and all clients.
+         */
+        public void close() {
+            closed = true;
+
+            // Close all clients in the pool
+            WeaviateClient client;
+            while ((client = availableClients.poll()) != null) {
+                try {
+                    // Weaviate client doesn't have explicit close method
+                    // The client will be garbage collected
+                } catch (Exception e) {
+                    LOG.warn("Error closing client", e);
+                }
+            }
+
+            currentPoolSize.set(0);
+            LOG.info("Connection pool closed for URL: {}", url);
+        }
+
+        /**
+         * Checks if the pool is closed.
+         *
+         * @return true if pool is closed
+         */
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateErrorHandler.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateErrorHandler.java
@@ -1,0 +1,435 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Enhanced error handling utility for Weaviate connector operations.
+ * Provides standardized error codes, retry mechanisms, and logging.
+ */
+public class WeaviateErrorHandler implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateErrorHandler.class);
+
+    /**
+     * Weaviate-specific error codes for better error categorization and handling.
+     */
+    public enum WeaviateErrorCode {
+
+        // Connection errors (1000-1099)
+        CONNECTION_FAILED(1001, "Failed to connect to Weaviate server", true),
+        CONNECTION_TIMEOUT(1002, "Connection timeout to Weaviate server", true),
+        AUTHENTICATION_FAILED(1003, "Authentication failed with Weaviate server", false),
+        INVALID_URL(1004, "Invalid Weaviate server URL", false),
+        SSL_HANDSHAKE_FAILED(1005, "SSL handshake failed", true),
+
+        // Configuration errors (1100-1199)
+        INVALID_CONFIG(1101, "Invalid configuration parameter", false),
+        MISSING_REQUIRED_CONFIG(1102, "Missing required configuration parameter", false),
+        INVALID_CLASS_NAME(1103, "Invalid Weaviate class name", false),
+        INVALID_VECTOR_DIMENSION(1104, "Invalid vector dimension", false),
+        INVALID_BATCH_SIZE(1105, "Invalid batch size configuration", false),
+
+        // Data processing errors (1200-1299)
+        DATA_CONVERSION_FAILED(1201, "Failed to convert data type", false),
+        VECTOR_CONVERSION_FAILED(1202, "Failed to convert vector data", false),
+        INVALID_VECTOR_FORMAT(1203, "Invalid vector data format", false),
+        SCHEMA_MISMATCH(1204, "Schema mismatch between source and target", false),
+        NULL_DATA_ERROR(1205, "Unexpected null data encountered", false),
+
+        // Query errors (1300-1399)
+        GRAPHQL_QUERY_FAILED(1301, "GraphQL query execution failed", true),
+        INVALID_QUERY_SYNTAX(1302, "Invalid GraphQL query syntax", false),
+        QUERY_TIMEOUT(1303, "Query execution timeout", true),
+        RESULT_PARSING_FAILED(1304, "Failed to parse query results", false),
+        EMPTY_RESULT_SET(1305, "Query returned empty result set", false),
+
+        // Write operation errors (1400-1499)
+        BATCH_WRITE_FAILED(1401, "Batch write operation failed", true),
+        OBJECT_CREATION_FAILED(1402, "Failed to create Weaviate object", true),
+        UPSERT_OPERATION_FAILED(1403, "Upsert operation failed", true),
+        BATCH_SIZE_EXCEEDED(1404, "Batch size limit exceeded", false),
+        WRITE_PERMISSION_DENIED(1405, "Write permission denied", false),
+
+        // Resource errors (1500-1599)
+        MEMORY_PRESSURE(1501, "System memory pressure detected", true),
+        CONNECTION_POOL_EXHAUSTED(1502, "Connection pool exhausted", true),
+        THREAD_POOL_EXHAUSTED(1503, "Thread pool exhausted", true),
+        DISK_SPACE_INSUFFICIENT(1504, "Insufficient disk space", false),
+        RESOURCE_CLEANUP_FAILED(1505, "Failed to cleanup resources", false),
+
+        // Generic errors (1900-1999)
+        UNKNOWN_ERROR(1901, "Unknown error occurred", true),
+        OPERATION_INTERRUPTED(1902, "Operation was interrupted", false),
+        SERIALIZATION_FAILED(1903, "Object serialization failed", false),
+        DESERIALIZATION_FAILED(1904, "Object deserialization failed", false),
+        VALIDATION_FAILED(1905, "Data validation failed", false);
+
+        private final int code;
+        private final String message;
+        private final boolean retryable;
+
+        WeaviateErrorCode(int code, String message, boolean retryable) {
+            this.code = code;
+            this.message = message;
+            this.retryable = retryable;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public boolean isRetryable() {
+            return retryable;
+        }
+    }
+
+    /**
+     * Weaviate-specific exception with error codes and context.
+     */
+    public static class WeaviateException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        private final WeaviateErrorCode errorCode;
+        private final String context;
+        private final long timestamp;
+
+        public WeaviateException(WeaviateErrorCode errorCode, String context) {
+            super(formatMessage(errorCode, context));
+            this.errorCode = errorCode;
+            this.context = context;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        public WeaviateException(WeaviateErrorCode errorCode, String context, Throwable cause) {
+            super(formatMessage(errorCode, context), cause);
+            this.errorCode = errorCode;
+            this.context = context;
+            this.timestamp = System.currentTimeMillis();
+        }
+
+        private static String formatMessage(WeaviateErrorCode errorCode, String context) {
+            return String.format("[WE-%d] %s%s",
+                    errorCode.getCode(),
+                    errorCode.getMessage(),
+                    context != null ? " - " + context : "");
+        }
+
+        public WeaviateErrorCode getErrorCode() {
+            return errorCode;
+        }
+
+        public String getContext() {
+            return context;
+        }
+
+        public long getTimestamp() {
+            return timestamp;
+        }
+
+        public boolean isRetryable() {
+            return errorCode.isRetryable();
+        }
+    }
+
+    /**
+     * Retry configuration for different types of operations.
+     */
+    public static class RetryConfig {
+
+        private final int maxRetries;
+        private final Duration initialDelay;
+        private final Duration maxDelay;
+        private final double backoffMultiplier;
+        private final boolean enableJitter;
+
+        public RetryConfig(int maxRetries, Duration initialDelay, Duration maxDelay,
+                double backoffMultiplier, boolean enableJitter) {
+            this.maxRetries = maxRetries;
+            this.initialDelay = initialDelay;
+            this.maxDelay = maxDelay;
+            this.backoffMultiplier = backoffMultiplier;
+            this.enableJitter = enableJitter;
+        }
+
+        public static RetryConfig defaultConfig() {
+            return new RetryConfig(3, Duration.ofSeconds(1), Duration.ofMinutes(1), 2.0, true);
+        }
+
+        public static RetryConfig connectionConfig() {
+            return new RetryConfig(5, Duration.ofSeconds(2), Duration.ofMinutes(2), 1.5, true);
+        }
+
+        public static RetryConfig queryConfig() {
+            return new RetryConfig(3, Duration.ofMillis(500), Duration.ofSeconds(30), 2.0, true);
+        }
+
+        public static RetryConfig writeConfig() {
+            return new RetryConfig(4, Duration.ofSeconds(1), Duration.ofMinutes(1), 1.8, true);
+        }
+
+        public int getMaxRetries() {
+            return maxRetries;
+        }
+
+        public Duration getInitialDelay() {
+            return initialDelay;
+        }
+
+        public Duration getMaxDelay() {
+            return maxDelay;
+        }
+
+        public double getBackoffMultiplier() {
+            return backoffMultiplier;
+        }
+
+        public boolean isEnableJitter() {
+            return enableJitter;
+        }
+    }
+
+    /**
+     * Executes an operation with retry logic and enhanced error handling.
+     */
+    public static <T> T executeWithRetry(String operationName, RetryableOperation<T> operation,
+            RetryConfig retryConfig) throws WeaviateException {
+        return executeWithRetry(operationName, operation, retryConfig, LOG);
+    }
+
+    /**
+     * Executes an operation with retry logic using custom logger.
+     */
+    public static <T> T executeWithRetry(String operationName, RetryableOperation<T> operation,
+            RetryConfig retryConfig, Logger logger) throws WeaviateException {
+        WeaviateException lastException = null;
+        long startTime = System.currentTimeMillis();
+
+        for (int attempt = 1; attempt <= retryConfig.getMaxRetries() + 1; attempt++) {
+            try {
+                logger.debug("Executing {} - attempt {}/{}", operationName, attempt, retryConfig.getMaxRetries() + 1);
+
+                T result = operation.execute();
+
+                if (attempt > 1) {
+                    long totalTime = System.currentTimeMillis() - startTime;
+                    logger.info("Operation {} succeeded on attempt {} after {}ms",
+                            operationName, attempt, totalTime);
+                }
+
+                return result;
+
+            } catch (WeaviateException e) {
+                lastException = e;
+                logger.warn("Operation {} failed on attempt {}/{}: [{}] {}",
+                        operationName, attempt, retryConfig.getMaxRetries() + 1,
+                        e.getErrorCode().getCode(), e.getMessage());
+
+                // Don't retry if error is not retryable or we've exhausted attempts
+                if (!e.isRetryable() || attempt > retryConfig.getMaxRetries()) {
+                    break;
+                }
+
+                // Calculate delay for next attempt
+                if (attempt <= retryConfig.getMaxRetries()) {
+                    long delayMs = calculateRetryDelay(attempt, retryConfig);
+                    logger.debug("Retrying {} in {}ms", operationName, delayMs);
+
+                    try {
+                        Thread.sleep(delayMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new WeaviateException(WeaviateErrorCode.OPERATION_INTERRUPTED,
+                                "Operation interrupted during retry delay");
+                    }
+                }
+
+            } catch (Exception e) {
+                // Wrap unexpected exceptions
+                lastException = new WeaviateException(WeaviateErrorCode.UNKNOWN_ERROR,
+                        "Unexpected error in " + operationName, e);
+                logger.error("Unexpected error in {} on attempt {}/{}",
+                        operationName, attempt, retryConfig.getMaxRetries() + 1, e);
+                break;
+            }
+        }
+
+        long totalTime = System.currentTimeMillis() - startTime;
+        logger.error("Operation {} failed after {} attempts in {}ms",
+                operationName, retryConfig.getMaxRetries() + 1, totalTime);
+
+        throw lastException != null ? lastException
+                : new WeaviateException(WeaviateErrorCode.UNKNOWN_ERROR, "Operation failed with unknown error");
+    }
+
+    /**
+     * Calculates retry delay with exponential backoff and optional jitter.
+     */
+    private static long calculateRetryDelay(int attempt, RetryConfig config) {
+        long baseDelay = config.getInitialDelay().toMillis();
+        long delay = (long) (baseDelay * Math.pow(config.getBackoffMultiplier(), attempt - 1));
+
+        // Cap at max delay
+        delay = Math.min(delay, config.getMaxDelay().toMillis());
+
+        // Add jitter if enabled
+        if (config.isEnableJitter()) {
+            double jitterFactor = 0.1; // 10% jitter
+            long jitter = (long) (delay * jitterFactor * ThreadLocalRandom.current().nextDouble());
+            delay += ThreadLocalRandom.current().nextBoolean() ? jitter : -jitter;
+        }
+
+        return Math.max(delay, 0);
+    }
+
+    /**
+     * Logs detailed error information for debugging and monitoring.
+     */
+    public static void logError(Logger logger, String operation, WeaviateException e, Object... context) {
+        StringBuilder contextStr = new StringBuilder();
+        if (context != null && context.length > 0) {
+            contextStr.append(" Context: ");
+            for (int i = 0; i < context.length; i += 2) {
+                if (i > 0)
+                    contextStr.append(", ");
+                if (i + 1 < context.length) {
+                    contextStr.append(context[i]).append("=").append(context[i + 1]);
+                } else {
+                    contextStr.append(context[i]);
+                }
+            }
+        }
+
+        logger.error("Weaviate operation '{}' failed: [WE-{}] {} - {} (retryable: {}){}",
+                operation, e.getErrorCode().getCode(), e.getErrorCode().getMessage(),
+                e.getContext(), e.isRetryable(), contextStr.toString(), e);
+    }
+
+    /**
+     * Logs warning for retryable errors.
+     */
+    public static void logRetryableError(Logger logger, String operation, WeaviateException e,
+            int attempt, int maxAttempts) {
+        logger.warn("Weaviate operation '{}' failed on attempt {}/{}: [WE-{}] {} - {} (will retry: {})",
+                operation, attempt, maxAttempts, e.getErrorCode().getCode(),
+                e.getErrorCode().getMessage(), e.getContext(), attempt < maxAttempts);
+    }
+
+    /**
+     * Creates a standardized error context string.
+     */
+    public static String createContext(String component, Object... keyValuePairs) {
+        StringBuilder context = new StringBuilder(component);
+        if (keyValuePairs != null && keyValuePairs.length > 0) {
+            context.append(" [");
+            for (int i = 0; i < keyValuePairs.length; i += 2) {
+                if (i > 0)
+                    context.append(", ");
+                if (i + 1 < keyValuePairs.length) {
+                    context.append(keyValuePairs[i]).append("=").append(keyValuePairs[i + 1]);
+                } else {
+                    context.append(keyValuePairs[i]);
+                }
+            }
+            context.append("]");
+        }
+        return context.toString();
+    }
+
+    /**
+     * Validates configuration and throws appropriate errors.
+     */
+    public static void validateConfig(String paramName, Object value, String component) {
+        if (value == null) {
+            throw new WeaviateException(WeaviateErrorCode.MISSING_REQUIRED_CONFIG,
+                    createContext(component, "parameter", paramName));
+        }
+
+        if (value instanceof String && ((String) value).trim().isEmpty()) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    createContext(component, "parameter", paramName, "reason", "empty string"));
+        }
+
+        if (value instanceof Number && ((Number) value).doubleValue() < 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    createContext(component, "parameter", paramName, "reason", "negative value"));
+        }
+    }
+
+    /**
+     * Wraps exceptions with appropriate Weaviate error codes.
+     */
+    public static WeaviateException wrapException(Throwable cause, String context) {
+        if (cause instanceof WeaviateException) {
+            return (WeaviateException) cause;
+        }
+
+        String message = cause.getMessage();
+        if (message == null) {
+            message = cause.getClass().getSimpleName();
+        }
+
+        // Categorize common exceptions
+        if (cause instanceof java.net.ConnectException ||
+                cause instanceof java.net.NoRouteToHostException) {
+            return new WeaviateException(WeaviateErrorCode.CONNECTION_FAILED, context, cause);
+        }
+
+        if (cause instanceof java.net.SocketTimeoutException ||
+                cause instanceof java.util.concurrent.TimeoutException) {
+            return new WeaviateException(WeaviateErrorCode.CONNECTION_TIMEOUT, context, cause);
+        }
+
+        if (cause instanceof java.security.cert.CertificateException ||
+                cause instanceof javax.net.ssl.SSLHandshakeException) {
+            return new WeaviateException(WeaviateErrorCode.SSL_HANDSHAKE_FAILED, context, cause);
+        }
+
+        if (cause instanceof InterruptedException) {
+            return new WeaviateException(WeaviateErrorCode.OPERATION_INTERRUPTED, context, cause);
+        }
+
+        if (cause instanceof OutOfMemoryError) {
+            return new WeaviateException(WeaviateErrorCode.MEMORY_PRESSURE, context, cause);
+        }
+
+        // Default to unknown error
+        return new WeaviateException(WeaviateErrorCode.UNKNOWN_ERROR, context, cause);
+    }
+
+    /**
+     * Functional interface for retryable operations.
+     */
+    @FunctionalInterface
+    public interface RetryableOperation<T> {
+
+        T execute() throws Exception;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateMonitoringUtils.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateMonitoringUtils.java
@@ -1,0 +1,434 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.utils;
+
+import org.apache.inlong.sort.base.metric.MetricOption;
+import org.apache.inlong.sort.base.metric.SinkExactlyMetric;
+import org.apache.inlong.sort.base.metric.SourceExactlyMetric;
+
+import org.apache.flink.metrics.MetricGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Enhanced monitoring and metrics utility for Weaviate connector operations.
+ * Provides detailed logging, performance metrics, and operational insights.
+ */
+public class WeaviateMonitoringUtils implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateMonitoringUtils.class);
+
+    // Metric keys for structured logging
+    public static final String METRIC_COMPONENT = "component";
+    public static final String METRIC_OPERATION = "operation";
+    public static final String METRIC_STATUS = "status";
+    public static final String METRIC_DURATION = "duration_ms";
+    public static final String METRIC_RECORDS = "records";
+    public static final String METRIC_BYTES = "bytes";
+    public static final String METRIC_ERROR_CODE = "error_code";
+    public static final String METRIC_BATCH_SIZE = "batch_size";
+    public static final String METRIC_RETRY_COUNT = "retry_count";
+
+    /**
+     * Performance metrics tracker for operations.
+     */
+    public static class PerformanceTracker {
+
+        private final String operationName;
+        private final Instant startTime;
+        private final Map<String, Object> context;
+        private final Logger logger;
+
+        public PerformanceTracker(String operationName, Logger logger) {
+            this.operationName = operationName;
+            this.startTime = Instant.now();
+            this.context = new HashMap<>();
+            this.logger = logger;
+
+            // Set MDC for structured logging
+            MDC.put(METRIC_OPERATION, operationName);
+            MDC.put("start_time", startTime.toString());
+        }
+
+        public PerformanceTracker addContext(String key, Object value) {
+            context.put(key, value);
+            MDC.put(key, String.valueOf(value));
+            return this;
+        }
+
+        public void recordSuccess(long recordCount, long byteCount) {
+            Duration duration = Duration.between(startTime, Instant.now());
+
+            MDC.put(METRIC_STATUS, "SUCCESS");
+            MDC.put(METRIC_DURATION, String.valueOf(duration.toMillis()));
+            MDC.put(METRIC_RECORDS, String.valueOf(recordCount));
+            MDC.put(METRIC_BYTES, String.valueOf(byteCount));
+
+            logger.info("Operation {} completed successfully in {}ms - {} records, {} bytes",
+                    operationName, duration.toMillis(), recordCount, byteCount);
+
+            // Calculate throughput metrics
+            if (duration.toMillis() > 0) {
+                double recordsPerSecond = (recordCount * 1000.0) / duration.toMillis();
+                double mbPerSecond = (byteCount * 1000.0) / (duration.toMillis() * 1024 * 1024);
+
+                logger.debug("Performance metrics - Records/sec: {:.2f}, MB/sec: {:.2f}",
+                        recordsPerSecond, mbPerSecond);
+
+                MDC.put("records_per_second", String.format("%.2f", recordsPerSecond));
+                MDC.put("mb_per_second", String.format("%.2f", mbPerSecond));
+            }
+
+            clearMDC();
+        }
+
+        public void recordFailure(WeaviateErrorHandler.WeaviateException error, int retryCount) {
+            Duration duration = Duration.between(startTime, Instant.now());
+
+            MDC.put(METRIC_STATUS, "FAILURE");
+            MDC.put(METRIC_DURATION, String.valueOf(duration.toMillis()));
+            MDC.put(METRIC_ERROR_CODE, String.valueOf(error.getErrorCode().getCode()));
+            MDC.put(METRIC_RETRY_COUNT, String.valueOf(retryCount));
+
+            logger.error("Operation {} failed after {}ms and {} retries: [WE-{}] {}",
+                    operationName, duration.toMillis(), retryCount,
+                    error.getErrorCode().getCode(), error.getMessage(), error);
+
+            clearMDC();
+        }
+
+        public void recordPartialSuccess(long successCount, long failureCount, long byteCount) {
+            Duration duration = Duration.between(startTime, Instant.now());
+
+            MDC.put(METRIC_STATUS, "PARTIAL_SUCCESS");
+            MDC.put(METRIC_DURATION, String.valueOf(duration.toMillis()));
+            MDC.put(METRIC_RECORDS, String.valueOf(successCount));
+            MDC.put(METRIC_BYTES, String.valueOf(byteCount));
+            MDC.put("failed_records", String.valueOf(failureCount));
+
+            logger.warn("Operation {} completed with partial success in {}ms - {} succeeded, {} failed",
+                    operationName, duration.toMillis(), successCount, failureCount);
+
+            clearMDC();
+        }
+
+        private void clearMDC() {
+            MDC.remove(METRIC_OPERATION);
+            MDC.remove(METRIC_STATUS);
+            MDC.remove(METRIC_DURATION);
+            MDC.remove(METRIC_RECORDS);
+            MDC.remove(METRIC_BYTES);
+            MDC.remove(METRIC_ERROR_CODE);
+            MDC.remove(METRIC_RETRY_COUNT);
+            MDC.remove("start_time");
+            MDC.remove("records_per_second");
+            MDC.remove("mb_per_second");
+            MDC.remove("failed_records");
+
+            // Clear custom context
+            for (String key : context.keySet()) {
+                MDC.remove(key);
+            }
+        }
+    }
+
+    /**
+     * Enhanced metrics wrapper for InLong audit integration.
+     */
+    public static class EnhancedMetrics {
+
+        private final SourceExactlyMetric sourceMetric;
+        private final SinkExactlyMetric sinkMetric;
+        private final String componentName;
+        private final Logger logger;
+
+        // Additional metrics tracking
+        private final AtomicLong totalOperations = new AtomicLong(0);
+        private final AtomicLong successfulOperations = new AtomicLong(0);
+        private final AtomicLong failedOperations = new AtomicLong(0);
+        private final AtomicLong totalRetries = new AtomicLong(0);
+        private final AtomicLong totalProcessingTime = new AtomicLong(0);
+
+        public EnhancedMetrics(String componentName, MetricOption metricOption,
+                MetricGroup metricGroup, boolean isSource) {
+            this.componentName = componentName;
+            this.logger = LoggerFactory.getLogger(componentName);
+
+            if (metricOption != null) {
+                if (isSource) {
+                    this.sourceMetric = new SourceExactlyMetric(metricOption, metricGroup);
+                    this.sinkMetric = null;
+                } else {
+                    this.sourceMetric = null;
+                    this.sinkMetric = new SinkExactlyMetric(metricOption, metricGroup);
+                }
+            } else {
+                this.sourceMetric = null;
+                this.sinkMetric = null;
+                logger.warn("MetricOption is null, InLong audit metrics will not be reported");
+            }
+        }
+
+        public void recordSourceMetrics(long recordCount, long byteCount, long timestamp) {
+            if (sourceMetric != null) {
+                try {
+                    sourceMetric.outputMetrics(recordCount, byteCount, timestamp);
+                    logger.debug("Source metrics reported: {} records, {} bytes", recordCount, byteCount);
+                } catch (Exception e) {
+                    logger.warn("Failed to report source metrics", e);
+                }
+            }
+
+            updateOperationMetrics(recordCount, true, 0);
+        }
+
+        public void recordSinkMetrics(long recordCount, long byteCount, long timestamp) {
+            if (sinkMetric != null) {
+                try {
+                    sinkMetric.invoke(recordCount, byteCount, timestamp);
+                    logger.debug("Sink metrics reported: {} records, {} bytes", recordCount, byteCount);
+                } catch (Exception e) {
+                    logger.warn("Failed to report sink metrics", e);
+                }
+            }
+
+            updateOperationMetrics(recordCount, true, 0);
+        }
+
+        public void recordFailure(long recordCount, int retryCount) {
+            updateOperationMetrics(recordCount, false, retryCount);
+
+            logger.warn("Operation failed for {} records after {} retries in component {}",
+                    recordCount, retryCount, componentName);
+        }
+
+        private void updateOperationMetrics(long recordCount, boolean success, int retryCount) {
+            totalOperations.addAndGet(recordCount);
+            if (success) {
+                successfulOperations.addAndGet(recordCount);
+            } else {
+                failedOperations.addAndGet(recordCount);
+            }
+            totalRetries.addAndGet(retryCount);
+        }
+
+        public void recordProcessingTime(long processingTimeMs) {
+            totalProcessingTime.addAndGet(processingTimeMs);
+        }
+
+        public void logPeriodicStats() {
+            long total = totalOperations.get();
+            long successful = successfulOperations.get();
+            long failed = failedOperations.get();
+            long retries = totalRetries.get();
+            long avgProcessingTime = total > 0 ? totalProcessingTime.get() / total : 0;
+
+            if (total > 0) {
+                double successRate = (successful * 100.0) / total;
+                double avgRetries = (double) retries / total;
+
+                logger.info("Component {} stats - Total: {}, Success: {} ({:.2f}%), Failed: {}, " +
+                        "Avg retries: {:.2f}, Avg processing time: {}ms",
+                        componentName, total, successful, successRate, failed,
+                        avgRetries, avgProcessingTime);
+
+                // Set MDC for structured logging
+                MDC.put(METRIC_COMPONENT, componentName);
+                MDC.put("total_operations", String.valueOf(total));
+                MDC.put("successful_operations", String.valueOf(successful));
+                MDC.put("failed_operations", String.valueOf(failed));
+                MDC.put("success_rate", String.format("%.2f", successRate));
+                MDC.put("avg_retries", String.format("%.2f", avgRetries));
+                MDC.put("avg_processing_time", String.valueOf(avgProcessingTime));
+
+                logger.info("Periodic stats logged for component {}", componentName);
+
+                // Clear MDC
+                MDC.clear();
+            }
+        }
+
+        public long getTotalOperations() {
+            return totalOperations.get();
+        }
+
+        public long getSuccessfulOperations() {
+            return successfulOperations.get();
+        }
+
+        public long getFailedOperations() {
+            return failedOperations.get();
+        }
+
+        public long getTotalRetries() {
+            return totalRetries.get();
+        }
+
+        public double getSuccessRate() {
+            long total = totalOperations.get();
+            return total > 0 ? (successfulOperations.get() * 100.0) / total : 0.0;
+        }
+    }
+
+    /**
+     * Connection health monitor for tracking connection status.
+     */
+    public static class ConnectionHealthMonitor {
+
+        private final String connectionId;
+        private final Logger logger;
+        private volatile boolean isHealthy = true;
+        private volatile long lastHealthCheckTime = 0;
+        private volatile long consecutiveFailures = 0;
+        private volatile String lastError = null;
+
+        public ConnectionHealthMonitor(String connectionId) {
+            this.connectionId = connectionId;
+            this.logger = LoggerFactory.getLogger(ConnectionHealthMonitor.class);
+        }
+
+        public void recordHealthCheck(boolean success, String errorMessage) {
+            lastHealthCheckTime = System.currentTimeMillis();
+
+            if (success) {
+                if (!isHealthy) {
+                    logger.info("Connection {} recovered after {} consecutive failures",
+                            connectionId, consecutiveFailures);
+                }
+                isHealthy = true;
+                consecutiveFailures = 0;
+                lastError = null;
+            } else {
+                consecutiveFailures++;
+                lastError = errorMessage;
+
+                if (isHealthy) {
+                    logger.warn("Connection {} became unhealthy: {}", connectionId, errorMessage);
+                    isHealthy = false;
+                } else {
+                    logger.debug("Connection {} still unhealthy (failure #{}): {}",
+                            connectionId, consecutiveFailures, errorMessage);
+                }
+            }
+
+            // Log structured health status
+            MDC.put("connection_id", connectionId);
+            MDC.put("is_healthy", String.valueOf(isHealthy));
+            MDC.put("consecutive_failures", String.valueOf(consecutiveFailures));
+            MDC.put("last_check_time", String.valueOf(lastHealthCheckTime));
+            if (lastError != null) {
+                MDC.put("last_error", lastError);
+            }
+
+            logger.debug("Connection health check completed for {}", connectionId);
+            MDC.clear();
+        }
+
+        public boolean isHealthy() {
+            return isHealthy;
+        }
+
+        public long getConsecutiveFailures() {
+            return consecutiveFailures;
+        }
+
+        public long getLastHealthCheckTime() {
+            return lastHealthCheckTime;
+        }
+
+        public String getLastError() {
+            return lastError;
+        }
+    }
+
+    /**
+     * Creates a performance tracker for an operation.
+     */
+    public static PerformanceTracker startOperation(String operationName, Logger logger) {
+        return new PerformanceTracker(operationName, logger);
+    }
+
+    /**
+     * Creates enhanced metrics wrapper.
+     */
+    public static EnhancedMetrics createMetrics(String componentName, MetricOption metricOption,
+            MetricGroup metricGroup, boolean isSource) {
+        return new EnhancedMetrics(componentName, metricOption, metricGroup, isSource);
+    }
+
+    /**
+     * Creates connection health monitor.
+     */
+    public static ConnectionHealthMonitor createHealthMonitor(String connectionId) {
+        return new ConnectionHealthMonitor(connectionId);
+    }
+
+    /**
+     * Logs system resource information for monitoring.
+     */
+    public static void logSystemResources(Logger logger) {
+        Runtime runtime = Runtime.getRuntime();
+        long maxMemory = runtime.maxMemory();
+        long totalMemory = runtime.totalMemory();
+        long freeMemory = runtime.freeMemory();
+        long usedMemory = totalMemory - freeMemory;
+
+        double memoryUsagePercent = (usedMemory * 100.0) / maxMemory;
+        int availableProcessors = runtime.availableProcessors();
+
+        MDC.put("max_memory_mb", String.valueOf(maxMemory / (1024 * 1024)));
+        MDC.put("used_memory_mb", String.valueOf(usedMemory / (1024 * 1024)));
+        MDC.put("memory_usage_percent", String.format("%.2f", memoryUsagePercent));
+        MDC.put("available_processors", String.valueOf(availableProcessors));
+
+        logger.debug("System resources - Memory: {:.2f}% ({} MB / {} MB), Processors: {}",
+                memoryUsagePercent, usedMemory / (1024 * 1024), maxMemory / (1024 * 1024),
+                availableProcessors);
+
+        MDC.clear();
+    }
+
+    /**
+     * Logs configuration information for debugging.
+     */
+    public static void logConfiguration(Logger logger, String component, Map<String, Object> config) {
+        logger.info("Configuration for component {}: {}", component, config);
+
+        MDC.put(METRIC_COMPONENT, component);
+        for (Map.Entry<String, Object> entry : config.entrySet()) {
+            MDC.put("config_" + entry.getKey(), String.valueOf(entry.getValue()));
+        }
+
+        logger.debug("Configuration logged for component {}", component);
+
+        // Clear config entries from MDC
+        for (String key : config.keySet()) {
+            MDC.remove("config_" + key);
+        }
+        MDC.remove(METRIC_COMPONENT);
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateTypeConverter.java
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/java/org/apache/inlong/sort/weaviate/utils/WeaviateTypeConverter.java
@@ -1,0 +1,713 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sort.weaviate.utils;
+
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateErrorCode;
+import org.apache.inlong.sort.weaviate.utils.WeaviateErrorHandler.WeaviateException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Type converter for Weaviate connector that handles data type conversions
+ * between
+ * Flink data types and Weaviate object properties.
+ * 
+ * This class provides bidirectional conversion:
+ * - RowData to Weaviate object (Map&lt;String, Object&gt;) for sink operations
+ * - Weaviate object to RowData for source operations
+ * - Vector data conversion (String, List to float[] array)
+ * - Data validation and error handling
+ */
+public class WeaviateTypeConverter implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(WeaviateTypeConverter.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    private final RowType rowType;
+    private final String vectorField;
+    private final Integer vectorDimension;
+
+    /**
+     * Constructor for WeaviateTypeConverter.
+     *
+     * @param rowType         The row type definition for the table
+     * @param vectorField     The name of the vector field (optional)
+     * @param vectorDimension The expected dimension of vector field (optional)
+     */
+    public WeaviateTypeConverter(RowType rowType, String vectorField, Integer vectorDimension) {
+        this.rowType = rowType;
+        this.vectorField = vectorField;
+        this.vectorDimension = vectorDimension;
+    }
+
+    /**
+     * Converts a RowData object to a Weaviate object with enhanced error handling.
+     * This is used for sink operations when writing data to Weaviate.
+     *
+     * @param rowData The Flink RowData to convert
+     * @return A Map representing the Weaviate object
+     * @throws WeaviateException if conversion fails
+     */
+    public Map<String, Object> convertRowDataToWeaviateObject(RowData rowData) throws WeaviateException {
+        if (rowData == null) {
+            throw new WeaviateException(WeaviateErrorCode.NULL_DATA_ERROR,
+                    WeaviateErrorHandler.createContext("WeaviateTypeConverter.convertRowDataToWeaviateObject",
+                            "reason", "RowData is null"));
+        }
+
+        Map<String, Object> weaviateObject = new HashMap<>();
+        List<RowType.RowField> fields = rowType.getFields();
+        String context = WeaviateErrorHandler.createContext("convertRowDataToWeaviateObject",
+                "fieldCount", fields.size());
+
+        LOG.debug("Converting RowData to Weaviate object: {}", context);
+
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField field = fields.get(i);
+            String fieldName = field.getName();
+            LogicalType fieldType = field.getType();
+
+            if (rowData.isNullAt(i)) {
+                // Handle null values based on configuration
+                weaviateObject.put(fieldName, null);
+                LOG.debug("Field '{}' is null, setting to null in Weaviate object", fieldName);
+                continue;
+            }
+
+            try {
+                Object value = convertFlinkValueToWeaviateValue(rowData, i, fieldType, fieldName);
+                weaviateObject.put(fieldName, value);
+                LOG.debug("Successfully converted field '{}' of type {} to value: {}",
+                        fieldName, fieldType.getTypeRoot(), value != null ? value.getClass().getSimpleName() : "null");
+            } catch (WeaviateException e) {
+                // Re-throw Weaviate exceptions with additional context
+                String fieldContext = WeaviateErrorHandler.createContext("field conversion",
+                        "fieldName", fieldName,
+                        "position", i,
+                        "fieldType", fieldType.getTypeRoot());
+                throw new WeaviateException(e.getErrorCode(), fieldContext + " - " + e.getContext(), e);
+            } catch (Exception e) {
+                String fieldContext = WeaviateErrorHandler.createContext("field conversion",
+                        "fieldName", fieldName,
+                        "position", i,
+                        "fieldType", fieldType.getTypeRoot());
+                LOG.error("Failed to convert field '{}' at position {} with type {}", fieldName, i, fieldType, e);
+                throw new WeaviateException(WeaviateErrorCode.DATA_CONVERSION_FAILED, fieldContext, e);
+            }
+        }
+
+        LOG.debug("Successfully converted RowData to Weaviate object with {} fields", weaviateObject.size());
+        return weaviateObject;
+    }
+
+    /**
+     * Converts a Weaviate object to a RowData object with enhanced error handling.
+     * This is used for source operations when reading data from Weaviate.
+     *
+     * @param weaviateObject The Weaviate object to convert
+     * @return A GenericRowData representing the converted data
+     * @throws WeaviateException if conversion fails
+     */
+    public GenericRowData convertWeaviateObjectToRowData(Map<String, Object> weaviateObject) throws WeaviateException {
+        if (weaviateObject == null) {
+            throw new WeaviateException(WeaviateErrorCode.NULL_DATA_ERROR,
+                    WeaviateErrorHandler.createContext("WeaviateTypeConverter.convertWeaviateObjectToRowData",
+                            "reason", "Weaviate object is null"));
+        }
+
+        List<RowType.RowField> fields = rowType.getFields();
+        GenericRowData rowData = new GenericRowData(fields.size());
+        String context = WeaviateErrorHandler.createContext("convertWeaviateObjectToRowData",
+                "fieldCount", fields.size(),
+                "objectKeys", weaviateObject.keySet().size());
+
+        LOG.debug("Converting Weaviate object to RowData: {}", context);
+
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField field = fields.get(i);
+            String fieldName = field.getName();
+            LogicalType fieldType = field.getType();
+
+            Object weaviateValue = weaviateObject.get(fieldName);
+
+            try {
+                Object convertedValue = convertWeaviateValueToFlinkValue(weaviateValue, fieldType, fieldName);
+                rowData.setField(i, convertedValue);
+                LOG.debug("Successfully converted Weaviate field '{}' of type {} from value: {} to Flink value",
+                        fieldName, fieldType.getTypeRoot(),
+                        weaviateValue != null ? weaviateValue.getClass().getSimpleName() : "null");
+            } catch (WeaviateException e) {
+                // Re-throw Weaviate exceptions with additional context
+                String fieldContext = WeaviateErrorHandler.createContext("field conversion",
+                        "fieldName", fieldName,
+                        "position", i,
+                        "fieldType", fieldType.getTypeRoot(),
+                        "weaviateValueType", weaviateValue != null ? weaviateValue.getClass().getSimpleName() : "null");
+                throw new WeaviateException(e.getErrorCode(), fieldContext + " - " + e.getContext(), e);
+            } catch (Exception e) {
+                String fieldContext = WeaviateErrorHandler.createContext("field conversion",
+                        "fieldName", fieldName,
+                        "position", i,
+                        "fieldType", fieldType.getTypeRoot(),
+                        "weaviateValueType", weaviateValue != null ? weaviateValue.getClass().getSimpleName() : "null");
+                LOG.error("Failed to convert Weaviate field '{}' with type {} and value {}", fieldName, fieldType,
+                        weaviateValue, e);
+                throw new WeaviateException(WeaviateErrorCode.DATA_CONVERSION_FAILED, fieldContext, e);
+            }
+        }
+
+        LOG.debug("Successfully converted Weaviate object to RowData with {} fields", fields.size());
+        return rowData;
+    }
+
+    /**
+     * Converts vector data from various formats to float array with enhanced error
+     * handling.
+     * Supports String (JSON array), List&lt;Number&gt;, and float[] formats.
+     *
+     * @param vectorData The vector data to convert
+     * @return A float array representing the vector
+     * @throws WeaviateException if conversion fails or dimension mismatch
+     */
+    public float[] convertToVector(Object vectorData) throws WeaviateException {
+        if (vectorData == null) {
+            return null;
+        }
+
+        String context = WeaviateErrorHandler.createContext("convertToVector",
+                "vectorDataType", vectorData.getClass().getSimpleName(),
+                "expectedDimension", vectorDimension);
+
+        LOG.debug("Converting vector data: {}", context);
+
+        float[] result;
+
+        try {
+            if (vectorData instanceof String) {
+                result = parseVectorFromString((String) vectorData);
+            } else if (vectorData instanceof List) {
+                result = convertListToFloatArray((List<?>) vectorData);
+            } else if (vectorData instanceof float[]) {
+                result = (float[]) vectorData;
+            } else if (vectorData instanceof double[]) {
+                double[] doubleArray = (double[]) vectorData;
+                result = new float[doubleArray.length];
+                for (int i = 0; i < doubleArray.length; i++) {
+                    result[i] = (float) doubleArray[i];
+                }
+            } else if (vectorData instanceof ArrayData) {
+                result = convertArrayDataToFloatArray((ArrayData) vectorData);
+            } else {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_VECTOR_FORMAT,
+                        context + " - Unsupported vector data type: " + vectorData.getClass());
+            }
+
+            // Validate vector dimension if specified
+            if (vectorDimension != null && result.length != vectorDimension) {
+                throw new WeaviateException(WeaviateErrorCode.INVALID_VECTOR_DIMENSION,
+                        WeaviateErrorHandler.createContext("vector dimension validation",
+                                "expected", vectorDimension, "actual", result.length));
+            }
+
+            LOG.debug("Successfully converted vector data to float array with {} dimensions", result.length);
+            return result;
+
+        } catch (WeaviateException e) {
+            // Re-throw Weaviate exceptions as-is
+            throw e;
+        } catch (Exception e) {
+            LOG.error("Failed to convert vector data: {}", context, e);
+            throw new WeaviateException(WeaviateErrorCode.VECTOR_CONVERSION_FAILED, context, e);
+        }
+    }
+
+    /**
+     * Converts a float array to vector data in the specified format.
+     * 
+     * @param vector       The float array to convert
+     * @param targetFormat The target format ("string", "list", or "array")
+     * @return The converted vector data
+     */
+    public Object convertFromVector(float[] vector, String targetFormat) {
+        if (vector == null) {
+            return null;
+        }
+
+        switch (targetFormat.toLowerCase()) {
+            case "string":
+                return vectorToString(vector);
+            case "list":
+                List<Float> list = new ArrayList<>();
+                for (float f : vector) {
+                    list.add(f);
+                }
+                return list;
+            case "array":
+            default:
+                return vector;
+        }
+    }
+
+    /**
+     * Converts a Flink value to a Weaviate value.
+     */
+    private Object convertFlinkValueToWeaviateValue(RowData rowData, int pos, LogicalType logicalType,
+            String fieldName) {
+        LogicalTypeRoot typeRoot = logicalType.getTypeRoot();
+
+        switch (typeRoot) {
+            case CHAR:
+            case VARCHAR:
+                StringData stringData = rowData.getString(pos);
+                String stringValue = stringData.toString();
+
+                // Handle vector field conversion
+                if (fieldName.equals(vectorField)) {
+                    return convertToVector(stringValue);
+                }
+                return stringValue;
+
+            case BOOLEAN:
+                return rowData.getBoolean(pos);
+
+            case DECIMAL:
+                DecimalData decimalData = rowData.getDecimal(pos, ((DecimalType) logicalType).getPrecision(),
+                        ((DecimalType) logicalType).getScale());
+                return decimalData.toBigDecimal();
+
+            case TINYINT:
+                return rowData.getByte(pos);
+
+            case SMALLINT:
+                return rowData.getShort(pos);
+
+            case INTEGER:
+                return rowData.getInt(pos);
+
+            case BIGINT:
+                return rowData.getLong(pos);
+
+            case FLOAT:
+                return rowData.getFloat(pos);
+
+            case DOUBLE:
+                return rowData.getDouble(pos);
+
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                TimestampData timestampData = rowData.getTimestamp(pos,
+                        ((org.apache.flink.table.types.logical.TimestampType) logicalType).getPrecision());
+                return timestampData.toLocalDateTime().format(TIMESTAMP_FORMATTER);
+
+            case ARRAY:
+                ArrayData arrayData = rowData.getArray(pos);
+                ArrayType arrayType = (ArrayType) logicalType;
+                LogicalType elementType = arrayType.getElementType();
+
+                // Handle vector array conversion
+                if (fieldName.equals(vectorField) && elementType.getTypeRoot() == LogicalTypeRoot.FLOAT) {
+                    return convertArrayDataToFloatArray(arrayData);
+                }
+
+                return convertArrayDataToList(arrayData, elementType);
+
+            case ROW:
+                RowData nestedRowData = rowData.getRow(pos, ((RowType) logicalType).getFieldCount());
+                return convertNestedRowDataToMap(nestedRowData, (RowType) logicalType);
+
+            default:
+                throw new IllegalArgumentException("Unsupported Flink type: " + typeRoot);
+        }
+    }
+
+    /**
+     * Converts a Weaviate value to a Flink value.
+     */
+    private Object convertWeaviateValueToFlinkValue(Object weaviateValue, LogicalType logicalType, String fieldName) {
+        if (weaviateValue == null) {
+            return null;
+        }
+
+        LogicalTypeRoot typeRoot = logicalType.getTypeRoot();
+
+        switch (typeRoot) {
+            case CHAR:
+            case VARCHAR:
+                if (fieldName.equals(vectorField) && weaviateValue instanceof List) {
+                    // Convert vector list back to string representation
+                    return StringData.fromString(vectorToString(convertListToFloatArray((List<?>) weaviateValue)));
+                }
+                return StringData.fromString(weaviateValue.toString());
+
+            case BOOLEAN:
+                if (weaviateValue instanceof Boolean) {
+                    return (Boolean) weaviateValue;
+                }
+                return Boolean.parseBoolean(weaviateValue.toString());
+
+            case DECIMAL:
+                if (weaviateValue instanceof BigDecimal) {
+                    return DecimalData.fromBigDecimal((BigDecimal) weaviateValue,
+                            ((DecimalType) logicalType).getPrecision(), ((DecimalType) logicalType).getScale());
+                }
+                return DecimalData.fromBigDecimal(new BigDecimal(weaviateValue.toString()),
+                        ((DecimalType) logicalType).getPrecision(), ((DecimalType) logicalType).getScale());
+
+            case TINYINT:
+                return ((Number) weaviateValue).byteValue();
+
+            case SMALLINT:
+                return ((Number) weaviateValue).shortValue();
+
+            case INTEGER:
+                return ((Number) weaviateValue).intValue();
+
+            case BIGINT:
+                return ((Number) weaviateValue).longValue();
+
+            case FLOAT:
+                return ((Number) weaviateValue).floatValue();
+
+            case DOUBLE:
+                return ((Number) weaviateValue).doubleValue();
+
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                LocalDateTime dateTime;
+                if (weaviateValue instanceof String) {
+                    try {
+                        dateTime = LocalDateTime.parse((String) weaviateValue, TIMESTAMP_FORMATTER);
+                    } catch (DateTimeParseException e) {
+                        // Try alternative formats
+                        dateTime = LocalDateTime.parse((String) weaviateValue);
+                    }
+                } else {
+                    throw new IllegalArgumentException("Cannot convert " + weaviateValue.getClass() + " to timestamp");
+                }
+                return TimestampData.fromLocalDateTime(dateTime);
+
+            case ARRAY:
+                ArrayType arrayType = (ArrayType) logicalType;
+                LogicalType elementType = arrayType.getElementType();
+
+                if (fieldName.equals(vectorField) && weaviateValue instanceof List) {
+                    // Convert vector list to ArrayData
+                    float[] vectorArray = convertListToFloatArray((List<?>) weaviateValue);
+                    Object[] objectArray = new Object[vectorArray.length];
+                    for (int i = 0; i < vectorArray.length; i++) {
+                        objectArray[i] = vectorArray[i];
+                    }
+                    return new GenericArrayData(objectArray);
+                }
+
+                if (weaviateValue instanceof List) {
+                    return convertListToArrayData((List<?>) weaviateValue, elementType);
+                }
+                throw new IllegalArgumentException("Cannot convert " + weaviateValue.getClass() + " to array");
+
+            case ROW:
+                if (weaviateValue instanceof Map) {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> mapValue = (Map<String, Object>) weaviateValue;
+                    return convertMapToRowData(mapValue, (RowType) logicalType);
+                }
+                throw new IllegalArgumentException("Cannot convert " + weaviateValue.getClass() + " to row");
+
+            default:
+                throw new IllegalArgumentException("Unsupported Flink type: " + typeRoot);
+        }
+    }
+
+    /**
+     * Parses vector from string representation (JSON array format).
+     */
+    private float[] parseVectorFromString(String vectorString) throws JsonProcessingException {
+        if (vectorString.trim().startsWith("[")) {
+            // JSON array format
+            JsonNode jsonNode = OBJECT_MAPPER.readTree(vectorString);
+            if (!jsonNode.isArray()) {
+                throw new IllegalArgumentException("Vector string must be a JSON array");
+            }
+
+            float[] result = new float[jsonNode.size()];
+            for (int i = 0; i < jsonNode.size(); i++) {
+                result[i] = (float) jsonNode.get(i).asDouble();
+            }
+            return result;
+        } else {
+            // Comma-separated values
+            String[] parts = vectorString.split(",");
+            float[] result = new float[parts.length];
+            for (int i = 0; i < parts.length; i++) {
+                result[i] = Float.parseFloat(parts[i].trim());
+            }
+            return result;
+        }
+    }
+
+    /**
+     * Converts a List to float array.
+     */
+    private float[] convertListToFloatArray(List<?> list) {
+        float[] result = new float[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            Object item = list.get(i);
+            if (item instanceof Number) {
+                result[i] = ((Number) item).floatValue();
+            } else {
+                result[i] = Float.parseFloat(item.toString());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Converts ArrayData to float array.
+     */
+    private float[] convertArrayDataToFloatArray(ArrayData arrayData) {
+        float[] result = new float[arrayData.size()];
+        for (int i = 0; i < arrayData.size(); i++) {
+            result[i] = arrayData.getFloat(i);
+        }
+        return result;
+    }
+
+    /**
+     * Converts float array to string representation.
+     */
+    private String vectorToString(float[] vector) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[");
+        for (int i = 0; i < vector.length; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            sb.append(vector[i]);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    /**
+     * Converts ArrayData to List.
+     */
+    private List<Object> convertArrayDataToList(ArrayData arrayData, LogicalType elementType) {
+        List<Object> result = new ArrayList<>();
+        for (int i = 0; i < arrayData.size(); i++) {
+            Object element = convertArrayElementToObject(arrayData, i, elementType);
+            result.add(element);
+        }
+        return result;
+    }
+
+    /**
+     * Converts array element to object based on type.
+     */
+    private Object convertArrayElementToObject(ArrayData arrayData, int index, LogicalType elementType) {
+        if (arrayData.isNullAt(index)) {
+            return null;
+        }
+
+        LogicalTypeRoot typeRoot = elementType.getTypeRoot();
+        switch (typeRoot) {
+            case VARCHAR:
+            case CHAR:
+                return arrayData.getString(index).toString();
+            case BOOLEAN:
+                return arrayData.getBoolean(index);
+            case TINYINT:
+                return arrayData.getByte(index);
+            case SMALLINT:
+                return arrayData.getShort(index);
+            case INTEGER:
+                return arrayData.getInt(index);
+            case BIGINT:
+                return arrayData.getLong(index);
+            case FLOAT:
+                return arrayData.getFloat(index);
+            case DOUBLE:
+                return arrayData.getDouble(index);
+            default:
+                throw new IllegalArgumentException("Unsupported array element type: " + typeRoot);
+        }
+    }
+
+    /**
+     * Converts List to ArrayData.
+     */
+    private ArrayData convertListToArrayData(List<?> list, LogicalType elementType) {
+        Object[] array = new Object[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = convertObjectToArrayElement(list.get(i), elementType);
+        }
+        return new GenericArrayData(array);
+    }
+
+    /**
+     * Converts object to array element based on type.
+     */
+    private Object convertObjectToArrayElement(Object obj, LogicalType elementType) {
+        if (obj == null) {
+            return null;
+        }
+
+        LogicalTypeRoot typeRoot = elementType.getTypeRoot();
+        switch (typeRoot) {
+            case VARCHAR:
+            case CHAR:
+                return StringData.fromString(obj.toString());
+            case BOOLEAN:
+                return obj instanceof Boolean ? (Boolean) obj : Boolean.parseBoolean(obj.toString());
+            case TINYINT:
+                return ((Number) obj).byteValue();
+            case SMALLINT:
+                return ((Number) obj).shortValue();
+            case INTEGER:
+                return ((Number) obj).intValue();
+            case BIGINT:
+                return ((Number) obj).longValue();
+            case FLOAT:
+                return ((Number) obj).floatValue();
+            case DOUBLE:
+                return ((Number) obj).doubleValue();
+            default:
+                throw new IllegalArgumentException("Unsupported array element type: " + typeRoot);
+        }
+    }
+
+    /**
+     * Converts nested RowData to Map.
+     */
+    private Map<String, Object> convertNestedRowDataToMap(RowData rowData, RowType rowType) {
+        Map<String, Object> result = new HashMap<>();
+        List<RowType.RowField> fields = rowType.getFields();
+
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField field = fields.get(i);
+            String fieldName = field.getName();
+            LogicalType fieldType = field.getType();
+
+            if (!rowData.isNullAt(i)) {
+                Object value = convertFlinkValueToWeaviateValue(rowData, i, fieldType, fieldName);
+                result.put(fieldName, value);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Converts Map to RowData.
+     */
+    private RowData convertMapToRowData(Map<String, Object> map, RowType rowType) {
+        List<RowType.RowField> fields = rowType.getFields();
+        GenericRowData rowData = new GenericRowData(fields.size());
+
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField field = fields.get(i);
+            String fieldName = field.getName();
+            LogicalType fieldType = field.getType();
+
+            Object mapValue = map.get(fieldName);
+            Object convertedValue = convertWeaviateValueToFlinkValue(mapValue, fieldType, fieldName);
+            rowData.setField(i, convertedValue);
+        }
+
+        return rowData;
+    }
+
+    /**
+     * Validates the converter configuration with enhanced error handling.
+     */
+    public void validate() throws WeaviateException {
+        String context = WeaviateErrorHandler.createContext("WeaviateTypeConverter.validate",
+                "vectorField", vectorField,
+                "vectorDimension", vectorDimension);
+
+        LOG.debug("Validating type converter configuration: {}", context);
+
+        if (rowType == null) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_CONFIG,
+                    context + " - RowType cannot be null");
+        }
+
+        if (vectorField != null) {
+            boolean vectorFieldExists = rowType.getFields().stream()
+                    .anyMatch(field -> field.getName().equals(vectorField));
+            if (!vectorFieldExists) {
+                String availableFields = rowType.getFields().stream()
+                        .map(RowType.RowField::getName)
+                        .reduce((a, b) -> a + ", " + b)
+                        .orElse("none");
+                throw new WeaviateException(WeaviateErrorCode.SCHEMA_MISMATCH,
+                        WeaviateErrorHandler.createContext("vector field validation",
+                                "vectorField", vectorField,
+                                "availableFields", availableFields));
+            }
+        }
+
+        if (vectorDimension != null && vectorDimension <= 0) {
+            throw new WeaviateException(WeaviateErrorCode.INVALID_VECTOR_DIMENSION,
+                    context + " - Vector dimension must be positive, got: " + vectorDimension);
+        }
+
+        LOG.info("Type converter configuration validated successfully: {}", context);
+    }
+
+    // Getters for configuration
+    public RowType getRowType() {
+        return rowType;
+    }
+
+    public String getVectorField() {
+        return vectorField;
+    }
+
+    public Integer getVectorDimension() {
+        return vectorDimension;
+    }
+}

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/weaviate/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,15 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+org.apache.inlong.sort.weaviate.table.WeaviateDynamicTableFactory


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #11988

### Motivation

We introduce a new Sort connector for Weaviate to extend Apache InLong’s connector ecosystem to vector databases on Flink 1.15. This enables:

- Unified and configurable read/write between heterogeneous sources and Weaviate using standard Flink SQL and InLong node abstractions.
- Support for AI/RAG scenarios by moving structured/semi-structured data along with vectors into Weaviate and syncing out to downstream systems.
- Better observability and reliability through InLong Audit metrics, configurable retry/backoff, batch ingestion, and memory/backpressure handling.
- A consistent developer and operator experience aligned with the existing InLong Sort framework.

### Modifications

The following changes are included:

Core module and configuration

- Added a new weaviate module under sort-flink v1.15 sort-connectors with standard package layout (table, source, sink, utils).
- Created child/parent Maven pom entries and dependency wiring (Weaviate Java Client, InLong Sort base modules).

Protocol nodes and registration 

- Implemented WeaviateExtractNode and WeaviateLoadNode with validation, InLongMetric/Metadata interfaces, genTableName/tableOptions, and constructor via JsonCreator.
- Registered new node types into JsonSubTypes in ExtractNode, LoadNode, and Node.

Options and factory 

- Implemented WeaviateOptions with required options: URL, CLASS_NAME; optional options: API_KEY, BATCH_SIZE, FLUSH_INTERVAL, VECTOR_FIELD, etc., with defaults and descriptions.
- Implemented WeaviateDynamicTableFactory (factoryIdentifier = weaviate-inlong) with requiredOptions/optionalOptions, validation, MetricOption construction, and creation of runtime sources/sinks.

Runtime and utilities

- WeaviateClientUtils: client creation, health-checks, retry helpers (extensible for pooling).
- WeaviateTypeConverter: type mapping from Flink data types to Weaviate, vector conversions (String/List to float[]), RowData <-> Weaviate object conversion, guardrails/validation.
- WeaviateSourceFunction: initializes client and SourceExactlyMetric, performs GraphQL queries, converts data, handles retry/cancel, reports metrics.
- WeaviateDynamicTableSource: returns SourceFunction runtime provider, copy/asSummaryString, integrates Audit.
- WeaviateSinkFunction: initializes client and SinkExactlyMetric, batching buffer and flush routines, memory/backpressure controls, retries and failure handling, metrics reporting.
- WeaviateDynamicTableSink: returns SinkFunction runtime provider, copy/asSummaryString, supports ChangelogMode (INSERT/UPDATE/DELETE), integrates Audit.

SPI registration

- Added META-INF/services entry for org.apache.flink.table.factories.Factory to register WeaviateDynamicTableFactory.

Integration tests

- Added WeaviateExtractToMySqlLoadTest and MySqlExtractToWeaviateLoadTest to verify end-to-end ETL flows: build ExtractNode/LoadNode/StreamInfo/GroupInfo; run via FlinkSqlParser; verify data correctness.

Performance optimizations

- Tuned batching in WeaviateSinkFunction, added memory usage monitoring with auto-flush safeguards.
- Prepared connection reuse strategies and backpressure handling interfaces.
- Optimized common GraphQL query patterns as appropriate.

Error handling and monitoring 

- Enhanced structured logging and error messages; introduced retry with backoff for connection and write failures.
- Strengthened failure handling for write errors (including partial failures).
- Integrated InLong Audit metrics across components (source/sink paths, TableFactory).

Backward compatibility and scope

- Additive change; existing connectors and pipelines are unaffected.
- New functionality is gated by table factory identifier weaviate-inlong and new node types.

### Verifying this change

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [x] This change added tests and can be verified as follows:
  - Added integration tests: WeaviateExtractToMySqlLoadTest validating Weaviate -> MySql flow using FlinkSqlParser and node graph construction.
  - Added integration tests: MySqlExtractToWeaviateLoadTest validating MySQL -> Weaviate ingestion with vector conversion and batch write behavior.
  - Manual checks: Verified factory SPI discovery with the weaviate-inlong identifier, audited metrics emission on source/sink paths, basic retry behavior on transient failures, and configuration validation for URL/CLASS_NAME/API_KEY/BATCH_SIZE/FLUSH_INTERVAL/VECTOR_FIELD.

### Documentation

- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? JavaDocs for public classes、option descriptions and user-facing docs are included; 
- user-facing docs：
[Weaviate Sort Connector.md](https://github.com/user-attachments/files/22228157/Weaviate.Sort.Connector.md)

