### PR TITLE
[INLONG-12106][Manager] Add relevant MQ cluster checks

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/group/InlongGroupServiceImpl.java
@@ -215,7 +215,27 @@ public class InlongGroupServiceImpl implements InlongGroupService {
         if (request.getEnableZookeeper() == null) {
             request.setEnableZookeeper(enableZookeeper ? InlongConstants.ENABLE_ZK : InlongConstants.DISABLE_ZK);
         }
-        InlongGroupOperator instance = groupOperatorFactory.getInstance(request.getMqType());
+
+        if (request.getEnableCreateResource() == null) {
+            request.setEnableCreateResource(InlongConstants.ENABLE_CREATE_RESOURCE);
+        }
+
+        if (request.getInlongGroupMode() == null) {
+            request.setInlongGroupMode(InlongConstants.STANDARD_MODE);
+        }
+
+        String mqType = request.getMqType();
+        if (InlongConstants.STANDARD_MODE.equals(request.getInlongGroupMode())
+                && InlongConstants.ENABLE_CREATE_RESOURCE.equals(request.getEnableCreateResource())) {
+            String clusterTag = request.getInlongClusterTag();
+            List<InlongClusterEntity> clusterEntities = clusterEntityMapper.selectByKey(clusterTag, null, mqType);
+            if (CollectionUtils.isEmpty(clusterEntities)) {
+                throw new BusinessException(String.format("cannot find any cluster by tag %s and type %s",
+                        clusterTag, mqType));
+            }
+        }
+
+        InlongGroupOperator instance = groupOperatorFactory.getInstance(mqType);
         groupId = instance.saveOpt(request, operator);
 
         // save ext info


### PR DESCRIPTION
Fixes https://github.com/apache/inlong/issues/12106

### Modifications
Before saving the connection, verify if there is a corresponding cluster
The reason for conducting the state judgment first is that some modes do not require the creation or deletion of MQ resources.
Refer to QueueResourceListener.listen(...)
### Verifying this change
- [x] This change added tests and can be verified as follows:
I didn't write unit tests, but conducted a front-end and back-end integration test. 
The results are as follows:
Adding data access when there is no corresponding MQ cluster
<img width="1369" height="626" alt="image" src="https://github.com/user-attachments/assets/ca7ea4e4-55c9-4919-9daf-019277bfbd9b" />
<img width="1345" height="663" alt="image" src="https://github.com/user-attachments/assets/61a58cbf-2664-4a32-8714-249d7799a62c" />
<img width="1377" height="651" alt="image" src="https://github.com/user-attachments/assets/e5cb24e1-3994-4c58-aed1-d8179c807842" />
Can intercept the creation operation

After creating the corresponding MQ cluster
<img width="1288" height="353" alt="image" src="https://github.com/user-attachments/assets/cd7fbddc-76f8-4dd6-980f-666e2c49edcf" />
<img width="1311" height="297" alt="image" src="https://github.com/user-attachments/assets/f3a10f25-553a-4ca9-a66f-7c24f588c083" />
Success in creation
And it will not affect the creation of data flow groups during data synchronization.
<img width="1313" height="203" alt="image" src="https://github.com/user-attachments/assets/2f6d3768-6652-4505-ab1d-cb5c24d5f7c7" />

### Documentation
  - Does this pull request introduce a new feature? (no)
