### PR TITLE
[INLONG-12202][SDK] Close connPool before netClient to avoid dial goroutine leak in Dataproxy Go SDK

### DIFF
--- a/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
+++ b/inlong-sdk/dataproxy-sdk-twins/dataproxy-sdk-golang/dataproxy/client.go
@@ -279,11 +279,21 @@ func (c *client) Close() {
 		for _, w := range c.workers {
 			w.close()
 		}
-		if c.netClient != nil {
-			_ = c.netClient.Stop()
-		}
+		// The connection pool must be closed before netClient. Once netClient.Stop()
+		// returns, gnet's event-loop has fully exited. After that, calling Dial will
+		// block forever inside gnet.Client.EnrollContext, waiting on the channel that
+		// signals connection registration completion (no event-loop is left to
+		// execute the registration task), causing a goroutine leak. The pool's
+		// Close() waits for in-flight dials to finish within a bounded time, trying
+		// to avoid new dials entering EnrollContext after netClient has stopped;
+		// for external Dialers that block indefinitely, Close will still return
+		// after the timeout.
 		if c.connPool != nil {
 			c.connPool.Close()
+		}
+		// Close netClient
+		if c.netClient != nil {
+			_ = c.netClient.Stop()
 		}
 	})
 }


### PR DESCRIPTION
<!-- Prepare a Pull Request
Change the title of pull request refer to the following example:
  [INLONG-XYZ][Component] Title of the pull request 
-->

<!-- Specify the issue this pull request going to fix.
The following *XYZ* should be replaced by the actual [GitHub Issue](https://github.com/apache/inlong/issues) number)-->

Fixes #12202

### Motivation

In the Dataproxy Go SDK, subsequent Dial calls can block forever in EnrollContext once the gnet event-loop has exited during client close, causing goroutine leaks.

### Modifications

Reordered the shutdown sequence in `client.Close()` to close the connection pool before stopping the netClient, reducing the window in which new dials can enter `EnrollContext` after the event-loop has already stopped.

### Verifying this change

*(Please pick either of the following options)*

- [x] This change is a trivial rework/code cleanup without any test coverage.

- [ ] This change is already covered by existing tests, such as:
  *(please describe tests)*

- [ ] This change added tests and can be verified as follows:

  *(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

  - Does this pull request introduce a new feature? no
