### PR TITLE
[INLONG-12183][SDK] Transform SDK supports $childIndex to map the row data subscript. For PB/JSON field mapping, the $root prefix can be omitted

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/JsonSourceData.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/JsonSourceData.java
@@ -38,6 +38,8 @@ public class JsonSourceData extends AbstractSourceData {
 
     public static final String CHILD_KEY = "$child";
 
+    public static final String CHILD_INDEX_KEY = "$childIndex";
+
     private JsonObject root;
 
     private JsonArray childRoot;
@@ -78,6 +80,9 @@ public class JsonSourceData extends AbstractSourceData {
         try {
             if (isContextField(fieldName)) {
                 return getContextField(fieldName);
+            }
+            if (StringUtils.equals(CHILD_INDEX_KEY, fieldName)) {
+                return rowNum;
             }
             JsonElement current = getFieldByElement(rowNum, fieldName);
             if (current == null) {
@@ -126,8 +131,9 @@ public class JsonSourceData extends AbstractSourceData {
                     return null;
                 }
             } else {
-                // error data
-                return null;
+                // default root node
+                current = root;
+                childNodes.add(0, new JsonNode(ROOT_KEY));
             }
             if (current == null) {
                 // error data

--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/PbSourceData.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/PbSourceData.java
@@ -59,6 +59,8 @@ public class PbSourceData extends AbstractSourceData {
 
     public static final String CHILD_KEY = "$child.";
 
+    public static final String CHILD_INDEX_KEY = "$childIndex";
+
     private Descriptors.Descriptor rootDesc;
 
     private Descriptors.Descriptor childDesc;
@@ -129,6 +131,9 @@ public class PbSourceData extends AbstractSourceData {
             // check(root);
             if (isContextField(fieldName)) {
                 return getContextField(fieldName);
+            }
+            if (StringUtils.equals(CHILD_INDEX_KEY, fieldName)) {
+                return rowNum;
             }
             Object fieldValue = findFieldNode(rowNum, fieldName);
             List<PbNode> childNodes = this.columnNodeMap.get(fieldName);

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestJson2RowDataProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestJson2RowDataProcessor.java
@@ -986,4 +986,208 @@ public class TestJson2RowDataProcessor extends AbstractProcessorTestBase {
         Assert.assertEquals("v_c", personRow.getString(2).toString());
         Assert.assertEquals("v_b", personRow.getString(3).toString());
     }
+
+    // ========== JsonSourceData: $childIndex and omitted $root prefix ==========
+
+    /**
+     * Verify that `$childIndex` maps to the current row index (0-based) when the JSON source
+     * is configured with a child-array root.
+     */
+    @Test
+    public void testJsonChildIndexMapping() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList("rowIdx", "sid", "msg");
+        // childRoot points to msgs -> multi-row output
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", "msgs");
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        String transformSql =
+                "select $childIndex as rowIdx, $root.sid as sid, $child.msg as msg from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"sid\":\"s1\",\"msgs\":["
+                + "{\"msg\":\"m0\"},"
+                + "{\"msg\":\"m1\"},"
+                + "{\"msg\":\"m2\"}"
+                + "]}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(3, output.size());
+
+        // row 0
+        Assert.assertEquals("0", output.get(0).getString(0).toString());
+        Assert.assertEquals("s1", output.get(0).getString(1).toString());
+        Assert.assertEquals("m0", output.get(0).getString(2).toString());
+        // row 1
+        Assert.assertEquals("1", output.get(1).getString(0).toString());
+        Assert.assertEquals("s1", output.get(1).getString(1).toString());
+        Assert.assertEquals("m1", output.get(1).getString(2).toString());
+        // row 2
+        Assert.assertEquals("2", output.get(2).getString(0).toString());
+        Assert.assertEquals("s1", output.get(2).getString(1).toString());
+        Assert.assertEquals("m2", output.get(2).getString(2).toString());
+    }
+
+    /**
+     * Verify that `$childIndex` also works when the source is a single-row JSON (no child array),
+     * in which case the index should always be 0.
+     */
+    @Test
+    public void testJsonChildIndexSingleRow() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList("rowIdx", "name");
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", null);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        String transformSql = "select $childIndex as rowIdx, $root.name as name from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"name\":\"Jane\"}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("0", output.get(0).getString(0).toString());
+        Assert.assertEquals("Jane", output.get(0).getString(1).toString());
+    }
+
+    /**
+     * Verify that the `$root` prefix can be omitted for JSON field mapping.
+     * `session_id` should behave identically to `$root.session_id`.
+     */
+    @Test
+    public void testJsonOmitRootPrefix() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList(
+                "session_id", "business", "product_id", "channel");
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", null);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        // field names without $root prefix
+        String transformSql = "select session_id as session_id,"
+                + "business as business,"
+                + "product_id as product_id,"
+                + "channel as channel from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"session_id\":\"1782780884\","
+                + "\"business\":\"pay\","
+                + "\"product_id\":\"1314\","
+                + "\"channel\":\"todo\"}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("1782780884", output.get(0).getString(0).toString());
+        Assert.assertEquals("pay", output.get(0).getString(1).toString());
+        Assert.assertEquals("1314", output.get(0).getString(2).toString());
+        Assert.assertEquals("todo", output.get(0).getString(3).toString());
+    }
+
+    /**
+     * Verify that omitting `$root` supports nested field paths (e.g. `person.name`),
+     * behaving identically to `$root.person.name`.
+     */
+    @Test
+    public void testJsonOmitRootPrefixWithNestedPath() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList("name", "city");
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", null);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        // nested paths without $root prefix
+        String transformSql = "select person.name as name,"
+                + "person.address.city as city from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"person\":{\"name\":\"Jane\","
+                + "\"address\":{\"city\":\"NYC\",\"zip\":\"10001\"}}}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("Jane", output.get(0).getString(0).toString());
+        Assert.assertEquals("NYC", output.get(0).getString(1).toString());
+    }
+
+    /**
+     * Verify that omitting `$root` yields the same result as explicitly using `$root`,
+     * and that both styles can be mixed in the same SQL.
+     */
+    @Test
+    public void testJsonOmitRootPrefixMixedWithExplicitRoot() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList("a1", "a2", "b1", "b2");
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", null);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        // mix explicit $root and omitted-prefix styles
+        String transformSql = "select $root.name as a1,"
+                + "name as a2,"
+                + "$root.person.name as b1,"
+                + "person.name as b2 from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"name\":\"John\",\"person\":{\"name\":\"Jane\"}}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        // a1 and a2 must be identical; b1 and b2 must be identical
+        Assert.assertEquals("John", output.get(0).getString(0).toString());
+        Assert.assertEquals("John", output.get(0).getString(1).toString());
+        Assert.assertEquals("Jane", output.get(0).getString(2).toString());
+        Assert.assertEquals("Jane", output.get(0).getString(3).toString());
+    }
+
+    /**
+     * Combined scenario: within a child-array row source, use both `$childIndex`
+     * and omitted-`$root` fields side-by-side.
+     */
+    @Test
+    public void testJsonChildIndexWithOmittedRootPrefix() throws Exception {
+        List<FieldInfo> sinkFields = this.getTestFieldList("idx", "sid", "msg");
+        JsonSourceInfo jsonSource = new JsonSourceInfo("UTF-8", "msgs");
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        // `sid` is omitted-$root (root-level field); `$child.msg` is the child element field
+        String transformSql =
+                "select $childIndex as idx, sid as sid, $child.msg as msg from source";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createJsonDecoder(jsonSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        String strJson = "{\"sid\":\"s1\",\"msgs\":["
+                + "{\"msg\":\"m0\"},"
+                + "{\"msg\":\"m1\"}"
+                + "]}";
+
+        List<RowData> output = processor.transform(strJson, new HashMap<>());
+        Assert.assertEquals(2, output.size());
+        Assert.assertEquals("0", output.get(0).getString(0).toString());
+        Assert.assertEquals("s1", output.get(0).getString(1).toString());
+        Assert.assertEquals("m0", output.get(0).getString(2).toString());
+        Assert.assertEquals("1", output.get(1).getString(0).toString());
+        Assert.assertEquals("s1", output.get(1).getString(1).toString());
+        Assert.assertEquals("m1", output.get(1).getString(2).toString());
+    }
 }


### PR DESCRIPTION
Fixes #12183

### Description

When users configure field-mapping SQL against a JSON / Protobuf source in Transform SDK, two developer-experience gaps exist today:

1. **No way to obtain the row index** inside a child-array (multi-row) source.
   When a source is configured with `childRoot` (e.g. `msgs` array), the decoder emits multiple rows. Users often need a monotonically-increasing index per output row (for de-duplication keys, ordered writes, debug, etc.). There is no built-in placeholder to reference this index in the `SELECT` expression.

2. **`$root.` prefix is mandatory but verbose.**
   To reference a root-level JSON field `session_id`, users must write `$root.session_id`. This is redundant for the very common case where the field is on the root object. Users coming from typical SQL / JSONPath expect to just write `session_id` or `person.name`.

This issue proposes to:

- Introduce a new reserved placeholder **`$childIndex`** that resolves to the current row index (0-based).
- Allow **omitting the `$root` prefix** for JSON field references. `session_id` behaves identically to `$root.session_id`; `person.address.city` behaves identically to `$root.person.address.city`. The two styles can be mixed in the same SQL.
- Keep the existing `$root.*` and `$child.*` semantics **fully backward compatible** — no behavior change for existing configs.

### Motivation / Use Cases

- **`$childIndex`**
  - Add a stable ordering column when flattening a JSON array into multiple rows.
  - Build composite deduplication keys `(sid, $childIndex)` for downstream sinks that require primary keys.
  - Debugging / observability of per-element position without adding it upstream.

- **Omitted `$root` prefix**
  - Reduce boilerplate in mapping SQL; align with common JSONPath / SQL intuition.
  - Simplify auto-generated mapping expressions in the manager / UI.

### Proposed Change

#### 1) `JsonSourceData`

- Add public constant `CHILD_INDEX_KEY = "$childIndex"`.
- In `getField(int rowNum, String fieldName)`, short-circuit when `fieldName` equals `$childIndex` and return `rowNum`. This works for both single-row sources (returns `0`) and multi-row child-array sources (returns the child index).
- In `getFieldByElement`, when the first path segment is neither `$root` nor `$child`, treat the reference as rooted at `root` and virtually prepend `$root` to the parsed node list. This makes `person.name` equivalent to `$root.person.name`.

Key snippets (already implemented):

```java
// JsonSourceData#getField
if (StringUtils.equals(CHILD_INDEX_KEY, fieldName)) {
    return rowNum;
}
```

```java
// JsonSourceData#getFieldByElement
} else {
    // default root node
    current = root;
    childNodes.add(0, new JsonNode(ROOT_KEY));
}
```

#### 2) `PbSourceData` (aligned semantics for Protobuf source)

- Add public constant `CHILD_INDEX_KEY = "$childIndex"`.
- In `getField(int rowNum, String fieldName)`, short-circuit when `fieldName` equals `$childIndex` and return `rowNum`.
- `findFieldNode` already falls back to parsing under `rootDesc` when the field name has no `$root.` / `$child.` prefix, giving the PB source the same omitted-prefix behavior as JSON.

Key snippet:

```java
// PbSourceData#getField
if (StringUtils.equals(CHILD_INDEX_KEY, fieldName)) {
    return rowNum;
}
```

#### 3) Tests

Add 6 new cases in `TestJson2RowDataProcessor` covering the two features and their combination:

| #   | Test                                          | Feature                                | Assertion                                                        |
| --- | --------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------- |
| 1   | `testJsonChildIndexMapping`                   | `$childIndex` on multi-row child array | 3 rows get indices `0` / `1` / `2`                               |
| 2   | `testJsonChildIndexSingleRow`                 | `$childIndex` on single-row source     | Index is `0`                                                     |
| 3   | `testJsonOmitRootPrefix`                      | Omit `$root` on flat fields            | `session_id` ≡ `$root.session_id`                                |
| 4   | `testJsonOmitRootPrefixWithNestedPath`        | Omit `$root` on nested path            | `person.address.city` ≡ `$root.person.address.city`              |
| 5   | `testJsonOmitRootPrefixMixedWithExplicitRoot` | Mix of both styles                     | Explicit and omitted forms produce identical results             |
| 6   | `testJsonChildIndexWithOmittedRootPrefix`     | Combined scenario                      | `$childIndex` + omitted `$root` + `$child.*` coexist             |

### Example

**Before** (verbose):

```sql
SELECT
  $root.session_id AS session_id,
  $root.business   AS business,
  $child.msg       AS msg
FROM source;
```

**After** (equivalent, with the new features):

```sql
SELECT
  $childIndex AS row_idx,     -- NEW: 0-based row index
  session_id  AS session_id,  -- NEW: $root prefix omitted
  business    AS business,    -- NEW: $root prefix omitted
  $child.msg  AS msg
FROM source;
```

### Backward Compatibility

- Fully backward compatible.
- `$root.*` and `$child.*` continue to work exactly as before.
- `$childIndex` is a new reserved token; users who did not previously have a field literally named `$childIndex` are not affected.
- No public API signature change; only new constants plus one new short-circuit branch in `getField`, and a fallback branch in `getFieldByElement`.

### Risks / Notes

- A field literally named `$childIndex` in the source payload will no longer be reachable via `$childIndex` — it must be referenced as `$root.$childIndex`. Given that `$`-prefixed field names are extremely uncommon in JSON / PB payloads, this is considered acceptable.
- The omitted-prefix fallback is only applied when the first path segment is not `$root` or `$child`, so it cannot shadow existing behavior.

### Files Changed

- `inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/JsonSourceData.java`
- `inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/decode/PbSourceData.java`
- `inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestJson2RowDataProcessor.java`

### Checklist

- [x] Backward-compatible with existing `$root.*` / `$child.*` field mappings
- [x] New unit tests added and passing locally
- [x] No changes to public APIs / method signatures
- [x] Behavior aligned between JSON source and PB source

---

### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
