### PR TITLE
[INLONG-12044][Dashboard] Fix the Agent installation method is missing

### DIFF
--- a/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
+++ b/inlong-dashboard/src/ui/pages/Clusters/NodeEditModal.tsx
@@ -244,7 +244,7 @@ const NodeEditModal: React.FC<NodeEditModalProps> = ({ id, type, clusterId, ...m
         name: 'isInstall',
         initialValue: false,
         hidden: type !== 'AGENT',
-        visible: () => form.getFieldValue('type') === 'AGENT',
+        visible: type === 'AGENT',
         rules: [{ required: true }],
         props: {
           onChange: ({ target: { value } }) => {


### PR DESCRIPTION
Fixes #12044 

### Modifications

Agent installation method is missing

### Verifying this change
Modify the visible condition to type==='AGENT' to avoid form.getFieldValue not retrieving the type value (which is undefined), causing the condition to fail.
before：
<img width="1077" height="544" alt="image" src="https://github.com/user-attachments/assets/28a6ec54-c4d6-43db-9804-7e6013404f25" />
after：

<img width="1047" height="588" alt="image" src="https://github.com/user-attachments/assets/57e1fa52-0d71-472f-b3ff-8f90b125528b" />

 
### Documentation


