### PR TITLE
[INLONG-12069][Audit] Fill with zero when there is no data for a given the API of day

### DIFF
--- a/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/cache/DayCache.java
+++ b/inlong-audit/audit-service/src/main/java/org/apache/inlong/audit/service/cache/DayCache.java
@@ -144,6 +144,10 @@ public class DayCache implements AutoCloseable {
             LOGGER.error("Query has exception! ", exception);
         }
 
+        if (result.isEmpty()) {
+            result.add(new StatData(startTime, inlongGroupId, inlongStreamId, auditId));
+        }
+
         return WILDCARD_STREAM_ID.equals(inlongStreamId)
                 ? AuditUtils.aggregateStatData(result, inlongStreamId)
                 : result;


### PR DESCRIPTION

- Fixes #12069

### Motivation

Ensure that the API returns a value of zero for days with no available data to maintain continuous and complete time series results.

### Modifications

Updated the API logic to fill missing data points with zero for any given day lacking records, thereby preventing gaps in the returned dataset.
