### PR TITLE
[INLONG-12121][SDK] Log remote server address on send timeout and server errors in DataProxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/connpool/connpool.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/connpool/connpool.go
@@ -567,7 +567,8 @@ func (p *connPool) innerWork() {
 	}
 }
 
-func getRemoteAddr(conn gnet.Conn) string {
+// GetRemoteAddr returns the remote address of the connection safely
+func GetRemoteAddr(conn gnet.Conn) string {
 	if conn == nil {
 		return ""
 	}
@@ -620,7 +621,7 @@ loop:
 
 	// close the expired conn and append new conn with the same addr
 	for _, expired := range expiredConns {
-		addr := getRemoteAddr(expired)
+		addr := GetRemoteAddr(expired)
 		p.log.Debug("connection expired, close it, addr:", addr, ", err:", nil)
 		CloseConn(expired, defaultConnCloseDelay)
 		_ = p.appendNewConn(addr)

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
@@ -86,22 +86,23 @@ func (h heartbeatReq) encode(buffer *bytes.Buffer) []byte {
 
 type batchCallback func()
 type batchReq struct {
-	pool         *sync.Pool
-	workerID     string
-	batchID      string
-	groupID      string
-	streamID     string
-	dataReqs     []*sendDataReq
-	dataSize     int
-	batchTime    time.Time
-	lastSendTime time.Time
-	retries      int
-	bufferPool   bufferpool.BufferPool
-	bytePool     bufferpool.BytePool
-	buffer       *bytes.Buffer
-	callback     batchCallback
-	metrics      *metrics
-	addColumns   string
+	pool               *sync.Pool
+	workerID           string
+	batchID            string
+	groupID            string
+	streamID           string
+	dataReqs           []*sendDataReq
+	dataSize           int
+	batchTime          time.Time
+	lastSendTime       time.Time
+	lastSendServerAddr string
+	retries            int
+	bufferPool         bufferpool.BufferPool
+	bytePool           bufferpool.BytePool
+	buffer             *bytes.Buffer
+	callback           batchCallback
+	metrics            *metrics
+	addColumns         string
 }
 
 func (b *batchReq) append(req *sendDataReq) {

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/bufferpool"
+	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/connpool"
 	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/logger"
 	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/syncx"
 	"github.com/apache/inlong/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/util"
@@ -418,7 +419,7 @@ func (w *worker) sendBatch(b *batchReq, retryOnFail bool) {
 
 	// record the remote server address at the moment the batch is dispatched
 	conn := w.getConn()
-	b.lastSendServerAddr = conn.RemoteAddr().String()
+	b.lastSendServerAddr = connpool.GetRemoteAddr(conn)
 
 	// error callback
 	onErr := func(c gnet.Conn, e error, inCallback bool) {

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -416,6 +416,10 @@ func (w *worker) sendBatch(b *batchReq, retryOnFail bool) {
 	b.lastSendTime = time.Now()
 	b.encode()
 
+	// record the remote server address at the moment the batch is dispatched
+	conn := w.getConn()
+	b.lastSendServerAddr = conn.RemoteAddr().String()
+
 	// error callback
 	onErr := func(c gnet.Conn, e error, inCallback bool) {
 		defer func() {
@@ -427,7 +431,8 @@ func (w *worker) sendBatch(b *batchReq, retryOnFail bool) {
 		}()
 
 		w.metrics.incError(errConnWriteFailed.getStrCode())
-		w.log.Error("send batch failed, err: ", e, ", inCallback: ", inCallback, ", logNum:", len(b.dataReqs))
+		w.log.Error("send batch failed, err: ", e, ", inCallback: ", inCallback, ", logNum:", len(b.dataReqs),
+			", workerID:", w.index, ", batchID:", b.batchID, ", serverAddr:", b.lastSendServerAddr)
 
 		// close already
 		if w.getState() == stateClosed {
@@ -459,9 +464,8 @@ func (w *worker) sendBatch(b *batchReq, retryOnFail bool) {
 	}
 
 	// very important：'cause we use gnet, we must call AsyncWrite to send data in goroutines that are different from gnet.OnTraffic() callback
-	conn := w.getConn()
 	if b.retries > 0 {
-		w.log.Debug("retry batch to conn:", conn.RemoteAddr(), ", workerID:", w.index, ", batchID:", b.batchID, ", logNum:", len(b.dataReqs))
+		w.log.Debug("retry batch to conn:", b.lastSendServerAddr, ", workerID:", w.index, ", batchID:", b.batchID, ", logNum:", len(b.dataReqs))
 	}
 	err := conn.AsyncWrite(b.buffer.Bytes(), func(c gnet.Conn, e error) error {
 		if e != nil {
@@ -564,7 +568,8 @@ func (w *worker) handleSendTimeout() {
 	for batchID, batch := range w.unackedBatches {
 		if time.Since(batch.lastSendTime) > w.options.SendTimeout {
 			w.log.Warn("worker[", w.index, "] send timeout, resend it now:", batch.batchID, "batchID:", batchID,
-				",last send time:", batch.lastSendTime.UnixMilli(), ", now:", time.Now().UnixMilli(), "timeout option:", w.options.SendTimeout)
+				", last send time:", batch.lastSendTime.UnixMilli(), ", now:", time.Now().UnixMilli(),
+				", timeout option:", w.options.SendTimeout, ", serverAddr:", batch.lastSendServerAddr)
 			//
 			// w.retryBatches <- batch
 			w.backoffRetry(context.Background(), batch)
@@ -651,7 +656,7 @@ func (w *worker) handleRsp(rsp *batchRsp) {
 		needSwitchConn, isRetryable := retryableServerErrorCodes[rsp.errCode]
 		if needSwitchConn && w.client != nil {
 			w.log.Warn("server error detected, switching connection, errCode:", rsp.errCode,
-				", batchID:", batch.batchID)
+				", batchID:", batch.batchID, ", serverAddr:", batch.lastSendServerAddr)
 			w.updateConn(nil, nil)
 		}
 
@@ -659,8 +664,8 @@ func (w *worker) handleRsp(rsp *batchRsp) {
 		if w.options.RetryOnServerError && isRetryable && batch.retries < w.options.MaxRetries {
 			delete(w.unackedBatches, batchID)
 
-			w.log.Warn("server error, will retry, errCode:", rsp.errCode,
-				", batchID:", batch.batchID, ", retries:", batch.retries)
+			w.log.Warn("server error, will retry, errCode:", rsp.errCode, ", batchID:", batch.batchID,
+				", retries:", batch.retries, ", serverAddr:", batch.lastSendServerAddr)
 
 			w.backoffRetry(context.Background(), batch)
 			return
@@ -674,10 +679,12 @@ func (w *worker) handleRsp(rsp *batchRsp) {
 				", batchID=" + rsp.batchID +
 				", groupID=" + rsp.groupID +
 				", streamID=" + rsp.streamID +
-				", dt=" + rsp.dt,
+				", dt=" + rsp.dt +
+				", serverAddr=" + batch.lastSendServerAddr,
 			serverErrCode: rsp.errCode,
 		}
-		w.log.Error("send succeed but got error code:", rsp.errCode)
+		w.log.Error("send succeed but got error code:", rsp.errCode,
+			", batchID:", batch.batchID, ", serverAddr:", batch.lastSendServerAddr)
 	}
 	batch.done(err)
 	delete(w.unackedBatches, batchID)


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12121

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->
Log remote server address on send timeout and server errors in DataProxy Go SDK to facilitate troubleshooting on the server side.

### Modifications

<!--Describe the modifications you've done.-->
Record the remote server address when sending batch messages and print it to the logs.
### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
