### PR TITLE
[INLONG-12119][SDK] Add connection timeout and tolerate partial endpoint failures during client initialization in DataProxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/connpool/connpool.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/connpool/connpool.go
@@ -19,8 +19,10 @@ package connpool
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -253,8 +255,8 @@ func (p *connPool) dialNewConn(ep string) (gnet.Conn, error) {
 func (p *connPool) initConns(count int) error {
 	// create some conns and then put them back to the pool
 	var wg sync.WaitGroup
-	conns := make(chan gnet.Conn, count)
-	errs := make(chan error, count)
+	var successCount atomic.Int32
+	errs := make(chan string, count)
 
 	for i := 0; i < count; i++ {
 		wg.Add(1)
@@ -262,28 +264,34 @@ func (p *connPool) initConns(count int) error {
 			defer wg.Done()
 			conn, err := p.newConn()
 			if err != nil {
-				errs <- err
+				errs <- err.Error()
 				return
 			}
-			conns <- conn
+			p.put(conn, nil, true)
+			successCount.Add(1)
 		}()
 	}
 
 	wg.Wait()
-	close(conns)
 	close(errs)
 
-	for err := range errs {
-		if err != nil {
-			for conn := range conns {
-				_ = conn.Close()
-			}
-			return err
+	succeeded := int(successCount.Load())
+	if failed := count - succeeded; failed > 0 {
+		// aggregate identical errors to avoid spammy logs
+		agg := make(map[string]int, failed)
+		for e := range errs {
+			agg[e]++
 		}
+		items := make([]string, 0, len(agg))
+		for msg, n := range agg {
+			items = append(items, fmt.Sprintf("%dx %s", n, msg))
+		}
+		p.log.Warnf("initConns partial failure, required=%d, succeeded=%d, failed=%d, errors=[%s]",
+			count, succeeded, failed, strings.Join(items, "; "))
 	}
-
-	for conn := range conns {
-		p.put(conn, nil, true)
+	// Only fail initialization when no endpoint is reachable at all
+	if succeeded == 0 {
+		return ErrNoAvailableEndpoint
 	}
 
 	return nil

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"math"
+	"net"
 	"sync"
 	"time"
 
@@ -213,7 +214,12 @@ func (c *client) initWorkers() error {
 }
 
 func (c *client) Dial(addr string, ctx any) (gnet.Conn, error) {
-	return c.netClient.DialContext("tcp", addr, ctx)
+	// Use net.DialTimeout to bound the TCP handshake duration
+	raw, err := net.DialTimeout("tcp", addr, c.options.ConnTimeout)
+	if err != nil {
+		return nil, err
+	}
+	return c.netClient.EnrollContext(raw, ctx)
 }
 
 func (c *client) Send(ctx context.Context, msg Message) error {


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12119

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Add a connection timeout and allow partial connection failures during client initialization in the DataProxy Go SDK to resolve the problem that client initialization hangs or fails due to endpoint anomalies.
### Modifications

<!--Describe the modifications you've done.-->
Modify the connection pool initialization logic in the DataProxy Go SDK.
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
