### PR TITLE
[INLONG-12191][Sort] Support InLong Transform SDK on the Pulsar sink pipeline

### DIFF
--- a/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/PulsarSinkConfig.java
+++ b/inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/PulsarSinkConfig.java
@@ -24,8 +24,20 @@ import lombok.EqualsAndHashCode;
 @Data
 public class PulsarSinkConfig extends SinkConfig {
 
+    public static final String MESSAGE_TYPE_CSV = "csv";
+    public static final Character CSV_DEFAULT_DELIMITER = '|';
+    public static final String MESSAGE_TYPE_KV = "kv";
+    public static final Character KV_DEFAULT_ENTRYSPLITTER = '&';
+    public static final Character KV_DEFAULT_KVSPLITTER = '=';
+    public static final String MESSAGE_TYPE_JSON = "json";
+
     private String pulsarTenant;
     private String namespace;
     private String topic;
     private Integer partitionNum;
+    private String messageType;
+    private Character delimiter;
+    private Character escapeChar;
+    private Character entrySplitter;
+    private Character kvSplitter;
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsCallback.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/cls/ClsCallback.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.standalone.sink.cls;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 
+import com.google.gson.Gson;
 import com.tencentcloudapi.cls.producer.Callback;
 import com.tencentcloudapi.cls.producer.Result;
 import com.tencentcloudapi.cls.producer.common.Attempt;
@@ -40,6 +41,7 @@ public class ClsCallback implements Callback {
     private final ClsSinkContext context;
     private final ProfileEvent event;
     private final String topicId;
+    private Gson gson = new Gson();
 
     /**
      * Constructor.
@@ -80,6 +82,8 @@ public class ClsCallback implements Callback {
      * @param result Send result.
      */
     private void onFailed(Result result) {
+        LOG.error("onFail,groupId:{},data:{},result:{}", event.getInlongGroupId(), new String(event.getBody()),
+                gson.toJson(result));
         if (isRetryable(result.getReservedAttempts())) {
             tx.rollback();
             tx.close();

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/DefaultEvent2PulsarRecordHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/DefaultEvent2PulsarRecordHandler.java
@@ -18,15 +18,22 @@
 package org.apache.inlong.sort.standalone.sink.pulsar;
 
 import org.apache.inlong.sdk.commons.protocol.EventConstants;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 
+import com.google.gson.Gson;
 import org.slf4j.Logger;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 
@@ -40,25 +47,57 @@ public class DefaultEvent2PulsarRecordHandler implements IEvent2PulsarRecordHand
     protected final ByteArrayOutputStream outMsg = new ByteArrayOutputStream();
     protected final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
     protected final Date currentDate = new Date();
+    protected final Gson gson = new Gson();
 
     /**
      * parse
-     * 
-     * @param  context
-     * @param  event
-     * @return             byte array
-     * @throws IOException
+     *
+     * @param  context     pulsar federation sink context
+     * @param  event       raw profile event
+     * @param  idConfig    id config resolved from event uid
+     * @return             a list of message payload byte arrays
+     * @throws IOException on any IO error
      */
     @Override
-    public byte[] parse(PulsarFederationSinkContext context, ProfileEvent event)
+    public List<byte[]> parse(PulsarFederationSinkContext context, ProfileEvent event, PulsarIdConfig idConfig)
             throws IOException {
-        String uid = event.getUid();
-        PulsarIdConfig idConfig = context.getIdConfig(uid);
-        if (idConfig == null) {
-            context.addSendResultMetric(event, context.getTaskName(), false, System.currentTimeMillis());
-            LOG.error("Can not find the id config:{}", uid);
-            return null;
+        TransformProcessor<String, ?> processor = context.getTransformProcessor(idConfig.getDataFlowId());
+        if (processor != null) {
+            return this.parseByTransform(context, event, processor);
+        } else {
+            byte[] record = this.parseByBytes(event, idConfig);
+            return Arrays.asList(record);
         }
+    }
+
+    public List<byte[]> parseByTransform(PulsarFederationSinkContext context, ProfileEvent event,
+            TransformProcessor<String, ?> processor) throws IOException {
+        // extParams
+        Map<String, Object> extParams = new ConcurrentHashMap<>();
+        extParams.putAll(context.getSinkContext().getParameters());
+        event.getHeaders().forEach((k, v) -> extParams.put(k, v));
+        // transform
+        List<?> results = processor.transformForBytes(event.getBody(), extParams);
+        if (results == null) {
+            return new ArrayList<>();
+        }
+        // build
+        List<byte[]> records = new ArrayList<>(results.size());
+        for (Object result : results) {
+            byte[] msgContent;
+            if (result instanceof String) {
+                msgContent = result.toString().getBytes();
+            } else if (result instanceof byte[]) {
+                msgContent = (byte[]) result;
+            } else {
+                msgContent = gson.toJson(result).getBytes();
+            }
+            records.add(msgContent);
+        }
+        return records;
+    }
+
+    public byte[] parseByBytes(ProfileEvent event, PulsarIdConfig idConfig) throws IOException {
         String delimiter = idConfig.getSeparator();
         byte separator = (byte) delimiter.charAt(0);
         outMsg.reset();
@@ -80,8 +119,7 @@ public class DefaultEvent2PulsarRecordHandler implements IEvent2PulsarRecordHand
                 break;
         }
         outMsg.write(event.getBody());
-        byte[] msgContent = outMsg.toByteArray();
-        return msgContent;
+        return outMsg.toByteArray();
     }
 
     /**

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/IEvent2PulsarRecordHandler.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/IEvent2PulsarRecordHandler.java
@@ -20,6 +20,7 @@ package org.apache.inlong.sort.standalone.sink.pulsar;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * 
@@ -28,12 +29,14 @@ import java.io.IOException;
 public interface IEvent2PulsarRecordHandler {
 
     /**
-     * parse
-     * 
-     * @param  context
-     * @param  event
-     * @return             ProducerRecord
-     * @throws IOException
+     * parse the event into one or more pulsar message payloads.
+     *
+     * @param  context     pulsar federation sink context
+     * @param  event       raw profile event
+     * @param  idConfig    id config resolved from event uid
+     * @return             a list of message payload byte arrays; empty/null means filtered
+     * @throws IOException on any IO error
      */
-    byte[] parse(PulsarFederationSinkContext context, ProfileEvent event) throws IOException;
+    List<byte[]> parse(PulsarFederationSinkContext context, ProfileEvent event, PulsarIdConfig idConfig)
+            throws IOException;
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarFederationSinkContext.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarFederationSinkContext.java
@@ -19,8 +19,18 @@ package org.apache.inlong.sort.standalone.sink.pulsar;
 
 import org.apache.inlong.common.pojo.sort.ClusterTagConfig;
 import org.apache.inlong.common.pojo.sort.TaskConfig;
+import org.apache.inlong.common.pojo.sort.dataflow.DataFlowConfig;
+import org.apache.inlong.common.pojo.sort.dataflow.sink.PulsarSinkConfig;
+import org.apache.inlong.common.pojo.sort.dataflow.sink.SinkConfig;
 import org.apache.inlong.common.pojo.sort.node.PulsarNodeConfig;
 import org.apache.inlong.common.pojo.sortstandalone.SortTaskConfig;
+import org.apache.inlong.sdk.transform.encode.SinkEncoder;
+import org.apache.inlong.sdk.transform.encode.SinkEncoderFactory;
+import org.apache.inlong.sdk.transform.pojo.CsvSinkInfo;
+import org.apache.inlong.sdk.transform.pojo.FieldInfo;
+import org.apache.inlong.sdk.transform.pojo.KvSinkInfo;
+import org.apache.inlong.sdk.transform.pojo.MapSinkInfo;
+import org.apache.inlong.sdk.transform.process.TransformProcessor;
 import org.apache.inlong.sort.standalone.channel.ProfileEvent;
 import org.apache.inlong.sort.standalone.config.holder.CommonPropertiesHolder;
 import org.apache.inlong.sort.standalone.config.holder.SortClusterConfigHolder;
@@ -33,7 +43,9 @@ import org.apache.inlong.sort.standalone.metrics.audit.AuditUtils;
 import org.apache.inlong.sort.standalone.sink.SinkContext;
 import org.apache.inlong.sort.standalone.utils.InlongLoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.flume.Channel;
 import org.apache.flume.Context;
 import org.slf4j.Logger;
@@ -45,6 +57,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("deprecation")
 public class PulsarFederationSinkContext extends SinkContext {
 
     public static final Logger LOG = InlongLoggerFactory.getLogger(PulsarFederationSinkContext.class);
@@ -52,6 +65,9 @@ public class PulsarFederationSinkContext extends SinkContext {
     private Map<String, PulsarIdConfig> idConfigMap = new ConcurrentHashMap<>();
     private PulsarNodeConfig pulsarNodeConfig;
     private CacheClusterConfig cacheClusterConfig;
+
+    // Map<threadId, Map<dataFlowId,TransformProcess>>
+    protected Map<Long, Map<String, TransformProcessor<String, ?>>> transformMap = new ConcurrentHashMap<>();
 
     public PulsarFederationSinkContext(String sinkName, Context context, Channel channel) {
         super(sinkName, context, channel);
@@ -65,8 +81,9 @@ public class PulsarFederationSinkContext extends SinkContext {
                 LOG.error("newSortTaskConfig is null.");
                 return;
             }
-            if ((this.taskConfig != null && this.taskConfig.equals(newTaskConfig))
-                    && (this.sortTaskConfig != null && this.sortTaskConfig.equals(newSortTaskConfig))) {
+            if ((newTaskConfig == null || StringUtils.equals(this.taskConfigJson, gson.toJson(newTaskConfig)))
+                    && (newSortTaskConfig == null
+                            || StringUtils.equals(this.sortTaskConfigJson, gson.toJson(newSortTaskConfig)))) {
                 LOG.info("Same sortTaskConfig, do nothing.");
                 return;
             }
@@ -78,8 +95,7 @@ public class PulsarFederationSinkContext extends SinkContext {
                 }
             }
 
-            this.taskConfig = newTaskConfig;
-            this.sortTaskConfig = newSortTaskConfig;
+            this.replaceConfig(newTaskConfig, newSortTaskConfig);
 
             CacheClusterConfig clusterConfig = new CacheClusterConfig();
             clusterConfig.setClusterName(this.taskName);
@@ -91,7 +107,12 @@ public class PulsarFederationSinkContext extends SinkContext {
             Map<String, PulsarIdConfig> fromTaskConfig = fromTaskConfig(taskConfig);
             Map<String, PulsarIdConfig> fromSortTaskConfig = fromSortTaskConfig(sortTaskConfig);
             SortConfigMetricReporter.reportClusterDiff(clusterId, taskName, fromTaskConfig, fromSortTaskConfig);
-            idConfigMap = unifiedConfiguration ? fromTaskConfig : fromSortTaskConfig;
+            if (unifiedConfiguration) {
+                this.idConfigMap = fromTaskConfig;
+                this.transformMap.clear();
+            } else {
+                this.idConfigMap = fromSortTaskConfig;
+            }
         } catch (Throwable e) {
             LOG.error(e.getMessage(), e);
         }
@@ -247,5 +268,92 @@ public class PulsarFederationSinkContext extends SinkContext {
                     strHandlerClass, t.getMessage(), t);
         }
         return null;
+    }
+
+    public TransformProcessor<String, ?> getTransformProcessor(String dataFlowId) {
+        Long threadId = Thread.currentThread().getId();
+        Map<String, TransformProcessor<String, ?>> transformProcessors = this.transformMap.get(threadId);
+        if (transformProcessors == null) {
+            transformProcessors = reloadTransform(taskConfig);
+            this.transformMap.put(threadId, transformProcessors);
+        }
+        return transformProcessors.get(dataFlowId);
+    }
+
+    private Map<String, TransformProcessor<String, ?>> reloadTransform(TaskConfig taskConfig) {
+        ImmutableMap.Builder<String, TransformProcessor<String, ?>> builder = new ImmutableMap.Builder<>();
+
+        taskConfig.getClusterTagConfigs()
+                .stream()
+                .map(ClusterTagConfig::getDataFlowConfigs)
+                .flatMap(Collection::stream)
+                .forEach(flow -> {
+                    if (StringUtils.isEmpty(flow.getTransformSql())) {
+                        return;
+                    }
+                    TransformProcessor<String, ?> transformProcessor = createTransform(flow);
+                    if (transformProcessor == null) {
+                        return;
+                    }
+                    builder.put(flow.getDataflowId(),
+                            transformProcessor);
+                });
+
+        return builder.build();
+    }
+
+    private TransformProcessor<String, ?> createTransform(DataFlowConfig dataFlowConfig) {
+        try {
+            LOG.info("try to create transform:{}", dataFlowConfig.toString());
+            return TransformProcessor.create(
+                    createTransformConfig(dataFlowConfig),
+                    createSourceDecoder(dataFlowConfig.getSourceConfig()),
+                    createSinkEncoder(dataFlowConfig.getSinkConfig()));
+        } catch (Exception e) {
+            LOG.error("failed to reload transform of dataflow={}, ex={}", dataFlowConfig.getDataflowId(),
+                    e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private SinkEncoder<?> createSinkEncoder(SinkConfig sinkConfig) {
+        if (!(sinkConfig instanceof PulsarSinkConfig)) {
+            throw new IllegalArgumentException("sinkInfo must be an instance of PulsarSinkConfig");
+        }
+        PulsarSinkConfig sSinkConfig = (PulsarSinkConfig) sinkConfig;
+        List<FieldInfo> fieldInfos = sSinkConfig.getFieldConfigs()
+                .stream()
+                .map(config -> new FieldInfo(config.getName(), deriveTypeConverter(config.getFormatInfo())))
+                .collect(Collectors.toList());
+
+        if (StringUtils.equalsIgnoreCase(PulsarSinkConfig.MESSAGE_TYPE_CSV, sSinkConfig.getMessageType())) {
+            Character delimiter = sSinkConfig.getDelimiter();
+            if (delimiter == null) {
+                delimiter = PulsarSinkConfig.CSV_DEFAULT_DELIMITER;
+            }
+            CsvSinkInfo sinkInfo = new CsvSinkInfo(sinkConfig.getEncodingType(), delimiter, sSinkConfig.getEscapeChar(),
+                    fieldInfos);
+            return SinkEncoderFactory.createCsvEncoder(sinkInfo);
+        } else if (StringUtils.equalsIgnoreCase(PulsarSinkConfig.MESSAGE_TYPE_KV, sSinkConfig.getMessageType())) {
+            Character entrySplitter = sSinkConfig.getEntrySplitter();
+            if (entrySplitter == null) {
+                entrySplitter = PulsarSinkConfig.KV_DEFAULT_ENTRYSPLITTER;
+            }
+            Character kvSplitter = sSinkConfig.getKvSplitter();
+            if (kvSplitter == null) {
+                kvSplitter = PulsarSinkConfig.KV_DEFAULT_KVSPLITTER;
+            }
+            KvSinkInfo sinkInfo = new KvSinkInfo(sinkConfig.getEncodingType(), fieldInfos);
+            sinkInfo.setEntryDelimiter(entrySplitter);
+            sinkInfo.setKvDelimiter(kvSplitter);
+            return SinkEncoderFactory.createKvEncoder(sinkInfo);
+        } else if (StringUtils.equalsIgnoreCase(PulsarSinkConfig.MESSAGE_TYPE_JSON, sSinkConfig.getMessageType())) {
+            MapSinkInfo sinkInfo = new MapSinkInfo(sinkConfig.getEncodingType(), fieldInfos);
+            return SinkEncoderFactory.createMapEncoder(sinkInfo);
+        } else {
+            CsvSinkInfo sinkInfo = new CsvSinkInfo(sinkConfig.getEncodingType(), PulsarSinkConfig.CSV_DEFAULT_DELIMITER,
+                    null, fieldInfos);
+            return SinkEncoderFactory.createCsvEncoder(sinkInfo);
+        }
     }
 }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarIdConfig.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarIdConfig.java
@@ -55,6 +55,7 @@ public class PulsarIdConfig extends IdConfig {
     private String topic;
     private DataTypeEnum dataType;
     private DataFlowConfig dataFlowConfig;
+    private String dataFlowId;
 
     public PulsarIdConfig(Map<String, String> idParam) {
         this.inlongGroupId = idParam.get(Constants.INLONG_GROUP_ID);
@@ -64,6 +65,7 @@ public class PulsarIdConfig extends IdConfig {
         this.topic = idParam.getOrDefault(Constants.TOPIC, uid);
         this.dataType = DataTypeEnum
                 .convert(idParam.getOrDefault(PulsarIdConfig.KEY_DATA_TYPE, DataTypeEnum.TEXT.getType()));
+        this.dataFlowId = this.uid;
     }
 
     public static PulsarIdConfig create(DataFlowConfig dataFlowConfig) {
@@ -97,6 +99,7 @@ public class PulsarIdConfig extends IdConfig {
                 .dataType(dataType)
                 .separator(separator)
                 .dataFlowConfig(dataFlowConfig)
+                .dataFlowId(dataFlowConfig.getDataflowId())
                 .build();
 
     }

--- a/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
+++ b/inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java
@@ -43,11 +43,14 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
@@ -276,35 +279,46 @@ public class PulsarProducerCluster implements LifecycleAware {
             throw new IllegalStateException();
         }
 
-        // sendAsync
-        byte[] sendBytes = this.handler.parse(sinkContext, profileEvent);
+        // resolve idConfig and parse into one or more message payloads
+        String uid = profileEvent.getUid();
+        PulsarIdConfig idConfig = sinkContext.getIdConfig(uid);
+        List<byte[]> records = this.handler.parse(sinkContext, profileEvent, idConfig);
         // check
-        if (sendBytes == null) {
+        if (records == null || records.isEmpty()) {
             tx.commit();
             profileEvent.ack();
             tx.close();
             return true;
         }
         long sendTime = System.currentTimeMillis();
-        CompletableFuture<MessageId> future = producer.newMessage()
-                .properties(headers)
-                .value(sendBytes)
-                .sendAsync();
-        // callback
-        future.whenCompleteAsync((msgId, ex) -> {
-            if (ex != null) {
-                LOG.error("Send fail:{}", ex.getMessage());
-                LOG.error(ex.getMessage(), ex);
-                tx.rollback();
-                tx.close();
-                sinkContext.addSendResultMetric(profileEvent, topic, false, sendTime);
-            } else {
-                tx.commit();
-                tx.close();
-                sinkContext.addSendResultMetric(profileEvent, topic, true, sendTime);
-                profileEvent.ack();
-            }
-        });
+        // send all records, commit tx after all completed
+        final int total = records.size();
+        final AtomicInteger remaining = new AtomicInteger(total);
+        final AtomicBoolean failed = new AtomicBoolean(false);
+        for (byte[] sendBytes : records) {
+            CompletableFuture<MessageId> future = producer.newMessage()
+                    .properties(headers)
+                    .value(sendBytes)
+                    .sendAsync();
+            future.whenCompleteAsync((msgId, ex) -> {
+                if (ex != null) {
+                    LOG.error("Send fail, uid:{}, topic:{}, error:{}", uid, topic, ex.getMessage(), ex);
+                    failed.compareAndSet(false, true);
+                    sinkContext.addSendResultMetric(profileEvent, topic, false, sendTime);
+                } else {
+                    sinkContext.addSendResultMetric(profileEvent, topic, true, sendTime);
+                }
+                if (remaining.decrementAndGet() == 0) {
+                    if (failed.get()) {
+                        tx.rollback();
+                    } else {
+                        tx.commit();
+                        profileEvent.ack();
+                    }
+                    tx.close();
+                }
+            });
+        }
         return true;
     }
 


### PR DESCRIPTION
Fixes #12191 

### Motivation

- **On-the-fly re-encoding** — decode an incoming line (CSV / KV / PB / JSON), apply SQL projection / filter / function calls (e.g. `STR_TO_MAP(URL_DECODE(event_value), '&', '=')['HY50']`), then emit CSV / KV / JSON to Pulsar.
- **Row explosion** — transforms like `$childIndex` + child-array unpacking can turn one event into multiple downstream messages; the sink pipeline must support that.
- **Filtering** — `WHERE` clauses can filter events entirely; the sink must ack the event without emitting anything, without leaking transactions.
- **Consistency with Kafka side** — reduce operational surprise for users: same `transformSql`, same encoding switch, same filter/explode semantics regardless of the underlying MQ.

### Modifications

### Proposed change

Four files changed. All changes are additive; existing Pulsar deployments without `transformSql` are unaffected.

#### 1) `inlong-common` : `PulsarSinkConfig`

Add encoding hints and defaults (mirroring `KafkaSinkConfig`):

```java
public static final String MESSAGE_TYPE_CSV = "csv";
public static final Character CSV_DEFAULT_DELIMITER = '|';
public static final String MESSAGE_TYPE_KV = "kv";
public static final Character KV_DEFAULT_ENTRYSPLITTER = '&';
public static final Character KV_DEFAULT_KVSPLITTER = '=';
public static final String MESSAGE_TYPE_JSON = "json";

private String messageType;
private Character delimiter;
private Character escapeChar;
private Character entrySplitter;
private Character kvSplitter;
```

The pre-existing fields (`pulsarTenant / namespace / topic / partitionNum`) are kept intact.

#### 2) `PulsarIdConfig`

Add `dataFlowId` (aligned with `KafkaIdConfig`) so the handler can look up the correct `TransformProcessor`:

- `Map<String,String>` constructor initializes `dataFlowId = uid` (back-compat).
- `create(DataFlowConfig)` builder sets `dataFlowId = dataFlowConfig.getDataflowId()`.

#### 3) `PulsarFederationSinkContext`

Introduce transform caching and encoder wiring:

```java
// Map<threadId, Map<dataFlowId, TransformProcessor>>
protected Map<Long, Map<String, TransformProcessor<String, ?>>> transformMap = new ConcurrentHashMap<>();

public TransformProcessor<String, ?> getTransformProcessor(String dataFlowId) { ... }
private Map<String, TransformProcessor<String, ?>> reloadTransform(TaskConfig taskConfig) { ... }
private TransformProcessor<String, ?> createTransform(DataFlowConfig dataFlowConfig) { ... }
private SinkEncoder<?> createSinkEncoder(SinkConfig sinkConfig) { ... }
```

Semantics:

- `reload()` uses `taskConfigJson` / `sortTaskConfigJson` for change detection (via `replaceConfig(...)` in the base `SinkContext`).
- When `unifiedConfiguration` is on and config changes, `transformMap.clear()` so stale processors on worker threads are dropped.
- `createTransform` builds a `TransformProcessor` using the base class helpers `createTransformConfig` + `createSourceDecoder` + our new `createSinkEncoder`.
- `createSinkEncoder` dispatches on `PulsarSinkConfig.messageType`:
  - `csv` → `CsvSinkInfo(encodingType, delimiter [default '|'], escapeChar, fieldInfos)`
  - `kv` → `KvSinkInfo(encodingType, fieldInfos)` + `entrySplitter [default '&']` + `kvSplitter [default '=']`
  - `json` → `MapSinkInfo(encodingType, fieldInfos)`
  - otherwise → default CSV encoder with `'|'`.

Flows without `transformSql` skip `TransformProcessor` construction entirely.

#### 4) `IEvent2PulsarRecordHandler` (**breaking** — see notes)

Signature updated to align with the Kafka handler and to allow 0/1/N outputs:

```java
public interface IEvent2PulsarRecordHandler {
    List<byte[]> parse(PulsarFederationSinkContext context, ProfileEvent event, PulsarIdConfig idConfig)
            throws IOException;
}
```

#### 5) `DefaultEvent2PulsarRecordHandler`

Two branches, matching the Kafka side 1:1:

```java
@Override
public List<byte[]> parse(PulsarFederationSinkContext context, ProfileEvent event, PulsarIdConfig idConfig)
        throws IOException {
    TransformProcessor<String, ?> processor = context.getTransformProcessor(idConfig.getDataFlowId());
    if (processor != null) {
        return parseByTransform(context, event, processor);
    }
    return Arrays.asList(parseByBytes(event, idConfig));
}
```

- **`parseByTransform`** — builds `extParams` from `context.getSinkContext().getParameters()` + `event.getHeaders()`, calls `processor.transformForBytes(event.getBody(), extParams)`, converts each result:
  - `String`  → `getBytes()`
  - `byte[]`  → as-is
  - other     → `gson.toJson(...).getBytes()`
- **`parseByBytes`** — the original behavior is preserved: for `TEXT` prepend `ftime + separator + extinfo + separator`, then append `event.getBody()`; for `PB / JCE / UNKNOWN` just emit `event.getBody()`.

#### 6) `PulsarProducerCluster#send`

Adapted to the new `List<byte[]>` contract while keeping the "one transaction per event" model:

- Resolve `PulsarIdConfig` from `event.getUid()`.
- Call `handler.parse(sinkContext, event, idConfig)`.
- If empty / null → `tx.commit(); event.ack(); tx.close();` (filter case).
- Otherwise send N messages in parallel and aggregate via `AtomicInteger remaining` + `AtomicBoolean failed`:
  - Every `sendAsync` callback records a per-message metric.
  - When the last message's callback fires: if any failed → `tx.rollback()`, else `tx.commit()` + `event.ack()`; finally `tx.close()`.

This preserves atomicity — an event either fully lands or fully rolls back — even when it fans out to multiple Pulsar messages.

### Behavior matrix

| Config | `transformSql` present? | `messageType` | Result |
| --- | --- | --- | --- |
| Pulsar sink (existing users) | ❌ | any / unset | Same as today: `parseByBytes` → 1 message per event |
| Pulsar sink | ✅ | `csv` | Transform → CSV encoder (custom delimiter / escape) → N messages |
| Pulsar sink | ✅ | `kv`  | Transform → KV encoder (custom entry / kv splitter) → N messages |
| Pulsar sink | ✅ | `json` | Transform → MAP (JSON) encoder → N messages |
| Pulsar sink | ✅ | unset / unknown | Transform → default CSV encoder with `'|'` |

### Backward compatibility

- **Wire config**: `PulsarSinkConfig` only adds fields/constants; old JSON that doesn't set `messageType / delimiter / escapeChar / entrySplitter / kvSplitter` deserializes fine.
- **Runtime behavior for existing flows**: when `transformSql` is empty, `TransformProcessor` is not built, `parseByTransform` is not taken, `parseByBytes` returns exactly one payload — semantically identical to today.
- **API break — internal SPI only**: `IEvent2PulsarRecordHandler#parse` return type changes from `byte[]` to `List<byte[]>` and gains `PulsarIdConfig`. This interface is a sort-standalone internal SPI (not published to `inlong-common`), and the only known implementation `DefaultEvent2PulsarRecordHandler` is updated in the same change. Users who plugged in a custom handler via the `eventHandler` common property will need a small adaptation:
  ```java
  // before
  byte[] out = doStuff(event);
  // after
  return Arrays.asList(doStuff(event));
  ```
- No public API on `SinkContext` / `PulsarFederationSinkContext` is removed or renamed; only additions.

### Risks / Notes

- **Custom `eventHandler` implementations must adapt** to the new interface signature. Because a wrong signature will surface as a `NoSuchMethodError` at boot, this failure is loud (not silent).
- **Per-message vs per-event metrics**: for a fanout event, `addSendResultMetric` is now invoked once per outbound message, which slightly changes metric cardinality (more accurate, but different from previous behavior). Existing dashboards that count "sink send success = event count" may need to switch to "sink send success = message count".
- **Transactional atomicity in fanout**: if any of the N sub-sends fails, the whole transaction rolls back (all N messages are considered unsent from the sort perspective, even the ones the broker already acked). This mirrors the current single-message semantics and keeps ack behavior predictable at the cost of possible duplicate delivery under partial failures — same trade-off the Kafka side already takes.
- **JSON encoding path** uses `MapSinkInfo` (`SinkEncoderFactory.createMapEncoder`) to keep parity with Kafka. If you need strict record-JSON in the future (schema-aware), that is a separate follow-up.

### Files changed

- `inlong-common/src/main/java/org/apache/inlong/common/pojo/sort/dataflow/sink/PulsarSinkConfig.java`
- `inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarIdConfig.java`
- `inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarFederationSinkContext.java`
- `inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/IEvent2PulsarRecordHandler.java`
- `inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/DefaultEvent2PulsarRecordHandler.java`
- `inlong-sort-standalone/sort-standalone-source/src/main/java/org/apache/inlong/sort/standalone/sink/pulsar/PulsarProducerCluster.java`

### Checklist

- [x] Behavior of existing Pulsar sink pipelines (no `transformSql`) is preserved
- [x] `PulsarSinkConfig` is JSON back-compat (only new fields/constants added)
- [x] `PulsarFederationSinkContext` caches `TransformProcessor` per worker thread and clears it on config change
- [x] `DefaultEvent2PulsarRecordHandler` supports 0 / 1 / N output rows
- [x] `PulsarProducerCluster` sends N messages under one transaction and commits/rolls back atomically
- [x] Parity with `KafkaFederationSinkContext` + `DefaultEvent2KafkaRecordHandler` on the transform code path
### Verifying this change

*(Please pick either of the following options)*

- [ ] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
  - If a feature is not applicable for documentation, explain why?
  - If a feature is not documented yet in this PR, please create a follow-up issue for adding the documentation
