### PR TITLE
[INLONG-12058][SDK] Support retry mechanism when "server error" occurs in dataproxy client

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options.go
@@ -68,6 +68,8 @@ type Options struct {
 	WorkerNum               int                   // worker number, default: 8
 	SendTimeout             time.Duration         // send timeout, default: 30000ms
 	MaxRetries              int                   // max retry count, default: 2
+	RetryOnServerError      bool                  // whether to retry on server error, default: false
+	RetryInitialInterval    time.Duration         // initial retry interval for exponential backoff, default: 100ms
 	BatchingMaxPublishDelay time.Duration         // the time period within which the messages sent will be batched, default: 20ms
 	BatchingMaxMessages     int                   // the maximum number of messages permitted in a batch, default: 50
 	BatchingMaxSize         int                   // the maximum number of bytes permitted in a batch, default: 40K
@@ -157,6 +159,10 @@ func (options *Options) ValidateAndSetDefault() error {
 
 	if options.MaxRetries <= 0 {
 		options.MaxRetries = 2
+	}
+
+	if options.RetryInitialInterval <= 0 {
+		options.RetryInitialInterval = 100 * time.Millisecond
 	}
 
 	if options.WriteBufferSize <= 0 {

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_producer.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/options_producer.go
@@ -50,6 +50,23 @@ func WithMaxRetries(n int) Option {
 	}
 }
 
+// WithRetryOnServerError sets RetryOnServerError
+func WithRetryOnServerError(retry bool) Option {
+	return func(o *Options) {
+		o.RetryOnServerError = retry
+	}
+}
+
+// WithRetryInitialInterval sets RetryInitialInterval
+func WithRetryInitialInterval(interval time.Duration) Option {
+	return func(o *Options) {
+		if interval <= 0 {
+			return
+		}
+		o.RetryInitialInterval = interval
+	}
+}
+
 // WithBatchingMaxPublishDelay sets BatchingMaxPublishDelay
 func WithBatchingMaxPublishDelay(t time.Duration) Option {
 	return func(o *Options) {


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12058

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Support retrying requests when the DataProxy server returns a non‑zero error code, improving the stability of data reporting in the DataProxy Go SDK.
### Modifications

<!--Describe the modifications you've done.-->
Add a retry mechanism for requests when a server error occurs, and introduce related configuration options for initializing the SDK client.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
