### PR TITLE
[INLONG-12185][Manager] Add validation when saving clustertag

### DIFF
--- a/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterRequest.java
+++ b/inlong-manager/manager-pojo/src/main/java/org/apache/inlong/manager/pojo/cluster/ClusterRequest.java
@@ -63,6 +63,7 @@ public abstract class ClusterRequest {
     @ApiModelProperty(value = "Cluster tags, separated by commas")
     @NotBlank(groups = {SaveValidation.class, UpdateByKeyValidation.class}, message = "clusterTags cannot be blank")
     @Length(max = 512, message = "length must be less than or equal to 512")
+    @Pattern(regexp = "^[a-zA-Z0-9_,.-]+$", message = "clusterTags contains invalid characters")
     private String clusterTags;
 
     @ApiModelProperty(value = "Cluster url")


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12185

### Motivation

Add validation when saving clustertag.

### Modifications

The current clustertag does not perform special character verification, which may cause injection issues with the command. It is necessary to add string verification.

