### PR TITLE
[INLONG-12139][Sort] SortConfigUtil.checkUpdate throws NPE when DataFlowConfig.version is null, causing SortConfig reload to permanently stall

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/metric/MetricObserver.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/metric/MetricObserver.java
@@ -101,7 +101,7 @@ public class MetricObserver {
                 listenerList.add(listener);
             } catch (Throwable t) {
                 LOG.error("Fail to init MetricListener:{},error:{}",
-                        listenerType, t.getMessage());
+                        listenerType, t.getMessage(), t);
             }
         }
         return listenerList;

--- a/inlong-common/src/main/java/org/apache/inlong/common/util/SortConfigUtil.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/util/SortConfigUtil.java
@@ -82,7 +82,8 @@ public class SortConfigUtil {
                 .map(key -> {
                     T lastElement = lastMap.get(key);
                     T currentElement = currentMap.get(key);
-                    Comparator<T> comparator = Comparator.comparing(versionExtractor);
+                    Comparator<T> comparator = Comparator.comparing(versionExtractor,
+                            Comparator.nullsFirst(Comparator.naturalOrder()));
                     return comparator.compare(lastElement, currentElement) < 0 ? currentElement : null;
                 })
                 .filter(Objects::nonNull)
@@ -138,7 +139,8 @@ public class SortConfigUtil {
                 .map(key -> {
                     T lastElement = lastMap.get(key);
                     T currentElement = currentMap.get(key);
-                    Comparator<T> comparator = Comparator.comparing(versionExtractor);
+                    Comparator<T> comparator = Comparator.comparing(versionExtractor,
+                            Comparator.nullsFirst(Comparator.naturalOrder()));
                     return comparator.compare(lastElement, currentElement) >= 0 ? lastElement : null;
                 })
                 .filter(Objects::nonNull)


### PR DESCRIPTION
Fixes #12139 

### Motivation

<!--Explain here the context, and why you're making that change. What is the problem you're trying to solve.-->

### Modifications

<!--Describe the modifications you've done.-->

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
