### PR TITLE
[INLONG-12065][Sort] Sort Format supports outputting complete row information when field parsing errors occur.

### DIFF
--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/FailureHandler.java
@@ -85,4 +85,34 @@ public interface FailureHandler extends Serializable {
     void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
             Exception exception) throws Exception;
 
+    /**
+     * This method is called when there is a failure occurred while converting any field to row.
+     *
+     * @param fieldName the filed name
+     * @param fieldText the filed test
+     * @param formatInfo the filed target type info
+     * @param exception the thrown exception
+     * @param head the predefined fields
+     * @param inLongMsgBody the fields
+     * @param originBody the origin body
+     * @throws Exception the exception
+     */
+    default void onConvertingFieldFailure(String fieldName, String fieldText, FormatInfo formatInfo,
+            InLongMsgHead head, InLongMsgBody inLongMsgBody, String originBody,
+            Exception exception) throws Exception {
+        onConvertingFieldFailure(fieldName, fieldText, formatInfo, exception);
+    }
+
+    /**
+     * This method is called when there is a failure occurred while field num error.
+     *
+     * @param predefinedFields predefined fields
+     * @param originBodyBytes origin body bytes
+     * @param originBody origin body
+     * @param actualNumFields actual number of fields
+     * @param fieldNameSize expected number of fields
+     */
+    default void onFieldNumError(String predefinedFields, byte[] originBodyBytes, String originBody,
+            int actualNumFields, int fieldNameSize) {
+    }
 }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgBody.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgBody.java
@@ -17,6 +17,9 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +28,7 @@ import java.util.Map;
 /**
  * The body deserialized from {@link InLongMsgBody}.
  */
+@Data
 public class InLongMsgBody implements Serializable {
 
     private static final long serialVersionUID = 1L;
@@ -32,7 +36,12 @@ public class InLongMsgBody implements Serializable {
     /**
      * The body of the record.
      */
-    private final byte[] data;
+    private final byte[] dataBytes;
+
+    /**
+     * The body of the record.
+     */
+    private final String data;
 
     /**
      * The interface of the record.
@@ -50,30 +59,16 @@ public class InLongMsgBody implements Serializable {
     private final Map<String, String> entries;
 
     public InLongMsgBody(
-            byte[] data,
+            byte[] dataBytes,
+            String data,
             String streamId,
             List<String> fields,
             Map<String, String> entries) {
+        this.dataBytes = dataBytes;
         this.data = data;
         this.streamId = streamId;
         this.fields = fields;
         this.entries = entries;
-    }
-
-    public byte[] getData() {
-        return data;
-    }
-
-    public String getStreamId() {
-        return streamId;
-    }
-
-    public List<String> getFields() {
-        return fields;
-    }
-
-    public Map<String, String> getEntries() {
-        return entries;
     }
 
     @Override
@@ -87,17 +82,22 @@ public class InLongMsgBody implements Serializable {
         }
 
         InLongMsgBody inLongMsgBody = (InLongMsgBody) o;
-        return Arrays.equals(data, inLongMsgBody.data);
+        return StringUtils.equals(data, inLongMsgBody.data)
+                && Arrays.equals(dataBytes, inLongMsgBody.dataBytes);
     }
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(data);
+        if (dataBytes != null) {
+            return Arrays.hashCode(dataBytes);
+        }
+        return data == null ? super.hashCode() : data.hashCode();
     }
 
     @Override
     public String toString() {
-        return "InLongMsgBody{" + "data=" + Arrays.toString(data) + ", streamId='" + streamId + '\''
+        return "InLongMsgBody{" + "data=" + (data == null ? new String(dataBytes) : data)
+                + ", streamId='" + streamId + '\''
                 + ", fields=" + fields + ", entries=" + entries + '}';
     }
 }

--- a/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgWrap.java
+++ b/inlong-sort/sort-formats/format-common/src/main/java/org/apache/inlong/sort/formats/inlongmsg/InLongMsgWrap.java
@@ -17,28 +17,27 @@
 
 package org.apache.inlong.sort.formats.inlongmsg;
 
+import lombok.Data;
+
 import java.io.Serializable;
 import java.util.List;
 
 /**
  * The body deserialized from {@link InLongMsgWrap}.
  */
+@Data
 public class InLongMsgWrap implements Serializable {
 
     private final InLongMsgHead inLongMsgHead;
 
     private final List<InLongMsgBody> inLongMsgBodyList;
 
-    public InLongMsgWrap(InLongMsgHead inLongMsgHead, List<InLongMsgBody> inLongMsgBodyList) {
+    private final byte[] originBody;
+
+    public InLongMsgWrap(InLongMsgHead inLongMsgHead,
+            List<InLongMsgBody> inLongMsgBodyList, byte[] originBody) {
         this.inLongMsgHead = inLongMsgHead;
         this.inLongMsgBodyList = inLongMsgBodyList;
-    }
-
-    public InLongMsgHead getInLongMsgHead() {
-        return inLongMsgHead;
-    }
-
-    public List<InLongMsgBody> getInLongMsgBodyList() {
-        return inLongMsgBodyList;
+        this.originBody = originBody;
     }
 }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
@@ -158,7 +158,7 @@ public final class InLongMsgBinlogFormatDeserializer extends AbstractInLongMsgFo
                 attributesFieldName,
                 metadataFieldName,
                 head.getAttributes(),
-                body.getData(),
+                body.getDataBytes(),
                 includeUpdateBefore);
     }
 

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
@@ -138,6 +138,7 @@ public class InLongMsgBinlogUtils {
         return new InLongMsgBody(
                 bytes,
                 null,
+                null,
                 Collections.emptyList(),
                 Collections.emptyMap());
     }

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
@@ -116,7 +116,8 @@ public class InLongMsgCsvUtils {
                     // Only parsed fields will be used by downstream, so it's safe to leave
                     // the other parameters empty.
                     return new InLongMsgBody(
-                            null,
+                            bytes,
+                            bodyStr,
                             null,
                             Arrays.asList(line),
                             Collections.emptyMap());

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvUtils.java
@@ -106,6 +106,7 @@ public class InLongMsgKvUtils {
         return list.stream().map((line) -> {
             return new InLongMsgBody(
                     bytes,
+                    text,
                     null,
                     Collections.emptyList(),
                     line);

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
@@ -94,7 +94,7 @@ public class InLongMsgTlogCsvUtils {
         List<String> fields =
                 Arrays.stream(segments, (isIncludeFirstSegment ? 0 : 1), segments.length).collect(Collectors.toList());
 
-        return new InLongMsgBody(bytes, streamId, fields, Collections.emptyMap());
+        return new InLongMsgBody(bytes, text, streamId, fields, Collections.emptyMap());
     }
 
     /**

--- a/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvUtils.java
+++ b/inlong-sort/sort-formats/format-row/format-inlongmsg-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvUtils.java
@@ -94,7 +94,7 @@ public class InLongMsgTlogKvUtils {
             entries = Collections.emptyMap();
         }
 
-        return new InLongMsgBody(bytes, streamId, Collections.emptyList(), entries);
+        return new InLongMsgBody(bytes, text, streamId, Collections.emptyList(), entries);
     }
 
     /**

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogFormatDeserializer.java
@@ -150,7 +150,7 @@ public final class InLongMsgBinlogFormatDeserializer extends AbstractInLongMsgFo
                 attributesFieldName,
                 metadataFieldName,
                 head.getAttributes(),
-                body.getData(),
+                body.getDataBytes(),
                 includeUpdateBefore,
                 failureHandler);
     }
@@ -163,7 +163,7 @@ public final class InLongMsgBinlogFormatDeserializer extends AbstractInLongMsgFo
                 attributesFieldName,
                 metadataFieldName,
                 head.getAttributes(),
-                body.getData(),
+                body.getDataBytes(),
                 includeUpdateBefore,
                 failureHandler);
     }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-binlog/src/main/java/org/apache/inlong/sort/formats/inlongmsgbinlog/InLongMsgBinlogUtils.java
@@ -103,6 +103,7 @@ public class InLongMsgBinlogUtils {
         return new InLongMsgBody(
                 bytes,
                 null,
+                null,
                 Collections.emptyList(),
                 Collections.emptyMap());
     }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvFormatDeserializer.java
@@ -268,11 +268,7 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
         List<String> fields = body.getFields();
         int actualNumFields = (predefinedFields == null ? 0 : predefinedFields.size())
                 + (fields == null ? 0 : fields.size());
-        if (needPrint() && actualNumFields != fieldNameSize) {
-            LOG.warn("The number of fields mismatches: expected={}, actual={}. " +
-                    "PredefinedFields=[{}], Fields=[{}]", fieldNameSize, actualNumFields,
-                    predefinedFields, fields);
-        }
+        checkFieldNameSize(head, body, actualNumFields, fieldNameSize, failureHandler);
 
         GenericRowData genericRowData = InLongMsgCsvUtils.deserializeRowData(
                 rowFormatInfo,
@@ -300,17 +296,14 @@ public final class InLongMsgCsvFormatDeserializer extends AbstractInLongMsgForma
         int actualNumFields = (predefinedFields == null ? 0 : predefinedFields.size())
                 + (fields == null ? 0 : fields.size());
 
-        if (needPrint() && actualNumFields != fieldNameSize) {
-            LOG.warn("The number of fields mismatches: expected={}, actual={}. " +
-                    "PredefinedFields=[{}], Fields=[{}]", fieldNameSize, actualNumFields,
-                    predefinedFields, fields);
-        }
+        checkFieldNameSize(head, body, actualNumFields, fieldNameSize, failureHandler);
 
         FormatMsg formatMsg = InLongMsgCsvUtils.deserializeFormatMsgData(
                 rowFormatInfo,
                 nullLiteral,
-                retainPredefinedField ? head.getPredefinedFields() : Collections.emptyList(),
-                body.getFields(),
+                retainPredefinedField,
+                head,
+                body,
                 converters, failureHandler);
 
         // Decorate result with time and attributes fields if needed

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/inlongmsgcsv/InLongMsgCsvUtils.java
@@ -124,7 +124,8 @@ public class InLongMsgCsvUtils {
                     // Only parsed fields will be used by downstream, so it's safe to leave
                     // the other parameters empty.
                     return new InLongMsgBody(
-                            null,
+                            bytes,
+                            bodyStr,
                             null,
                             Arrays.asList(line),
                             Collections.emptyMap());
@@ -134,13 +135,15 @@ public class InLongMsgCsvUtils {
     public static FormatMsg deserializeFormatMsgData(
             RowFormatInfo rowFormatInfo,
             String nullLiteral,
-            List<String> predefinedFields,
-            List<String> fields,
+            boolean retainPredefinedField,
+            InLongMsgHead head,
+            InLongMsgBody body,
             FieldToRowDataConverters.FieldToRowDataConverter[] converters,
             FailureHandler failureHandler) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
-
+        List<String> predefinedFields = retainPredefinedField ? head.getPredefinedFields() : Collections.emptyList();
+        List<String> fields = body.getFields();
         GenericRowData rowData = new GenericRowData(fieldNames.length);
         long rowDataLength = 0L;
         // Deserialize pre-defined fields
@@ -158,7 +161,7 @@ public class InLongMsgCsvUtils {
                     fieldName,
                     fieldFormatInfo,
                     fieldText,
-                    nullLiteral, failureHandler));
+                    nullLiteral, head, body, body.getData(), failureHandler));
             rowData.setField(i, field);
             rowDataLength += getFormatValueLength(fieldFormatInfo, fieldText);
         }
@@ -179,7 +182,7 @@ public class InLongMsgCsvUtils {
                     fieldName,
                     fieldFormatInfo,
                     fieldText,
-                    nullLiteral, failureHandler));
+                    nullLiteral, head, body, body.getData(), failureHandler));
             rowData.setField(i + predefinedFields.size(), field);
             rowDataLength += getFormatValueLength(fieldFormatInfo, fieldText);
         }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/inlongmsgkv/InLongMsgKvFormatDeserializer.java
@@ -254,8 +254,9 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
         GenericRowData genericRowData = InLongMsgKvUtils.deserializeRowData(
                 rowFormatInfo,
                 nullLiteral,
-                retainPredefinedField ? head.getPredefinedFields() : Collections.emptyList(),
-                body.getEntries(),
+                retainPredefinedField,
+                head,
+                body,
                 converters,
                 failureHandler);
 
@@ -272,8 +273,9 @@ public final class InLongMsgKvFormatDeserializer extends AbstractInLongMsgFormat
         FormatMsg formatMsg = InLongMsgKvUtils.deserializeFormatMsgData(
                 rowFormatInfo,
                 nullLiteral,
-                retainPredefinedField ? head.getPredefinedFields() : Collections.emptyList(),
-                body.getEntries(),
+                retainPredefinedField,
+                head,
+                body,
                 converters,
                 failureHandler);
 

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-pb/src/main/java/org/apache/inlong/sort/formats/inlongmsgpb/InLongMsgPbDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-pb/src/main/java/org/apache/inlong/sort/formats/inlongmsgpb/InLongMsgPbDeserializationSchema.java
@@ -93,7 +93,8 @@ public class InLongMsgPbDeserializationSchema implements DeserializationSchema<R
         }
     }
 
-    public void deserializeFormatMsg(byte[] message, Collector<FormatMsg> out) throws Exception {
+    public void deserializeFormatMsg(byte[] message, Collector<FormatMsg> out,
+            byte[] originBody) throws Exception {
         byte[] decompressed = decompressor.decompress(message);
         MessageObjs msgObjs = MessageObjs.parseFrom(decompressed);
         List<MessageObj> msgList = msgObjs.getMsgsList();

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvFormatDeserializer.java
@@ -267,10 +267,7 @@ public final class InLongMsgTlogCsvFormatDeserializer extends AbstractInLongMsgF
         List<String> fields = body.getFields();
         int actualNumFields = (predefinedFields == null ? 0 : predefinedFields.size())
                 + (fields == null ? 0 : fields.size());
-        if (needPrint() && actualNumFields != fieldNameSize) {
-            LOG.warn("The number of fields mismatches: " + fieldNameSize +
-                    " expected, but was " + actualNumFields + ".");
-        }
+        checkFieldNameSize(head, body, actualNumFields, fieldNameSize, failureHandler);
         GenericRowData dataRow =
                 InLongMsgTlogCsvUtils.deserializeRowData(
                         rowFormatInfo,
@@ -294,18 +291,13 @@ public final class InLongMsgTlogCsvFormatDeserializer extends AbstractInLongMsgF
         List<String> fields = body.getFields();
         int actualNumFields = (predefinedFields == null ? 0 : predefinedFields.size())
                 + (fields == null ? 0 : fields.size());
-
-        if (needPrint() && actualNumFields != fieldNameSize) {
-            LOG.warn("The number of fields mismatches: " + fieldNameSize +
-                    " expected, but was " + actualNumFields + ".");
-        }
-
+        checkFieldNameSize(head, body, actualNumFields, fieldNameSize, failureHandler);
         FormatMsg formatMsg =
                 InLongMsgTlogCsvUtils.deserializeFormatMsgData(
                         rowFormatInfo,
                         nullLiteral,
-                        head.getPredefinedFields(),
-                        body.getFields(),
+                        head,
+                        body,
                         converters, failureHandler);
 
         GenericRowData genericRowData = InLongMsgUtils.decorateRowDataWithNeededHeadFields(

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogcsv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogcsv/InLongMsgTlogCsvUtils.java
@@ -109,7 +109,7 @@ public class InLongMsgTlogCsvUtils {
                 for (int j = startIndex; j < segments[i].length; j++) {
                     fields.add(segments[i][j]);
                 }
-                inLongMsgBodies.add(new InLongMsgBody(null, tid, fields, Collections.emptyMap()));
+                inLongMsgBodies.add(new InLongMsgBody(bytes, text, tid, fields, Collections.emptyMap()));
             }
         }
         return inLongMsgBodies;
@@ -184,13 +184,13 @@ public class InLongMsgTlogCsvUtils {
     }
 
     public static FormatMsg deserializeFormatMsgData(RowFormatInfo rowFormatInfo,
-            String nullLiteral,
-            List<String> predefinedFields,
-            List<String> fields,
+            String nullLiteral, InLongMsgHead head, InLongMsgBody inLongMsgBody,
             FieldToRowDataConverters.FieldToRowDataConverter[] converters,
             FailureHandler failureHandler) throws Exception {
         String[] fieldNames = rowFormatInfo.getFieldNames();
         FormatInfo[] fieldFormatInfos = rowFormatInfo.getFieldFormatInfos();
+        List<String> predefinedFields = head.getPredefinedFields();
+        List<String> fields = inLongMsgBody.getFields();
 
         GenericRowData rowData = new GenericRowData(fieldNames.length);
         long rowDataLength = 0L;
@@ -211,7 +211,9 @@ public class InLongMsgTlogCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral, failureHandler));
+                            nullLiteral, head, inLongMsgBody,
+                            inLongMsgBody.getData(),
+                            failureHandler));
             rowData.setField(i, field);
             rowDataLength += getFormatValueLength(fieldFormatInfo, fieldText);
         }
@@ -232,7 +234,8 @@ public class InLongMsgTlogCsvUtils {
                             fieldName,
                             fieldFormatInfo,
                             fieldText,
-                            nullLiteral, failureHandler));
+                            nullLiteral, head, inLongMsgBody, inLongMsgBody.getData(),
+                            failureHandler));
             rowData.setField(i + predefinedFields.size(), field);
             rowDataLength += getFormatValueLength(fieldFormatInfo, fieldText);
         }

--- a/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializer.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-inlongmsg-rowdata-tlogkv/src/main/java/org/apache/inlong/sort/formats/inlongmsgtlogkv/InLongMsgTlogKvFormatDeserializer.java
@@ -247,8 +247,8 @@ public final class InLongMsgTlogKvFormatDeserializer extends AbstractInLongMsgFo
                 InLongMsgTlogKvUtils.deserializeFormatMsgData(
                         rowFormatInfo,
                         nullLiteral,
-                        head.getPredefinedFields(),
-                        body.getEntries(), converters, failureHandler);
+                        head,
+                        body, converters, failureHandler);
 
         RowData rowData = InLongMsgUtils.decorateRowWithNeededHeadFields(
                 timeFieldName,

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/src/main/java/org/apache/inlong/sort/formats/base/DefaultDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-base/src/main/java/org/apache/inlong/sort/formats/base/DefaultDeserializationSchema.java
@@ -137,6 +137,20 @@ public abstract class DefaultDeserializationSchema<T> implements Deserialization
         return Objects.equals(failureHandler, that.failureHandler);
     }
 
+    protected void checkFieldNameSize(String body, int actualNumFields, int fieldNameSize,
+            FailureHandler failureHandler) {
+        if (actualNumFields != fieldNameSize) {
+            if (failureHandler != null) {
+                failureHandler.onFieldNumError(null, null, body,
+                        actualNumFields, fieldNameSize);
+            } else {
+                LOG.warn("The number of fields mismatches: {}"
+                        + ",expected, but was {}. origin text: {}",
+                        fieldNameSize, actualNumFields, body);
+            }
+        }
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(failureHandler);

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/csv/CsvRowDataDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-csv/src/main/java/org/apache/inlong/sort/formats/csv/CsvRowDataDeserializationSchema.java
@@ -255,10 +255,7 @@ public final class CsvRowDataDeserializationSchema extends DefaultDeserializatio
 
             String[] fieldTexts = splitCsv(text, delimiter, escapeChar, quoteChar);
 
-            if (needPrint() && fieldTexts.length != fieldNameSize) {
-                LOG.warn("The number of fields mismatches: expected=[{}], actual=[{}]. Text=[{}].",
-                        fieldNames.length, fieldTexts.length, text);
-            }
+            checkFieldNameSize(text, fieldTexts.length, fieldNameSize, failureHandler);
 
             GenericRowData rowData = new GenericRowData(fieldNames.length);
 
@@ -271,7 +268,7 @@ public final class CsvRowDataDeserializationSchema extends DefaultDeserializatio
                                     fieldNames[i],
                                     fieldFormatInfos[i],
                                     fieldTexts[i],
-                                    nullLiteral, failureHandler);
+                                    nullLiteral, null, null, text, failureHandler);
 
                     rowData.setField(i, converters[i].convert(field));
                 }
@@ -297,10 +294,7 @@ public final class CsvRowDataDeserializationSchema extends DefaultDeserializatio
 
             String[] fieldTexts = splitCsv(text, delimiter, escapeChar, quoteChar);
 
-            if (needPrint() && fieldTexts.length != fieldNameSize) {
-                LOG.warn("The number of fields mismatches: expected=[{}], actual=[{}]. Text=[{}].",
-                        fieldNames.length, fieldTexts.length, text);
-            }
+            checkFieldNameSize(text, fieldTexts.length, fieldNameSize, failureHandler);
 
             GenericRowData rowData = new GenericRowData(fieldNames.length);
 
@@ -313,7 +307,7 @@ public final class CsvRowDataDeserializationSchema extends DefaultDeserializatio
                                     fieldNames[i],
                                     fieldFormatInfos[i],
                                     fieldTexts[i],
-                                    nullLiteral, failureHandler);
+                                    nullLiteral, null, null, text, failureHandler);
 
                     rowData.setField(i, converters[i].convert(field));
                     rowDataLength += getFormatValueLength(fieldFormatInfos[i], fieldTexts[i]);

--- a/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/kv/KvRowDataDeserializationSchema.java
+++ b/inlong-sort/sort-formats/format-rowdata/format-rowdata-kv/src/main/java/org/apache/inlong/sort/formats/kv/KvRowDataDeserializationSchema.java
@@ -202,7 +202,7 @@ public class KvRowDataDeserializationSchema extends DefaultDeserializationSchema
                         fieldName,
                         fieldFormatInfo,
                         fieldText,
-                        nullLiteral, failureHandler);
+                        nullLiteral, null, null, text, failureHandler);
                 rowData.setField(i, converters[i].convert(field));
             }
             return rowData;
@@ -237,7 +237,7 @@ public class KvRowDataDeserializationSchema extends DefaultDeserializationSchema
                         fieldName,
                         fieldFormatInfo,
                         fieldText,
-                        nullLiteral, failureHandler);
+                        nullLiteral, null, null, text, failureHandler);
                 rowData.setField(i, converters[i].convert(field));
                 rowDataLength += getFormatValueLength(fieldFormatInfo, fieldText);
             }


### PR DESCRIPTION
Fixes #12065 
### Modifications
modifications like this
>
```
try {

            return ((BasicFormatInfo<?>) fieldFormatInfo).deserialize(fieldText);
        } catch (Exception e) {
            if (failureHandler != null) {
                failureHandler.onConvertingFieldFailure(fieldName, fieldText, fieldFormatInfo,
                        head, inLongMsgBody, originBody, e);
            } else {
                LOG.warn("Could not properly deserialize the" + "text: {},for field:{}"
                        + ". predefinedFields = {},fields = {}, attr={}, originBody={}",
                        fieldText, fieldName,
                        head == null ? "" : head.getPredefinedFields(),
                        inLongMsgBody == null ? "" : inLongMsgBody.getFields(),
                        head == null ? "" : head.getAttributes(),
                        originBody == null ? (inLongMsgBody == null ? "" : new String(inLongMsgBody.getDataBytes()))
                                : originBody,
                        e);
            }
        }
```

When defining the failureHandler, the output shall be generated through onConvertingFieldFailure if it is implemented; otherwise, the output shall be written to the log.
