### PR TITLE
[INLONG-12144][Manager] Perform permission verification for the deletion operation of streamsource

### DIFF
--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/source/StreamSourceServiceImpl.java
@@ -385,7 +385,13 @@ public class StreamSourceServiceImpl implements StreamSourceService {
                 groupId, streamId, operator);
         Preconditions.expectNotBlank(groupId, ErrorCodeEnum.GROUP_ID_IS_EMPTY);
         Preconditions.expectNotBlank(streamId, ErrorCodeEnum.STREAM_ID_IS_EMPTY);
-
+        InlongGroupEntity groupEntity = groupMapper.selectByGroupId(groupId);
+        if (groupEntity == null) {
+            throw new BusinessException(ErrorCodeEnum.GROUP_NOT_FOUND,
+                    String.format("InlongGroup does not exist with InlongGroupId=%s", groupId));
+        }
+        userService.checkUser(groupEntity.getInCharges(), operator,
+                "Current user does not have permission to delete source info");
         int sourceCount = sourceMapper.logicalDeleteByRelatedId(groupId, streamId,
                 SourceStatus.TO_BE_ISSUED_DELETE.getCode());
         int fieldCount = sourceFieldMapper.updateByRelatedId(groupId, streamId);


### PR DESCRIPTION


Fixes #12114 

### Motivation

Currently, the deletion-related operations of streamsource do not perform permission verification, which can lead to ordinary users being able to delete the data of any other user, posing a security risk.

### Modifications

Perform permission verification for the deletion operation of streamsource.
