### PR TITLE
[INLONG-12077][CI] Make swapfile setup idempotent to avoid Text file busy failures

### DIFF
--- a/.github/workflows/ci_ut.yml
+++ b/.github/workflows/ci_ut.yml
@@ -109,6 +109,15 @@ jobs:
         run: |
           sudo sysctl -w vm.max_map_count=262144
           sudo sysctl -w fs.file-max=65536
+          if swapon --show=NAME | grep -q '^/swapfile$'; then
+            echo "Swapfile already active, skipping creation"
+            exit 0
+          fi
+          if [ -f /swapfile ]; then
+            echo "Swapfile exists but not active, recreating"
+            sudo swapoff /swapfile || true
+            sudo rm -f /swapfile
+          fi
           sudo fallocate -l 5G /swapfile
           sudo chmod 600 /swapfile
           sudo mkswap /swapfile


### PR DESCRIPTION
[INLONG-12077][CI] Make swapfile setup idempotent to avoid Text file busy failures

Fixes #12077

### Motivation

CI occasionally fails with `fallocate: fallocate failed: Text file busy` when `/swapfile` already exists or is active on the runner.

### Modifications

Make the swapfile setup step idempotent. If `/swapfile` is already active, skip creation; if it exists but is inactive, recreate it before enabling swap.

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (no)
