### PR TITLE
[INLONG-12031][Release] Bumped version of branch-2.3.0 to 2.3.0

### DIFF
--- a/inlong-agent/agent-common/pom.xml
+++ b/inlong-agent/agent-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-common</artifactId>

--- a/inlong-agent/agent-core/pom.xml
+++ b/inlong-agent/agent-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-core</artifactId>

--- a/inlong-agent/agent-docker/pom.xml
+++ b/inlong-agent/agent-docker/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-docker</artifactId>

--- a/inlong-agent/agent-installer/pom.xml
+++ b/inlong-agent/agent-installer/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-installer</artifactId>

--- a/inlong-agent/agent-plugins/pom.xml
+++ b/inlong-agent/agent-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-plugins</artifactId>

--- a/inlong-agent/agent-release/pom.xml
+++ b/inlong-agent/agent-release/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-agent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>agent-release</artifactId>

--- a/inlong-agent/pom.xml
+++ b/inlong-agent/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-agent</artifactId>

--- a/inlong-audit/audit-common/pom.xml
+++ b/inlong-audit/audit-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-common</artifactId>

--- a/inlong-audit/audit-docker/pom.xml
+++ b/inlong-audit/audit-docker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>audit-docker</artifactId>
     <name>Apache InLong - Audit Docker</name>

--- a/inlong-audit/audit-proxy/pom.xml
+++ b/inlong-audit/audit-proxy/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-proxy</artifactId>

--- a/inlong-audit/audit-release/pom.xml
+++ b/inlong-audit/audit-release/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-release</artifactId>

--- a/inlong-audit/audit-sdk/pom.xml
+++ b/inlong-audit/audit-sdk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-sdk</artifactId>

--- a/inlong-audit/audit-service/pom.xml
+++ b/inlong-audit/audit-service/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-service</artifactId>

--- a/inlong-audit/audit-store/pom.xml
+++ b/inlong-audit/audit-store/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-store</artifactId>

--- a/inlong-audit/audit-tool/pom.xml
+++ b/inlong-audit/audit-tool/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-audit</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>audit-tool</artifactId>

--- a/inlong-audit/pom.xml
+++ b/inlong-audit/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-audit</artifactId>

--- a/inlong-common/pom.xml
+++ b/inlong-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-common</artifactId>

--- a/inlong-dashboard/pom.xml
+++ b/inlong-dashboard/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-dashboard</artifactId>

--- a/inlong-dataproxy/dataproxy-dist/pom.xml
+++ b/inlong-dataproxy/dataproxy-dist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-dataproxy</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>dataproxy-dist</artifactId>

--- a/inlong-dataproxy/dataproxy-docker/pom.xml
+++ b/inlong-dataproxy/dataproxy-docker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-dataproxy</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>dataproxy-docker</artifactId>

--- a/inlong-dataproxy/dataproxy-source/pom.xml
+++ b/inlong-dataproxy/dataproxy-source/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-dataproxy</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>dataproxy-source</artifactId>

--- a/inlong-dataproxy/pom.xml
+++ b/inlong-dataproxy/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-dataproxy</artifactId>

--- a/inlong-distribution/pom.xml
+++ b/inlong-distribution/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-distribution</artifactId>

--- a/inlong-manager/manager-client-examples/pom.xml
+++ b/inlong-manager/manager-client-examples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-client-examples</artifactId>

--- a/inlong-manager/manager-client-tools/pom.xml
+++ b/inlong-manager/manager-client-tools/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-client-tools</artifactId>

--- a/inlong-manager/manager-client/pom.xml
+++ b/inlong-manager/manager-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-client</artifactId>

--- a/inlong-manager/manager-common/pom.xml
+++ b/inlong-manager/manager-common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-common</artifactId>

--- a/inlong-manager/manager-dao/pom.xml
+++ b/inlong-manager/manager-dao/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-dao</artifactId>

--- a/inlong-manager/manager-docker/pom.xml
+++ b/inlong-manager/manager-docker/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-docker</artifactId>

--- a/inlong-manager/manager-plugins/base/pom.xml
+++ b/inlong-manager/manager-plugins/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>manager-plugins</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-plugins-base</artifactId>

--- a/inlong-manager/manager-plugins/manager-plugins-flink-v1.13/pom.xml
+++ b/inlong-manager/manager-plugins/manager-plugins-flink-v1.13/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>manager-plugins</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-plugins-flink-v1.13</artifactId>

--- a/inlong-manager/manager-plugins/manager-plugins-flink-v1.15/pom.xml
+++ b/inlong-manager/manager-plugins/manager-plugins-flink-v1.15/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>manager-plugins</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-plugins-flink-v1.15</artifactId>

--- a/inlong-manager/manager-plugins/manager-plugins-flink-v1.18/pom.xml
+++ b/inlong-manager/manager-plugins/manager-plugins-flink-v1.18/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>manager-plugins</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-plugins-flink-v1.18</artifactId>

--- a/inlong-manager/manager-plugins/pom.xml
+++ b/inlong-manager/manager-plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-plugins</artifactId>

--- a/inlong-manager/manager-pojo/pom.xml
+++ b/inlong-manager/manager-pojo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-pojo</artifactId>

--- a/inlong-manager/manager-schedule/pom.xml
+++ b/inlong-manager/manager-schedule/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-schedule</artifactId>

--- a/inlong-manager/manager-service/pom.xml
+++ b/inlong-manager/manager-service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-service</artifactId>

--- a/inlong-manager/manager-test/pom.xml
+++ b/inlong-manager/manager-test/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-test</artifactId>

--- a/inlong-manager/manager-web/pom.xml
+++ b/inlong-manager/manager-web/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-web</artifactId>

--- a/inlong-manager/manager-workflow/pom.xml
+++ b/inlong-manager/manager-workflow/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-manager</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>manager-workflow</artifactId>

--- a/inlong-manager/pom.xml
+++ b/inlong-manager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-manager</artifactId>

--- a/inlong-sdk/dataproxy-sdk/pom.xml
+++ b/inlong-sdk/dataproxy-sdk/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sdk</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>dataproxy-sdk</artifactId>

--- a/inlong-sdk/dirty-data-sdk/pom.xml
+++ b/inlong-sdk/dirty-data-sdk/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sdk</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>dirty-data-sdk</artifactId>
     <name>Apache InLong - Dirty Data SDK</name>

--- a/inlong-sdk/pom.xml
+++ b/inlong-sdk/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>inlong-sdk</artifactId>
     <packaging>pom</packaging>

--- a/inlong-sdk/sdk-common/pom.xml
+++ b/inlong-sdk/sdk-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sdk</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sdk-common</artifactId>

--- a/inlong-sdk/sort-sdk/pom.xml
+++ b/inlong-sdk/sort-sdk/pom.xml
@@ -23,10 +23,10 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sdk</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>sort-sdk</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
 
     <name>Apache InLong - Sort SDK</name>
 

--- a/inlong-sdk/transform-sdk/pom.xml
+++ b/inlong-sdk/transform-sdk/pom.xml
@@ -23,10 +23,10 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sdk</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>transform-sdk</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
 
     <name>Apache InLong - Transform SDK</name>
 

--- a/inlong-sort-standalone/pom.xml
+++ b/inlong-sort-standalone/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-sort-standalone</artifactId>

--- a/inlong-sort-standalone/sort-standalone-common/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort-standalone</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-standalone-common</artifactId>

--- a/inlong-sort-standalone/sort-standalone-dist/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-dist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort-standalone</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-standalone-dist</artifactId>

--- a/inlong-sort-standalone/sort-standalone-source/pom.xml
+++ b/inlong-sort-standalone/sort-standalone-source/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort-standalone</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-standalone-source</artifactId>

--- a/inlong-sort/pom.xml
+++ b/inlong-sort/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-sort</artifactId>

--- a/inlong-sort/sort-api/pom.xml
+++ b/inlong-sort/sort-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-api</artifactId>

--- a/inlong-sort/sort-common/pom.xml
+++ b/inlong-sort/sort-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-common</artifactId>

--- a/inlong-sort/sort-core/pom.xml
+++ b/inlong-sort/sort-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-core</artifactId>

--- a/inlong-sort/sort-dist/pom.xml
+++ b/inlong-sort/sort-dist/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-dist</artifactId>

--- a/inlong-sort/sort-end-to-end-tests/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-end-to-end-tests</artifactId>

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.13/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-end-to-end-tests</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-end-to-end-tests-v1.13</artifactId>

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.15/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-end-to-end-tests</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-end-to-end-tests-v1.15</artifactId>

--- a/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.18/pom.xml
+++ b/inlong-sort/sort-end-to-end-tests/sort-end-to-end-tests-v1.18/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-end-to-end-tests</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-end-to-end-tests-v1.18</artifactId>

--- a/inlong-sort/sort-flink/base/pom.xml
+++ b/inlong-sort/sort-flink/base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-base</artifactId>

--- a/inlong-sort/sort-flink/cdc-base/pom.xml
+++ b/inlong-sort/sort-flink/cdc-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-cdc-base</artifactId>

--- a/inlong-sort/sort-flink/pom.xml
+++ b/inlong-sort/sort-flink/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-v1.13</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/doris/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-doris</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-6/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch6</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch7</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/elasticsearch-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch-base</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/filesystem/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-filesystem</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-hbase</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hive/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-hive</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/hudi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-hudi</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/iceberg/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-iceberg</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-jdbc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-kafka</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/kudu/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-kudu</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mongodb-cdc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-mongodb-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/mysql-cdc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-mysql-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/oracle-cdc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-oracle-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connectors-v1.13</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/postgres-cdc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-postgres-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/pulsar/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-pulsar</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/redis/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-redis</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/sqlserver-cdc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-sqlserver-cdc</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/starrocks/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-starrocks</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-connectors/tubemq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-tubemq</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.13/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.13/sort-flink-dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.13</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-dependencies-v1.13</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/elasticsearch-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>sort-connector-elasticsearch-base-v1.15</artifactId>
     <packaging>jar</packaging>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hbase/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hbase/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-hbase-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hudi/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/hudi/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-hudi-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/iceberg/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-iceberg-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/jdbc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-jdbc-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-kafka-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mongodb-cdc/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-mongodb-cdc-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/mysql-cdc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-mysql-cdc-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connectors-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/postgres-cdc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-postgres-cdc-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/pulsar/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-pulsar-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/redis/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-redis-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/sqlserver-cdc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-sqlserver-cdc-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/starrocks/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-starrocks-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-connectors/tubemq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-tubemq-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.15/sort-flink-dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.15</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-dependencies-v1.15</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch-base/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch-base/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>sort-connector-elasticsearch-base-v1.18</artifactId>
     <packaging>jar</packaging>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch6/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch6/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch6-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch7/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/elasticsearch7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-elasticsearch7-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/jdbc/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/jdbc/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-jdbc-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/kafka/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/kafka/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-kafka-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connectors-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/pulsar/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-connectors/pulsar/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-connectors-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-connector-pulsar-v1.18</artifactId>

--- a/inlong-sort/sort-flink/sort-flink-v1.18/sort-flink-dependencies/pom.xml
+++ b/inlong-sort/sort-flink/sort-flink-v1.18/sort-flink-dependencies/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-flink-v1.18</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-flink-dependencies-v1.18</artifactId>

--- a/inlong-sort/sort-formats/format-common/pom.xml
+++ b/inlong-sort/sort-formats/format-common/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-common</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-base/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-base</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-csv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-csv</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-base/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-base</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-binlog</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-csv</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-kv</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-pb/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-pb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-pb</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-tlogcsv</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-tlogkv</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-json-v1.13/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-json-v1.13/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-json-v1.13</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-json-v1.15/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-json-v1.15/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-json-v1.15</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-json-v1.18/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-json-v1.18/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-json-v1.18</artifactId>

--- a/inlong-sort/sort-formats/format-row/format-kv/pom.xml
+++ b/inlong-sort/sort-formats/format-row/format-kv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-row</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-kv</artifactId>

--- a/inlong-sort/sort-formats/format-row/pom.xml
+++ b/inlong-sort/sort-formats/format-row/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>format-row</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-base</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-binlog</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-csv</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-kv</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-pb/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-pb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-pb</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/pom.xml
@@ -23,7 +23,7 @@ under the License.
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>sort-format-inlongmsg-rowdata-tlogcsv</artifactId>
     <packaging>jar</packaging>

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-inlongmsg-rowdata-tlogkv</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-rowdata-base</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-csv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-csv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-rowdata-csv</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-json/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-rowdata-json</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>format-rowdata</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-format-rowdata-kv</artifactId>

--- a/inlong-sort/sort-formats/format-rowdata/pom.xml
+++ b/inlong-sort/sort-formats/format-rowdata/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>sort-formats</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>format-rowdata</artifactId>

--- a/inlong-sort/sort-formats/pom.xml
+++ b/inlong-sort/sort-formats/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-sort</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>sort-formats</artifactId>

--- a/inlong-tubemq/pom.xml
+++ b/inlong-tubemq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>inlong-tubemq</artifactId>

--- a/inlong-tubemq/tubemq-client/pom.xml
+++ b/inlong-tubemq/tubemq-client/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-client</artifactId>

--- a/inlong-tubemq/tubemq-connectors/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-connectors</artifactId>

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-flume/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-connectors</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>tubemq-connector-flume</artifactId>
     <name>Apache InLong - TubeMQ Connectors-flume</name>

--- a/inlong-tubemq/tubemq-connectors/tubemq-connector-spark/pom.xml
+++ b/inlong-tubemq/tubemq-connectors/tubemq-connector-spark/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-connectors</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-connector-spark</artifactId>

--- a/inlong-tubemq/tubemq-core/pom.xml
+++ b/inlong-tubemq/tubemq-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-core</artifactId>

--- a/inlong-tubemq/tubemq-docker/pom.xml
+++ b/inlong-tubemq/tubemq-docker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-docker</artifactId>

--- a/inlong-tubemq/tubemq-docker/tubemq-all/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-all/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-docker</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-all</artifactId>

--- a/inlong-tubemq/tubemq-docker/tubemq-build/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-build/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-docker</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-build</artifactId>

--- a/inlong-tubemq/tubemq-docker/tubemq-cpp/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-cpp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-docker</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-cpp</artifactId>

--- a/inlong-tubemq/tubemq-docker/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-docker/tubemq-manager/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>tubemq-docker</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-manager-docker</artifactId>

--- a/inlong-tubemq/tubemq-example/pom.xml
+++ b/inlong-tubemq/tubemq-example/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-example</artifactId>

--- a/inlong-tubemq/tubemq-manager/pom.xml
+++ b/inlong-tubemq/tubemq-manager/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-manager</artifactId>

--- a/inlong-tubemq/tubemq-server/pom.xml
+++ b/inlong-tubemq/tubemq-server/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.inlong</groupId>
         <artifactId>inlong-tubemq</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>tubemq-server</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.apache.inlong</groupId>
     <artifactId>inlong</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
     <packaging>pom</packaging>
     <name>Apache InLong</name>
 


### PR DESCRIPTION
- Fixes #12031

### Motivation

This commit updates the version number of branch-2.3.0 to reflect the official release version 2.3.0.

### Modifications

Updated all relevant version identifiers in the branch-2.3.0 codebase to 2.3.0.
