### PR TITLE
[INLONG-12200][SDK] Avoid calling the handler while holding the lock to prevent reentrant deadlock in Dataproxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/discoverer.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/discoverer.go
@@ -158,10 +158,20 @@ func (d *dataProxyDiscoverer) lookup() {
 		d.log.Infof("update server endpoint list %s: %v", d.url, allEndpointAddrStr)
 	}
 
-	d.RLock()
-	defer d.RUnlock()
 	if len(addEndpoints) > 0 || len(delEndpoints) > 0 {
+		// Copy the handler list while holding the lock, then invoke callbacks after
+		// releasing it, to avoid calling external code while holding the lock: if a
+		// handler calls back into AddEventHandler/DelEventHandler/GetEndpoints
+		// (which need Lock/RLock) from within OnEndpointUpdate, the same goroutine
+		// re-entering the RWMutex would deadlock
+		d.RLock()
+		handlers := make([]discoverer.EventHandler, 0, len(d.eventHandlers))
 		for h := range d.eventHandlers {
+			handlers = append(handlers, h)
+		}
+		d.RUnlock()
+
+		for _, h := range handlers {
 			h.OnEndpointUpdate(allEndpoints, addEndpoints, delEndpoints)
 		}
 	}

--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/discoverer/dns.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/discoverer/dns.go
@@ -186,10 +186,20 @@ func (d *dnsDiscoverer) lookup() {
 		d.log.Infof("update domain host list %s: %v", d.domain, allHostStr)
 	}
 
-	d.RLock()
-	defer d.RUnlock()
 	if len(addEndpoints) > 0 || len(delEndpoints) > 0 {
+		// Copy the handler list while holding the lock, then invoke callbacks after
+		// releasing it, to avoid calling external code while holding the lock: if a
+		// handler calls back into AddEventHandler/DelEventHandler/GetEndpoints
+		// (which need Lock/RLock) from within OnEndpointUpdate, the same goroutine
+		// re-entering the RWMutex would deadlock
+		d.RLock()
+		handlers := make([]EventHandler, 0, len(d.eventHandlers))
 		for h := range d.eventHandlers {
+			handlers = append(handlers, h)
+		}
+		d.RUnlock()
+
+		for _, h := range handlers {
 			h.OnEndpointUpdate(allEndpoints, addEndpoints, delEndpoints)
 		}
 	}


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12200 

### Motivation

In the Dataproxy Go SDK, if an OnEndpointUpdate handler calls back into AddEventHandler/DelEventHandler/GetEndpoints from within the Manager-based or DNS discoverer's lookup, the same goroutine re-enters the discoverer's RWMutex and deadlocks.

### Modifications

In both the Manager-based discoverer (`dataproxy/discoverer.go`) and the DNS discoverer (`discoverer/dns.go`), copy the handler list while holding the read lock, release the lock, and only then invoke the `OnEndpointUpdate` callbacks.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
