### PR TITLE
[INLONG-12079][Manager] Fix the problem of AuditAlertRuleRequest lacks validation for orderField and orderType

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditAlertRuleServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/core/impl/AuditAlertRuleServiceImpl.java
@@ -28,6 +28,8 @@ import org.apache.inlong.manager.pojo.audit.AuditAlertCondition;
 import org.apache.inlong.manager.pojo.audit.AuditAlertRule;
 import org.apache.inlong.manager.pojo.audit.AuditAlertRulePageRequest;
 import org.apache.inlong.manager.pojo.audit.AuditAlertRuleRequest;
+import org.apache.inlong.manager.pojo.common.OrderFieldEnum;
+import org.apache.inlong.manager.pojo.common.OrderTypeEnum;
 import org.apache.inlong.manager.pojo.common.PageResult;
 import org.apache.inlong.manager.service.core.AuditAlertRuleService;
 
@@ -213,7 +215,8 @@ public class AuditAlertRuleServiceImpl implements AuditAlertRuleService {
 
         // Start pagination
         PageHelper.startPage(request.getPageNum(), request.getPageSize());
-
+        OrderFieldEnum.checkOrderField(request);
+        OrderTypeEnum.checkOrderType(request);
         // Get from database
         Page<AuditAlertRuleEntity> entityPage = (Page<AuditAlertRuleEntity>) alertRuleMapper.selectByCondition(request);
 


### PR DESCRIPTION

Fixes #12079

### Motivation

The AuditAlertRuleRequest lacks validation for orderField and orderType, which will result in any value in orderField or orderType being injected into the SQL statement unchanged, posing a security risk.

### Modifications

Add authentication processes for orderField and orderType in AuditAlertRuleServiceImpl.
