### PR TITLE
[INLONG-12199][SDK] Fix the issue where sending on an already-closed channel during shutdown causes a panic in Dataproxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/worker.go
@@ -449,7 +449,13 @@ func (w *worker) sendBatch(b *batchReq, retryOnFail bool) {
 			// can not call w.updateConn() in callback, updateConn() may open new conn, which will call gent.Client.Dial()
 			// gent.Client.Dial() and this callback are run in a same goroutine, it will be blocked
 			w.updateConnAsync(errConnWriteFailed)
-			w.sendFailedBatches <- &sendFailedBatchReq{batch: b, retry: retryOnFail}
+			// There is a TOCTOU window between checking state and sending: sendFailedBatches
+			// may already have been closed by closeAll() by the time we send. safeSend
+			// guards against the resulting panic as a fallback; a failed send means the
+			// channel has been closed, so we mark the batch as done to release its resources
+			if !safeSend(w, w.sendFailedBatches, &sendFailedBatchReq{batch: b, retry: retryOnFail}) {
+				b.done(errConnWriteFailed)
+			}
 			return
 		}
 
@@ -538,9 +544,15 @@ func (w *worker) backoffRetry(ctx context.Context, batch *batchReq) {
 				return
 			}
 
-			// put the batch into the retry channel
+			// Put the batch into the retry channel. There is a TOCTOU window between checking state
+			// and sending: retryBatches may already have been closed by closeAll() by
+			// the time we send. safeSend guards against the resulting panic as a
+			// fallback; a failed send means the channel has been closed, so we mark the
+			// batch as done to release its resources
 			w.log.Debug("put to retry...")
-			w.retryBatches <- batch
+			if !safeSend(w, w.retryBatches, batch) {
+				batch.done(errSendTimeout)
+			}
 		case <-ctx.Done():
 			// in the case the process exit, just end up the batch sending routine
 			batch.done(errSendTimeout)
@@ -634,12 +646,26 @@ func (w *worker) handleSendHeartbeat() {
 	}
 }
 
+// safeSend sends v on ch, using recover as a fallback to guard against the
+// panic caused by sending on an already-closed channel
+func safeSend[T any](w *worker, ch chan T, v T) (sent bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			// Sending on an already-closed channel during shutdown; discard the data
+			w.log.Warn("send to closed channel during close, drop it, workerID:", w.index, ", recover:", rec)
+			sent = false
+		}
+	}()
+	ch <- v
+	return true
+}
+
 func (w *worker) onRsp(rsp *batchRsp) {
 	// close already
 	if w.getState() == stateClosed {
 		return
 	}
-	w.responseBatches <- rsp
+	safeSend(w, w.responseBatches, rsp)
 }
 
 func (w *worker) handleRsp(rsp *batchRsp) {


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12199 

### Motivation

In the Dataproxy Go SDK, sending on the already-closed sendFailedBatches, retryBatches, or responseBatches channels during shutdown can raise a "send on closed channel" panic and crash the process.

### Modifications

Introduced a `safeSend` helper that recovers from the closed-channel panic when sending on these channels, and marks the batch as done to release its resources when the send fails.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
