### PR TITLE
[INLONG-12100][Manager][SDK][Common]  Fix incorrect spelling: "seperated" → "separated" in multiple files

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/heartbeat/HeartbeatMsg.java
@@ -90,7 +90,7 @@ public class HeartbeatMsg {
     private String nodeGroup;
 
     /**
-     * Ext tag of cluster, key=value pairs seperated by &
+     * Ext tag of cluster, key=value pairs separated by &
      */
     private String extTag;
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mysql/MySQLBinlogSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mysql/MySQLBinlogSource.java
@@ -63,10 +63,10 @@ public class MySQLBinlogSource extends StreamSource {
     @ApiModelProperty("Whether include schema, default is 'false'")
     private String includeSchema;
 
-    @ApiModelProperty(value = "List of DBs to be collected, seperated by ',', supporting regular expressions")
+    @ApiModelProperty(value = "List of DBs to be collected, separated by ',', supporting regular expressions")
     private String databaseWhiteList;
 
-    @ApiModelProperty(value = "List of tables to be collected, seperated by ',',supporting regular expressions")
+    @ApiModelProperty(value = "List of tables to be collected, separated by ',',supporting regular expressions")
     private String tableWhiteList;
 
     @ApiModelProperty("Database time zone, Default is UTC")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mysql/MySQLBinlogSourceDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/mysql/MySQLBinlogSourceDTO.java
@@ -62,11 +62,11 @@ public class MySQLBinlogSourceDTO {
     private String includeSchema;
 
     @ApiModelProperty(value = "List of DBs to be collected, supporting regular expressions, "
-            + "seperated by ',', for example: db1,test_db*", notes = "DBs not in this list are excluded. If not set, all DBs are monitored")
+            + "separated by ',', for example: db1,test_db*", notes = "DBs not in this list are excluded. If not set, all DBs are monitored")
     private String databaseWhiteList;
 
     @ApiModelProperty(value = "List of tables to be collected, supporting regular expressions, "
-            + "seperated by ',', for example: tb1,user*", notes = "Tables not in this list are excluded. By default, all tables are monitored")
+            + "separated by ',', for example: tb1,user*", notes = "Tables not in this list are excluded. By default, all tables are monitored")
     private String tableWhiteList;
 
     @ApiModelProperty("Database time zone, Default is UTC")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oceanbase/OceanBaseBinlogSource.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oceanbase/OceanBaseBinlogSource.java
@@ -63,10 +63,10 @@ public class OceanBaseBinlogSource extends StreamSource {
     @ApiModelProperty("Whether include schema, default is 'false'")
     private String includeSchema;
 
-    @ApiModelProperty(value = "List of DBs to be collected, seperated by ',', supporting regular expressions")
+    @ApiModelProperty(value = "List of DBs to be collected, separated by ',', supporting regular expressions")
     private String databaseWhiteList;
 
-    @ApiModelProperty(value = "List of tables to be collected, seperated by ',',supporting regular expressions")
+    @ApiModelProperty(value = "List of tables to be collected, separated by ',',supporting regular expressions")
     private String tableWhiteList;
 
     @ApiModelProperty("Database time zone, Default is UTC")

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oceanbase/OceanBaseBinlogSourceDTO.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/source/oceanbase/OceanBaseBinlogSourceDTO.java
@@ -62,11 +62,11 @@ public class OceanBaseBinlogSourceDTO {
     private String includeSchema;
 
     @ApiModelProperty(value = "List of DBs to be collected, supporting regular expressions, "
-            + "seperated by ',', for example: db1,test_db*", notes = "DBs not in this list are excluded. If not set, all DBs are monitored")
+            + "separated by ',', for example: db1,test_db*", notes = "DBs not in this list are excluded. If not set, all DBs are monitored")
     private String databaseWhiteList;
 
     @ApiModelProperty(value = "List of tables to be collected, supporting regular expressions, "
-            + "seperated by ',', for example: tb1,user*", notes = "Tables not in this list are excluded. By default, all tables are monitored")
+            + "separated by ',', for example: tb1,user*", notes = "Tables not in this list are excluded. By default, all tables are monitored")
     private String tableWhiteList;
 
     @ApiModelProperty("Database time zone, Default is UTC")

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-cpp/README.md
@@ -58,7 +58,7 @@ Refer to `release/conf/config_example.json`.
 | name                     | default value                                                      | description                                                                                                |
 |:-------------------------|:-------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------|
 | thread_num               | 10                                                                 | number of network sending threads                                                                          |
-| inlong_group_ids         | ""                                                                 | the list of inlong_group_id, seperated by commas, such as "b_inlong_group_test_01, b_inlong_group_test_02" |
+| inlong_group_ids         | ""                                                                 | the list of inlong_group_id, separated by commas, such as "b_inlong_group_test_01, b_inlong_group_test_02" |
 | enable_groupId_isolation | false                                                              | whether different groupid data using different buffer pools inside the sdk                                 |
 | buffer_num_per_groupId   | 5                                                                  | number of buffer pools of each groupid                                                                     |
 | enable_pack              | true                                                               | whether multiple messages are packed while sending to dataproxy                                            |

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-python/README.md
@@ -110,7 +110,7 @@ Refer to `demo/config_example.json`.
 | name                     | default value                                                      | description                                                                                                |
 |:-------------------------|:-------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------|
 | thread_num               | 10                                                                 | number of network sending threads                                                                          |
-| inlong_group_ids         | ""                                                                 | the list of inlong_group_id, seperated by commas, such as "b_inlong_group_test_01, b_inlong_group_test_02" |
+| inlong_group_ids         | ""                                                                 | the list of inlong_group_id, separated by commas, such as "b_inlong_group_test_01, b_inlong_group_test_02" |
 | enable_groupId_isolation | false                                                              | whether different groupid data using different buffer pools inside the sdk                                 |
 | buffer_num_per_groupId   | 5                                                                  | number of buffer pools of each groupid                                                                     |
 | enable_pack              | true                                                               | whether multiple messages are packed while sending to dataproxy                                            |


### PR DESCRIPTION
Fixes https://github.com/apache/inlong/issues/12100

### Modifications

Fix incorrect spelling: "seperated" → "separated" in multiple files

### Verifying this change

- [x] This change is a trivial rework/code cleanup without any test coverage.

### Documentation

  - Does this pull request introduce a new feature? (no)
