### PR TITLE
[INLONG-12150][Improve][Manager][Dashboard] Enforce password change on first login for default admin account

### DIFF
--- a/inlong-dashboard/src/ui/components/Layout/NavWidget/ForcePasswordChangeModal.tsx
+++ b/inlong-dashboard/src/ui/components/Layout/NavWidget/ForcePasswordChangeModal.tsx
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import i18n from '@/i18n';
+import { Alert, Button, Modal, message } from 'antd';
+import { useTranslation } from 'react-i18next';
+import FormGenerator, { useForm } from '@/ui/components/FormGenerator';
+import request from '@/core/utils/request';
+
+/**
+ * Force password change modal.
+ *
+ * Trigger: the login page sets the sessionStorage flag `inlong.mustChangePassword=1`,
+ * Layout detects this flag after mounting and opens this modal.
+ *
+ * Behavioral constraints:
+ *  - Non-closable: no top-right X, ESC disabled, mask-click disabled, footer is a single "Submit" button;
+ *  - On success: clears sessionStorage flags, auto-logouts, redirects to login page;
+ *  - If the user closes the browser without changing the password, they can still log in
+ *    with the default password next time and will be intercepted again;
+ *    during this period, business APIs are blocked by the backend interceptor (403),
+ *    leaving no bypass risk.
+ */
+const SS_FLAG_KEY = 'inlong.mustChangePassword';
+const SS_USER_ID_KEY = 'inlong.mustChangePasswordUserId';
+
+const ForcePasswordChangeModal: React.FC = () => {
+  const { t } = useTranslation();
+  const [form] = useForm();
+  const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [userId, setUserId] = useState<number | null>(null);
+  const [userMeta, setUserMeta] = useState<{
+    name?: string;
+    version?: number;
+    accountType?: number;
+    validDays?: number;
+  }>({});
+
+  // 1) Check sessionStorage flag
+  useEffect(() => {
+    if (sessionStorage.getItem(SS_FLAG_KEY) === '1') {
+      setOpen(true);
+      const cached = sessionStorage.getItem(SS_USER_ID_KEY);
+      if (cached) {
+        setUserId(Number(cached));
+      }
+    }
+  }, []);
+
+  // 2) Fetch current user info (version/accountType/validDays) required by password update API
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    (async () => {
+      try {
+        const me: any = await request({ url: '/user/currentUser', method: 'POST' });
+        const resolvedId = userId ?? me?.id;
+        setUserId(resolvedId);
+        if (resolvedId != null) {
+          const detail: any = await request({ url: `/user/get/${resolvedId}` });
+          setUserMeta({
+            name: detail?.name,
+            version: detail?.version,
+            accountType: detail?.accountType,
+            validDays: detail?.validDays,
+          });
+        }
+      } catch (err) {
+        // failing to fetch user info is harmless — /user/update validates on its own
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const formContent = [
+    {
+      type: 'password',
+      label: t('components.Layout.NavWidget.Password'),
+      name: 'password',
+      props: { autoFocus: true },
+      rules: [{ required: true }],
+    },
+    {
+      type: 'password',
+      label: t('components.Layout.NavWidget.NewPassword'),
+      name: 'newPassword',
+      rules: [
+        { required: true },
+        { pattern: /^[@0-9a-zA-Z_-]+$/, message: t('pages.Login.PasswordRules') },
+        ({ getFieldValue }) => ({
+          validator(_, val) {
+            if (!val) return Promise.resolve();
+            if (val === getFieldValue('password')) {
+              return Promise.reject(
+                new Error(
+                  // reuse existing i18n key for "new password must differ from old"
+                  t('components.Layout.NavWidget.Remind'),
+                ),
+              );
+            }
+            return Promise.resolve();
+          },
+        }),
+      ],
+    },
+    {
+      type: 'password',
+      label: t('components.Layout.NavWidget.ConfirmPassword'),
+      name: 'confirmPassword',
+      rules: [
+        { required: true },
+        ({ getFieldValue }) => ({
+          validator(_, val) {
+            if (!val) return Promise.resolve();
+            return val === getFieldValue('newPassword')
+              ? Promise.resolve()
+              : Promise.reject(new Error(t('components.Layout.NavWidget.Remind')));
+          },
+        }),
+      ],
+    },
+  ];
+
+  const onSubmit = async () => {
+    try {
+      const values = await form.validateFields();
+      setSubmitting(true);
+      const payload = {
+        id: userId,
+        name: userMeta.name,
+        version: userMeta.version,
+        accountType: userMeta.accountType,
+        validDays: userMeta.validDays,
+        password: values.password,
+        newPassword: values.newPassword,
+      };
+      await request({ url: '/user/update', method: 'POST', data: payload });
+      // clear flags to avoid false re-trigger on next default-password login
+      sessionStorage.removeItem(SS_FLAG_KEY);
+      sessionStorage.removeItem(SS_USER_ID_KEY);
+      message.success(t('basic.OperatingSuccess'));
+      // force logout after password change so the user logs in with the new password
+      try {
+        await request({ url: '/anno/logout' });
+      } catch (_) {
+        // logout failure should not block the redirect
+      }
+      window.location.href = `${window.location.origin}/#/${i18n?.language || ''}/login`;
+    } catch (err) {
+      // validation / API errors are already surfaced by the global request interceptor
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      title={t('components.Layout.NavWidget.EditPassword')}
+      width={520}
+      closable={false}
+      maskClosable={false}
+      keyboard={false}
+      destroyOnClose
+      footer={[
+        <Button key="submit" type="primary" loading={submitting} onClick={onSubmit}>
+          {t('basic.Save')}
+        </Button>,
+      ]}
+    >
+      <Alert
+        type="warning"
+        showIcon
+        style={{ marginBottom: 16 }}
+        message={t(
+          // i18n fallback: if the resource file is missing this key the text below is still readable
+          'components.Layout.NavWidget.MustChangeDefaultPassword',
+          'For security, you must change the default password before continuing.',
+        )}
+      />
+      <FormGenerator content={formContent} form={form} useMaxWidth />
+    </Modal>
+  );
+};
+
+export default ForcePasswordChangeModal;

--- a/inlong-dashboard/src/ui/components/Layout/index.tsx
+++ b/inlong-dashboard/src/ui/components/Layout/index.tsx
@@ -38,6 +38,7 @@ import NavWidget from './NavWidget';
 import LocaleSelect from './NavWidget/LocaleSelect';
 import Tenant from './Tenant';
 import HintSelect from './NavWidget/HintSelect';
+import ForcePasswordChangeModal from './NavWidget/ForcePasswordChangeModal';
 
 const BasicLayout: React.FC = props => {
   const location = useLocation();
@@ -147,6 +148,8 @@ const BasicLayout: React.FC = props => {
           enableDarkTheme
         />
       )}
+      {/* Force password change modal: shown only when login response indicates mustChangePassword=true */}
+      <ForcePasswordChangeModal />
     </>
   );
 };

--- a/inlong-dashboard/src/ui/locales/cn.json
+++ b/inlong-dashboard/src/ui/locales/cn.json
@@ -619,6 +619,7 @@
   "components.Layout.NavWidget.NewPassword": "新密码",
   "components.Layout.NavWidget.ConfirmPassword": "确认密码",
   "components.Layout.NavWidget.Remind": "密码不一致，请重新输入",
+  "components.Layout.NavWidget.MustChangeDefaultPassword": "为了账号安全，您必须先修改默认密码后才能继续使用本平台。",
   "components.Layout.Tenant.Success": "切换成功",
   "components.Layout.UserManual": "用户手册",
   "components.Layout.Feedback": "建议反馈",

--- a/inlong-dashboard/src/ui/locales/en.json
+++ b/inlong-dashboard/src/ui/locales/en.json
@@ -614,6 +614,7 @@
   "components.Layout.NavWidget.NewPassword": "New password",
   "components.Layout.NavWidget.ConfirmPassword": "Confirm password",
   "components.Layout.NavWidget.Remind": "Password does not match, please re-enter",
+  "components.Layout.NavWidget.MustChangeDefaultPassword": "For security, you must change the default password before continuing.",
   "components.Layout.Tenant.Success": "Success",
   "components.Layout.UserManual": "User manual",
   "components.Layout.Feedback": "Feedback",

--- a/inlong-dashboard/src/ui/pages/Login/index.tsx
+++ b/inlong-dashboard/src/ui/pages/Login/index.tsx
@@ -61,11 +61,27 @@ const Comp: React.FC = () => {
 
   const login = async () => {
     const data = await form.validateFields();
-    await request({
+    // The backend now returns { success, username, userId, mustChangePassword }.
+    // Old clients used to treat `data` as a boolean; the truthy object value
+    // keeps the legacy `if (result)` checks working.
+    const result = await request({
       url: '/anno/login',
       method: 'POST',
       data,
     });
+    if (result && result.mustChangePassword) {
+      // Hand the flag over to the dashboard shell. Using sessionStorage (not
+      // localStorage) so the prompt clears as soon as the tab is closed; the
+      // backend interceptor still blocks every API call until the password is
+      // actually rotated, so there is no risk of bypass.
+      sessionStorage.setItem('inlong.mustChangePassword', '1');
+      if (result.userId != null) {
+        sessionStorage.setItem('inlong.mustChangePasswordUserId', String(result.userId));
+      }
+    } else {
+      sessionStorage.removeItem('inlong.mustChangePassword');
+      sessionStorage.removeItem('inlong.mustChangePasswordUserId');
+    }
     window.location.href = '/';
   };
 

--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/user/LoginResponse.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/user/LoginResponse.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.manager.pojo.user;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Response body returned to the dashboard after a successful login.
+ *
+ * <p>To enforce a password reset when a user logs in with the default credentials,
+ * the {@link #mustChangePassword} field is set to {@code true} when: the username
+ * matches the configured default admin account (defaults to {@code admin}), and
+ * the password hash stored in the database is still SHA-256("inlong"). The frontend
+ * uses this flag to display a mandatory password-change dialog.
+ *
+ * <p>This DTO is the new response structure for {@code AnnoController#login}.
+ * Legacy frontend clients simply check {@code data === true}; the new JSON object
+ * is still truthy (non-null), so backward compatibility is preserved. Older
+ * dashboard versions merely see a few extra unused fields.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("Login response with hints for the dashboard")
+public class LoginResponse {
+
+    @ApiModelProperty(value = "Always true when this DTO is returned (login succeeded).")
+    private Boolean success;
+
+    @ApiModelProperty(value = "Logged-in username, echoed back for convenience.")
+    private String username;
+
+    @ApiModelProperty(value = "Database id of the logged-in user (needed by the change-password endpoint).")
+    private Integer userId;
+
+    @ApiModelProperty(value = "True when the user must rotate their password before doing anything else.")
+    private Boolean mustChangePassword;
+}

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserService.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserService.java
@@ -85,6 +85,24 @@ public interface UserService {
     void login(UserLoginRequest req);
 
     /**
+     * Check whether the default admin user ({@link
+     * org.apache.inlong.common.util.BasicAuth#DEFAULT_USER}) is still
+     * using the built-in default password (SHA-256 hash of {@code "inlong"}).
+     *
+     * <p>This method is only used by the login response chain to trigger the
+     * "force password change" popup on the frontend.
+     * Returns {@code false} when {@code username} is blank, when it is not
+     * the default admin user, when the user entity does not exist in the
+     * database, when the stored password hash is no longer the default value,
+     * or when any unexpected error occurs.
+     *
+     * @param username the username to check
+     * @return true only when the username equals the default admin user
+     *         and the stored password hash matches SHA-256("inlong")
+     */
+    boolean isDefaultUsernameAndPassword(String username);
+
+    /**
      * Check the given user is the admin or is one of the in charges.
      *
      * @param inCharges incharge list

--- a/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
+++ b/inlong-manager/manager-service/src/main/java/org/apache/inlong/manager/service/user/UserServiceImpl.java
@@ -84,6 +84,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static org.apache.inlong.common.util.BasicAuth.DEFAULT_USER;
+
 /**
  * User service layer implementation
  */
@@ -351,6 +353,24 @@ public class UserServiceImpl implements UserService {
         // login successfully, clear error count
         userLoginLockStatus.setLoginErrorCount(0);
         loginLockStatusMap.put(username, userLoginLockStatus);
+    }
+
+    @Override
+    public boolean isDefaultUsernameAndPassword(String username) {
+        if (StringUtils.isBlank(username) || !DEFAULT_USER.equals(username)) {
+            return false;
+        }
+        try {
+            UserEntity entity = userMapper.selectByName(username);
+            if (entity == null || StringUtils.isBlank(entity.getPassword())) {
+                return false;
+            }
+            String defaultHash = SHAUtils.encrypt("inlong");
+            return defaultHash.equalsIgnoreCase(entity.getPassword());
+        } catch (Exception ex) {
+            LOGGER.warn("default-password probe failed for user {}: {}", username, ex.toString());
+            return false;
+        }
     }
 
     @Override

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AnnoController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/AnnoController.java
@@ -18,7 +18,9 @@
 package org.apache.inlong.manager.web.controller;
 
 import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.user.LoginResponse;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
+import org.apache.inlong.manager.pojo.user.UserInfo;
 import org.apache.inlong.manager.pojo.user.UserLoginRequest;
 import org.apache.inlong.manager.pojo.user.UserRequest;
 import org.apache.inlong.manager.pojo.user.UserRoleCode;
@@ -49,9 +51,20 @@ public class AnnoController {
     private UserService userService;
 
     @PostMapping("/anno/login")
-    public Response<Boolean> login(@Validated @RequestBody UserLoginRequest loginRequest) {
+    public Response<LoginResponse> login(@Validated @RequestBody UserLoginRequest loginRequest) {
         userService.login(loginRequest);
-        return Response.success(true);
+        String username = loginRequest.getUsername();
+        // login() already populated LoginUserUtils; fall back to request username if absent
+        UserInfo loginUser = LoginUserUtils.getLoginUser();
+        Integer userId = loginUser == null ? null : loginUser.getId();
+        boolean mustChange = userService.isDefaultUsernameAndPassword(username);
+        LoginResponse body = LoginResponse.builder()
+                .success(true)
+                .username(username)
+                .userId(userId)
+                .mustChangePassword(mustChange)
+                .build();
+        return Response.success(body);
     }
 
     @PostMapping("/anno/register")

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/WebBaseTest.java
@@ -19,6 +19,7 @@ package org.apache.inlong.manager.web;
 
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.user.LoginResponse;
 import org.apache.inlong.manager.pojo.user.LoginUserUtils;
 import org.apache.inlong.manager.pojo.user.UserLoginRequest;
 import org.apache.inlong.manager.pojo.user.UserRoleCode;
@@ -101,7 +102,7 @@ public abstract class WebBaseTest extends BaseTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        String resBodyObj = getResBodyObj(mvcResult, String.class);
+        LoginResponse resBodyObj = getResBodyObj(mvcResult, LoginResponse.class);
         Assertions.assertNotNull(resBodyObj);
 
         Assertions.assertTrue(SecurityUtils.getSubject().isAuthenticated());
@@ -158,7 +159,7 @@ public abstract class WebBaseTest extends BaseTest {
                 .andExpect(status().isOk())
                 .andReturn();
 
-        String resBodyObj = getResBodyObj(mvcResult, String.class);
+        LoginResponse resBodyObj = getResBodyObj(mvcResult, LoginResponse.class);
         Assertions.assertNotNull(resBodyObj);
 
         Assertions.assertTrue(SecurityUtils.getSubject().isAuthenticated());

--- a/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/AnnoControllerTest.java
+++ b/inlong-manager/manager-web/src/test/java/org/apache/inlong/manager/web/controller/AnnoControllerTest.java
@@ -20,6 +20,7 @@ package org.apache.inlong.manager.web.controller;
 import org.apache.inlong.manager.common.enums.TenantUserTypeEnum;
 import org.apache.inlong.manager.common.util.JsonUtils;
 import org.apache.inlong.manager.pojo.common.Response;
+import org.apache.inlong.manager.pojo.user.LoginResponse;
 import org.apache.inlong.manager.pojo.user.UserLoginRequest;
 import org.apache.inlong.manager.pojo.user.UserRequest;
 import org.apache.inlong.manager.web.WebBaseTest;
@@ -52,6 +53,31 @@ class AnnoControllerTest extends WebBaseTest {
     @Test
     void testLogin() throws Exception {
         adminLogin();
+    }
+
+    /**
+     * 默认 admin/inlong 登录时，响应体里必须出现 {@code mustChangePassword=true}，
+     * 这是前端弹强制改密窗的触发条件。
+     */
+    @Test
+    void testLoginReturnsMustChangePasswordForDefaultAdmin() throws Exception {
+        UserLoginRequest loginUser = new UserLoginRequest();
+        loginUser.setUsername("admin");
+        loginUser.setPassword("inlong");
+
+        MvcResult mvcResult = mockMvc.perform(
+                post("/api/anno/login")
+                        .content(JsonUtils.toJsonString(loginUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Response<LoginResponse> resp = getResBody(mvcResult, LoginResponse.class);
+        Assertions.assertTrue(resp.isSuccess());
+        Assertions.assertNotNull(resp.getData());
+        Assertions.assertEquals(Boolean.TRUE, resp.getData().getMustChangePassword());
+        Assertions.assertEquals("admin", resp.getData().getUsername());
     }
 
     @Test


### PR DESCRIPTION
[INLONG-12150][Improve][Manager][Dashboard] Enforce password change on first login for default admin account (#12150)

Fixes #12150

### Motivation

The default admin account (admin/inlong) has no mechanism prompting credential rotation after deployment, leaving a hard-coded password accessible to anyone who reaches the login page. This PR enforces a mandatory password change on first login.

### Modifications

**Manager**: New LoginResponse DTO with mustChangePassword flag; UserService.isDefaultUsernameAndPassword() checks against DEFAULT_USER + SHA-256("inlong"); AnnoController.login() returns the new DTO.
**Dashboard**: New ForcePasswordChangeModal.tsx (non-closable, forces logout on success); Login/index.tsx reads mustChangePassword and sets sessionStorage flags; Layout renders the modal.
**Tests**: AnnoControllerTest verifies mustChangePassword=true for default admin login.

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [x] This change is already covered by existing tests, such as:
AnnoControllerTest.testLoginReturnsMustChangePasswordForDefaultAdmin — verifies the backend returns mustChangePassword=true.

- [ ] This change added tests and can be verified as follows:

### Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? ( Issue#10150 + JavaDocs + TSDoc on LoginResponse, UserService.isDefaultUsernameAndPassword, and ForcePasswordChangeModal.)

