### PR TITLE
[INLONG-12198][SDK] Make getWorker atomic in Dataproxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
@@ -257,8 +257,9 @@ func (c *client) SendAsync(ctx context.Context, msg Message, cb Callback) {
 
 func (c *client) getWorker() (*worker, error) {
 	workerNum := uint64(len(c.workers))
-	start := c.curWorkerIndex.Load()
-	c.curWorkerIndex.Add(1)
+	// Use the return value of the atomic increment as the starting index, ensuring
+	// concurrent callers each get a distinct sequence number.
+	start := c.curWorkerIndex.Add(1) - 1
 
 	for i := uint64(0); i < workerNum; i++ {
 		w := c.workers[(start+i)%workerNum]


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12198

### Motivation

In the Dataproxy Go SDK, concurrent Send calls can start the round-robin scan from the same worker index, so the load is not evenly distributed across workers under high concurrency.

### Modifications

Changed `client.getWorker()` to use the return value of the atomic increment (`Add(1) - 1`) as the starting index, ensuring each concurrent caller gets a distinct sequence number.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
