### PR TITLE
[INLONG-12104][Manager] Fix failure to logically delete associated data for data flow groups

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -668,15 +668,6 @@ public class InlongGroupServiceImpl implements InlongGroupService {
             streamService.logicDeleteAll(groupId, operator);
         }
 
-        entity.setIsDeleted(entity.getId());
-        entity.setStatus(GroupStatus.CONFIG_DELETED.getCode());
-        entity.setModifier(operator);
-        int rowCount = groupMapper.updateByIdentifierSelective(entity);
-        if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
-            LOGGER.error("inlong group has already updated for groupId={} curVersion={}", groupId, entity.getVersion());
-            throw new BusinessException(ErrorCodeEnum.CONFIG_EXPIRED);
-        }
-
         // logically delete the associated extension info
         groupExtMapper.logicDeleteAllByGroupId(groupId);
 
@@ -687,6 +678,14 @@ public class InlongGroupServiceImpl implements InlongGroupService {
             } catch (Exception e) {
                 LOGGER.warn("failed to delete schedule info for groupId={}, error msg: {}", groupId, e.getMessage());
             }
+        }
+
+        entity.setIsDeleted(entity.getId());
+        entity.setModifier(operator);
+        int rowCount = groupMapper.updateByIdentifierSelective(entity);
+        if (rowCount != InlongConstants.AFFECTED_ONE_ROW) {
+            LOGGER.error("inlong group has already updated for groupId={} curVersion={}", groupId, entity.getVersion());
+            throw new BusinessException(ErrorCodeEnum.CONFIG_EXPIRED);
         }
 
         LOGGER.info("success to delete group and group ext property for groupId={} by user={}", groupId, operator);

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupCompleteListener.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/listener/group/UpdateGroupCompleteListener.java
@@ -88,6 +88,7 @@ public class UpdateGroupCompleteListener implements ProcessEventListener {
                 break;
             case DELETE:
                 // delete process completed, then delete the group info
+                groupService.updateStatus(groupId, GroupStatus.CONFIG_DELETED.getCode(), operator);
                 groupService.delete(groupId, operator);
                 break;
             default:


### PR DESCRIPTION
Fixes https://github.com/apache/inlong/issues/12104

### Motivation

This PR ensures that when a data flow group is removed, all its associated records are deleted simultaneously.

### Modifications
1. Change the status of the group to "GroupStatus.CONFIG_DELETED" in advance
2. Move the update operation of the data stream group after the last two deletion operations
### Verifying this change
- [x] This change added tests and can be verified as follows:
I didn't write unit tests, but conducted a front-end and back-end integration test. 
The results are as follows:

**Create a data flow group**
<img width="1837" height="264" alt="image" src="https://github.com/user-attachments/assets/50f5b50b-441f-4234-9daf-7a0d9b0b028a" />

**Relevant data**
<img width="706" height="216" alt="image" src="https://github.com/user-attachments/assets/1d79f9d8-4446-4a41-9892-3fa656415a36" />
<img width="500" height="218" alt="image" src="https://github.com/user-attachments/assets/269a752f-6d1a-4234-a4ae-40e456f49199" />
<img width="501" height="212" alt="image" src="https://github.com/user-attachments/assets/114e92bb-7ac0-429b-b091-bab7b15daffd" />

**After deletion**
<img width="1839" height="296" alt="image" src="https://github.com/user-attachments/assets/ca2d15d7-fc63-412b-b11a-8a7a7a6d2731" />
<img width="691" height="216" alt="image" src="https://github.com/user-attachments/assets/96eb2611-5401-45b7-b6db-3681b7ef1185" />
<img width="505" height="217" alt="image" src="https://github.com/user-attachments/assets/546a8744-b9cc-41c3-a6db-c40f5c10b54e" />
<img width="500" height="221" alt="image" src="https://github.com/user-attachments/assets/572984ee-c121-4cf5-a4c8-3ce85e1fe2ef" />

The "is_deleted" field of the relevant data can be correctly modified.

### Documentation

  - Does this pull request introduce a new feature? (no)