### PR TITLE
[INLONG-12088][Audit] Audit routing data source management supports domain names

### DIFF
--- a/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/utils/RouteUtils.java
+++ b/inlong-audit/audit-common/src/main/java/org/apache/inlong/audit/utils/RouteUtils.java
@@ -30,9 +30,8 @@ import java.util.regex.PatternSyntaxException;
 public class RouteUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(RouteUtils.class);
-    private static final Pattern JDBC_ADDRESS_PATTERN = Pattern.compile("^jdbc:\\w+://([\\w.-]+):(\\d+)");
+    private static final Pattern JDBC_ADDRESS_PATTERN = Pattern.compile("^jdbc:\\w+://([a-zA-Z0-9.-]+):(\\d+)");
     private static final String HOST_PORT_SEPARATOR = ":";
-    private static final int EXPECTED_GROUP_COUNT = 2;
 
     public static boolean isValidRegex(String regex) {
         if (regex == null || regex.isEmpty()) {
@@ -73,8 +72,10 @@ public class RouteUtils {
 
     /**
      * Extracts the host:port address from a JDBC URL.
+     * Both IP addresses and domain names are supported.
      *
      * @param jdbcUrl the JDBC URL, e.g. "jdbc:mysql://127.0.0.1:3306/testdb"
+     *               or "jdbc:mysql://db.example.com:3306/testdb"
      * @return host:port string, or null if the URL is null, blank, or does not match
      */
     public static String extractAddress(String jdbcUrl) {
@@ -83,7 +84,7 @@ public class RouteUtils {
         }
         try {
             Matcher matcher = JDBC_ADDRESS_PATTERN.matcher(jdbcUrl);
-            if (matcher.find() && matcher.groupCount() >= EXPECTED_GROUP_COUNT) {
+            if (matcher.find()) {
                 return matcher.group(1) + HOST_PORT_SEPARATOR + matcher.group(2);
             }
         } catch (Exception e) {

--- a/inlong-audit/audit-common/src/test/java/org/apache/inlong/audit/utils/RouteUtilsTest.java
+++ b/inlong-audit/audit-common/src/test/java/org/apache/inlong/audit/utils/RouteUtilsTest.java
@@ -209,4 +209,67 @@ public class RouteUtilsTest {
         result = RouteUtils.matchesAuditRoute("1", "groupIdABC", auditRouteList);
         assertFalse(result);
     }
+
+    @Test
+    public void extractAddress_DomainStartingWithHyphen() {
+        String jdbcUrl = "jdbc:mysql://-invalid.example.com:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals("-invalid.example.com:3306", result);
+    }
+
+    @Test
+    public void extractAddress_DomainEndingWithHyphen() {
+        String jdbcUrl = "jdbc:mysql://invalid-.example.com:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals("invalid-.example.com:3306", result);
+    }
+
+    @Test
+    public void extractAddress_DomainStartingWithDot() {
+        String jdbcUrl = "jdbc:mysql://.invalid.com:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals(".invalid.com:3306", result);
+    }
+
+    @Test
+    public void extractAddress_DomainEndingWithDot() {
+        String jdbcUrl = "jdbc:mysql://invalid.com.:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals("invalid.com.:3306", result);
+    }
+
+    @Test
+    public void extractAddress_JdbcUrlWithQueryParameters() {
+        String jdbcUrl = "jdbc:mysql://localhost:3306/testdb?useSSL=false&serverTimezone=UTC";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals("localhost:3306", result);
+    }
+
+    @Test
+    public void extractAddress_JdbcUrlWithQueryParametersAndDomain() {
+        String jdbcUrl = "jdbc:mysql://db.example.com:3306/testdb?useSSL=false&characterEncoding=utf8";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertEquals("db.example.com:3306", result);
+    }
+
+    @Test
+    public void extractAddress_IPv6Address_ReturnsNull() {
+        String jdbcUrl = "jdbc:mysql://[::1]:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertNull(result);
+    }
+
+    @Test
+    public void extractAddress_IPv6FullAddress_ReturnsNull() {
+        String jdbcUrl = "jdbc:mysql://[2001:db8:85a3::8a2e:370:7334]:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertNull(result);
+    }
+
+    @Test
+    public void extractAddress_DomainWithUnderscore_ReturnsNull() {
+        String jdbcUrl = "jdbc:mysql://my_server.example.com:3306/testdb";
+        String result = RouteUtils.extractAddress(jdbcUrl);
+        assertNull(result);
+    }
 }


### PR DESCRIPTION
- Fixes #12088

### Motivation

Enable audit routing data source management to support domain names, allowing for more flexible and scalable configuration.

### Modifications
- Updated audit routing data source management to accept domain names as valid inputs.
- Enhanced resolution logic to handle domain names properly during routing.
- Ensured backward compatibility with IP-based configurations.