### PR TITLE
[INLONG-12179][Manager] Cluster node adds permission verification

### DIFF
--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -248,6 +248,7 @@ public class InlongClusterController {
     @GetMapping(value = "/cluster/node/get/{id}")
     @ApiOperation(value = "Get cluster node by id")
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterNodeResponse> getNode(@PathVariable Integer id) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.getNode(id, currentUser));
@@ -287,6 +288,7 @@ public class InlongClusterController {
     @ApiOperation(value = "Delete cluster node")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER_NODE)
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteNode(@PathVariable Integer id) {
         return Response.success(clusterService.deleteNode(id, LoginUserUtils.getLoginUser().getName()));
     }
@@ -295,6 +297,7 @@ public class InlongClusterController {
     @ApiOperation(value = "Delete cluster node")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER_NODE)
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> unloadNode(@PathVariable Integer id) {
         return Response.success(clusterService.unloadNode(id, LoginUserUtils.getLoginUser().getName()));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -48,7 +48,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/InlongClusterController.java
@@ -89,6 +89,7 @@ public class InlongClusterController {
     @GetMapping(value = "/cluster/tag/get/{id}")
     @ApiOperation(value = "Get cluster tag by id")
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterTagResponse> getTag(@PathVariable Integer id) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.getTag(id, currentUser));
@@ -96,6 +97,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/tag/list")
     @ApiOperation(value = "List cluster tags")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<PageResult<ClusterTagResponse>> listTag(@RequestBody ClusterTagPageRequest request) {
         request.setCurrentUser(LoginUserUtils.getLoginUser().getName());
         request.setIsAdminRole(LoginUserUtils.isInlongAdminOrTenantAdmin());
@@ -132,6 +134,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/tenant/tag/list")
     @ApiOperation(value = "List tenant cluster tags")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<PageResult<TenantClusterTagInfo>> listTenantTag(@RequestBody TenantClusterTagPageRequest request) {
         return Response.success(clusterService.listTenantTag(request));
     }
@@ -162,7 +165,7 @@ public class InlongClusterController {
     @PostMapping(value = "/cluster/save")
     @ApiOperation(value = "Save cluster")
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody ClusterRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.save(request, currentUser));
@@ -171,6 +174,7 @@ public class InlongClusterController {
     @GetMapping(value = "/cluster/get/{id}")
     @ApiOperation(value = "Get cluster by id")
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterInfo> get(@PathVariable Integer id) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.get(id, currentUser));
@@ -178,6 +182,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/list")
     @ApiOperation(value = "List clusters")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<PageResult<ClusterInfo>> list(@RequestBody ClusterPageRequest request) {
         request.setCurrentUser(LoginUserUtils.getLoginUser().getName());
         request.setIsAdminRole(
@@ -256,6 +261,7 @@ public class InlongClusterController {
 
     @PostMapping(value = "/cluster/node/list")
     @ApiOperation(value = "List cluster nodes by pagination")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<PageResult<ClusterNodeResponse>> listNode(@RequestBody ClusterPageRequest request) {
         String currentUser = LoginUserUtils.getLoginUser().getName();
         return Response.success(clusterService.listNode(request, currentUser));
@@ -304,20 +310,21 @@ public class InlongClusterController {
 
     @RequestMapping(value = "/cluster/node/getManagerSSHPublicKey", method = RequestMethod.GET)
     @ApiOperation(value = "Obtain the SSH public key from the manager to install the agent.")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<String> getManagerSSHPublicKey() {
         return Response.success(clusterService.getManagerSSHPublicKey());
     }
 
     @PostMapping("/cluster/node/testSSHConnection")
     @ApiOperation(value = "Test SSH connection for inlong cluster node")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> testSSHConnection(@RequestBody ClusterNodeRequest request) {
         return Response.success(clusterService.testSSHConnection(request));
     }
 
     @PostMapping("/cluster/testConnection")
     @ApiOperation(value = "Test connection for inlong cluster")
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> testConnection(@Validated @RequestBody ClusterRequest request) {
         return Response.success(clusterService.testConnection(request));
     }
@@ -326,6 +333,7 @@ public class InlongClusterController {
     @ApiOperation(value = "Start inlong cluster process")
     @OperationLog(operation = OperationType.START, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "clusterTag", value = "Inlong cluster tag", dataTypeClass = String.class)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> startProcess(@PathVariable String clusterTag,
             @RequestParam(required = false, defaultValue = "false") boolean sync) {
         String operator = LoginUserUtils.getLoginUser().getName();

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
@@ -48,6 +48,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;
@@ -96,6 +97,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/tag/save")
     @ApiOperation(value = "Save cluster tag")
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Integer> saveTag(@Validated(SaveValidation.class) @RequestBody ClusterTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -105,6 +107,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/tag/update")
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster tag")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> updateTag(@Validated(UpdateValidation.class) @RequestBody ClusterTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -143,6 +146,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/save")
     @ApiOperation(value = "Save cluster")
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -152,6 +156,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/update")
     @ApiOperation(value = "Update cluster")
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
+    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -161,6 +166,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/bindTag")
     @ApiOperation(value = "Bind or unbind cluster tag")
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> bindTag(@Validated @RequestBody BindTagRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -171,6 +177,7 @@ public class OpenInLongClusterController {
     @ApiOperation(value = "Delete cluster by id")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> delete(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "cluster id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -180,6 +187,7 @@ public class OpenInLongClusterController {
     @GetMapping(value = "/cluster/node/get/{id}")
     @ApiOperation(value = "Get cluster node by id")
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterNodeResponse> getNode(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "Cluster node id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -213,6 +221,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/node/save")
     @ApiOperation(value = "Save cluster node")
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Integer> saveNode(@Validated @RequestBody ClusterNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -222,6 +231,7 @@ public class OpenInLongClusterController {
     @RequestMapping(value = "/cluster/node/update", method = RequestMethod.POST)
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
     @ApiOperation(value = "Update cluster node")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> updateNode(@Validated(UpdateValidation.class) @RequestBody ClusterNodeRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -232,6 +242,7 @@ public class OpenInLongClusterController {
     @ApiOperation(value = "Delete cluster node")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster node ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteNode(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "cluster id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
@@ -78,6 +78,7 @@ public class OpenInLongClusterController {
     @GetMapping(value = "/cluster/tag/get/{id}")
     @ApiOperation(value = "Get cluster tag by id")
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterTagResponse> getTag(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "tag id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -86,6 +87,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/tag/list")
     @ApiOperation(value = "List cluster tags")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<List<ClusterTagResponse>> listTag(@RequestBody ClusterTagPageRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -118,6 +120,7 @@ public class OpenInLongClusterController {
     @ApiOperation(value = "Delete cluster tag by id")
     @OperationLog(operation = OperationType.DELETE, operationTarget = OperationTarget.CLUSTER)
     @ApiImplicitParam(name = "id", value = "Cluster tag ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> deleteTag(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "tag id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -127,6 +130,7 @@ public class OpenInLongClusterController {
     @GetMapping(value = "/cluster/get/{id}")
     @ApiOperation(value = "Get cluster by id")
     @ApiImplicitParam(name = "id", value = "Cluster ID", dataTypeClass = Integer.class, required = true)
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<ClusterInfo> get(@PathVariable Integer id) {
         Preconditions.expectNotNull(id, ErrorCodeEnum.INVALID_PARAMETER, "cluster id cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -135,6 +139,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/list")
     @ApiOperation(value = "List clusters")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<List<ClusterInfo>> list(@RequestBody ClusterPageRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -146,7 +151,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/save")
     @ApiOperation(value = "Save cluster")
     @OperationLog(operation = OperationType.CREATE, operationTarget = OperationTarget.CLUSTER)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Integer> save(@Validated(SaveValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -156,7 +161,7 @@ public class OpenInLongClusterController {
     @PostMapping(value = "/cluster/update")
     @ApiOperation(value = "Update cluster")
     @OperationLog(operation = OperationType.UPDATE, operationTarget = OperationTarget.CLUSTER)
-    @RequiresRoles(logical = Logical.OR, value = {UserRoleCode.INLONG_ADMIN, UserRoleCode.TENANT_ADMIN})
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<Boolean> update(@Validated(UpdateByIdValidation.class) @RequestBody ClusterRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -196,6 +201,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/node/list")
     @ApiOperation(value = "List cluster nodes")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<List<ClusterNodeResponse>> listNode(@RequestBody ClusterPageRequest request) {
         Preconditions.expectNotNull(request, ErrorCodeEnum.INVALID_PARAMETER, "request cannot be null");
         Preconditions.expectNotNull(LoginUserUtils.getLoginUser(), ErrorCodeEnum.LOGIN_USER_EMPTY);
@@ -261,6 +267,7 @@ public class OpenInLongClusterController {
 
     @PostMapping(value = "/cluster/tenant/tag/list")
     @ApiOperation(value = "List tenant cluster tags")
+    @RequiresRoles(UserRoleCode.INLONG_ADMIN)
     public Response<PageResult<TenantClusterTagInfo>> listTenantTag(@RequestBody TenantClusterTagPageRequest request) {
         return Response.success(clusterService.listTenantTag(request));
     }

--- a/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
+++ b/inlong-manager/manager-web/src/main/java/org/apache/inlong/manager/web/controller/openapi/OpenInLongClusterController.java
@@ -48,7 +48,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import org.apache.shiro.authz.annotation.Logical;
 import org.apache.shiro.authz.annotation.RequiresRoles;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.validation.annotation.Validated;


### PR DESCRIPTION

Fixes #12179

### Motivation

Cluster node adds permission verification.
### Modifications

Cluster node adds permission verification.
The current cluster node has not added permission verification, which allows anyone to modify it. Permission verification needs to be added.