### PR TITLE
[INLONG-12189][SDK] Support Map and JsonObject key access via [...] in ArrayParser

### DIFF
--- a/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/ArrayParser.java
+++ b/inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/ArrayParser.java
@@ -23,10 +23,12 @@ import org.apache.inlong.sdk.transform.process.operator.OperatorTools;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import net.sf.jsqlparser.expression.ArrayExpression;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * ArrayParser
@@ -54,10 +56,36 @@ public class ArrayParser implements ValueParser {
             Number rightObj = (Number) rightValue;
             return leftObj.get(rightObj.intValue());
         }
+        if (leftValue instanceof Map<?, ?>) {
+            Map<?, ?> leftObj = (Map<?, ?>) leftValue;
+            return leftObj.get(rightValue);
+        }
         if (leftValue instanceof JsonArray && rightValue instanceof Number) {
             JsonArray leftObj = (JsonArray) leftValue;
             Number rightObj = (Number) rightValue;
             JsonElement result = leftObj.get(rightObj.intValue());
+            if (result.isJsonNull()) {
+                return null;
+            }
+            if (result.isJsonPrimitive()) {
+                JsonPrimitive jsonPrim = (JsonPrimitive) result;
+                if (jsonPrim.isString()) {
+                    return jsonPrim.getAsString();
+                } else if (jsonPrim.isBoolean()) {
+                    return jsonPrim.getAsBoolean();
+                } else if (jsonPrim.isNumber()) {
+                    return jsonPrim.getAsNumber();
+                }
+                return jsonPrim.toString();
+            }
+            if (result.isJsonArray() || result.isJsonObject()) {
+                return result;
+            }
+        }
+        if (leftValue instanceof JsonObject && rightValue instanceof String) {
+            JsonObject leftObj = (JsonObject) leftValue;
+            String rightObj = (String) rightValue;
+            JsonElement result = leftObj.get(rightObj);
             if (result.isJsonNull()) {
                 return null;
             }

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestCsv2RowDataProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestCsv2RowDataProcessor.java
@@ -49,6 +49,7 @@ import java.util.List;
  * sink produces zero rows.
  */
 public class TestCsv2RowDataProcessor extends AbstractProcessorTestBase {
+
     @Test
     public void testCsv2RowDataHitHY50AndEventCode() throws Exception {
         List<FieldInfo> sourceFields = this.getTestFieldList(
@@ -82,8 +83,8 @@ public class TestCsv2RowDataProcessor extends AbstractProcessorTestBase {
         List<RowData> output = processor.transform(testData, new HashMap<>());
         Assert.assertEquals(1, output.size());
         Assert.assertEquals("2026-08-20 12:48:56.929", output.get(0).getString(0).toString());
-        Assert.assertEquals("extinfo=127.0.0.1",      output.get(0).getString(1).toString());
-        Assert.assertEquals("OnPageEnter",            output.get(0).getString(2).toString());
+        Assert.assertEquals("extinfo=127.0.0.1", output.get(0).getString(1).toString());
+        Assert.assertEquals("OnPageEnter", output.get(0).getString(2).toString());
         Assert.assertEquals("welfare_milestone_operations", output.get(0).getString(3).toString());
     }
 
@@ -116,8 +117,8 @@ public class TestCsv2RowDataProcessor extends AbstractProcessorTestBase {
                 SinkEncoderFactory.createRowEncoder(rowSink));
 
         // Note: this record does NOT satisfy the WHERE clause:
-        //  - event_code = 'OnPageMod'  (not 'OnPageEnter')
-        //  - HY50 in the decoded map = 'ActivityPage' (not 'welfare_milestone_operations')
+        // - event_code = 'OnPageMod' (not 'OnPageEnter')
+        // - HY50 in the decoded map = 'ActivityPage' (not 'welfare_milestone_operations')
         // event_value only carries a single URL-encoded HY50 KV entry.
         String testData = "2026-08-20 12:48:56.929"
                 + "|extinfo=127.0.0.1"

--- a/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestCsv2RowDataProcessor.java
+++ b/inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestCsv2RowDataProcessor.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.inlong.sdk.transform.process.processor;
+
+import org.apache.inlong.sdk.transform.decode.SourceDecoderFactory;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.CsvSourceInfo;
+import org.apache.inlong.sdk.transform.pojo.FieldInfo;
+import org.apache.inlong.sdk.transform.pojo.RowDataSinkInfo;
+import org.apache.inlong.sdk.transform.pojo.TransformConfig;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
+
+import org.apache.flink.table.data.RowData;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * TestCsv2RowDataProcessor
+ * <p>
+ * Verifies that CSV source data can be transformed into {@link RowData} via SQL that:
+ * <ul>
+ *   <li>selects a small set of source columns as-is;</li>
+ *   <li>URL-decodes the {@code event_value} column and turns it into a KV map with
+ *       {@code STR_TO_MAP(URL_DECODE(event_value), '&', '=')}, then extracts the
+ *       {@code HY50} entry via bracket key access;</li>
+ *   <li>filters rows with {@code HY50 = 'welfare_milestone_operations'} and
+ *       {@code event_code = 'OnPageEnter'}.</li>
+ * </ul>
+ * The supplied test payload has {@code event_code=OnPageMod} and HY50 value
+ * {@code ActivityPage}, so the WHERE clause filters the record out and the
+ * sink produces zero rows.
+ */
+public class TestCsv2RowDataProcessor extends AbstractProcessorTestBase {
+    @Test
+    public void testCsv2RowDataHitHY50AndEventCode() throws Exception {
+        List<FieldInfo> sourceFields = this.getTestFieldList(
+                "ftime", "extinfo", "event_code", "event_value");
+        List<FieldInfo> sinkFields = this.getTestFieldList(
+                "ftime", "extinfo", "event_code", "HY50");
+
+        CsvSourceInfo csvSource = new CsvSourceInfo("UTF-8", '|', '\\', sourceFields);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        String transformSql = "select "
+                + "ftime as ftime,"
+                + "extinfo as extinfo,"
+                + "event_code as event_code,"
+                + "STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] as HY50 "
+                + "from source "
+                + "WHERE  STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] = 'welfare_milestone_operations' "
+                + "AND event_code = 'OnPageEnter'";
+
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                new TransformConfig(transformSql),
+                SourceDecoderFactory.createCsvDecoder(csvSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        // Positive sample: satisfies BOTH WHERE conditions.
+        String testData = "2026-08-20 12:48:56.929"
+                + "|extinfo=127.0.0.1"
+                + "|OnPageEnter"
+                + "|HY50%3Dwelfare_milestone_operations";
+
+        List<RowData> output = processor.transform(testData, new HashMap<>());
+        Assert.assertEquals(1, output.size());
+        Assert.assertEquals("2026-08-20 12:48:56.929", output.get(0).getString(0).toString());
+        Assert.assertEquals("extinfo=127.0.0.1",      output.get(0).getString(1).toString());
+        Assert.assertEquals("OnPageEnter",            output.get(0).getString(2).toString());
+        Assert.assertEquals("welfare_milestone_operations", output.get(0).getString(3).toString());
+    }
+
+    @Test
+    public void testCsv2RowDataFilteredByHY50AndEventCode() throws Exception {
+        // ==== source fields: 4 columns aligned with the pipe-delimited payload ====
+        List<FieldInfo> sourceFields = this.getTestFieldList(
+                "ftime", "extinfo", "event_code", "event_value");
+
+        // ==== sink fields: 3 pass-through columns + extracted HY50 ====
+        List<FieldInfo> sinkFields = this.getTestFieldList(
+                "ftime", "extinfo", "event_code", "HY50");
+
+        CsvSourceInfo csvSource = new CsvSourceInfo("UTF-8", '|', '\\', sourceFields);
+        RowDataSinkInfo rowSink = new RowDataSinkInfo("UTF-8", sinkFields);
+
+        String transformSql = "select "
+                + "ftime as ftime,"
+                + "extinfo as extinfo,"
+                + "event_code as event_code,"
+                + "STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] as HY50 "
+                + "from source "
+                + "WHERE  STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] = 'welfare_milestone_operations' "
+                + "AND event_code = 'OnPageEnter'";
+
+        TransformConfig config = new TransformConfig(transformSql);
+        TransformProcessor<String, RowData> processor = TransformProcessor.create(
+                config,
+                SourceDecoderFactory.createCsvDecoder(csvSource),
+                SinkEncoderFactory.createRowEncoder(rowSink));
+
+        // Note: this record does NOT satisfy the WHERE clause:
+        //  - event_code = 'OnPageMod'  (not 'OnPageEnter')
+        //  - HY50 in the decoded map = 'ActivityPage' (not 'welfare_milestone_operations')
+        // event_value only carries a single URL-encoded HY50 KV entry.
+        String testData = "2026-08-20 12:48:56.929"
+                + "|extinfo=127.0.0.1"
+                + "|OnPageMod"
+                + "|HY50%3DActivityPage";
+
+        List<RowData> output = processor.transform(testData, new HashMap<>());
+
+        // The record fails BOTH WHERE conditions, so nothing is emitted.
+        Assert.assertEquals(0, output.size());
+    }
+}


### PR DESCRIPTION
Fixes #12189 

### Motivation

1. **KV map lookup after `STR_TO_MAP`** — decode a URL-encoded query string and pluck a specific parameter in one line:

    ```sql
    SELECT
      STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] AS HY50
    FROM source
    WHERE STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] = 'welfare_milestone_operations'
      AND event_code = 'OnPageEnter';
    ```

2. **JSON key access** — read fields off a raw `JsonObject` produced by JSON helper functions using the intuitive `obj['field']` syntax, without additional casting.

3. **Consistency** — align bracket-access semantics with common SQL / JSONPath expectations, reduce boilerplate, and remove edge cases where a valid-looking expression silently returned `null`.

### Modifications

`ArrayParser#parse` now handles four shapes; the two new branches (Map, JsonObject) are highlighted:

```java
@Override
public Object parse(SourceData sourceData, int rowIndex, Context context) {
    Object leftValue  = this.left.parse(sourceData, rowIndex, context);
    Object rightValue = this.right.parse(sourceData, rowIndex, context);

    // 1) List indexed by Number (existing)
    if (leftValue instanceof List<?> && rightValue instanceof Number) {
        return ((List<?>) leftValue).get(((Number) rightValue).intValue());
    }

    // 2) Map indexed by any key type (NEW)
    if (leftValue instanceof Map<?, ?>) {
        return ((Map<?, ?>) leftValue).get(rightValue);
    }

    // 3) JsonArray indexed by Number (existing) — primitives unwrapped
    if (leftValue instanceof JsonArray && rightValue instanceof Number) {
        JsonElement result = ((JsonArray) leftValue).get(((Number) rightValue).intValue());
        return unwrapJsonElement(result);
    }

    // 4) JsonObject indexed by String key (NEW) — primitives unwrapped
    if (leftValue instanceof JsonObject && rightValue instanceof String) {
        JsonElement result = ((JsonObject) leftValue).get((String) rightValue);
        return unwrapJsonElement(result);
    }

    return null;
}
```

Where `unwrapJsonElement`:

- returns `null` for `JsonNull`;
- returns the natural Java value for `JsonPrimitive` (`String` / `Boolean` / `Number`, fallback to `toString()`);
- returns the original `JsonArray` / `JsonObject` for structural elements, so chained bracket access keeps working.

### Behavior matrix

| `leftValue` type | `rightValue` type | Result |
| --- | --- | --- |
| `List<?>` | `Number` | `list.get(index.intValue())` |
| `Map<?, ?>` | any | `map.get(rightValue)` (new) |
| `JsonArray` | `Number` | element at index, primitives unwrapped |
| `JsonObject` | `String` | value at key, primitives unwrapped (new) |
| Any other combination | | `null` |

### Example

Before this change, the following expression silently returned `null` and the `WHERE` clause could never match:

```sql
SELECT
  STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] AS HY50
FROM source
WHERE STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50'] = 'welfare_milestone_operations'
  AND event_code = 'OnPageEnter';
```

After this change the map lookup works as intended, so both projection and filter behave correctly.

### Tests

- Added `TestCsv2RowDataProcessor` (peer of `TestCsv2KvProcessor`) which drives the CSV → RowData pipeline with a SQL that uses `STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50']` in both `SELECT` and `WHERE`, exercising the new `Map` branch end-to-end.
- Existing `List` / `JsonArray` bracket-access tests continue to pass unchanged.

### Backward compatibility

- Fully backward compatible.
- The two existing branches (`List[Number]`, `JsonArray[Number]`) keep identical semantics.
- The fallback for unrecognized type combinations still returns `null`, so previously-null expressions can only turn into a real value — never into an unexpected error.
- No public API / method signature change.

### Risks / Notes

- `Map<?, ?>` uses `map.get(rightValue)` directly; when the SQL parser resolves the bracket key as a `String` while the map key is a boxed number (or vice versa), the lookup will return `null` due to `.equals` type mismatch. This matches Java `Map` semantics and is consistent with how other Transform SDK operators treat mixed key types.
- For `JsonObject`, missing keys resolve to `null` (Gson returns `null` from `get`); no exception is thrown.
- `JsonPrimitive` unwrapping intentionally mirrors what `JsonSourceData` already does elsewhere, so downstream comparison/arithmetic operators receive the same Java type regardless of whether the value originated from the source or from a JSON helper function.

### Files changed

- `inlong-sdk/transform-sdk/src/main/java/org/apache/inlong/sdk/transform/process/parser/ArrayParser.java`
- `inlong-sdk/transform-sdk/src/test/java/org/apache/inlong/sdk/transform/process/processor/TestCsv2RowDataProcessor.java` *(new; end-to-end coverage for `Map[key]`)*

### Checklist

- [x] Backward-compatible with existing `List[Number]` / `JsonArray[Number]` usage
- [x] New unit / integration test added and passing locally
- [x] No changes to public APIs / method signatures
- [x] Behavior of primitive-unwrapping for JSON branches aligned with `JsonSourceData`

---
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
