### PR TITLE
[INLONG-12115][Manager] Set the default value of openapi.auth.enabled to true.

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/InlongShiroImpl.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/auth/InlongShiroImpl.java
@@ -77,7 +77,7 @@ public class InlongShiroImpl implements InlongShiro {
     @Autowired
     private InlongTenantService tenantService;
 
-    @Value("${openapi.auth.enabled:false}")
+    @Value("${openapi.auth.enabled:true}")
     private Boolean openAPIAuthEnabled;
 
     @Override

--- a/inlong-manager/manager-web/src/main/resources/application.properties
+++ b/inlong-manager/manager-web/src/main/resources/application.properties
@@ -58,7 +58,7 @@ inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"
 
 # Clients (e.g. agent and dataproxy) must be authenticated by secretId and secretKey if turned on
-openapi.auth.enabled=false
+openapi.auth.enabled=true
 
 # Audit view by role, see audit id definitions: https://inlong.apache.org/docs/modules/audit/overview#audit-id
 audit.admin.ids=3,4,5,6

--- a/inlong-manager/manager-web/src/test/resources/application.properties
+++ b/inlong-manager/manager-web/src/test/resources/application.properties
@@ -59,4 +59,4 @@ inlong.encrypt.version=1
 inlong.encrypt.key.value1="I!N@L#O$N%G^"
 
 # clients (e.g. agent and dataproxy) must be authenticated by secretId and secretKey if turned on
-openapi.auth.enabled=false
+openapi.auth.enabled=true


### PR DESCRIPTION

Fixes #12115 

### Motivation

Set the default value of openapi.auth.enabled to true.

### Modifications

Set the default value of openapi.auth.enabled to true.
