### PR TITLE
[INLONG-12197][SDK] Make batch done idempotent in Dataproxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/request.go
@@ -87,6 +87,7 @@ func (h heartbeatReq) encode(buffer *bytes.Buffer) []byte {
 type batchCallback func()
 type batchReq struct {
 	pool               *sync.Pool
+	finished           bool
 	workerID           string
 	batchID            string
 	groupID            string
@@ -111,6 +112,13 @@ func (b *batchReq) append(req *sendDataReq) {
 }
 
 func (b *batchReq) done(err error) {
+	// Idempotency guard: if the batch has already been done, return immediately
+	// to avoid releasing resources or invoking callbacks more than once.
+	if b.finished {
+		return
+	}
+	b.finished = true
+
 	errorCode := getErrorCode(err)
 	for i, req := range b.dataReqs {
 		req.done(err, errorCode)


### PR DESCRIPTION
Fixes #12197

### Motivation

In the Dataproxy Go SDK, `batchReq.done()` may be invoked more than once for the same batch, resulting in callbacks being called twice and resources being released multiple times.

### Modifications

Added a `finished` guard field to `batchReq.done()` so that repeated calls after the first one return immediately without releasing resources or invoking callbacks again.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
